### PR TITLE
[Debt] Replace pool stream enum with work stream model

### DIFF
--- a/api/app/Builders/PoolBuilder.php
+++ b/api/app/Builders/PoolBuilder.php
@@ -137,7 +137,7 @@ class PoolBuilder extends Builder
         return $this->whereIn('publishing_group', $publishingGroups);
     }
 
-    public function streams(?array $streams): self
+    public function whereWorkStreamsIn(?array $streams): self
     {
 
         if (empty($streams)) {

--- a/api/app/Builders/PoolBuilder.php
+++ b/api/app/Builders/PoolBuilder.php
@@ -6,7 +6,6 @@ use App\Enums\PoolStatus;
 use App\Models\Team;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
 
 class PoolBuilder extends Builder
 {
@@ -141,7 +140,6 @@ class PoolBuilder extends Builder
     public function streams(?array $streams): self
     {
 
-        Log::debug($streams);
         if (empty($streams)) {
             return $this;
         }

--- a/api/app/Builders/PoolBuilder.php
+++ b/api/app/Builders/PoolBuilder.php
@@ -6,6 +6,7 @@ use App\Enums\PoolStatus;
 use App\Models\Team;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 
 class PoolBuilder extends Builder
 {
@@ -140,6 +141,7 @@ class PoolBuilder extends Builder
     public function streams(?array $streams): self
     {
 
+        Log::debug($streams);
         if (empty($streams)) {
             return $this;
         }

--- a/api/app/Builders/PoolBuilder.php
+++ b/api/app/Builders/PoolBuilder.php
@@ -170,7 +170,7 @@ class PoolBuilder extends Builder
     /**
      * Custom sort to handle issues with how laravel aliases
      * aggregate selects and orderBys for json fields in `lighthouse-php`
-     *
+
      * The column used in the orderBy is `table_aggregate_column->property`
      * But is actually aliased to snake case `table_aggregate_columnproperty`
      */
@@ -181,6 +181,25 @@ class PoolBuilder extends Builder
 
         if ($order && $locale) {
             return $this->withMax('legacyTeam', 'display_name->'.$locale)->orderBy('legacy_team_max_display_name'.$locale, $order);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Custom sort to handle issues with how laravel aliases
+     * aggregate selects and orderBys for json fields in `lighthouse-php`
+     *
+     * The column used in the orderBy is `table_aggregate_column->property`
+     * But is actually aliased to snake case `table_aggregate_columnproperty`
+     */
+    public function orderByWorkStreamName(?array $args): self
+    {
+        $order = $args['order'] ?? null;
+        $locale = $args['locale'] ?? null;
+
+        if ($order && $locale) {
+            return $this->withMax('workStream', 'name->'.$locale)->orderBy('work_stream_max_name'.$locale, $order);
         }
 
         return $this;

--- a/api/app/Builders/PoolBuilder.php
+++ b/api/app/Builders/PoolBuilder.php
@@ -144,7 +144,9 @@ class PoolBuilder extends Builder
             return $this;
         }
 
-        return $this->whereIn('stream', $streams);
+        return $this->whereHas('workStream', function ($query) use ($streams) {
+            $query->whereIn('id', $streams);
+        });
     }
 
     public function whereClassifications(?array $classifications): self

--- a/api/app/Console/Commands/MigratePoolStream.php
+++ b/api/app/Console/Commands/MigratePoolStream.php
@@ -53,6 +53,10 @@ class MigratePoolStream extends Command
                     $jobPosterTemplate->work_stream_id = $stream->id;
                     $jobPosterTemplate->save();
                     $jobPosterTemplatesUpdated++;
+                } else {
+                    $this->error(sprintf('Work stream (%s) not found for job poster template (%s)',
+                        $jobPosterTemplate->stream,
+                        $jobPosterTemplate->id));
                 }
             }
         });
@@ -68,6 +72,10 @@ class MigratePoolStream extends Command
                     $pool->work_stream_id = $stream->id;
                     $pool->save();
                     $poolsUpdated++;
+                } else {
+                    $this->error(sprintf('Work stream (%s) not found for pool (%s)',
+                        $pool->stream,
+                        $pool->id));
                 }
             }
         });
@@ -82,6 +90,10 @@ class MigratePoolStream extends Command
                 if ($streams) {
                     $applicantFilter->workStreams()->sync($streams);
                     $applicantFiltersUpdated++;
+                } else {
+                    $this->error(sprintf('Work streams (%s) not found for applicant filter (%s)',
+                        implode(', ', $applicantFilter->qualified_streams),
+                        $applicantFilter->id));
                 }
             }
         });

--- a/api/app/Console/Commands/MigratePoolStream.php
+++ b/api/app/Console/Commands/MigratePoolStream.php
@@ -67,7 +67,7 @@ class MigratePoolStream extends Command
         $this->info('Updated applicant filter work streams...');
         ApplicantFilter::whereNotNull('qualified_streams')->chunkById(200, function (Collection $applicantFilters) use ($workStreams, &$applicantFiltersUpdated) {
             foreach ($applicantFilters as $applicantFilter) {
-                $streams = $workStreams->whereIn('key', $applicantFilter->qualified_streams)?->pluck('id');
+                $streams = $workStreams->whereIn('key', $applicantFilter->qualified_streams)->pluck('id');
                 if ($streams) {
                     $applicantFilter->workStreams()->sync($streams);
                     $applicantFiltersUpdated++;

--- a/api/app/Console/Commands/MigratePoolStream.php
+++ b/api/app/Console/Commands/MigratePoolStream.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\ApplicantFilter;
+use App\Models\JobPosterTemplate;
+use App\Models\Pool;
+use App\Models\WorkStream;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+class MigratePoolStream extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:migrate-pool-stream';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Migrates the pool stream enum to work stream model';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+
+        $workStreams = WorkStream::all();
+
+        $this->info('Updating job poster template work streams...');
+        $jobPosterTemplatesUpdated = 0;
+        JobPosterTemplate::whereNotNull('stream')->chunkById(200, function (Collection $jobPosterTemplates) use ($workStreams, &$jobPosterTemplatesUpdated) {
+            foreach ($jobPosterTemplates as $jobPosterTemplate) {
+                $stream = $workStreams->where('key', $jobPosterTemplate->stream)->first();
+                if ($stream) {
+                    $jobPosterTemplate->work_stream_id = $stream->id;
+                    $jobPosterTemplate->save();
+                    $jobPosterTemplatesUpdated++;
+                }
+            }
+        });
+        $this->info("Updated $jobPosterTemplatesUpdated job poster templates");
+
+        $this->newLine();
+        $this->info('Updating pool work streams...');
+        $poolsUpdated = 0;
+        Pool::whereNotNull('stream')->chunkById(200, function (Collection $pools) use ($workStreams, &$poolsUpdated) {
+            foreach ($pools as $pool) {
+                $stream = $workStreams->where('key', $pool->stream)->first();
+                if ($stream) {
+                    $pool->work_stream_id = $stream->id;
+                    $pool->save();
+                    $poolsUpdated++;
+                }
+            }
+        });
+        $this->info("Updated $poolsUpdated pools");
+
+        $applicantFiltersUpdated = 0;
+        $this->newLine();
+        $this->info('Updated applicant filter work streams...');
+        ApplicantFilter::whereNotNull('qualified_streams')->chunkById(200, function (Collection $applicantFilters) use ($workStreams, &$applicantFiltersUpdated) {
+            foreach ($applicantFilters as $applicantFilter) {
+                $streams = $workStreams->whereIn('key', $applicantFilter->qualified_streams)?->pluck('id');
+                if ($streams) {
+                    $applicantFilter->workStreams()->sync($streams);
+                    $applicantFiltersUpdated++;
+                }
+            }
+        });
+        $this->info("Updated $applicantFiltersUpdated applicant filters");
+
+        $this->newLine();
+        $this->info('Migration completed');
+        $this->table(['Model', 'Affected'], [
+            ['JobPosterTemplate', $jobPosterTemplatesUpdated],
+            ['Pool', $poolsUpdated],
+            ['ApplicantFilter', $applicantFiltersUpdated],
+        ]);
+
+    }
+}

--- a/api/app/Console/Commands/MigratePoolStream.php
+++ b/api/app/Console/Commands/MigratePoolStream.php
@@ -9,6 +9,17 @@ use App\Models\WorkStream;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 
+/**
+ *  Temporary command to support migration of
+ *  PoolStream enum to WorkStream model.
+ *
+ *  NOTE: Should be ran at any point during deployment.
+ *  The rest of the code does not explicitly depend on this
+ *  command but it should not be left since the frontend will
+ *  display empty values until this has been ran.
+ *
+ *  TODO: Remove in #12142
+ */
 class MigratePoolStream extends Command
 {
     /**

--- a/api/app/Console/Commands/MigratePoolStream.php
+++ b/api/app/Console/Commands/MigratePoolStream.php
@@ -87,7 +87,7 @@ class MigratePoolStream extends Command
         ApplicantFilter::whereNotNull('qualified_streams')->chunkById(200, function (Collection $applicantFilters) use ($workStreams, &$applicantFiltersUpdated) {
             foreach ($applicantFilters as $applicantFilter) {
                 $streams = $workStreams->whereIn('key', $applicantFilter->qualified_streams)->pluck('id');
-                if ($streams) {
+                if ($streams->count()) {
                     $applicantFilter->workStreams()->sync($streams);
                     $applicantFiltersUpdated++;
                 } else {

--- a/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
+++ b/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
@@ -28,8 +28,8 @@ final class CountPoolCandidatesByPool
                 $query->whereClassifications($filters['qualifiedClassifications']);
             }
 
-            if (array_key_exists('qualifiedStreams', $filters)) {
-                $query->whereWorkStreamsIn($filters['qualifiedStreams']);
+            if (array_key_exists('workStreams', $filters)) {
+                $query->whereWorkStreamsIn($filters['workStreams']);
             }
         });
 

--- a/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
+++ b/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
@@ -29,7 +29,7 @@ final class CountPoolCandidatesByPool
             }
 
             if (array_key_exists('qualifiedStreams', $filters)) {
-                $query->streams($filters['qualifiedStreams']);
+                $query->whereWorkStreamsIn($filters['qualifiedStreams']);
             }
         });
 

--- a/api/app/GraphQL/Validators/PoolIsCompleteValidator.php
+++ b/api/app/GraphQL/Validators/PoolIsCompleteValidator.php
@@ -30,7 +30,7 @@ final class PoolIsCompleteValidator extends Validator
             'name.fr' => ['string'],
             'classification_id' => ['required', 'uuid', 'exists:classifications,id'],
             'department_id' => ['required', 'uuid', 'exists:departments,id'],
-            'stream' => ['required', 'string'],
+            'work_stream_id' => ['required', 'uuid', 'exists:work_streams,id'],
             'opportunity_length' => ['required', 'string'],
 
             // Closing date

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -49,6 +49,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property string $team_id
  * @property string $department_id
  * @property string $community_id
+ * @property string $work_stream_id
  * @property ?string $area_of_selection
  * @property array $selection_limitations
  * @property \Illuminate\Support\Carbon $created_at
@@ -129,6 +130,7 @@ class Pool extends Model
         'process_number',
         'department_id',
         'community_id',
+        'work_stream_id',
     ];
 
     /**

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -310,7 +310,7 @@ class PoolCandidate extends Model
             })
             // Now scope for valid pools, according to streams
             ->whereHas('pool', function ($query) use ($streams) {
-                $query->streams($streams);
+                $query->whereWorkStreamsIn($streams);
             });
 
         return $query;

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -310,7 +310,7 @@ class PoolCandidate extends Model
             })
             // Now scope for valid pools, according to streams
             ->whereHas('pool', function ($query) use ($streams) {
-                $query->whereIn('stream', $streams);
+                $query->streams($streams);
             });
 
         return $query;

--- a/api/app/Models/PoolCandidateSearchRequest.php
+++ b/api/app/Models/PoolCandidateSearchRequest.php
@@ -152,7 +152,6 @@ class PoolCandidateSearchRequest extends Model
             return $query;
         }
 
-        // streams is an array of PoolStream enums
         $query->whereHas('applicantFilter', function ($filterQuery) use ($streams) {
             $filterQuery->whereHas('workStreams', function ($workStreamQuery) use ($streams) {
                 $workStreamQuery->whereIn('applicant_filter_work_stream.work_stream_id', $streams);

--- a/api/app/Models/PoolCandidateSearchRequest.php
+++ b/api/app/Models/PoolCandidateSearchRequest.php
@@ -146,18 +146,16 @@ class PoolCandidateSearchRequest extends Model
         return $query;
     }
 
-    public static function scopeStreams(Builder $query, ?array $streams): Builder
+    public static function scopeWorkStreams(Builder $query, ?array $streams): Builder
     {
         if (empty($streams)) {
             return $query;
         }
 
         // streams is an array of PoolStream enums
-        $query->whereHas('applicantFilter', function ($query) use ($streams) {
-            $query->where(function ($query) use ($streams) {
-                foreach ($streams as $index => $stream) {
-                    $query->orWhereJsonContains('qualified_streams', $stream);
-                }
+        $query->whereHas('applicantFilter', function ($filterQuery) use ($streams) {
+            $filterQuery->whereHas('workStreams', function ($workStreamQuery) use ($streams) {
+                $workStreamQuery->whereIn('applicant_filter_work_stream.work_stream_id', $streams);
             });
         });
 

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -779,7 +779,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
                 }
 
                 if (array_key_exists('qualifiedStreams', $filters)) {
-                    $query->streams($filters['qualifiedStreams']);
+                    $query->whereWorkStreamsIn($filters['qualifiedStreams']);
                 }
             });
 

--- a/api/database/factories/ApplicantFilterFactory.php
+++ b/api/database/factories/ApplicantFilterFactory.php
@@ -95,20 +95,18 @@ class ApplicantFilterFactory extends Factory
             )->get();
             $filter->pools()->saveMany($pools);
             $filter->qualifiedClassifications()->saveMany($pools->flatMap(fn ($pool) => $pool->classification));
-            $stream = (empty($pools) || count($pools) === 0) ? $this->faker->randomElements(
-                array_column(PoolStream::cases(), 'name'),
-            ) : [$pools[0]->stream];
+            $streams = $pools->flatMap(fn ($pool) => $pool->workStream);
+            $filter->workStreams()->saveMany($streams);
 
             $ATIP = Community::where('key', 'atip')->first();
             $digital = Community::where('key', 'digital')->first();
 
-            if (in_array(PoolStream::ACCESS_INFORMATION_PRIVACY->name, $stream) && $ATIP?->id) {
+            if ($streams->first()?->key === PoolStream::ACCESS_INFORMATION_PRIVACY->name && $ATIP?->id) {
                 $filter->community_id = $ATIP->id;
             } elseif ($digital?->id) {
                 $filter->community_id = $digital->id;
             }
 
-            $filter->qualified_streams = $stream;
             $filter->save();
         });
     }

--- a/api/database/factories/ApplicantFilterFactory.php
+++ b/api/database/factories/ApplicantFilterFactory.php
@@ -4,7 +4,6 @@ namespace Database\Factories;
 
 use App\Enums\LanguageAbility;
 use App\Enums\OperationalRequirement;
-use App\Enums\PoolStream;
 use App\Enums\PositionDuration;
 use App\Enums\WorkRegion;
 use App\Models\ApplicantFilter;
@@ -101,7 +100,9 @@ class ApplicantFilterFactory extends Factory
             $ATIP = Community::where('key', 'atip')->first();
             $digital = Community::where('key', 'digital')->first();
 
-            if ($streams->first()?->key === PoolStream::ACCESS_INFORMATION_PRIVACY->name && $ATIP?->id) {
+            $isATIP = $streams->contains(fn ($stream) => $stream->key === 'ACCESS_INFORMATION_PRIVACY');
+
+            if ($isATIP && $ATIP?->id) {
                 $filter->community_id = $ATIP->id;
             } elseif ($digital?->id) {
                 $filter->community_id = $digital->id;

--- a/api/database/factories/ApplicantFilterFactory.php
+++ b/api/database/factories/ApplicantFilterFactory.php
@@ -95,7 +95,7 @@ class ApplicantFilterFactory extends Factory
             )->get();
             $filter->pools()->saveMany($pools);
             $filter->qualifiedClassifications()->saveMany($pools->flatMap(fn ($pool) => $pool->classification));
-            $streams = $pools->flatMap(fn ($pool) => $pool->workStream);
+            $streams = $pools->map(fn ($pool) => $pool->workStream);
             $filter->workStreams()->saveMany($streams);
 
             $ATIP = Community::where('key', 'atip')->first();

--- a/api/database/factories/ApplicantFilterFactory.php
+++ b/api/database/factories/ApplicantFilterFactory.php
@@ -110,4 +110,18 @@ class ApplicantFilterFactory extends Factory
             $filter->save();
         });
     }
+
+    /**
+     * Create an ApplicantFilter with specific work streams
+     *
+     * @var \Illuminate\Support\Collection<array-key, \App\Models\WorkStream>
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
+    public function withWorkStreams(array $workStreams)
+    {
+        return $this->afterCreating(function (ApplicantFilter $filter) use ($workStreams) {
+            $filter->workStreams()->saveMany($workStreams);
+        });
+    }
 }

--- a/api/database/factories/PoolFactory.php
+++ b/api/database/factories/PoolFactory.php
@@ -188,9 +188,9 @@ class PoolFactory extends Factory
             // the base state is draft already
             $hasSpecialNote = $this->faker->boolean();
             $isRemote = $this->faker->boolean();
-            $workStreamId = WorkStream::inRandomOrder()->first()?->id;
-            if (! $workStreamId) {
-                $workStreamId = WorkStream::factory()->create()->id;
+            $workStream = WorkStream::inRandomOrder()->first();
+            if (! $workStream) {
+                $workStream = WorkStream::factory()->create();
             }
 
             return [
@@ -207,7 +207,7 @@ class PoolFactory extends Factory
                 'special_note' => ! $hasSpecialNote ? ['en' => $this->faker->paragraph().' EN', 'fr' => $this->faker->paragraph().' FR'] : null,
                 'is_remote' => $this->faker->boolean,
                 'stream' => $this->faker->randomElement(PoolStream::cases())->name,
-                'work_stream_id' => $workStreamId,
+                'work_stream_id' => $workStream->id,
                 'process_number' => $this->faker->word(),
                 'publishing_group' => $this->faker->randomElement(array_column(PublishingGroup::cases(), 'name')),
                 'opportunity_length' => $this->faker->randomElement(array_column(PoolOpportunityLength::cases(), 'name')),

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -852,7 +852,7 @@ input PoolFilterInput {
   generalSearch: String @scope
   name: String @scope
   team: String @scope
-  streams: [UUID!] @scope
+  workStreams: [UUID!] @scope
   statuses: [PoolStatus!] = [] @scope
   processNumber: String @scope
   publishingGroups: [PublishingGroup!] @scope
@@ -919,7 +919,7 @@ input PoolCandidateSearchRequestInput {
   status: [PoolCandidateSearchStatus] @scope(name: "searchRequestStatus")
   departments: [ID] @scope
   classifications: [ID] @scope
-  streams: [UUID] @scope
+  workStreams: [UUID] @scope
   fullName: String @scope
   email: String @scope
   id: ID @scope

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -277,7 +277,7 @@ type Pool implements HasRoleAssignments {
     @rename(attribute: "security_clearance")
   language: LocalizedPoolLanguage @rename(attribute: "advertisement_language")
   status: LocalizedPoolStatus @rename(attribute: "status")
-  stream: LocalizedPoolStream
+  workStream: WorkStream @belongsTo
   processNumber: String @rename(attribute: "process_number")
   publishingGroup: LocalizedPublishingGroup
     @rename(attribute: "publishing_group")
@@ -1831,7 +1831,7 @@ input UpdatePoolInput {
   name: LocalizedStringInput
   classification: ClassificationBelongsTo
   department: DepartmentBelongsTo
-  stream: PoolStream
+  workStream: WorkStreamBelongsTo
   processNumber: String @rename(attribute: "process_number")
   # Closing date
   closingDate: DateTime

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -852,7 +852,7 @@ input PoolFilterInput {
   generalSearch: String @scope
   name: String @scope
   team: String @scope
-  workStreams: [UUID!] @scope
+  workStreams: [UUID!] @scope(name: "whereWorkStreamsIn")
   statuses: [PoolStatus!] = [] @scope
   processNumber: String @scope
   publishingGroups: [PublishingGroup!] @scope

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -589,8 +589,7 @@ type ApplicantFilter {
   skills: [Skill] @belongsToMany
   # request creation connects to qualifiedClassifications
   qualifiedClassifications: [Classification] @belongsToMany # Filters applicants based on the classifications pools they've qualified in.
-  qualifiedStreams: [LocalizedPoolStream]
-    @rename(attribute: "qualified_streams") # Filters applicants based on the streams of the pools they've qualified in.
+  workStreams: [WorkStream!] @belongsToMany
   pools: [Pool] @belongsToMany @canResolved(ability: "view")
   community: Community @belongsTo # Currently does not affect search, scope needs to be added
 }
@@ -892,7 +891,7 @@ input ApplicantFilterInput {
   skillsIntersectional: [IdInput] @scope @pluck(key: "id") # AND filtering skills as opposed to OR
   qualifiedClassifications: [ClassificationFilterInput]
     @scope(name: "qualifiedClassifications") # Filters applicants based on the classification of pools they are currently qualified and available in.
-  qualifiedStreams: [PoolStream] @scope(name: "qualifiedStreams") # Filters applicants based on the stream of pools they are currently qualified and available in.
+  qualifiedStreams: [UUID!] @scope(name: "qualifiedStreams") # Filters applicants based on the stream of pools they are currently qualified and available in.
   community: IdInput @scope(name: "candidatesInCommunity") @pluck(key: "id")
 }
 
@@ -920,7 +919,7 @@ input PoolCandidateSearchRequestInput {
   status: [PoolCandidateSearchStatus] @scope(name: "searchRequestStatus")
   departments: [ID] @scope
   classifications: [ID] @scope
-  streams: [PoolStream] @scope
+  streams: [UUID] @scope
   fullName: String @scope
   email: String @scope
   id: ID @scope
@@ -1583,7 +1582,7 @@ input CreateApplicantFilterInput {
   citizenship: CitizenshipStatus
   armedForcesStatus: ArmedForcesStatus @rename(attribute: "armed_forces_status")
   qualifiedClassifications: ClassificationBelongsToMany
-  qualifiedStreams: [PoolStream] @rename(attribute: "qualified_streams")
+  workStreams: WorkStreamBelongsToMany
   community: CommunityBelongsTo
 }
 

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -853,7 +853,7 @@ input PoolFilterInput {
   generalSearch: String @scope
   name: String @scope
   team: String @scope
-  streams: [PoolStream!] @scope
+  streams: [UUID!] @scope
   statuses: [PoolStatus!] = [] @scope
   processNumber: String @scope
   publishingGroups: [PublishingGroup!] @scope

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -589,7 +589,7 @@ type ApplicantFilter {
   skills: [Skill] @belongsToMany
   # request creation connects to qualifiedClassifications
   qualifiedClassifications: [Classification] @belongsToMany # Filters applicants based on the classifications pools they've qualified in.
-  workStreams: [WorkStream!] @belongsToMany
+  workStreams: [WorkStream!] @belongsToMany # Filters applicants based on the streams of the pools they've qualified in.
   pools: [Pool] @belongsToMany @canResolved(ability: "view")
   community: Community @belongsTo # Currently does not affect search, scope needs to be added
 }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -866,6 +866,11 @@ input PoolTeamDisplayNameOrderByInput {
   order: SortOrder!
 }
 
+input PoolWorkStreamNameOrderByInput {
+  locale: String!
+  order: SortOrder!
+}
+
 input PoolBookmarksOrderByInput {
   column: String!
   order: SortOrder!
@@ -1025,6 +1030,7 @@ type Query {
     where: PoolFilterInput
     orderByPoolBookmarks: PoolBookmarksOrderByInput @scope
     orderByTeamDisplayName: PoolTeamDisplayNameOrderByInput @scope
+    orderByWorkStreamName: PoolWorkStreamNameOrderByInput @scope
     orderByColumn: OrderByColumnInput @scope
     orderBy: _
       @orderBy(

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -891,7 +891,7 @@ input ApplicantFilterInput {
   skillsIntersectional: [IdInput] @scope @pluck(key: "id") # AND filtering skills as opposed to OR
   qualifiedClassifications: [ClassificationFilterInput]
     @scope(name: "qualifiedClassifications") # Filters applicants based on the classification of pools they are currently qualified and available in.
-  qualifiedStreams: [UUID!] @scope(name: "qualifiedStreams") # Filters applicants based on the stream of pools they are currently qualified and available in.
+  workStreams: [IdInput] @scope(name: "qualifiedStreams") # Filters applicants based on the stream of pools they are currently qualified and available in.
   community: IdInput @scope(name: "candidatesInCommunity") @pluck(key: "id")
 }
 

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1205,7 +1205,7 @@ input PoolFilterInput {
   generalSearch: String
   name: String
   team: String
-  streams: [PoolStream!]
+  streams: [UUID!]
   statuses: [PoolStatus!] = []
   processNumber: String
   publishingGroups: [PublishingGroup!]

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1240,7 +1240,7 @@ input ApplicantFilterInput {
   skills: [IdInput]
   skillsIntersectional: [IdInput]
   qualifiedClassifications: [ClassificationFilterInput]
-  qualifiedStreams: [UUID!]
+  workStreams: [IdInput]
   community: IdInput
 }
 

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1205,7 +1205,7 @@ input PoolFilterInput {
   generalSearch: String
   name: String
   team: String
-  streams: [UUID!]
+  workStreams: [UUID!]
   statuses: [PoolStatus!] = []
   processNumber: String
   publishingGroups: [PublishingGroup!]
@@ -1264,7 +1264,7 @@ input PoolCandidateSearchRequestInput {
   status: [PoolCandidateSearchStatus]
   departments: [ID]
   classifications: [ID]
-  streams: [UUID]
+  workStreams: [UUID]
   fullName: String
   email: String
   id: ID

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -737,7 +737,7 @@ type Pool implements HasRoleAssignments {
   securityClearance: LocalizedSecurityStatus
   language: LocalizedPoolLanguage
   status: LocalizedPoolStatus
-  stream: LocalizedPoolStream
+  workStream: WorkStream
   processNumber: String
   publishingGroup: LocalizedPublishingGroup
   opportunityLength: LocalizedPoolOpportunityLength
@@ -1869,7 +1869,7 @@ input UpdatePoolInput {
   name: LocalizedStringInput
   classification: ClassificationBelongsTo
   department: DepartmentBelongsTo
-  stream: PoolStream
+  workStream: WorkStreamBelongsTo
   processNumber: String
   closingDate: DateTime
   closingReason: String

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -346,6 +346,7 @@ type Query {
     where: PoolFilterInput
     orderByPoolBookmarks: PoolBookmarksOrderByInput
     orderByTeamDisplayName: PoolTeamDisplayNameOrderByInput
+    orderByWorkStreamName: PoolWorkStreamNameOrderByInput
     orderByColumn: OrderByColumnInput
     orderBy: [QueryPoolsPaginatedOrderByRelationOrderByClause!]
 
@@ -1214,6 +1215,11 @@ input PoolFilterInput {
 }
 
 input PoolTeamDisplayNameOrderByInput {
+  locale: String!
+  order: SortOrder!
+}
+
+input PoolWorkStreamNameOrderByInput {
   locale: String!
   order: SortOrder!
 }

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -972,7 +972,7 @@ type ApplicantFilter {
   positionDuration: [PositionDuration]
   skills: [Skill]
   qualifiedClassifications: [Classification]
-  qualifiedStreams: [LocalizedPoolStream]
+  workStreams: [WorkStream!]
   pools: [Pool]
   community: Community
 }
@@ -1240,7 +1240,7 @@ input ApplicantFilterInput {
   skills: [IdInput]
   skillsIntersectional: [IdInput]
   qualifiedClassifications: [ClassificationFilterInput]
-  qualifiedStreams: [PoolStream]
+  qualifiedStreams: [UUID!]
   community: IdInput
 }
 
@@ -1264,7 +1264,7 @@ input PoolCandidateSearchRequestInput {
   status: [PoolCandidateSearchStatus]
   departments: [ID]
   classifications: [ID]
-  streams: [PoolStream]
+  streams: [UUID]
   fullName: String
   email: String
   id: ID
@@ -1640,7 +1640,7 @@ input CreateApplicantFilterInput {
   citizenship: CitizenshipStatus
   armedForcesStatus: ArmedForcesStatus
   qualifiedClassifications: ClassificationBelongsToMany
-  qualifiedStreams: [PoolStream]
+  workStreams: WorkStreamBelongsToMany
   community: CommunityBelongsTo
 }
 

--- a/api/tests/Feature/ApplicantFilterTest.php
+++ b/api/tests/Feature/ApplicantFilterTest.php
@@ -84,13 +84,13 @@ class ApplicantFilterTest extends TestCase
             'positionDuration' => $filter->position_duration,
             'skills' => $filter->skills->map($onlyId)->toArray(),
             'pools' => $filter->pools->map($onlyId)->toArray(),
+            'workStreams' => $filter->workStreams->map($onlyId)->toArray(),
             'qualifiedClassifications' => $filter->qualifiedClassifications->map(function ($classification) {
                 return [
                     'group' => $classification->group,
                     'level' => $classification->level,
                 ];
             })->toArray(),
-            'qualifiedStreams' => $filter->qualified_streams,
             'community' => ['id' => $filter->community->id],
         ];
     }
@@ -283,7 +283,7 @@ class ApplicantFilterTest extends TestCase
                                 fr
                             }
                         }
-                        qualifiedStreams { value }
+                        workStreams { id }
                         qualifiedClassifications {
                             id
                             name {
@@ -307,7 +307,7 @@ class ApplicantFilterTest extends TestCase
         $this->assertCount($filter->qualifiedClassifications->count(), $retrievedFilter['qualifiedClassifications']);
         $this->assertCount($filter->skills->count(), $retrievedFilter['skills']);
         $this->assertCount($filter->pools->count(), $retrievedFilter['pools']);
-        $this->assertCount(count($filter->qualified_streams), $retrievedFilter['qualifiedStreams']);
+        $this->assertCount($filter->workStreams->count(), $retrievedFilter['workStreams']);
 
         // Assert that all the content in each collection is correct.
         foreach ($filter->pools as $pool) {
@@ -323,8 +323,8 @@ class ApplicantFilterTest extends TestCase
             $response->assertJsonFragment(['id' => $skill->id, 'name' => $skill->name]);
         }
 
-        $response->assertJsonFragment(['qualifiedStreams' => [[
-            'value' => $filter->qualified_streams[0],
+        $response->assertJsonFragment(['workStreams' => [[
+            'id' => $filter->workStreams->first()?->id,
         ]]]);
         $response->assertJsonFragment(['community' => ['id' => $filter->community_id]]);
     }

--- a/api/tests/Feature/ApplicantFilterTest.php
+++ b/api/tests/Feature/ApplicantFilterTest.php
@@ -12,6 +12,7 @@ use App\Models\Pool;
 use App\Models\PoolCandidate;
 use App\Models\PoolCandidateSearchRequest;
 use App\Models\User;
+use App\Models\WorkStream;
 use Database\Seeders\ClassificationSeeder;
 use Database\Seeders\CommunitySeeder;
 use Database\Seeders\DepartmentSeeder;
@@ -426,6 +427,7 @@ class ApplicantFilterTest extends TestCase
         ]);
 
         $community = Community::where('key', 'digital')->first();
+        $workStream = WorkStream::where('key', PoolStream::BUSINESS_ADVISORY_SERVICES->name)->first();
         $pool = Pool::factory()
             ->published()
             ->candidatesAvailableInSearch()
@@ -434,7 +436,7 @@ class ApplicantFilterTest extends TestCase
                     'en' => 'Test Pool EN',
                     'fr' => 'Test Pool FR',
                 ],
-                'stream' => PoolStream::BUSINESS_ADVISORY_SERVICES->name,
+                'work_stream_id' => $workStream->id,
                 'community_id' => $community->id,
             ]);
         // Create candidates who may show up in searches
@@ -475,7 +477,7 @@ class ApplicantFilterTest extends TestCase
         $candidateSkills = $candidateUser->experiences[0]->skills;
         $filter->skills()->saveMany($candidateSkills->shuffle()->take(3));
         $filter->pools()->save($pool);
-        $filter->qualified_streams = $pool->stream;
+        $filter->workStreams()->saveMany([$pool->workStream]);
         $filter->save();
         $response = $this->graphQL(
             /** @lang GraphQL */

--- a/api/tests/Feature/ApplicantFilterTest.php
+++ b/api/tests/Feature/ApplicantFilterTest.php
@@ -104,6 +104,9 @@ class ApplicantFilterTest extends TestCase
         $input['pools'] = [
             'sync' => $filter->pools->pluck('id')->toArray(),
         ];
+        $input['workStreams'] = [
+            'sync' => $filter->workStreams->pluck('id')->toArray(),
+        ];
         $input['qualifiedClassifications'] = [
             'sync' => $filter->qualifiedClassifications->pluck('id')->toArray(),
         ];
@@ -323,9 +326,11 @@ class ApplicantFilterTest extends TestCase
             $response->assertJsonFragment(['id' => $skill->id, 'name' => $skill->name]);
         }
 
-        $response->assertJsonFragment(['workStreams' => [[
-            'id' => $filter->workStreams->first()?->id,
-        ]]]);
+        foreach ($filter->workStreams as $workStream) {
+            $response->assertJsonFragment([
+                'id' => $workStream->id,
+            ]);
+        }
         $response->assertJsonFragment(['community' => ['id' => $filter->community_id]]);
     }
 
@@ -549,7 +554,7 @@ class ApplicantFilterTest extends TestCase
                         locationPreferences { value }
                         operationalRequirements { value }
                         positionDuration
-                        qualifiedStreams { value }
+                        workStreams { id }
                         qualifiedClassifications {
                             group
                             level
@@ -575,7 +580,6 @@ class ApplicantFilterTest extends TestCase
 
         $retrievedFilter['locationPreferences'] = $this->filterEnumToInput($retrievedFilter, 'locationPreferences');
         $retrievedFilter['operationalRequirements'] = $this->filterEnumToInput($retrievedFilter, 'operationalRequirements');
-        $retrievedFilter['qualifiedStreams'] = $this->filterEnumToInput($retrievedFilter, 'qualifiedStreams');
 
         // Now use the retrieved filter to get the same count
         $response = $this->graphQL(

--- a/api/tests/Feature/ApplicantFilterTest.php
+++ b/api/tests/Feature/ApplicantFilterTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature;
 
 use App\Enums\LanguageAbility;
 use App\Enums\PoolCandidateSearchStatus;
-use App\Enums\PoolStream;
 use App\Facades\Notify;
 use App\Models\ApplicantFilter;
 use App\Models\Community;
@@ -12,7 +11,6 @@ use App\Models\Pool;
 use App\Models\PoolCandidate;
 use App\Models\PoolCandidateSearchRequest;
 use App\Models\User;
-use App\Models\WorkStream;
 use Database\Seeders\ClassificationSeeder;
 use Database\Seeders\CommunitySeeder;
 use Database\Seeders\DepartmentSeeder;
@@ -432,7 +430,6 @@ class ApplicantFilterTest extends TestCase
         ]);
 
         $community = Community::where('key', 'digital')->first();
-        $workStream = WorkStream::where('key', PoolStream::BUSINESS_ADVISORY_SERVICES->name)->first();
         $pool = Pool::factory()
             ->published()
             ->candidatesAvailableInSearch()
@@ -441,7 +438,6 @@ class ApplicantFilterTest extends TestCase
                     'en' => 'Test Pool EN',
                     'fr' => 'Test Pool FR',
                 ],
-                'work_stream_id' => $workStream->id,
                 'community_id' => $community->id,
             ]);
         // Create candidates who may show up in searches

--- a/api/tests/Feature/ApplicantTest.php
+++ b/api/tests/Feature/ApplicantTest.php
@@ -8,7 +8,6 @@ use App\Enums\IndigenousCommunity;
 use App\Enums\LanguageAbility;
 use App\Enums\OperationalRequirement;
 use App\Enums\PoolCandidateStatus;
-use App\Enums\PoolStream;
 use App\Enums\PositionDuration;
 use App\Enums\PublishingGroup;
 use App\Facades\Notify;

--- a/api/tests/Feature/ApplicantTest.php
+++ b/api/tests/Feature/ApplicantTest.php
@@ -2017,7 +2017,7 @@ class ApplicantTest extends TestCase
             ->graphQL($query,
                 [
                     'where' => [
-                        'qualifiedStreams' => [$targetStream->id],
+                        'workStreams' => [['id' => $targetStream->id]],
                     ],
                 ]
             )->assertJson([
@@ -2036,9 +2036,9 @@ class ApplicantTest extends TestCase
                                 'level' => $targetClassification->level,
                             ],
                         ],
-                        'qualifiedStreams' => [
-                            $targetStream->id,
-                        ],
+                        'workStreams' => [[
+                            'id' => $targetStream->id,
+                        ]],
                     ],
                 ]
             )->assertJson([

--- a/api/tests/Feature/ApplicantTest.php
+++ b/api/tests/Feature/ApplicantTest.php
@@ -21,6 +21,7 @@ use App\Models\PoolCandidate;
 use App\Models\Skill;
 use App\Models\User;
 use App\Models\WorkExperience;
+use App\Models\WorkStream;
 use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
@@ -1922,24 +1923,24 @@ class ApplicantTest extends TestCase
         $targetClassification = Classification::factory()->create();
         $excludedClassification = Classification::factory()->create();
 
-        $targetStream = PoolStream::BUSINESS_ADVISORY_SERVICES->name;
-        $excludedStream = PoolStream::ACCESS_INFORMATION_PRIVACY->name;
+        $targetStream = WorkStream::factory()->create();
+        $excludedStream = WorkStream::factory()->create();
 
         $targetClassificationPool = Pool::factory()->candidatesAvailableInSearch()->create([
             'classification_id' => $targetClassification,
-            'stream' => $excludedStream,
+            'work_stream_id' => $excludedStream->id,
         ]);
         $targetStreamPool = Pool::factory()->candidatesAvailableInSearch()->create([
             'classification_id' => $excludedClassification,
-            'stream' => $targetStream,
+            'work_stream_id' => $targetStream->id,
         ]);
         $targetStreamAndClassificationPool = Pool::factory()->candidatesAvailableInSearch()->create([
             'classification_id' => $targetClassification,
-            'stream' => $targetStream,
+            'work_stream_id' => $targetStream->id,
         ]);
         $excludedPool = Pool::factory()->candidatesAvailableInSearch()->create([
             'classification_id' => $excludedClassification,
-            'stream' => $excludedStream,
+            'work_stream_id' => $excludedStream->id,
         ]);
 
         $targetUser = User::factory()->create();
@@ -2017,7 +2018,7 @@ class ApplicantTest extends TestCase
             ->graphQL($query,
                 [
                     'where' => [
-                        'qualifiedStreams' => [$targetStream],
+                        'qualifiedStreams' => [$targetStream->id],
                     ],
                 ]
             )->assertJson([
@@ -2037,7 +2038,7 @@ class ApplicantTest extends TestCase
                             ],
                         ],
                         'qualifiedStreams' => [
-                            $targetStream,
+                            $targetStream->id,
                         ],
                     ],
                 ]

--- a/api/tests/Feature/CountPoolCandidatesByPoolTest.php
+++ b/api/tests/Feature/CountPoolCandidatesByPoolTest.php
@@ -57,7 +57,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
     }
 
     // The user has no candidates so should get no results
-    public function test_empty_does_not_return_user_with_no_candidates()
+    public function testEmptyDoesNotReturnUserWithNoCandidates()
     {
         // Create user to test for
         User::factory()->create();
@@ -84,7 +84,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // single candidate can be returned with no filters
     // creates a single candidate and expects it to be returned
-    public function test_that_empty_returns_a_candidate()
+    public function testThatEmptyReturnsACandidate()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user = User::factory()->create([]);
@@ -141,7 +141,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // the attached pool can have its properties requested
     // creates a single candidate and expects it to be returned with the pool properties
-    public function test_that_pool_properties_can_be_returned()
+    public function testThatPoolPropertiesCanBeReturned()
     {
         $pool = Pool::factory()->published()->candidatesAvailableInSearch()->create([
             'name' => [
@@ -188,7 +188,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // single user returns two candidate is returned with no filters
     // creates one users with two candidates and expects both candidates to be returned
-    public function test_that_empty_returns_two_candidates_for_one_user()
+    public function testThatEmptyReturnsTwoCandidatesForOneUser()
     {
         $pool1 = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $pool2 = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
@@ -227,7 +227,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // test has diploma
     // creates three users with/without/null diploma and expects only one to come back
-    public function test_has_diploma()
+    public function testHasDiploma()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create([
@@ -272,7 +272,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // test equity - Is woman
     // creates three users with/without/null isWoman and expects only one to come back
-    public function test_equity_is_woman()
+    public function testEquityIsWoman()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create([
@@ -321,7 +321,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // test language ability
     // creates a user for bilingual, english, and french then filter for english and expect two to come back
-    public function test_language_ability()
+    public function testLanguageAbility()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create([
@@ -372,7 +372,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // test operational requirements
     // creates a three users with different op reqs, filter for a combination that two users have, expect to get 2 candidates
-    public function test_operational_requirements()
+    public function testOperationalRequirements()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create([
@@ -429,7 +429,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // test location preferences
     // creates a three users with different location preferences, filter for a combination that two users have, expect to get 2 candidates
-    public function test_location_preferences()
+    public function testLocationPreferences()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create([
@@ -486,7 +486,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // test position duration
     // creates a three users with/without/null would accept temporary and expects only one to come back
-    public function test_would_accept_temporary()
+    public function testWouldAcceptTemporary()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create([
@@ -532,7 +532,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
     // test skills
     // creates a three users various skills and filter for the skills on two of them
     // filtering is OR using User::scopeSkillsAdditive
-    public function test_skills()
+    public function testSkills()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $skills = Skill::factory(3)->create();
@@ -586,7 +586,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
         ]);
     }
 
-    public function test_expiry_filter()
+    public function testExpiryFilter()
     {
         $pool1 = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $pool2 = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
@@ -620,7 +620,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
         ]);
     }
 
-    public function test_only_it_jobs_appear()
+    public function testOnlyItJobsAppear()
     {
         $user = User::factory()->create([]);
 
@@ -669,7 +669,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // candidates with one of three statuses should be found by this query
     // tests PoolCandidate::scopeAvailable
-    public function test_available_statuses_appear()
+    public function testAvailableStatusesAppear()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create();
@@ -721,7 +721,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
     }
 
     // similar to above and assert all other statuses are filtered out
-    public function test_unavailable_statuses_do_not_appear()
+    public function testUnavailableStatusesDoNotAppear()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $allStatusesEnums = PoolCandidateStatus::cases();
@@ -765,7 +765,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
     // tests PoolCandidate::scopeQualifiedStreams
     // tests PoolCandidate::scopeQualifiedClassifications
     // which will also redundantly test availability
-    public function test_additional_availability_scopes()
+    public function testAdditionalAvailabilityScopes()
     {
         Classification::factory()->create([
             'group' => 'IT',

--- a/api/tests/Feature/CountPoolCandidatesByPoolTest.php
+++ b/api/tests/Feature/CountPoolCandidatesByPoolTest.php
@@ -5,7 +5,6 @@ namespace Tests\Feature;
 use App\Enums\LanguageAbility;
 use App\Enums\OperationalRequirement;
 use App\Enums\PoolCandidateStatus;
-use App\Enums\PoolStream;
 use App\Enums\PositionDuration;
 use App\Enums\PublishingGroup;
 use App\Enums\WorkRegion;
@@ -16,6 +15,7 @@ use App\Models\Pool;
 use App\Models\PoolCandidate;
 use App\Models\Skill;
 use App\Models\User;
+use App\Models\WorkStream;
 use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
@@ -771,9 +771,10 @@ class CountPoolCandidatesByPoolTest extends TestCase
             'group' => 'IT',
             'level' => 1,
         ]);
+        $stream = WorkStream::factory()->create();
         $pool = Pool::factory()->candidatesAvailableInSearch()->create([
             'published_at' => config('constants.past_date'),
-            'stream' => PoolStream::ACCESS_INFORMATION_PRIVACY->name,
+            'work_stream_id' => $stream->id,
         ]);
         $user1 = User::factory()->create();
         PoolCandidate::factory()->create([
@@ -802,7 +803,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
                             'level' => 1,
                         ],
                     ],
-                    'qualifiedStreams' => [PoolStream::ACCESS_INFORMATION_PRIVACY->name],
+                    'qualifiedStreams' => [$stream->id],
                 ],
             ]
         )->assertSimilarJson([

--- a/api/tests/Feature/CountPoolCandidatesByPoolTest.php
+++ b/api/tests/Feature/CountPoolCandidatesByPoolTest.php
@@ -57,7 +57,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
     }
 
     // The user has no candidates so should get no results
-    public function testEmptyDoesNotReturnUserWithNoCandidates()
+    public function test_empty_does_not_return_user_with_no_candidates()
     {
         // Create user to test for
         User::factory()->create();
@@ -84,7 +84,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // single candidate can be returned with no filters
     // creates a single candidate and expects it to be returned
-    public function testThatEmptyReturnsACandidate()
+    public function test_that_empty_returns_a_candidate()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user = User::factory()->create([]);
@@ -141,7 +141,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // the attached pool can have its properties requested
     // creates a single candidate and expects it to be returned with the pool properties
-    public function testThatPoolPropertiesCanBeReturned()
+    public function test_that_pool_properties_can_be_returned()
     {
         $pool = Pool::factory()->published()->candidatesAvailableInSearch()->create([
             'name' => [
@@ -188,7 +188,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // single user returns two candidate is returned with no filters
     // creates one users with two candidates and expects both candidates to be returned
-    public function testThatEmptyReturnsTwoCandidatesForOneUser()
+    public function test_that_empty_returns_two_candidates_for_one_user()
     {
         $pool1 = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $pool2 = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
@@ -227,7 +227,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // test has diploma
     // creates three users with/without/null diploma and expects only one to come back
-    public function testHasDiploma()
+    public function test_has_diploma()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create([
@@ -272,7 +272,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // test equity - Is woman
     // creates three users with/without/null isWoman and expects only one to come back
-    public function testEquityIsWoman()
+    public function test_equity_is_woman()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create([
@@ -321,7 +321,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // test language ability
     // creates a user for bilingual, english, and french then filter for english and expect two to come back
-    public function testLanguageAbility()
+    public function test_language_ability()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create([
@@ -372,7 +372,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // test operational requirements
     // creates a three users with different op reqs, filter for a combination that two users have, expect to get 2 candidates
-    public function testOperationalRequirements()
+    public function test_operational_requirements()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create([
@@ -429,7 +429,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // test location preferences
     // creates a three users with different location preferences, filter for a combination that two users have, expect to get 2 candidates
-    public function testLocationPreferences()
+    public function test_location_preferences()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create([
@@ -486,7 +486,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // test position duration
     // creates a three users with/without/null would accept temporary and expects only one to come back
-    public function testWouldAcceptTemporary()
+    public function test_would_accept_temporary()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create([
@@ -532,7 +532,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
     // test skills
     // creates a three users various skills and filter for the skills on two of them
     // filtering is OR using User::scopeSkillsAdditive
-    public function testSkills()
+    public function test_skills()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $skills = Skill::factory(3)->create();
@@ -586,7 +586,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
         ]);
     }
 
-    public function testExpiryFilter()
+    public function test_expiry_filter()
     {
         $pool1 = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $pool2 = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
@@ -620,7 +620,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
         ]);
     }
 
-    public function testOnlyItJobsAppear()
+    public function test_only_it_jobs_appear()
     {
         $user = User::factory()->create([]);
 
@@ -669,7 +669,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // candidates with one of three statuses should be found by this query
     // tests PoolCandidate::scopeAvailable
-    public function testAvailableStatusesAppear()
+    public function test_available_statuses_appear()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create();
@@ -721,7 +721,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
     }
 
     // similar to above and assert all other statuses are filtered out
-    public function testUnavailableStatusesDoNotAppear()
+    public function test_unavailable_statuses_do_not_appear()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $allStatusesEnums = PoolCandidateStatus::cases();
@@ -765,7 +765,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
     // tests PoolCandidate::scopeQualifiedStreams
     // tests PoolCandidate::scopeQualifiedClassifications
     // which will also redundantly test availability
-    public function testAdditionalAvailabilityScopes()
+    public function test_additional_availability_scopes()
     {
         Classification::factory()->create([
             'group' => 'IT',
@@ -803,7 +803,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
                             'level' => 1,
                         ],
                     ],
-                    'qualifiedStreams' => [$stream->id],
+                    'workStreams' => [['id' => $stream->id]],
                 ],
             ]
         )->assertSimilarJson([

--- a/api/tests/Feature/CountPoolCandidatesByPoolTest.php
+++ b/api/tests/Feature/CountPoolCandidatesByPoolTest.php
@@ -57,7 +57,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
     }
 
     // The user has no candidates so should get no results
-    public function testEmptyDoesNotReturnUserWithNoCandidates()
+    public function test_empty_does_not_return_user_with_no_candidates()
     {
         // Create user to test for
         User::factory()->create();
@@ -84,7 +84,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // single candidate can be returned with no filters
     // creates a single candidate and expects it to be returned
-    public function testThatEmptyReturnsACandidate()
+    public function test_that_empty_returns_a_candidate()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user = User::factory()->create([]);
@@ -141,7 +141,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // the attached pool can have its properties requested
     // creates a single candidate and expects it to be returned with the pool properties
-    public function testThatPoolPropertiesCanBeReturned()
+    public function test_that_pool_properties_can_be_returned()
     {
         $pool = Pool::factory()->published()->candidatesAvailableInSearch()->create([
             'name' => [
@@ -188,7 +188,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // single user returns two candidate is returned with no filters
     // creates one users with two candidates and expects both candidates to be returned
-    public function testThatEmptyReturnsTwoCandidatesForOneUser()
+    public function test_that_empty_returns_two_candidates_for_one_user()
     {
         $pool1 = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $pool2 = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
@@ -227,7 +227,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // test has diploma
     // creates three users with/without/null diploma and expects only one to come back
-    public function testHasDiploma()
+    public function test_has_diploma()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create([
@@ -272,7 +272,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // test equity - Is woman
     // creates three users with/without/null isWoman and expects only one to come back
-    public function testEquityIsWoman()
+    public function test_equity_is_woman()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create([
@@ -321,7 +321,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // test language ability
     // creates a user for bilingual, english, and french then filter for english and expect two to come back
-    public function testLanguageAbility()
+    public function test_language_ability()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create([
@@ -372,7 +372,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // test operational requirements
     // creates a three users with different op reqs, filter for a combination that two users have, expect to get 2 candidates
-    public function testOperationalRequirements()
+    public function test_operational_requirements()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create([
@@ -429,7 +429,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // test location preferences
     // creates a three users with different location preferences, filter for a combination that two users have, expect to get 2 candidates
-    public function testLocationPreferences()
+    public function test_location_preferences()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create([
@@ -486,7 +486,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // test position duration
     // creates a three users with/without/null would accept temporary and expects only one to come back
-    public function testWouldAcceptTemporary()
+    public function test_would_accept_temporary()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create([
@@ -532,7 +532,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
     // test skills
     // creates a three users various skills and filter for the skills on two of them
     // filtering is OR using User::scopeSkillsAdditive
-    public function testSkills()
+    public function test_skills()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $skills = Skill::factory(3)->create();
@@ -586,7 +586,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
         ]);
     }
 
-    public function testExpiryFilter()
+    public function test_expiry_filter()
     {
         $pool1 = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $pool2 = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
@@ -620,7 +620,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
         ]);
     }
 
-    public function testOnlyItJobsAppear()
+    public function test_only_it_jobs_appear()
     {
         $user = User::factory()->create([]);
 
@@ -669,7 +669,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
 
     // candidates with one of three statuses should be found by this query
     // tests PoolCandidate::scopeAvailable
-    public function testAvailableStatusesAppear()
+    public function test_available_statuses_appear()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $user1 = User::factory()->create();
@@ -721,7 +721,7 @@ class CountPoolCandidatesByPoolTest extends TestCase
     }
 
     // similar to above and assert all other statuses are filtered out
-    public function testUnavailableStatusesDoNotAppear()
+    public function test_unavailable_statuses_do_not_appear()
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create($this->poolData());
         $allStatusesEnums = PoolCandidateStatus::cases();
@@ -765,12 +765,23 @@ class CountPoolCandidatesByPoolTest extends TestCase
     // tests PoolCandidate::scopeQualifiedStreams
     // tests PoolCandidate::scopeQualifiedClassifications
     // which will also redundantly test availability
-    public function testAdditionalAvailabilityScopes()
+    public function test_additional_availability_scopes()
     {
         Classification::factory()->create([
             'group' => 'IT',
             'level' => 1,
         ]);
+
+        $unaccosiatedStream = WorkStream::factory()->create();
+        $unaccosiatedPool = Pool::factory()->candidatesAvailableInSearch()->published()->create([
+            'work_stream_id' => $unaccosiatedStream->id,
+        ]);
+        PoolCandidate::factory()->create([
+            'pool_id' => $unaccosiatedPool->id,
+            'pool_candidate_status' => PoolCandidateStatus::QUALIFIED_AVAILABLE->name,
+            'expiry_date' => config('constants.far_future_date'),
+        ]);
+
         $stream = WorkStream::factory()->create();
         $pool = Pool::factory()->candidatesAvailableInSearch()->create([
             'published_at' => config('constants.past_date'),

--- a/api/tests/Feature/PoolCandidateSearchRequestPaginatedTest.php
+++ b/api/tests/Feature/PoolCandidateSearchRequestPaginatedTest.php
@@ -302,15 +302,11 @@ class PoolCandidateSearchRequestPaginatedTest extends TestCase
 
         $stream1 = WorkStream::factory()->create();
 
-        $applicantFilter1 = ApplicantFilter::factory()->create([
-            'qualified_streams' => [$stream1->id],
-        ]);
+        $applicantFilter1 = ApplicantFilter::factory()->withWorkStreams([$stream1])->create();
 
         $stream2 = WorkStream::factory()->create();
 
-        $applicantFilter2 = ApplicantFilter::factory()->create([
-            'qualified_streams' => [$stream2->id],
-        ]);
+        $applicantFilter2 = ApplicantFilter::factory()->withWorkStreams([$stream2])->create();
 
         PoolCandidateSearchRequest::factory()->count(1)->create([
             'applicant_filter_id' => $applicantFilter1->id,
@@ -321,7 +317,7 @@ class PoolCandidateSearchRequestPaginatedTest extends TestCase
 
         // streams null results in 3 results
         $this->actingAs($this->requestResponder, 'api')
-            ->graphQL($this->searchRequestQuery, ['where' => ['streams' => null]])
+            ->graphQL($this->searchRequestQuery, ['where' => ['workStreams' => null]])
             ->assertJsonFragment(['count' => 3]);
 
         $unattachedStream = WorkStream::factory()->create();
@@ -332,7 +328,7 @@ class PoolCandidateSearchRequestPaginatedTest extends TestCase
                 $this->searchRequestQuery,
                 [
                     'where' => [
-                        'streams' => [$unattachedStream->id],
+                        'workStreams' => [$unattachedStream->id],
                     ],
                 ]
             )
@@ -344,7 +340,7 @@ class PoolCandidateSearchRequestPaginatedTest extends TestCase
                 $this->searchRequestQuery,
                 [
                     'where' => [
-                        'streams' => [$stream1->id],
+                        'workStreams' => [$stream1->id],
                     ],
                 ]
             )
@@ -356,7 +352,7 @@ class PoolCandidateSearchRequestPaginatedTest extends TestCase
                 $this->searchRequestQuery,
                 [
                     'where' => [
-                        'streams' => [$stream1->id, $unattachedStream->id],
+                        'workStreams' => [$stream1->id, $unattachedStream->id],
                     ],
                 ]
             )
@@ -368,7 +364,7 @@ class PoolCandidateSearchRequestPaginatedTest extends TestCase
                 $this->searchRequestQuery,
                 [
                     'where' => [
-                        'streams' => [$stream1->id, $stream2->id],
+                        'workStreams' => [$stream1->id, $stream2->id],
                     ],
                 ]
             )

--- a/api/tests/Feature/PoolTest.php
+++ b/api/tests/Feature/PoolTest.php
@@ -1193,7 +1193,7 @@ class PoolTest extends TestCase
             ',
             [
                 'where' => [
-                    'streams' => [
+                    'workStreams' => [
                         $ATIPStream->id,
                         $businessStream->id,
                     ],

--- a/api/tests/Feature/PoolTest.php
+++ b/api/tests/Feature/PoolTest.php
@@ -17,6 +17,7 @@ use App\Models\User;
 use App\Models\WorkStream;
 use Carbon\Carbon;
 use Database\Helpers\ApiErrorEnums;
+use Database\Seeders\CommunitySeeder;
 use Database\Seeders\RolePermissionSeeder;
 use Database\Seeders\SkillFamilySeeder;
 use Database\Seeders\SkillSeeder;
@@ -1161,7 +1162,7 @@ class PoolTest extends TestCase
      */
     public function testPoolStreamsScope(): void
     {
-        $this->seed(WorkStreamSeeder::class);
+        $this->seed([CommunitySeeder::class, WorkStreamSeeder::class]);
         $ATIPStream = WorkStream::where('key', PoolStream::ACCESS_INFORMATION_PRIVACY->name)->sole();
         $businessStream = WorkStream::where('key', PoolStream::BUSINESS_ADVISORY_SERVICES->name)->sole();
         $dbStream = WorkStream::where('key', PoolStream::DATABASE_MANAGEMENT->name)->sole();

--- a/apps/playwright/tests/admin/pool-candidate.spec.ts
+++ b/apps/playwright/tests/admin/pool-candidate.spec.ts
@@ -224,7 +224,7 @@ test.describe("Pool candidates", () => {
     await appPage.page.getByRole("button", { name: "Save changes" }).click();
     await appPage.waitForGraphqlResponse("PoolCandidate_UpdateNotes");
     await expect(
-      appPage.page.getByRole("button", { name: "Edit notes" }),
+      appPage.page.getByRole("button", { name: /edit notes/i }),
     ).toBeVisible();
     await expect(appPage.page.getByText(/Notes notes notes/i)).toBeVisible();
   });
@@ -371,8 +371,9 @@ test.describe("Pool candidates", () => {
     await expect(
       appPage.page.getByRole("button", { name: "Removed", exact: true }),
     ).toBeHidden();
+    await appPage.waitForGraphqlResponse("ReinstateCandidate");
     await expect(
-      appPage.page.getByRole("button", { name: "Record final decision" }),
+      appPage.page.getByRole("button", { name: /remove candidate/i }),
     ).toBeVisible();
   });
 });

--- a/apps/playwright/tests/search-workflows.spec.ts
+++ b/apps/playwright/tests/search-workflows.spec.ts
@@ -9,6 +9,7 @@ import {
   PoolCandidateStatus,
   Skill,
   SkillCategory,
+  WorkStream,
 } from "@gc-digital-talent/graphql";
 
 import { test, expect } from "~/fixtures";
@@ -21,12 +22,14 @@ import { createUserWithRoles, me } from "~/utils/user";
 import graphql from "~/utils/graphql";
 import { createAndPublishPool } from "~/utils/pools";
 import { getClassifications } from "~/utils/classification";
+import { getWorkStreams } from "~/utils/workStreams";
 
 test.describe("Talent search", () => {
   const uniqueTestId = Date.now().valueOf();
   const sub = `playwright.sub.${uniqueTestId}`;
   const poolName = `Search pool ${uniqueTestId}`;
   let classification: Classification;
+  let workStream: WorkStream;
   let skill: Skill | undefined;
 
   const expectNoCandidate = async (page: Page) => {
@@ -79,12 +82,16 @@ test.describe("Talent search", () => {
     const classifications = await getClassifications(adminCtx, {});
     classification = classifications[0];
 
+    const workStreams = await getWorkStreams(adminCtx, {});
+    workStream = workStreams[0];
+
     const adminUser = await me(adminCtx, {});
     // Accepted pool
     const createdPool = await createAndPublishPool(adminCtx, {
       userId: adminUser.id,
       skillIds: technicalSkill ? [technicalSkill?.id] : undefined,
       classificationId: classification.id,
+      workStreamId: workStream.id,
       name: {
         en: poolName,
         fr: `${poolName} (FR)`,
@@ -138,7 +145,7 @@ test.describe("Talent search", () => {
     await expectNoCandidate(appPage.page);
 
     await streamFilter.selectOption({
-      label: "Business Line Advisory Services",
+      label: workStream.name?.en ?? "",
     });
 
     await expect(poolCard).toBeVisible();

--- a/apps/playwright/tests/search-workflows.spec.ts
+++ b/apps/playwright/tests/search-workflows.spec.ts
@@ -228,7 +228,7 @@ test.describe("Talent search", () => {
     ).toBeVisible();
 
     await expect(
-      appPage.page.getByText("Business Line Advisory Services"),
+      appPage.page.getByText(workStream?.name?.en ?? ""),
     ).toBeVisible();
 
     await expect(

--- a/apps/playwright/utils/workStreams.ts
+++ b/apps/playwright/utils/workStreams.ts
@@ -1,0 +1,30 @@
+
+import { WorkStream } from "@gc-digital-talent/graphql";
+
+import { GraphQLRequestFunc, GraphQLResponse } from "./graphql";
+
+const Test_WorkStreamQueryDocument = /* GraphQL */ `
+  query WorkStreams {
+    workStreams {
+      id
+      key
+      name {
+        en
+        fr
+      }
+    }
+  }
+`;
+
+/**
+ * Get work streams
+ *
+ * Get all the work streams directly from the API.
+ */
+export const getWorkStreams: GraphQLRequestFunc<WorkStream[]> = async (ctx) => {
+  return ctx
+    .post(Test_WorkStreamQueryDocument)
+    .then(
+      (res: GraphQLResponse<"workStreams", WorkStream[]>) => res.workStreams,
+    );
+};

--- a/apps/playwright/utils/workStreams.ts
+++ b/apps/playwright/utils/workStreams.ts
@@ -1,4 +1,3 @@
-
 import { WorkStream } from "@gc-digital-talent/graphql";
 
 import { GraphQLRequestFunc, GraphQLResponse } from "./graphql";

--- a/apps/web/src/components/ApplicationCard/ApplicationCard.tsx
+++ b/apps/web/src/components/ApplicationCard/ApplicationCard.tsx
@@ -46,9 +46,9 @@ export const ApplicationCard_Fragment = graphql(/* GraphQL */ `
     pool {
       id
       closingDate
-      stream {
-        value
-        label {
+      workStream {
+        id
+        name {
           en
           fr
         }
@@ -114,13 +114,13 @@ const ApplicationCard = ({
     application.submittedAt,
   );
   const applicationTitle = getShortPoolTitleHtml(intl, {
-    stream: application.pool.stream,
+    workStream: application.pool.workStream,
     name: application.pool.name,
     publishingGroup: application.pool.publishingGroup,
     classification: application.pool.classification,
   });
   const applicationTitleString = getShortPoolTitleLabel(intl, {
-    stream: application.pool.stream,
+    workStream: application.pool.workStream,
     name: application.pool.name,
     publishingGroup: application.pool.publishingGroup,
     classification: application.pool.classification,

--- a/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
+++ b/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
@@ -118,9 +118,9 @@ export const AssessmentResultsTable_Fragment = graphql(/* GraphQL */ `
           fr
         }
       }
-      stream {
-        value
-        label {
+      workStream {
+        id
+        name {
           en
           fr
         }
@@ -133,13 +133,6 @@ export const AssessmentResultsTable_Fragment = graphql(/* GraphQL */ `
         id
         group
         level
-      }
-      stream {
-        value
-        label {
-          en
-          fr
-        }
       }
       assessmentSteps {
         id

--- a/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
+++ b/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
@@ -118,13 +118,6 @@ export const AssessmentResultsTable_Fragment = graphql(/* GraphQL */ `
           fr
         }
       }
-      workStream {
-        id
-        name {
-          en
-          fr
-        }
-      }
       name {
         en
         fr

--- a/apps/web/src/components/CandidateDialog/ChangeDateDialog.tsx
+++ b/apps/web/src/components/CandidateDialog/ChangeDateDialog.tsx
@@ -37,9 +37,9 @@ export const ChangeDateDialog_PoolCandidateFragment = graphql(/* GraphQL */ `
     expiryDate
     pool {
       id
-      stream {
-        value
-        label {
+      workStream {
+        id
+        name {
           en
           fr
         }
@@ -177,7 +177,7 @@ const ChangeDateDialog = ({
           <p data-h2-font-weight="base(800)">
             -{" "}
             {getShortPoolTitleHtml(intl, {
-              stream: selectedCandidate.pool.stream,
+              workStream: selectedCandidate.pool.workStream,
               name: selectedCandidate.pool.name,
               publishingGroup: selectedCandidate.pool.publishingGroup,
               classification: selectedCandidate.pool.classification,

--- a/apps/web/src/components/CandidateDialog/ChangeStatusDialog.tsx
+++ b/apps/web/src/components/CandidateDialog/ChangeStatusDialog.tsx
@@ -78,9 +78,9 @@ const ChangeStatusDialog_UserFragment = graphql(/* GraphQL */ `
           group
           level
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }
@@ -123,9 +123,9 @@ export const ChangeStatusDialog_PoolCandidateFragment = graphql(/* GraphQL */ `
     }
     pool {
       id
-      stream {
-        value
-        label {
+      workStream {
+        id
+        name {
           en
           fr
         }
@@ -264,7 +264,7 @@ const ChangeStatusDialogForm = ({
                     {getShortPoolTitleHtml(
                       intl,
                       {
-                        stream: r.poolCandidate.pool.stream,
+                        workStream: r.poolCandidate.pool.workStream,
                         name: r.poolCandidate.pool.name,
                         publishingGroup: r.poolCandidate.pool.publishingGroup,
                         classification: r.poolCandidate.pool.classification,
@@ -412,7 +412,7 @@ const ChangeStatusDialog = ({
               {
                 status: getLocalizedName(selectedCandidate.status?.label, intl),
                 poolName: getShortPoolTitleLabel(intl, {
-                  stream: selectedCandidate.pool.stream,
+                  workStream: selectedCandidate.pool.workStream,
                   name: selectedCandidate.pool.name,
                   publishingGroup: selectedCandidate.pool.publishingGroup,
                   classification: selectedCandidate.pool.classification,
@@ -453,7 +453,7 @@ const ChangeStatusDialog = ({
           <p data-h2-font-weight="base(700)">
             -{" "}
             {getShortPoolTitleHtml(intl, {
-              stream: selectedCandidate.pool.stream,
+              workStream: selectedCandidate.pool.workStream,
               name: selectedCandidate.pool.name,
               publishingGroup: selectedCandidate.pool.publishingGroup,
               classification: selectedCandidate.pool.classification,

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -195,9 +195,9 @@ const CandidatesTableCandidatesPaginated_Query = graphql(/* GraphQL */ `
               group
               level
             }
-            stream {
-              value
-              label {
+            workStream {
+              id
+              name {
                 en
                 fr
               }
@@ -718,7 +718,7 @@ const PoolCandidatesTable = ({
           columnHelper.accessor(
             ({ poolCandidate: { pool } }) =>
               getFullPoolTitleLabel(intl, {
-                stream: pool.stream,
+                workStream: pool.workStream,
                 name: pool.name,
                 publishingGroup: pool.publishingGroup,
                 classification: pool.classification,
@@ -737,7 +737,7 @@ const PoolCandidatesTable = ({
                 processCell(
                   {
                     id: pool.id,
-                    stream: pool.stream,
+                    workStream: pool.workStream,
                     name: pool.name,
                     publishingGroup: pool.publishingGroup,
                     classification: pool.classification,

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -13,7 +13,6 @@ import { parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 import { Link, Chip, Spoiler } from "@gc-digital-talent/ui";
 import {
   CandidateExpiryFilter,
-  PoolStream,
   PublishingGroup,
   Maybe,
   Pool,
@@ -380,7 +379,10 @@ export function transformPoolCandidateSearchInputToFormValues(
       input?.appliedClassifications
         ?.filter(notEmpty)
         .map((c) => `${c.group}-${c.level}`) ?? [],
-    stream: input?.applicantFilter?.qualifiedStreams?.filter(notEmpty) ?? [],
+    stream:
+      input?.applicantFilter?.workStreams
+        ?.filter(notEmpty)
+        .map(({ id }) => id) ?? [],
     languageAbility: input?.applicantFilter?.languageAbility ?? "",
     workRegion:
       input?.applicantFilter?.locationPreferences?.filter(notEmpty) ?? [],
@@ -427,7 +429,7 @@ export function transformFormValuesToFilterState(
       languageAbility: data.languageAbility
         ? stringToEnumLanguage(data.languageAbility)
         : undefined,
-      qualifiedStreams: data.stream as PoolStream[],
+      workStreams: data.stream.map((id) => ({ id })),
       operationalRequirements: data.operationalRequirement
         .map((requirement) => {
           return stringToEnumOperational(requirement);

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -100,14 +100,14 @@ export const candidateNameCell = (
 };
 
 export const processCell = (
-  pool: Pick<Pool, "id" | "stream" | "name" | "publishingGroup"> & {
+  pool: Pick<Pool, "id" | "workStream" | "name" | "publishingGroup"> & {
     classification?: Maybe<Pick<Classification, "group" | "level">>;
   },
   paths: ReturnType<typeof useRoutes>,
   intl: IntlShape,
 ) => {
   const poolName = getFullPoolTitleLabel(intl, {
-    stream: pool.stream,
+    workStream: pool.workStream,
     name: pool.name,
     publishingGroup: pool.publishingGroup,
     classification: pool.classification,

--- a/apps/web/src/components/PoolCard/PoolCard.tsx
+++ b/apps/web/src/components/PoolCard/PoolCard.tsx
@@ -41,9 +41,9 @@ import IconLabel from "./IconLabel";
 export const PoolCard_Fragment = graphql(/* GraphQL */ `
   fragment PoolCard on Pool {
     id
-    stream {
-      value
-      label {
+    workStream {
+      id
+      name {
         en
         fr
       }
@@ -258,7 +258,7 @@ const PoolCard = ({ poolQuery, headingLevel = "h3" }: PoolCardProps) => {
             data-h2-min-height="base(x4.5) p-tablet(auto)"
           >
             {getShortPoolTitleHtml(intl, {
-              stream: pool.stream,
+              workStream: pool.workStream,
               name: pool.name,
               publishingGroup: pool.publishingGroup,
               classification: pool.classification,

--- a/apps/web/src/components/PoolFilterInput/usePoolFilterOptions.ts
+++ b/apps/web/src/components/PoolFilterInput/usePoolFilterOptions.ts
@@ -32,9 +32,9 @@ const PoolFilter_Query = graphql(/* GraphQL */ `
             fr
           }
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }
@@ -85,7 +85,7 @@ const usePoolFilterOptions = (
       pools.map((pool) => ({
         value: pool.id,
         label: getShortPoolTitleLabel(intl, {
-          stream: pool.stream,
+          workStream: pool.workStream,
           name: pool.name,
           publishingGroup: pool.publishingGroup,
           classification: pool.classification,

--- a/apps/web/src/components/PoolStatusTable/PoolStatusTable.tsx
+++ b/apps/web/src/components/PoolStatusTable/PoolStatusTable.tsx
@@ -65,9 +65,9 @@ const PoolStatusTable_Fragment = graphql(/* GraphQL */ `
           group
           level
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }
@@ -105,7 +105,7 @@ const PoolStatusTable = ({ userQuery }: PoolStatusTableProps) => {
     columnHelper.accessor(
       (row) =>
         getShortPoolTitleLabel(intl, {
-          stream: row.pool.stream,
+          workStream: row.pool.workStream,
           name: row.pool.name,
           publishingGroup: row.pool.publishingGroup,
           classification: row.pool.classification,
@@ -195,7 +195,7 @@ const PoolStatusTable = ({ userQuery }: PoolStatusTableProps) => {
       },
     ),
     columnHelper.accessor(
-      ({ pool: { stream } }) => getLocalizedName(stream?.label, intl),
+      ({ pool: { workStream } }) => getLocalizedName(workStream?.name, intl),
       {
         id: "application",
         enableHiding: false,

--- a/apps/web/src/components/PoolStatusTable/types.ts
+++ b/apps/web/src/components/PoolStatusTable/types.ts
@@ -24,9 +24,9 @@ const PoolStatusTable_PoolCandidateFragment = graphql(/* GraphQL */ `
           fr
         }
       }
-      stream {
-        value
-        label {
+      workStream {
+        id
+        name {
           en
           fr
         }

--- a/apps/web/src/components/RecruitmentAvailabilityDialog/RecruitmentAvailabilityDialog.tsx
+++ b/apps/web/src/components/RecruitmentAvailabilityDialog/RecruitmentAvailabilityDialog.tsx
@@ -32,9 +32,9 @@ const RecruitmentAvailabilityDialog_Fragment = graphql(/* GraphQL */ `
     suspendedAt
     pool {
       id
-      stream {
-        value
-        label {
+      workStream {
+        id
+        name {
           en
           fr
         }
@@ -77,7 +77,7 @@ const RecruitmentAvailabilityDialog = ({
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const isSuspended = !!candidate.suspendedAt;
   const title = poolTitle(intl, {
-    stream: candidate.pool.stream,
+    workStream: candidate.pool.workStream,
     name: candidate.pool.name,
     publishingGroup: candidate.pool.publishingGroup,
     classification: candidate.pool.classification,

--- a/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -111,7 +111,7 @@ const ApplicantFilters = ({
   ).map((label) => getLocalizedName(label, intl));
 
   const streams = unpackMaybes(
-    applicantFilter?.qualifiedStreams?.flatMap((stream) => stream?.label),
+    applicantFilter?.workStreams?.flatMap((stream) => stream?.name),
   ).map((label) => getLocalizedName(label, intl));
 
   const communityName: string =

--- a/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -142,7 +142,7 @@ const ApplicantFilters = ({
               applicantFilter
                 ? applicantFilter?.pools?.filter(notEmpty)?.map((pool) =>
                     getShortPoolTitleHtml(intl, {
-                      stream: pool.stream,
+                      workStream: pool.workStream,
                       name: pool.name,
                       publishingGroup: pool.publishingGroup,
                       classification: pool.classification,
@@ -277,8 +277,8 @@ const SearchRequestFilters = ({
     ? poolCandidateFilter?.pools?.filter(notEmpty)
     : [];
 
-  const streams = pools?.map((pool) =>
-    pool.stream?.label ? getLocalizedName(pool.stream.label, intl) : "",
+  const streams = pools?.map(({ workStream }) =>
+    getLocalizedName(workStream?.name, intl, true),
   );
 
   // eslint-disable-next-line deprecation/deprecation
@@ -373,7 +373,7 @@ const SearchRequestFilters = ({
                 pools
                   ? pools.map((pool) =>
                       getShortPoolTitleHtml(intl, {
-                        stream: pool.stream,
+                        workStream: pool.workStream,
                         name: pool.name,
                         publishingGroup: pool.publishingGroup,
                         classification: pool.classification,

--- a/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
@@ -91,7 +91,7 @@ const transformSearchRequestInput = (
     status: filterState?.status,
     departments: filterState?.departments,
     classifications: filterState?.classifications,
-    streams: filterState?.streams,
+    workStreams: filterState?.workStreams,
   };
 };
 

--- a/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
@@ -125,9 +125,9 @@ const SearchRequestTable_Query = graphql(/* GraphQL */ `
             group
             level
           }
-          qualifiedStreams {
-            value
-            label {
+          workStreams {
+            id
+            name {
               en
               fr
             }
@@ -270,8 +270,8 @@ const SearchRequestTable = ({ title }: SearchRequestTableProps) => {
     columnHelper.accessor(
       ({ applicantFilter }) =>
         unpackMaybes(
-          applicantFilter?.qualifiedStreams?.map((stream) =>
-            getLocalizedName(stream?.label, intl),
+          applicantFilter?.workStreams?.map((workStream) =>
+            getLocalizedName(workStream?.name, intl),
           ),
         ).join(","),
       {
@@ -287,8 +287,8 @@ const SearchRequestTable = ({ title }: SearchRequestTableProps) => {
           cells.commaList({
             list:
               unpackMaybes(
-                applicantFilter?.qualifiedStreams?.map((stream) =>
-                  getLocalizedName(stream?.label, intl, true),
+                applicantFilter?.workStreams?.map((workStream) =>
+                  getLocalizedName(workStream?.name, intl, true),
                 ),
               ) ?? [],
           }),

--- a/apps/web/src/components/SearchRequestTable/components/SearchRequestFilterDialog.tsx
+++ b/apps/web/src/components/SearchRequestTable/components/SearchRequestFilterDialog.tsx
@@ -53,9 +53,9 @@ const SearchRequestFilterData_Query = graphql(/* GraphQL */ `
         fr
       }
     }
-    streams: localizedEnumStrings(enumName: "PoolStream") {
-      value
-      label {
+    workStreams {
+      id
+      name {
         en
         fr
       }
@@ -133,11 +133,14 @@ const SearchRequestFilterDialog = ({
           }))}
         />
         <Combobox
-          id="streams"
-          name="streams"
+          id="workStreams"
+          name="workStreams"
           isMulti
           label={intl.formatMessage(adminMessages.streams)}
-          options={localizedEnumToOptions(data?.streams, intl)}
+          options={unpackMaybes(data?.workStreams).map((workStream) => ({
+            value: workStream.id,
+            label: getLocalizedName(workStream?.name, intl),
+          }))}
         />
       </div>
     </FilterDialog>

--- a/apps/web/src/components/SearchRequestTable/components/utils.tsx
+++ b/apps/web/src/components/SearchRequestTable/components/utils.tsx
@@ -7,10 +7,7 @@ import {
   SortOrder,
 } from "@gc-digital-talent/graphql";
 
-import {
-  stringToEnumRequestStatus,
-  stringToEnumStream,
-} from "~/utils/requestUtils";
+import { stringToEnumRequestStatus } from "~/utils/requestUtils";
 
 export interface FormValues {
   status?: string[];
@@ -31,7 +28,7 @@ export function transformFormValuesToSearchRequestFilterInput(
       ? data.classifications
       : undefined,
     workStreams: data.workStreams?.length
-      ? data.workStreams.map(stringToEnumStream).filter(notEmpty)
+      ? data.workStreams.filter(notEmpty)
       : undefined,
   };
 }

--- a/apps/web/src/components/SearchRequestTable/components/utils.tsx
+++ b/apps/web/src/components/SearchRequestTable/components/utils.tsx
@@ -16,7 +16,7 @@ export interface FormValues {
   status?: string[];
   departments?: string[];
   classifications?: string[];
-  streams?: string[];
+  workStreams?: string[];
 }
 
 export function transformFormValuesToSearchRequestFilterInput(
@@ -30,8 +30,8 @@ export function transformFormValuesToSearchRequestFilterInput(
     classifications: data.classifications?.length
       ? data.classifications
       : undefined,
-    streams: data.streams?.length
-      ? data.streams.map(stringToEnumStream).filter(notEmpty)
+    workStreams: data.workStreams?.length
+      ? data.workStreams.map(stringToEnumStream).filter(notEmpty)
       : undefined,
   };
 }
@@ -69,6 +69,6 @@ export function transformSearchRequestFilterInputToFormValues(
     status: input?.status?.filter(notEmpty) ?? [],
     departments: input?.departments?.filter(notEmpty) ?? [],
     classifications: input?.classifications?.filter(notEmpty) ?? [],
-    streams: input?.streams?.filter(notEmpty) ?? [],
+    workStreams: input?.workStreams?.filter(notEmpty) ?? [],
   };
 }

--- a/apps/web/src/pages/Applications/ApplicationWelcomePage/ApplicationWelcomePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationWelcomePage/ApplicationWelcomePage.tsx
@@ -71,7 +71,7 @@ const ApplicationWelcome = ({ application }: ApplicationPageProps) => {
     stepOrdinal: currentStepOrdinal,
   });
   const poolName = getShortPoolTitleHtml(intl, {
-    stream: application.pool.stream,
+    workStream: application.pool.workStream,
     name: application.pool.name,
     publishingGroup: application.pool.publishingGroup,
     classification: application.pool.classification,

--- a/apps/web/src/pages/Applications/fragment.ts
+++ b/apps/web/src/pages/Applications/fragment.ts
@@ -258,9 +258,9 @@ const Application_PoolCandidateFragment = graphql(/* GraphQL */ `
         en
         fr
       }
-      stream {
-        value
-        label {
+      workStream {
+        id
+        name {
           en
           fr
         }

--- a/apps/web/src/pages/Manager/components/ReviewTalentRequestDialog.tsx
+++ b/apps/web/src/pages/Manager/components/ReviewTalentRequestDialog.tsx
@@ -55,8 +55,8 @@ const ReviewTalentRequestDialog_Query = graphql(/* GraphQL */ `
           group
           level
         }
-        qualifiedStreams {
-          label {
+        workStreams {
+          name {
             fr
             en
           }
@@ -126,7 +126,7 @@ const ReviewTalentRequestDialogContent = ({
   const classifications = unpackMaybes(
     request.applicantFilter?.qualifiedClassifications,
   );
-  const workStreams = unpackMaybes(request.applicantFilter?.qualifiedStreams);
+  const workStreams = unpackMaybes(request.applicantFilter?.workStreams);
   const equityDescriptions = equitySelectionsToDescriptions(
     request.applicantFilter?.equity,
     intl,
@@ -189,7 +189,7 @@ const ReviewTalentRequestDialogContent = ({
             {workStreams.length > 0
               ? deriveSingleString(
                   workStreams,
-                  (stream) => getLocalizedName(stream.label, intl),
+                  (workStream) => getLocalizedName(workStream.name, intl),
                   locale,
                 )
               : nullMessage}

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -105,9 +105,9 @@ const PoolCandidate_SnapshotQuery = graphql(/* GraphQL */ `
           group
           level
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }
@@ -168,7 +168,7 @@ export const ViewPoolCandidate = ({
       },
       {
         label: getFullPoolTitleLabel(intl, {
-          stream: poolCandidate.pool.stream,
+          workStream: poolCandidate.pool.workStream,
           name: poolCandidate.pool.name,
           publishingGroup: poolCandidate.pool.publishingGroup,
           classification: poolCandidate.pool.classification,

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -102,9 +102,9 @@ export const EditPool_Fragment = graphql(/* GraphQL */ `
     ...EditPoolYourImpact
 
     id
-    stream {
-      value
-      label {
+    workStream {
+      id
+      name {
         en
         fr
       }
@@ -277,7 +277,7 @@ export const EditPoolForm = ({
       areaOfSelection: pool.areaOfSelection,
       classification: pool.classification,
       department: pool.department,
-      stream: pool.stream,
+      workStream: pool.workStream,
       name: pool.name,
       processNumber: pool.processNumber,
       publishingGroup: pool.publishingGroup,
@@ -315,7 +315,7 @@ export const EditPoolForm = ({
         areaOfSelection: pool.areaOfSelection,
         classification: pool.classification,
         department: pool.department,
-        stream: pool.stream,
+        workStream: pool.workStream,
         name: pool.name,
         processNumber: pool.processNumber,
         publishingGroup: pool.publishingGroup,
@@ -370,7 +370,7 @@ export const EditPoolForm = ({
     educationRequirements: {
       id: "education-requirements",
       hasError: educationRequirementIsNull({
-        stream: pool.stream,
+        workStream: pool.workStream,
         name: pool.name,
         processNumber: pool.processNumber,
         publishingGroup: pool.publishingGroup,

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
@@ -29,7 +29,7 @@ const Display = ({
     selectionLimitations: poolSelectionLimitations,
     classification,
     department,
-    stream,
+    workStream,
     name,
     processNumber,
     publishingGroup,
@@ -105,10 +105,10 @@ const Display = ({
             : notProvided}
         </ToggleForm.FieldDisplay>
         <ToggleForm.FieldDisplay
-          hasError={!stream}
+          hasError={!workStream}
           label={intl.formatMessage(processMessages.stream)}
         >
-          {getLocalizedName(stream?.label, intl)}
+          {getLocalizedName(workStream?.name, intl)}
         </ToggleForm.FieldDisplay>
         <ToggleForm.FieldDisplay
           hasError={!name?.en}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
@@ -77,9 +77,9 @@ const EditPoolName_Fragment = graphql(/* GraphQL */ `
         fr
       }
     }
-    stream {
-      value
-      label {
+    workStream {
+      id
+      name {
         en
         fr
       }
@@ -149,9 +149,9 @@ const PoolNameOptions_Query = graphql(/* GraphQL */ `
         fr
       }
     }
-    streams: localizedEnumStrings(enumName: "PoolStream") {
-      value
-      label {
+    workStreams {
+      id
+      name {
         en
         fr
       }
@@ -393,7 +393,12 @@ const PoolNameSection = ({
                   nullSelection={intl.formatMessage(
                     uiMessages.nullSelectionOption,
                   )}
-                  options={localizedEnumToOptions(data?.streams, intl)}
+                  options={unpackMaybes(data?.workStreams).map(
+                    (workStream) => ({
+                      value: workStream.id,
+                      label: getLocalizedName(workStream?.name, intl),
+                    }),
+                  )}
                   disabled={formDisabled}
                 />
                 <Input

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/utils.ts
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/utils.ts
@@ -9,12 +9,12 @@ import {
   LocalizedString,
   Maybe,
   Pool,
-  PoolStream,
   PublishingGroup,
   UpdatePoolInput,
   Department,
   PoolAreaOfSelection,
   PoolSelectionLimitation,
+  WorkStream,
 } from "@gc-digital-talent/graphql";
 
 export interface FormValues {
@@ -22,7 +22,7 @@ export interface FormValues {
   selectionLimitations?: Maybe<PoolSelectionLimitation[]>;
   classification?: Classification["id"];
   department?: Department["id"];
-  stream?: PoolStream;
+  stream?: WorkStream["id"];
   specificTitleEn?: LocalizedString["en"];
   specificTitleFr?: LocalizedString["fr"];
   processNumber?: string;
@@ -35,7 +35,7 @@ export const dataToFormValues = (initialData: Pool): FormValues => ({
   selectionLimitations: initialData.selectionLimitations?.map((l) => l.value),
   classification: initialData.classification?.id ?? "",
   department: initialData.department?.id ?? "",
-  stream: initialData.stream?.value ?? undefined,
+  stream: initialData.workStream?.id ?? undefined,
   specificTitleEn: initialData.name?.en ?? "",
   specificTitleFr: initialData.name?.fr ?? "",
   processNumber: initialData.processNumber ?? "",
@@ -50,7 +50,7 @@ export type PoolNameSubmitData = Pick<
   | "classification"
   | "department"
   | "name"
-  | "stream"
+  | "workStream"
   | "processNumber"
   | "publishingGroup"
   | "opportunityLength"
@@ -71,7 +71,7 @@ export const formValuesToSubmitData = (
         connect: formValues.department,
       }
     : undefined,
-  stream: formValues.stream ? formValues.stream : undefined,
+  workStream: formValues.stream ? { connect: formValues.stream } : undefined,
   name: {
     en: formValues.specificTitleEn,
     fr: formValues.specificTitleFr,

--- a/apps/web/src/pages/Pools/EditPoolPage/components/UpdatePublishedProcessDialog/UpdatePublishedProcessDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/UpdatePublishedProcessDialog/UpdatePublishedProcessDialog.tsx
@@ -23,9 +23,9 @@ import { PublishedEditableSectionProps } from "../../types";
 const UpdatePublishedProcessDialog_Fragment = graphql(/* GraphQL */ `
   fragment UpdatePublishedProcessDialog on Pool {
     id
-    stream {
-      value
-      label {
+    workStream {
+      id
+      name {
         en
         fr
       }
@@ -64,7 +64,7 @@ const UpdatePublishedProcessDialog = ({
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const pool = getFragment(UpdatePublishedProcessDialog_Fragment, poolQuery);
   const title = getShortPoolTitleHtml(intl, {
-    stream: pool.stream,
+    workStream: pool.workStream,
     name: pool.name,
     publishingGroup: pool.publishingGroup,
     classification: pool.classification,

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolFilterDialog.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolFilterDialog.tsx
@@ -21,7 +21,7 @@ export interface FormValues {
   publishingGroups: PublishingGroup[];
   statuses: PoolStatus[];
   classifications: Scalars["UUID"]["output"][];
-  streams: Scalars["UUID"]["output"][];
+  workStreams: Scalars["UUID"]["output"][];
 }
 
 const PoolFilterDialogOptions_Fragment = graphql(/* GraphQL */ `
@@ -91,8 +91,8 @@ const PoolFilterDialog = ({
           options={localizedEnumToOptions(data?.statuses, intl)}
         />
         <Combobox
-          id="streams"
-          name="streams"
+          id="workStreams"
+          name="workStreams"
           isMulti
           label={intl.formatMessage(adminMessages.streams)}
           options={unpackMaybes(data?.workStreams).map((workStream) => ({

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolFilterDialog.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolFilterDialog.tsx
@@ -4,14 +4,13 @@ import { Combobox, localizedEnumToOptions } from "@gc-digital-talent/forms";
 import {
   FragmentType,
   PoolStatus,
-  PoolStream,
   PublishingGroup,
   Scalars,
   getFragment,
   graphql,
 } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
-import { commonMessages } from "@gc-digital-talent/i18n";
+import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 
 import FilterDialog, {
   CommonFilterDialogProps,
@@ -22,7 +21,7 @@ export interface FormValues {
   publishingGroups: PublishingGroup[];
   statuses: PoolStatus[];
   classifications: Scalars["UUID"]["output"][];
-  streams: PoolStream[];
+  streams: Scalars["UUID"]["output"][];
 }
 
 const PoolFilterDialogOptions_Fragment = graphql(/* GraphQL */ `
@@ -45,9 +44,9 @@ const PoolFilterDialogOptions_Fragment = graphql(/* GraphQL */ `
         fr
       }
     }
-    streams: localizedEnumStrings(enumName: "PoolStream") {
-      value
-      label {
+    workStreams {
+      id
+      name {
         en
         fr
       }
@@ -96,7 +95,10 @@ const PoolFilterDialog = ({
           name="streams"
           isMulti
           label={intl.formatMessage(adminMessages.streams)}
-          options={localizedEnumToOptions(data?.streams, intl)}
+          options={unpackMaybes(data?.workStreams).map((workStream) => ({
+            value: workStream.id,
+            label: getLocalizedName(workStream.name, intl),
+          }))}
         />
         <Combobox
           id="classifications"

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -73,9 +73,9 @@ const defaultState = {
 const PoolTable_PoolFragment = graphql(/* GraphQL */ `
   fragment PoolTable_Pool on Pool {
     id
-    stream {
-      value
-      label {
+    workStream {
+      id
+      name {
         en
         fr
       }
@@ -299,7 +299,8 @@ const PoolTable = ({ title, initialFilterInput }: PoolTableProps) => {
       },
     }),
     columnHelper.accessor(
-      (row) => poolNameAccessor({ name: row.name, stream: row.stream }, intl),
+      (row) =>
+        poolNameAccessor({ name: row.name, workStream: row.workStream }, intl),
       {
         id: "name",
         header: intl.formatMessage(commonMessages.name),
@@ -323,9 +324,9 @@ const PoolTable = ({ title, initialFilterInput }: PoolTableProps) => {
         classificationCell(pool.classification),
     }),
     columnHelper.accessor(
-      ({ stream }) => getLocalizedName(stream?.label, intl),
+      ({ workStream }) => getLocalizedName(workStream?.name, intl),
       {
-        id: "stream",
+        id: "workStream",
         enableColumnFilter: false,
         header: intl.formatMessage({
           defaultMessage: "Stream",

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -59,6 +59,7 @@ import {
   poolBookmarkCell,
   getPoolBookmarkSort,
   getOrderByColumnSort,
+  getWorkStreamNameSort,
 } from "./helpers";
 import PoolFilterDialog, { FormValues } from "./PoolFilterDialog";
 import { PoolBookmark_Fragment } from "./PoolBookmark";
@@ -129,6 +130,7 @@ const PoolTable_Query = graphql(/* GraphQL */ `
     $where: PoolFilterInput
     $orderByPoolBookmarks: PoolBookmarksOrderByInput
     $orderByTeamDisplayName: PoolTeamDisplayNameOrderByInput
+    $orderByWorkStreamName: PoolWorkStreamNameOrderByInput
     $orderByColumn: OrderByColumnInput
     $orderBy: [QueryPoolsPaginatedOrderByRelationOrderByClause!]
     $first: Int
@@ -145,6 +147,7 @@ const PoolTable_Query = graphql(/* GraphQL */ `
       where: $where
       orderByPoolBookmarks: $orderByPoolBookmarks
       orderByTeamDisplayName: $orderByTeamDisplayName
+      orderByWorkStreamName: $orderByWorkStreamName
       orderByColumn: $orderByColumn
       orderBy: $orderBy
       first: $first
@@ -257,6 +260,7 @@ const PoolTable = ({ title, initialFilterInput }: PoolTableProps) => {
       first: paginationState.pageSize,
       orderByPoolBookmarks: getPoolBookmarkSort(),
       orderByTeamDisplayName: getTeamDisplayNameSort(sortState, locale),
+      orderByWorkStreamName: getWorkStreamNameSort(sortState, locale),
       orderByColumn: getOrderByColumnSort(sortState),
       orderBy: sortState ? getOrderByClause(sortState) : undefined,
     },

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
@@ -16,6 +16,7 @@ import {
   PoolBookmarksOrderByInput,
   PoolFilterInput,
   PoolTeamDisplayNameOrderByInput,
+  PoolWorkStreamNameOrderByInput,
   QueryPoolsPaginatedOrderByClassificationColumn,
   QueryPoolsPaginatedOrderByRelationOrderByClause,
   QueryPoolsPaginatedOrderByUserColumn,
@@ -173,7 +174,6 @@ export function getOrderByClause(
     ["id", "id"],
     ["name", "name"],
     ["publishingGroup", "publishing_group"],
-    ["stream", "stream"],
     ["processNumber", "process_number"],
     ["ownerName", "FIRST_NAME"],
     ["ownerEmail", "EMAIL"],
@@ -251,6 +251,20 @@ export function getTeamDisplayNameSort(
   locale?: Locales,
 ): PoolTeamDisplayNameOrderByInput | undefined {
   const sortingRule = sortingRules?.find((rule) => rule.id === "team");
+
+  if (!sortingRule) return undefined;
+
+  return {
+    locale: locale ?? "en",
+    order: sortingRule.desc ? SortOrder.Desc : SortOrder.Asc,
+  };
+}
+
+export function getWorkStreamNameSort(
+  sortingRules?: SortingState,
+  locale?: Locales,
+): PoolWorkStreamNameOrderByInput | undefined {
+  const sortingRule = sortingRules?.find((rule) => rule.id === "workStream");
 
   if (!sortingRule) return undefined;
 

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
@@ -32,11 +32,11 @@ import { FormValues } from "./PoolFilterDialog";
 import PoolBookmark, { PoolBookmark_Fragment } from "./PoolBookmark";
 
 export function poolNameAccessor(
-  pool: Pick<Pool, "name" | "stream">,
+  pool: Pick<Pool, "name" | "workStream">,
   intl: IntlShape,
 ) {
   const name = getLocalizedName(pool.name, intl);
-  return `${name.toLowerCase()} ${getLocalizedName(pool.stream?.label, intl, true)}`;
+  return `${name.toLowerCase()} ${getLocalizedName(pool?.workStream?.name, intl, true)}`;
 }
 
 export function viewCell(

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
@@ -296,7 +296,7 @@ export function transformFormValuesToFilterInput(
   return {
     publishingGroups: data.publishingGroups,
     statuses: data.statuses,
-    streams: data.streams,
+    workStreams: data.workStreams,
     classifications: data.classifications.map((classification) => {
       const [group, level] = classification.split("-");
       return { group, level: Number(level) };
@@ -310,7 +310,7 @@ export function transformPoolFilterInputToFormValues(
   return {
     publishingGroups: unpackMaybes(input?.publishingGroups),
     statuses: unpackMaybes(input?.statuses),
-    streams: unpackMaybes(input?.streams),
+    workStreams: unpackMaybes(input?.workStreams),
     classifications: unpackMaybes(input?.classifications).map(
       (c) => `${c.group}-${c.level}`,
     ),

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -136,9 +136,9 @@ export const PoolAdvertisement_Fragment = graphql(/* GraphQL */ `
       en
       fr
     }
-    stream {
-      value
-      label {
+    workStream {
+      id
+      name {
         en
         fr
       }
@@ -253,9 +253,9 @@ export const PoolAdvertisement_Fragment = graphql(/* GraphQL */ `
       en
       fr
     }
-    stream {
-      value
-      label {
+    workStream {
+      id
+      name {
         en
         fr
       }
@@ -328,13 +328,13 @@ export const PoolPoster = ({
     });
   }
   const poolTitle = getShortPoolTitleLabel(intl, {
-    stream: pool.stream,
+    workStream: pool.workStream,
     name: pool.name,
     publishingGroup: pool.publishingGroup,
     classification: pool.classification,
   });
   const fullPoolTitle = getFullPoolTitleHtml(intl, {
-    stream: pool.stream,
+    workStream: pool.workStream,
     name: pool.name,
     publishingGroup: pool.publishingGroup,
     classification: pool.classification,
@@ -664,7 +664,7 @@ export const PoolPoster = ({
                       description: "Label for pool advertisement stream",
                     }) + intl.formatMessage(commonMessages.dividingColon)
                   }
-                  value={getLocalizedName(pool.stream?.label, intl)}
+                  value={getLocalizedName(pool?.workStream?.name, intl)}
                   suffix={
                     classification?.group === "IT" ? (
                       <Link

--- a/apps/web/src/pages/Pools/PoolLayout.tsx
+++ b/apps/web/src/pages/Pools/PoolLayout.tsx
@@ -38,9 +38,9 @@ export const PoolLayout_Fragment = graphql(/* GraphQL */ `
   fragment PoolLayout on Pool {
     ...AssessmentPlanStatus
     id
-    stream {
-      value
-      label {
+    workStream {
+      id
+      name {
         en
         fr
       }
@@ -92,7 +92,7 @@ const heroTitle = ({ currentPage, intl, pool }: HeroTitleProps) => {
     return currentPage?.title;
   }
   return getShortPoolTitleLabel(intl, {
-    stream: pool.stream,
+    workStream: pool.workStream,
     name: pool.name,
     publishingGroup: pool.publishingGroup,
     classification: pool.classification,
@@ -127,7 +127,7 @@ const PoolHeader = ({ poolQuery }: PoolHeaderProps) => {
     id: pool.id,
     name: pool.name,
     publishingGroup: pool.publishingGroup,
-    stream: pool.stream,
+    workStream: pool.workStream,
     classification: pool.classification,
   });
   const currentPage = useCurrentPage<PageNavKeys>(pages);

--- a/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
@@ -71,9 +71,9 @@ export const ViewPool_Fragment = graphql(/* GraphQL */ `
     }
     closingDate
     processNumber
-    stream {
-      value
-      label {
+    workStream {
+      id
+      name {
         en
         fr
       }
@@ -123,7 +123,7 @@ export const ViewPool = ({
   const { roleAssignments } = useAuthorization();
   const pool = getFragment(ViewPool_Fragment, poolQuery);
   const poolName = getShortPoolTitleHtml(intl, {
-    stream: pool.stream,
+    workStream: pool.workStream,
     name: pool.name,
     publishingGroup: pool.publishingGroup,
     classification: pool.classification,

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
@@ -144,9 +144,6 @@ const CareerTimelineApplication_Fragment = graphql(/* GraphQL */ `
       publishingGroup {
         value
       }
-      stream {
-        value
-      }
     }
   }
 `);

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -177,9 +177,9 @@ const RequestOptions_Query = graphql(/* GraphQL */ `
         fr
       }
     }
-    streams: localizedEnumStrings(enumName: "PoolStream") {
-      value
-      label {
+    workStreams {
+      id
+      name {
         en
         fr
       }
@@ -286,7 +286,7 @@ export const RequestForm = ({
           equity: applicantFilter?.equity,
           languageAbility: applicantFilter?.languageAbility,
           operationalRequirements: applicantFilter?.operationalRequirements,
-          qualifiedStreams,
+          workStreams: { sync: qualifiedStreams },
           community: {
             connect: community?.id ?? communities[0].id,
           },
@@ -386,10 +386,8 @@ export const RequestForm = ({
         ),
       ),
     ),
-    qualifiedStreams: unpackMaybes(
-      applicantFilter?.qualifiedStreams?.map((stream) =>
-        enumInputToLocalizedEnum(stream, optionsData?.streams),
-      ),
+    workStreams: unpackMaybes(optionsData?.workStreams).filter((workStream) =>
+      applicantFilter?.qualifiedStreams?.includes(workStream.id),
     ),
     qualifiedClassifications:
       applicantFilter?.qualifiedClassifications

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -43,7 +43,6 @@ import {
   graphql,
   FragmentType,
   getFragment,
-  PoolStream,
 } from "@gc-digital-talent/graphql";
 
 import SEO from "~/components/SEO/SEO";
@@ -260,7 +259,7 @@ export const RequestForm = ({
     const qualifiedStreams = applicantFilter?.workStreams;
     let community = communities?.find((c) => c.key === "digital");
     const ATIPStream = optionsData?.workStreams?.find(
-      (workStream) => workStream?.key === PoolStream.AccessInformationPrivacy,
+      (workStream) => workStream?.key === "ACCESS_INFORMATION_PRIVACY",
     );
     if (
       qualifiedStreams?.some((workStream) => workStream?.id === ATIPStream?.id)

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -131,9 +131,9 @@ const PoolsInFilter_Query = graphql(/* GraphQL */ `
           group
           level
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/FormFields.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/FormFields.tsx
@@ -12,9 +12,15 @@ import {
   commonMessages,
   errorMessages,
   getEmploymentEquityGroup,
+  getLocalizedName,
   sortWorkRegion,
 } from "@gc-digital-talent/i18n";
-import { Classification, Skill, graphql } from "@gc-digital-talent/graphql";
+import {
+  Classification,
+  Skill,
+  WorkStream,
+  graphql,
+} from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 
 import { NullSelection } from "~/types/searchRequest";
@@ -29,13 +35,6 @@ import { classificationAriaLabels, classificationLabels } from "../labels";
 
 const SearchRequestOptions_Query = graphql(/* GraphQL */ `
   query SearchRequestOptions {
-    poolStreams: localizedEnumStrings(enumName: "PoolStream") {
-      value
-      label {
-        en
-        fr
-      }
-    }
     languageAbilities: localizedEnumStrings(enumName: "LanguageAbility") {
       value
       label {
@@ -56,9 +55,14 @@ const SearchRequestOptions_Query = graphql(/* GraphQL */ `
 interface FormFieldsProps {
   classifications: Pick<Classification, "group" | "level">[];
   skills: Skill[];
+  workStreams: WorkStream[];
 }
 
-const FormFields = ({ classifications, skills }: FormFieldsProps) => {
+const FormFields = ({
+  classifications,
+  skills,
+  workStreams,
+}: FormFieldsProps) => {
   const intl = useIntl();
   const [{ data }] = useQuery({
     query: SearchRequestOptions_Query,
@@ -74,11 +78,15 @@ const FormFields = ({ classifications, skills }: FormFieldsProps) => {
     ),
   }));
 
+  const workStreamOptions = workStreams.map((workStream) => ({
+    value: workStream.id,
+    label: getLocalizedName(workStream.name, intl),
+  }));
+
   const languageAbilityOptions = localizedEnumToOptions(
     data?.languageAbilities,
     intl,
   );
-  const streamOptions = localizedEnumToOptions(data?.poolStreams, intl);
   const sortedWorkRegions = sortWorkRegion(unpackMaybes(data?.workRegions));
   const workRegionOptions = localizedEnumToOptions(sortedWorkRegions, intl);
 
@@ -133,7 +141,7 @@ const FormFields = ({ classifications, skills }: FormFieldsProps) => {
               id: "QJ5uDV",
               description: "Placeholder for stream filter in search form.",
             })}
-            options={streamOptions}
+            options={workStreamOptions}
             rules={{
               required: intl.formatMessage(errorMessages.required),
             }}

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.stories.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.stories.tsx
@@ -6,13 +6,10 @@ import {
   fakeClassifications,
   fakePools,
   fakeLocalizedEnum,
+  fakeWorkStreams,
 } from "@gc-digital-talent/fake-data";
 import { MockGraphqlDecorator } from "@gc-digital-talent/storybook-helpers";
-import {
-  LanguageAbility,
-  PoolStream,
-  WorkRegion,
-} from "@gc-digital-talent/graphql";
+import { LanguageAbility, WorkRegion } from "@gc-digital-talent/graphql";
 
 import { SearchForm } from "./SearchForm";
 
@@ -21,6 +18,7 @@ faker.seed(0);
 const mockPools = fakePools(10);
 const poolResponse = fakePools(3);
 const mockClassifications = fakeClassifications();
+const mockWorkStreams = fakeWorkStreams();
 const skills = getStaticSkills();
 
 export default {
@@ -29,13 +27,13 @@ export default {
   args: {
     pools: mockPools,
     classifications: mockClassifications,
+    workStreams: mockWorkStreams,
     skills,
   },
 } as Meta<typeof SearchForm>;
 
 const SearchRequestOptions = {
   data: {
-    poolStreams: fakeLocalizedEnum(PoolStream),
     languageAbilities: fakeLocalizedEnum(LanguageAbility),
     workRegions: fakeLocalizedEnum(WorkRegion),
   },

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -17,6 +17,7 @@ import {
   Classification,
   ApplicantFilterInput,
   Skill,
+  WorkStream,
 } from "@gc-digital-talent/graphql";
 import { commonMessages } from "@gc-digital-talent/i18n";
 
@@ -44,9 +45,14 @@ const styledCount = (chunks: ReactNode) => (
 interface SearchFormProps {
   classifications: Pick<Classification, "group" | "level" | "id">[];
   skills: Skill[];
+  workStreams: WorkStream[];
 }
 
-export const SearchForm = ({ classifications, skills }: SearchFormProps) => {
+export const SearchForm = ({
+  classifications,
+  skills,
+  workStreams,
+}: SearchFormProps) => {
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();
@@ -145,7 +151,11 @@ export const SearchForm = ({ classifications, skills }: SearchFormProps) => {
                     "Content displayed in the How To area of the hero section of the Search page.",
                 })}
               </p>
-              <FormFields skills={skills} classifications={classifications} />
+              <FormFields
+                skills={skills}
+                classifications={classifications}
+                workStreams={workStreams}
+              />
             </div>
             <div data-h2-display="base(none) p-tablet(block)">
               <EstimatedCandidates
@@ -246,6 +256,13 @@ const SearchForm_Query = graphql(/* GraphQL */ `
       group
       level
     }
+    workStreams {
+      id
+      name {
+        en
+        fr
+      }
+    }
     skills {
       id
       key
@@ -285,10 +302,15 @@ const SearchFormAPI = () => {
 
   const skills = unpackMaybes<Skill>(data?.skills);
   const classifications = unpackMaybes(data?.classifications);
+  const workStreams = unpackMaybes(data?.workStreams);
 
   return (
     <Pending fetching={fetching} error={error}>
-      <SearchForm skills={skills} classifications={classifications} />
+      <SearchForm
+        skills={skills}
+        classifications={classifications}
+        workStreams={workStreams}
+      />
     </Pending>
   );
 };

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
@@ -22,9 +22,9 @@ const testId = (text: ReactNode) => (
 const SearchResultCard_PoolFragment = graphql(/* GraphQL */ `
   fragment SearchResultCard_Pool on Pool {
     id
-    stream {
-      value
-      label {
+    workStream {
+      id
+      name {
         en
         fr
       }
@@ -121,7 +121,7 @@ const SearchResultCard = ({ candidateCount, pool }: SearchResultCardProps) => {
         id={`search_pool_${pool.id}`}
       >
         {getShortPoolTitleHtml(intl, {
-          stream: pool.stream,
+          workStream: pool.workStream,
           name: pool.name,
           publishingGroup: pool.publishingGroup,
           classification: pool.classification,

--- a/apps/web/src/pages/SearchRequests/SearchPage/utils.ts
+++ b/apps/web/src/pages/SearchRequests/SearchPage/utils.ts
@@ -104,7 +104,7 @@ export const dataToFormValues = (
   data: ApplicantFilterInput,
   selectedClassifications?: Maybe<Pick<Classification, "group" | "level">[]>,
 ): FormValues => {
-  const stream = data?.qualifiedStreams?.find(notEmpty);
+  const stream = data?.workStreams?.find(notEmpty);
 
   return {
     classification: getCurrentClassification(selectedClassifications),
@@ -117,7 +117,7 @@ export const dataToFormValues = (
     ],
     educationRequirement: data.hasDiploma ? "has_diploma" : "no_diploma",
     skills: data.skills?.filter(notEmpty).map((s) => s.id) ?? [],
-    stream: stream ?? "",
+    stream: stream?.id ?? "",
     locationPreferences: data.locationPreferences?.filter(notEmpty) ?? [],
     operationalRequirements:
       data.operationalRequirements?.filter(notEmpty) ?? [],
@@ -172,6 +172,6 @@ export const formValuesToData = (
       ? durationSelectionToEnum(values.employmentDuration)
       : undefined,
     locationPreferences: values.locationPreferences ?? [],
-    qualifiedStreams: values.stream ? [values.stream] : undefined,
+    workStreams: values.stream ? [{ id: values.stream }] : undefined,
   };
 };

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
@@ -1,24 +1,14 @@
 import { useIntl } from "react-intl";
-import omit from "lodash/omit";
-import pick from "lodash/pick";
 
-import { identity, notEmpty } from "@gc-digital-talent/helpers";
+import { notEmpty } from "@gc-digital-talent/helpers";
 import {
-  ApplicantFilterInput,
   PoolCandidateFilter,
   ApplicantFilter,
-  IdInput,
-  Classification,
-  ClassificationFilterInput,
   PoolCandidateSearchInput,
   PoolCandidateStatus,
   CandidateSuspendedFilter,
   CandidateExpiryFilter,
 } from "@gc-digital-talent/graphql";
-import {
-  localizedEnumArrayToInput,
-  localizedEnumToInput,
-} from "@gc-digital-talent/i18n";
 
 import PoolCandidatesTable from "~/components/PoolCandidatesTable/PoolCandidatesTable";
 import adminMessages from "~/messages/adminMessages";
@@ -33,70 +23,23 @@ function isPoolCandidateFilter(
   return false;
 }
 
-function omitIdAndTypename<T extends object | null | undefined>(
-  x: T,
-): Omit<T, "id" | "__typename"> {
-  return omit(x, ["id", "__typename"]) as Omit<T, "id" | "__typename">;
-}
-
-function pickId<T extends IdInput>(x: T): IdInput {
-  return pick(x, ["id"]);
-}
-
-function classificationToInput(c: Classification): ClassificationFilterInput {
-  return pick(c, ["group", "level"]);
-}
-
-// Maps each property in ApplicantFilterInput to a function which transforms the matching value from an ApplicantFilter object to the appropriate shape for ApplicantFilterInput.
-type MappingType = {
-  [Property in keyof Omit<
-    ApplicantFilterInput,
-    "email" | "name" | "generalSearch" | "skillsIntersectional"
-  >]: (x: ApplicantFilter[Property]) => ApplicantFilterInput[Property];
-};
-
 const transformApplicantFilterToPoolCandidateSearchInput = (
   applicantFilter: ApplicantFilter,
 ): PoolCandidateSearchInput => {
-  // GraphQL will error if an input object includes any unexpected attributes.
-  // Therefore, transforming ApplicantFilter to ApplicantFilterInput requires omitting any fields not included in the Input type.
-  const mapping: MappingType = {
-    equity: omitIdAndTypename,
-    hasDiploma: identity,
-    languageAbility: localizedEnumToInput,
-    locationPreferences: localizedEnumArrayToInput,
-    operationalRequirements: localizedEnumArrayToInput,
-    pools: (pools) => pools?.filter(notEmpty).map(pickId),
-    skills: (skills) => skills?.filter(notEmpty).map(pickId),
-    positionDuration: identity,
-    qualifiedStreams: localizedEnumArrayToInput,
-    community: (community) => (community ? pickId(community) : undefined),
-  };
-
-  const emptyFilter: ApplicantFilterInput = {};
-
   return {
-    applicantFilter: Object.entries(mapping).reduce(
-      (applicantFilterInput, filterEntry) => {
-        const [key, transform] = filterEntry;
-        const typedKey = key as keyof MappingType;
-
-        // There should be way to get the types to work without using "any", but I'm having trouble.
-        // I think its safe to fallback on any here because mapping has just been defined, and we can be confident that key and transform line up correctly.
-
-        // eslint-disable-next-line no-param-reassign, @typescript-eslint/no-unsafe-assignment
-        applicantFilterInput[typedKey] = transform(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-          applicantFilter[typedKey] as any,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ) as any;
-        return applicantFilterInput;
-      },
-      emptyFilter,
-    ),
+    applicantFilter: {
+      ...applicantFilter,
+      languageAbility: applicantFilter.languageAbility?.value,
+      locationPreferences: applicantFilter?.locationPreferences
+        ?.filter(notEmpty)
+        .map((workRegion) => workRegion?.value),
+      operationalRequirements: applicantFilter?.operationalRequirements
+        ?.filter(notEmpty)
+        .map((req) => req?.value),
+    },
     appliedClassifications: applicantFilter.qualifiedClassifications
       ?.filter(notEmpty)
-      .map(classificationToInput),
+      .map(({ group, level }) => ({ group, level })),
     poolCandidateStatus: [
       PoolCandidateStatus.QualifiedAvailable,
       PoolCandidateStatus.PlacedCasual,

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
@@ -1,6 +1,6 @@
 import { useIntl } from "react-intl";
 
-import { notEmpty } from "@gc-digital-talent/helpers";
+import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 import {
   PoolCandidateFilter,
   ApplicantFilter,
@@ -28,7 +28,14 @@ const transformApplicantFilterToPoolCandidateSearchInput = (
 ): PoolCandidateSearchInput => {
   return {
     applicantFilter: {
-      ...applicantFilter,
+      equity: {
+        isWoman: applicantFilter.equity?.isWoman ?? undefined,
+        hasDisability: applicantFilter.equity?.hasDisability,
+        isIndigenous: applicantFilter.equity?.isIndigenous,
+        isVisibleMinority: applicantFilter.equity?.isVisibleMinority,
+      },
+      hasDiploma: applicantFilter?.hasDiploma,
+      positionDuration: applicantFilter?.positionDuration,
       languageAbility: applicantFilter.languageAbility?.value,
       locationPreferences: applicantFilter?.locationPreferences
         ?.filter(notEmpty)
@@ -36,6 +43,14 @@ const transformApplicantFilterToPoolCandidateSearchInput = (
       operationalRequirements: applicantFilter?.operationalRequirements
         ?.filter(notEmpty)
         .map((req) => req?.value),
+      pools: unpackMaybes(applicantFilter.pools).map(({ id }) => ({ id })),
+      skills: unpackMaybes(applicantFilter.skills).map(({ id }) => ({ id })),
+      qualifiedStreams: unpackMaybes(applicantFilter.workStreams).map(
+        ({ id }) => id,
+      ),
+      community: applicantFilter?.community?.id
+        ? { id: applicantFilter.community.id }
+        : undefined,
     },
     appliedClassifications: applicantFilter.qualifiedClassifications
       ?.filter(notEmpty)

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
@@ -45,9 +45,9 @@ const transformApplicantFilterToPoolCandidateSearchInput = (
         .map((req) => req?.value),
       pools: unpackMaybes(applicantFilter.pools).map(({ id }) => ({ id })),
       skills: unpackMaybes(applicantFilter.skills).map(({ id }) => ({ id })),
-      qualifiedStreams: unpackMaybes(applicantFilter.workStreams).map(
-        ({ id }) => id,
-      ),
+      workStreams: unpackMaybes(applicantFilter.workStreams).map(({ id }) => ({
+        id,
+      })),
       community: applicantFilter?.community?.id
         ? { id: applicantFilter.community.id }
         : undefined,

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
@@ -389,9 +389,9 @@ const ViewSearchRequest_SearchRequestFragment = graphql(/* GraphQL */ `
         group
         level
       }
-      qualifiedStreams {
-        value
-        label {
+      workStreams {
+        id
+        name {
           en
           fr
         }

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
@@ -296,9 +296,9 @@ const ViewSearchRequest_SearchRequestFragment = graphql(/* GraphQL */ `
           group
           level
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }
@@ -367,9 +367,9 @@ const ViewSearchRequest_SearchRequestFragment = graphql(/* GraphQL */ `
           en
           fr
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }

--- a/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
+++ b/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
@@ -170,9 +170,9 @@ const AdminUserProfileUser_Fragment = graphql(/* GraphQL */ `
           group
           level
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }

--- a/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
@@ -172,9 +172,9 @@ export const UserInfo_Fragment = graphql(/* GraphQL */ `
             fr
           }
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }

--- a/apps/web/src/pages/Users/UserInformationPage/components/AddToPoolDialog.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/AddToPoolDialog.tsx
@@ -63,9 +63,9 @@ const AvailablePoolsToAddTo_Query = graphql(/* GraphQL */ `
             fr
           }
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }
@@ -187,7 +187,7 @@ const AddToPoolDialog = ({ user, poolCandidates }: AddToPoolDialogProps) => {
                 {rejectedRequests.map((rejected) => (
                   <li key={rejected.pool.id}>
                     {getShortPoolTitleHtml(intl, {
-                      stream: rejected.pool.stream,
+                      workStream: rejected.pool.workStream,
                       name: rejected.pool.name,
                       publishingGroup: rejected.pool.publishingGroup,
                       classification: rejected.pool.classification,

--- a/apps/web/src/pages/Users/UserInformationPage/components/NotesSection.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/NotesSection.tsx
@@ -51,7 +51,7 @@ const NotesSection = ({ user }: BasicUserInformationProps) => {
                 },
                 {
                   poolName: getShortPoolTitleHtml(intl, {
-                    stream: candidate.pool.stream,
+                    workStream: candidate.pool.workStream,
                     name: candidate.pool.name,
                     publishingGroup: candidate.pool.publishingGroup,
                     classification: candidate.pool.classification,
@@ -72,7 +72,7 @@ const NotesSection = ({ user }: BasicUserInformationProps) => {
                 },
                 {
                   poolName: getShortPoolTitleHtml(intl, {
-                    stream: candidate.pool.stream,
+                    workStream: candidate.pool.workStream,
                     name: candidate.pool.name,
                     publishingGroup: candidate.pool.publishingGroup,
                     classification: candidate.pool.classification,
@@ -122,7 +122,7 @@ const NotesSection = ({ user }: BasicUserInformationProps) => {
                       },
                       {
                         poolName: getShortPoolTitleHtml(intl, {
-                          stream: candidate.pool.stream,
+                          workStream: candidate.pool.workStream,
                           name: candidate.pool.name,
                           publishingGroup: candidate.pool.publishingGroup,
                           classification: candidate.pool.classification,

--- a/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/UserCandidatesTable.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/UserCandidatesTable.tsx
@@ -84,9 +84,9 @@ const UserCandidatesTableRow_Fragment = graphql(/* GraphQL */ `
           en
           fr
         }
-        stream {
-          value
-          label {
+        workStream {
+          id
+          name {
             en
             fr
           }
@@ -188,7 +188,7 @@ const UserCandidatesTable = ({
     columnHelper.accessor(
       ({ pool }) =>
         getFullPoolTitleLabel(intl, {
-          stream: pool.stream,
+          workStream: pool.workStream,
           name: pool.name,
           publishingGroup: pool.publishingGroup,
           classification: pool.classification,
@@ -205,7 +205,7 @@ const UserCandidatesTable = ({
           processCell(
             {
               id: pool.id,
-              stream: pool.stream,
+              workStream: pool.workStream,
               name: pool.name,
               publishingGroup: pool.publishingGroup,
               classification: pool.classification,

--- a/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/helpers.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/helpers.tsx
@@ -106,14 +106,14 @@ export const priorityCell = (
 };
 
 export const processCell = (
-  pool: Pick<Pool, "id" | "stream" | "name" | "publishingGroup"> & {
+  pool: Pick<Pool, "id" | "workStream" | "name" | "publishingGroup"> & {
     classification?: Maybe<Pick<Classification, "group" | "level">>;
   },
   paths: ReturnType<typeof useRoutes>,
   intl: IntlShape,
 ) => {
   const poolName = getFullPoolTitleLabel(intl, {
-    stream: pool.stream,
+    workStream: pool.workStream,
     name: pool.name,
     publishingGroup: pool.publishingGroup,
     classification: pool.classification,

--- a/apps/web/src/types/searchRequest.ts
+++ b/apps/web/src/types/searchRequest.ts
@@ -2,7 +2,6 @@ import {
   Scalars,
   ApplicantFilterInput,
   LanguageAbility,
-  PoolStream,
   UserPoolFilterInput,
   Classification,
 } from "@gc-digital-talent/graphql";
@@ -16,7 +15,7 @@ export type FormValues = Pick<
   languageAbility: LanguageAbility | typeof NullSelection;
   employmentDuration: string;
   classification: string | undefined;
-  stream: PoolStream | "";
+  stream?: string;
   skills: string[] | undefined;
   employmentEquity: string[] | undefined;
   educationRequirement: "has_diploma" | "no_diploma";

--- a/apps/web/src/utils/poolUtils.test.ts
+++ b/apps/web/src/utils/poolUtils.test.ts
@@ -4,9 +4,7 @@
 
 import { createIntl, createIntlCache } from "react-intl";
 
-import {
-  fakeClassifications,
-} from "@gc-digital-talent/fake-data";
+import { fakeClassifications } from "@gc-digital-talent/fake-data";
 
 import { formattedPoolPosterTitle } from "./poolUtils";
 
@@ -26,8 +24,8 @@ describe("poolUtils tests", () => {
         id: "uuid",
         name: {
           en: "Software solutions EN",
-          fr: "Software solutions FR"
-        }
+          fr: "Software solutions FR",
+        },
       },
       intl,
     };

--- a/apps/web/src/utils/poolUtils.test.ts
+++ b/apps/web/src/utils/poolUtils.test.ts
@@ -70,13 +70,13 @@ describe("poolUtils tests", () => {
       expect(
         formattedPoolPosterTitle({
           ...baseInputs,
-          stream: null,
+          workStream: null,
         }).label,
       ).toBe("Web Developer (IT-01)");
       expect(
         formattedPoolPosterTitle({
           ...baseInputs,
-          stream: undefined,
+          workStream: undefined,
         }).label,
       ).toBe("Web Developer (IT-01)");
     });
@@ -85,14 +85,14 @@ describe("poolUtils tests", () => {
         formattedPoolPosterTitle({
           ...baseInputs,
           classification: undefined,
-          stream: null,
+          workStream: null,
         }).label,
       ).toBe("Web Developer");
       expect(
         formattedPoolPosterTitle({
           ...baseInputs,
           classification: null,
-          stream: undefined,
+          workStream: undefined,
         }).label,
       ).toBe("Web Developer");
     });
@@ -101,7 +101,7 @@ describe("poolUtils tests", () => {
         formattedPoolPosterTitle({
           title: "",
           classification: null,
-          stream: null,
+          workStream: null,
           intl,
         }).label,
       ).toBe("");

--- a/apps/web/src/utils/poolUtils.test.ts
+++ b/apps/web/src/utils/poolUtils.test.ts
@@ -6,9 +6,7 @@ import { createIntl, createIntlCache } from "react-intl";
 
 import {
   fakeClassifications,
-  toLocalizedEnum,
 } from "@gc-digital-talent/fake-data";
-import { PoolStream } from "@gc-digital-talent/graphql";
 
 import { formattedPoolPosterTitle } from "./poolUtils";
 
@@ -24,7 +22,13 @@ describe("poolUtils tests", () => {
     const baseInputs = {
       title: "Web Developer",
       classification: fakeClassifications()[0],
-      stream: toLocalizedEnum(PoolStream.SoftwareSolutions),
+      workStream: {
+        id: "uuid",
+        name: {
+          en: "Software solutions EN",
+          fr: "Software solutions FR"
+        }
+      },
       intl,
     };
     test("should combine title, classification and stream if all are provided", () => {

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -23,8 +23,8 @@ import {
   Maybe,
   Classification,
   Pool,
-  LocalizedPoolStream,
   LocalizedPoolStatus,
+  WorkStream,
 } from "@gc-digital-talent/graphql";
 
 import { PageNavInfo } from "~/types/pages";
@@ -90,7 +90,7 @@ export const formatClassificationString = ({
 interface formattedPoolPosterTitleProps {
   title: Maybe<string> | undefined;
   classification: Maybe<Pick<Classification, "group" | "level">> | undefined;
-  stream?: Maybe<LocalizedPoolStream>;
+  workStream?: Maybe<WorkStream>;
   short?: boolean;
   intl: IntlShape;
 }
@@ -98,14 +98,14 @@ interface formattedPoolPosterTitleProps {
 export const formattedPoolPosterTitle = ({
   title,
   classification,
-  stream,
+  workStream,
   short,
   intl,
 }: formattedPoolPosterTitleProps): {
   html: ReactNode;
   label: string;
 } => {
-  const streamString = stream ? getLocalizedName(stream.label, intl) : "";
+  const streamString = getLocalizedName(workStream?.name, intl, true);
   const groupAndLevel = classification
     ? formatClassificationString(classification)
     : "";
@@ -146,7 +146,7 @@ interface PoolTitleOptions {
 }
 
 type PoolTitle = Maybe<
-  Pick<Pool, "name" | "publishingGroup" | "stream"> & {
+  Pick<Pool, "name" | "publishingGroup" | "workStream"> & {
     classification?: Maybe<Pick<Classification, "group" | "level">>;
   }
 >;
@@ -183,7 +183,7 @@ export const poolTitle = (
   const formattedTitle = formattedPoolPosterTitle({
     title: specificTitle,
     classification: pool?.classification,
-    stream: pool?.stream,
+    workStream: pool?.workStream,
     short: options?.short,
     intl,
   });
@@ -232,7 +232,7 @@ export const useAdminPoolPages = (
 ) => {
   const paths = useRoutes();
   const poolName = getFullPoolTitleLabel(intl, {
-    stream: pool.stream,
+    workStream: pool.workStream,
     name: pool.name,
     publishingGroup: pool.publishingGroup,
     classification: pool.classification,

--- a/apps/web/src/utils/requestUtils.tsx
+++ b/apps/web/src/utils/requestUtils.tsx
@@ -1,7 +1,4 @@
-import {
-  PoolCandidateSearchStatus,
-  PoolStream,
-} from "@gc-digital-talent/graphql";
+import { PoolCandidateSearchStatus } from "@gc-digital-talent/graphql";
 
 export function stringToEnumRequestStatus(
   selection: string,
@@ -12,13 +9,6 @@ export function stringToEnumRequestStatus(
     )
   ) {
     return selection as PoolCandidateSearchStatus;
-  }
-  return undefined;
-}
-
-export function stringToEnumStream(selection: string): PoolStream | undefined {
-  if (Object.values(PoolStream).includes(selection as PoolStream)) {
-    return selection as PoolStream;
   }
   return undefined;
 }

--- a/apps/web/src/utils/testData.ts
+++ b/apps/web/src/utils/testData.ts
@@ -8,6 +8,7 @@ import {
   fakePools,
   fakeSkillFamilies,
   fakeSkills,
+  fakeWorkStreams,
   toLocalizedEnum,
 } from "@gc-digital-talent/fake-data";
 import {
@@ -31,6 +32,7 @@ const fakePool = fakePools(
   fakeSkills(20, fakeSkillFamilies(6)),
   fakeClassifications(),
   fakeDepartments(),
+  fakeWorkStreams(),
   3,
 )[0];
 // make three assessment steps which assess all the pool skills

--- a/apps/web/src/validators/process/classification.ts
+++ b/apps/web/src/validators/process/classification.ts
@@ -5,16 +5,16 @@ import { Pool } from "@gc-digital-talent/graphql";
   Note: The pool.classification should not be null, therefore it doesn't need to checked
 */
 export function isInNullState({
-  stream,
+  workStream,
   name,
   processNumber,
   publishingGroup,
 }: Pick<
   Pool,
-  "stream" | "name" | "processNumber" | "publishingGroup"
+  "workStream" | "name" | "processNumber" | "publishingGroup"
 >): boolean {
   return !!(
-    !stream &&
+    !workStream &&
     !name?.en &&
     !name?.fr &&
     !processNumber &&
@@ -27,7 +27,7 @@ export function hasEmptyRequiredFields({
   areaOfSelection,
   classification,
   department,
-  stream,
+  workStream,
   name,
   processNumber,
   publishingGroup,
@@ -37,7 +37,7 @@ export function hasEmptyRequiredFields({
   | "areaOfSelection"
   | "classification"
   | "department"
-  | "stream"
+  | "workStream"
   | "name"
   | "processNumber"
   | "publishingGroup"
@@ -47,7 +47,7 @@ export function hasEmptyRequiredFields({
     !areaOfSelection?.value ||
     !classification ||
     !department ||
-    !stream ||
+    !workStream ||
     !name?.en ||
     !name?.fr ||
     !processNumber ||

--- a/packages/fake-data/src/fakeApplicantFilters.ts
+++ b/packages/fake-data/src/fakeApplicantFilters.ts
@@ -8,17 +8,19 @@ import {
   LanguageAbility,
   PositionDuration,
   Skill,
-  PoolStream,
+  WorkStream,
 } from "@gc-digital-talent/graphql";
 
 import fakeSkills from "./fakeSkills";
 import fakePools from "./fakePools";
+import fakeWorkStreams from "./fakeWorkStreams";
 import toLocalizedEnum from "./fakeLocalizedEnum";
 
 const generateApplicantFilters = (
   operationalRequirements: OperationalRequirement[],
   pools: Pool[],
   skills: Skill[],
+  workStreams: WorkStream[],
 ): ApplicantFilter => {
   return {
     __typename: "ApplicantFilter",
@@ -47,9 +49,7 @@ const generateApplicantFilters = (
       Object.values(PositionDuration),
     ),
     skills,
-    qualifiedStreams: faker.helpers
-      .arrayElements<PoolStream>(Object.values(PoolStream), 1)
-      .map((stream) => toLocalizedEnum(stream)),
+    workStreams: faker.helpers.arrayElements<WorkStream>(workStreams, 1),
   };
 };
 
@@ -60,9 +60,15 @@ export default (): ApplicantFilter[] => {
     );
   const pools = fakePools();
   const skills = fakeSkills(5);
+  const workStreams = fakeWorkStreams();
 
   faker.seed(0); // repeatable results
   return Array.from({ length: 20 }, () =>
-    generateApplicantFilters(operationalRequirements, pools, skills),
+    generateApplicantFilters(
+      operationalRequirements,
+      pools,
+      skills,
+      workStreams,
+    ),
   );
 };

--- a/packages/fake-data/src/fakePools.ts
+++ b/packages/fake-data/src/fakePools.ts
@@ -13,7 +13,6 @@ import {
   PoolLanguage,
   User,
   UserPublicProfile,
-  PoolStream,
   PublishingGroup,
   SecurityStatus,
   Skill,
@@ -27,6 +26,7 @@ import {
   PoolOpportunityLength,
   PoolAreaOfSelection,
   PoolSelectionLimitation,
+  WorkStream,
 } from "@gc-digital-talent/graphql";
 
 import fakeScreeningQuestions from "./fakeScreeningQuestions";
@@ -39,12 +39,14 @@ import toLocalizedString from "./fakeLocalizedString";
 import fakeAssessmentSteps from "./fakeAssessmentSteps";
 import fakeDepartments from "./fakeDepartments";
 import toLocalizedEnum from "./fakeLocalizedEnum";
+import fakeWorkStreams from "./fakeWorkStreams";
 
 const generatePool = (
   users: User[],
   skills: Skill[],
   classifications: Classification[],
   departments: Department[],
+  workStreams: WorkStream[],
   englishName = "",
   frenchName = "",
   essentialSkillCount = -1,
@@ -58,8 +60,8 @@ const generatePool = (
     essentialSkillCount > 0
       ? essentialSkillCount
       : faker.number.int({
-          max: 10,
-        }),
+        max: 10,
+      }),
   );
   const nonessentialSkills = faker.helpers.arrayElements(
     skills,
@@ -106,10 +108,8 @@ const generatePool = (
     },
     classification: faker.helpers.arrayElement<Classification>(classifications),
     department: faker.helpers.arrayElement<Department>(departments),
+    workStream: faker.helpers.arrayElement<WorkStream>(workStreams),
     keyTasks: toLocalizedString(faker.lorem.paragraphs()),
-    stream: toLocalizedEnum(
-      faker.helpers.arrayElement<PoolStream>(Object.values(PoolStream)),
-    ),
     processNumber: faker.helpers.maybe(() => faker.lorem.word()),
     publishingGroup: faker.helpers.maybe(() =>
       toLocalizedEnum(
@@ -155,10 +155,10 @@ const generatePool = (
     selectionLimitations:
       areaOfSelection.value == PoolAreaOfSelection.Employees
         ? faker.helpers.arrayElements(
-            Object.values(PoolSelectionLimitation).map((l) =>
-              toLocalizedEnum(l),
-            ),
-          )
+          Object.values(PoolSelectionLimitation).map((l) =>
+            toLocalizedEnum(l),
+          ),
+        )
         : [],
   };
 };
@@ -168,6 +168,7 @@ export default (
   skills = fakeSkills(100, fakeSkillFamilies(6)),
   classifications = fakeClassifications(),
   departments = fakeDepartments(),
+  workStreams = fakeWorkStreams(),
   essentialSkillCount = -1,
 ): Pool[] => {
   const users = fakeUsers();
@@ -180,6 +181,7 @@ export default (
           skills,
           classifications,
           departments,
+          workStreams,
           "CMO",
           "CMO",
           essentialSkillCount,
@@ -191,6 +193,7 @@ export default (
           skills,
           classifications,
           departments,
+          workStreams,
           "IT Apprenticeship Program for Indigenous Peoples",
           "Programme d’apprentissage en TI pour les personnes autochtones",
           essentialSkillCount,
@@ -202,6 +205,7 @@ export default (
           skills,
           classifications,
           departments,
+          workStreams,
           "",
           "",
           essentialSkillCount,

--- a/packages/fake-data/src/fakePools.ts
+++ b/packages/fake-data/src/fakePools.ts
@@ -60,8 +60,8 @@ const generatePool = (
     essentialSkillCount > 0
       ? essentialSkillCount
       : faker.number.int({
-        max: 10,
-      }),
+          max: 10,
+        }),
   );
   const nonessentialSkills = faker.helpers.arrayElements(
     skills,
@@ -155,10 +155,10 @@ const generatePool = (
     selectionLimitations:
       areaOfSelection.value == PoolAreaOfSelection.Employees
         ? faker.helpers.arrayElements(
-          Object.values(PoolSelectionLimitation).map((l) =>
-            toLocalizedEnum(l),
-          ),
-        )
+            Object.values(PoolSelectionLimitation).map((l) =>
+              toLocalizedEnum(l),
+            ),
+          )
         : [],
   };
 };

--- a/packages/fake-data/src/fakeWorkStreams.ts
+++ b/packages/fake-data/src/fakeWorkStreams.ts
@@ -1,0 +1,21 @@
+
+import { faker } from "@faker-js/faker/locale/en";
+
+import { WorkStream } from "@gc-digital-talent/graphql";
+
+import toLocalizedString from "./fakeLocalizedString";
+
+const generateWorkStream = (): WorkStream => {
+  return {
+    id: faker.string.uuid(),
+    key: faker.helpers.slugify(faker.string.sample()),
+    name: toLocalizedString(faker.company.catchPhrase()),
+    plainLanguageName: toLocalizedString(faker.company.catchPhrase()),
+  };
+};
+
+export default (numToGenerate = 10): WorkStream[] => {
+  faker.seed(0); // repeatable results
+
+  return Array.from({ length: numToGenerate }, () => generateWorkStream());
+};

--- a/packages/fake-data/src/fakeWorkStreams.ts
+++ b/packages/fake-data/src/fakeWorkStreams.ts
@@ -1,4 +1,3 @@
-
 import { faker } from "@faker-js/faker/locale/en";
 
 import { WorkStream } from "@gc-digital-talent/graphql";

--- a/packages/fake-data/src/index.ts
+++ b/packages/fake-data/src/index.ts
@@ -16,6 +16,7 @@ import fakeSkills, { getStaticSkills } from "./fakeSkills";
 import fakeTeams from "./fakeTeams";
 import fakeUsers, { fakeApplicants, fakeUser } from "./fakeUsers";
 import fakeUserSkills from "./fakeUserSkills";
+import fakeWorkStreams from "./fakeWorkStreams";
 
 // Faker Generated Data
 export {
@@ -38,6 +39,7 @@ export {
   fakeUsers,
   fakeUser,
   fakeUserSkills,
+  fakeWorkStreams,
   fakeLocalizedEnum,
   toLocalizedEnum,
 };


### PR DESCRIPTION
🤖 Related to #7574 

## 👋 Introduction

This is replacing the deprecated `PoolStream` enum with the new `WorkStream` model.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

<!--
1. ...
2. ...
 -->

## 🚚 Deployment

Run the command `php artisan app:migrate-pool-stream`
