### PR TITLE
[Copy] French Label for the French - Your Impact textarea in the edit pool page

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8519,7 +8519,7 @@
     "description": "Message when a claim does not apply to the specific process"
   },
   "fPy7Mg": {
-    "defaultMessage": "Le français - Votre impact",
+    "defaultMessage": "Français - Votre impact",
     "description": "Label for the French - Your Impact textarea in the edit pool page."
   },
   "fQ7zxR": {


### PR DESCRIPTION
🤖 Resolves #12280.

## 👋 Introduction

This PR fixes the French **Label for the French - Your Impact textarea in the edit pool page** to be consistent with other similar labels.

## 🧪 Testing

1. Create a process
2. Switch to French
3. Verify label exists with **Français - Votre impact**

## 📸 Screenshot

<img width="1155" alt="Screen Shot 2024-12-12 at 11 46 14" src="https://github.com/user-attachments/assets/a4ab3ea4-0ec8-4146-899f-cac95f8d6271" />
