### PR TITLE
[Debt] Wraps GC Notify API request in conditionals

### DIFF
--- a/api/app/Notifications/GcNotifyEmailChannel.php
+++ b/api/app/Notifications/GcNotifyEmailChannel.php
@@ -3,6 +3,7 @@
 namespace App\Notifications;
 
 use App\Jobs\GcNotifyApiRequest;
+use Illuminate\Support\Facades\Log;
 
 class GcNotifyEmailChannel
 {
@@ -12,7 +13,16 @@ class GcNotifyEmailChannel
     public function send(object $notifiable, CanBeSentViaGcNotifyEmail $notification): void
     {
         $message = $notification->toGcNotifyEmail($notifiable);
-
-        GcNotifyApiRequest::dispatch($message);
+        if (! config('notify.client.apiKey')) {
+            $errorMessage = 'GC Notify API key is missing.';
+            Log::error($errorMessage);
+            throw new \Exception($errorMessage);
+        } elseif (! $message->templateId) {
+            $errorMessage = 'GC Notify Template ID is missing.';
+            Log::error($errorMessage);
+            throw new \Exception($errorMessage);
+        } else {
+            GcNotifyApiRequest::dispatch($message);
+        }
     }
 }


### PR DESCRIPTION
🤖 Resolves #11654.

## 👋 Introduction

This PR wraps GC Notify API request in conditionals to avoid making unnescary API rquests if there is no API key or template id.

## 🧪 Testing

1. `make queue-work`
2. In a separate terminal instance from `make queue-work`, `make artisan CMD="send-notifications:system notification_test --channelEmail"`
3. Verify all emails fail in terminal and are logged in `api/storage/logs/laravel.log`

## 📸 Screenshot
<img width="1217" alt="Screen Shot 2024-12-10 at 10 54 27" src="https://github.com/user-attachments/assets/91351550-c23b-4ccd-b659-0fd85728ef38">

