### PR TITLE
[Fix] Stabilizes `ThemeSwitcher` story for Chromatic

### DIFF
--- a/apps/web/src/components/ThemeSwitcher/ThemeSwitcher.stories.tsx
+++ b/apps/web/src/components/ThemeSwitcher/ThemeSwitcher.stories.tsx
@@ -1,14 +1,15 @@
-import { Meta, StoryFn } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 
 import { OverlayOrDialogDecorator } from "@gc-digital-talent/storybook-helpers";
 
 import ThemeSwitcher from "./ThemeSwitcher";
 
-export default {
+const meta = {
   component: ThemeSwitcher,
   decorators: [OverlayOrDialogDecorator],
-} as Meta;
+} satisfies Meta<typeof ThemeSwitcher>;
+export default meta;
 
-const Template: StoryFn<typeof ThemeSwitcher> = () => <ThemeSwitcher />;
+type Story = StoryObj<typeof ThemeSwitcher>;
 
-export const Default = Template.bind({});
+export const Default: Story = {};

--- a/apps/web/src/components/ThemeSwitcher/ThemeSwitcher.stories.tsx
+++ b/apps/web/src/components/ThemeSwitcher/ThemeSwitcher.stories.tsx
@@ -1,12 +1,23 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { OverlayOrDialogDecorator } from "@gc-digital-talent/storybook-helpers";
+import {
+  allModes,
+  OverlayOrDialogDecorator,
+} from "@gc-digital-talent/storybook-helpers";
 
 import ThemeSwitcher from "./ThemeSwitcher";
 
 const meta = {
   component: ThemeSwitcher,
   decorators: [OverlayOrDialogDecorator],
+  parameters: {
+    chromatic: {
+      modes: {
+        light: allModes.light,
+        dark: allModes.dark,
+      },
+    },
+  },
 } satisfies Meta<typeof ThemeSwitcher>;
 export default meta;
 


### PR DESCRIPTION
🤖 Resolves #11162.

## 👋 Introduction

This PR (🤞) fixes unstable storybook snapshots for the `ThemeSwitcher` component in Chromatic.

## 🧪 Testing

1. Open Chromatic build for this PR
3. Verify `ThemeSwitcher` story has snapshots for all the modes listed (light, dark)