### PR TITLE
[Bug] Remove defaulting to personal for experience type select

### DIFF
--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -239,7 +239,7 @@ export const ExperienceForm = ({
   const defaultValues =
     experienceId && experience && experienceType
       ? queryResultToDefaultValues(experienceType, experience)
-      : {};
+      : { experienceType };
 
   const methods = useForm<FormValues>({
     shouldFocusError: false,

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -213,7 +213,7 @@ export interface ExperienceFormProps {
   edit?: boolean;
   experienceQuery?: FragmentType<typeof ExperienceFormExperience_Fragment>;
   experienceId?: string;
-  experienceType: ExperienceType;
+  experienceType?: ExperienceType;
   skillsQuery: FragmentType<typeof ExperienceFormSkill_Fragment>[];
   userId: string;
 }
@@ -237,9 +237,9 @@ export const ExperienceForm = ({
   const skills = getFragment(ExperienceFormSkill_Fragment, skillsQuery);
 
   const defaultValues =
-    experienceId && experience
+    experienceId && experience && experienceType
       ? queryResultToDefaultValues(experienceType, experience)
-      : { experienceType };
+      : {};
 
   const methods = useForm<FormValues>({
     shouldFocusError: false,
@@ -675,7 +675,7 @@ const ExperienceFormContainer = ({ edit }: ExperienceFormContainerProps) => {
           edit={edit}
           experienceQuery={experience}
           experienceId={experienceId}
-          experienceType={experienceType ?? "personal"}
+          experienceType={experienceType}
           skillsQuery={skills}
           userId={userAuthInfo?.id ?? ""}
         />


### PR DESCRIPTION
🤖 Resolves #12146 

## 👋 Introduction

Get rid of the fallback to personal, allowing the null state to happen again


## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->


1. Navigate to `/en/applicant/career-timeline`
2. Test creating experiences has a null select
3. Test editing experiences unchanged

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

![image](https://github.com/user-attachments/assets/a40ade8e-e988-4a32-b04b-c9712c12e6ed)
