### PR TITLE
Add php-cli to linux instructions

### DIFF
--- a/documentation/linux-setup.md
+++ b/documentation/linux-setup.md
@@ -114,7 +114,7 @@ We use [PHP](https://www.php.net/) version 8.3 to run the backend app. Ubuntu 22
 
 ```
 LC_ALL=C.UTF-8 sudo add-apt-repository ppa:ondrej/php
-sudo apt-get install php8.3 php8.3-mbstring php8.3-xml php8.3-pgsql php8.3-zip php8.3-curl php8.3-bcmath php8.3-gd php8.3-dom php8.3-intl
+sudo apt-get install php8.3 php8.3-cli php8.3-mbstring php8.3-xml php8.3-pgsql php8.3-zip php8.3-curl php8.3-bcmath php8.3-gd php8.3-dom php8.3-intl
 ```
 
 Double check:


### PR DESCRIPTION
🤖 Resolves <!-- issue # -->

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Adds a missing dependency for running PHP locally.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. `php -v` runs  and shows 8.3 locally

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

## 🚚 Deployment

<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the linked issue if deployment steps are needed

 -->
