### PR TITLE
[Feature] Utility function to detect the VPN

### DIFF
--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -139,6 +139,13 @@ server {
         fastcgi_index index.php;
     }
 
+    # Simulate being off the VPN and the firewall redirecting to the restricted page.
+    # Don't forget to also comment out the location rule for /admin/graphql
+    # location ~* /admin(/|$) {
+    #     absolute_redirect on;
+    #     return 301 http://localhost:8000/restricted.html;
+    # }
+
     # api
     location = /graphql {
         access_log off;
@@ -153,12 +160,6 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root/api/public/index.php;
     }
-
-    # simulate being off the VPN and the firewall redirecting to the restricted page
-    # location = /admin {
-    #     absolute_redirect on;
-    #     return 301 http://localhost:8000/restricted.html;
-    # }
 
     # graphql online web interface
     location = /graphiql {

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -153,6 +153,13 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root/api/public/index.php;
     }
+
+    # simulate being off the VPN and the firewall redirecting to the restricted page
+    # location = /admin/graphql {
+    #     absolute_redirect on;
+    #     return 301 http://localhost:8000/restricted.html;
+    # }
+
     # graphql online web interface
     location = /graphiql {
         fastcgi_pass 127.0.0.1:9000;

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -155,7 +155,7 @@ server {
     }
 
     # simulate being off the VPN and the firewall redirecting to the restricted page
-    # location = /admin/graphql {
+    # location = /admin {
     #     absolute_redirect on;
     #     return 301 http://localhost:8000/restricted.html;
     # }

--- a/packages/client/src/exchanges/specialErrorExchange.ts
+++ b/packages/client/src/exchanges/specialErrorExchange.ts
@@ -18,11 +18,16 @@ const specialErrorExchange = ({ intl }: { intl: IntlShape }) => {
         tap((result) => {
           const err = result.error;
           if (err) {
-            const res = err.response as Response;
+            const errRes = err.response as Response;
+            // I think this is old error condition from when the firewall responded directly when blocking
             if (
-              res?.status === 403 &&
+              errRes?.status === 403 &&
               err?.networkError?.message?.includes("Request Rejected")
             ) {
+              toast.error(intl.formatMessage(errorMessages.requestRejected));
+            }
+            // This is the new error condition from when the firewall responds a redirect to restricted.html
+            if (errRes?.url?.endsWith("/restricted.html")) {
               toast.error(intl.formatMessage(errorMessages.requestRejected));
             }
           }

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -1,5 +1,6 @@
 import ClientProvider from "./components/ClientProvider/ClientProvider";
 import { isUuidError } from "./utils/errors";
+import canAccessProtectedEndpoint from "./utils/canAccessProtectedEndpoint";
 
 export default ClientProvider;
-export { isUuidError };
+export { isUuidError, canAccessProtectedEndpoint };

--- a/packages/client/src/utils/canAccessProtectedEndpoint.ts
+++ b/packages/client/src/utils/canAccessProtectedEndpoint.ts
@@ -1,0 +1,21 @@
+import { apiHost, protectedUrl } from "../constants";
+
+async function canAccessProtectedEndpoint(): Promise<boolean> {
+  const response = await fetch(`${apiHost}${protectedUrl}`, {
+    method: "POST",
+    body: `{ "query": "{ __typename }" }`,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  // The firewall will redirect to a restricted page if the user is not allowed to access the endpoint
+  if (response.redirected && response.url.endsWith("/restricted.html")) {
+    return false;
+  }
+
+  // otherwise check if we got an OK
+  return response.ok;
+}
+
+export default canAccessProtectedEndpoint;


### PR DESCRIPTION
🤖 Resolves #12071 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Adds a utility function to detect if the protected endpoint is reachable (and therefore, on the VPN).  As a bonus, I also updated the special error exchange to better detect being off the VPN.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->
Unfortunately, we don't have a way to test for the VPN locally, or even on UAT.  I added an Nginx rule (commented out by default) to simulate it.  I hope it's an accurate simulation.  :crossed_fingers: 

## 🧪 Testing

1. Since the AC doesn't specify that this function should be used anywhere, plop this testing code with a button on a page somehwere:
```tsx
async function handleClick() {
  const result = await canAccessProtectedEndpoint();
  console.log(result);
}
```
2. Rebuild and test that your button returns `true`.
3. Enable the firewall simulator and test that the button returns `false`.
   1. Open `infrastructure/conf/nginx-conf-local/default`
   2. Comment out the block labelled "privileged access to the API behind the VPN"
   3. Uncomment the block labelled "simulate being off the VPN"
   4. Restart the webserver container
4. With the firewall simulator still enabled, visit the admin site and observe the "request wasn't completed" error toasts.
## 📸 Screenshot

![image](https://github.com/user-attachments/assets/1d5ee829-130c-4694-8d04-025f0c97c1e1)
