### PR TITLE
[Bug] Profile doc handling null employment category

### DIFF
--- a/api/app/Traits/Generator/GeneratesUserDoc.php
+++ b/api/app/Traits/Generator/GeneratesUserDoc.php
@@ -337,8 +337,7 @@ trait GeneratesUserDoc
                     $this->localize('experiences.seniority_role'),
                     $this->localizeEnum($experience->ext_role_seniority, ExternalRoleSeniority::class)
                 );
-            }
-            if ($experience->employment_category === EmploymentCategory::CANADIAN_ARMED_FORCES->name) {
+            } elseif ($experience->employment_category === EmploymentCategory::CANADIAN_ARMED_FORCES->name) {
                 $section->addTitle(
                     sprintf(
                         '%s %s %s',
@@ -361,8 +360,7 @@ trait GeneratesUserDoc
                     $this->localize('experiences.rank_category'),
                     $this->localizeEnum($experience->caf_rank, CafRank::class)
                 );
-            }
-            if ($experience->employment_category === EmploymentCategory::GOVERNMENT_OF_CANADA->name) {
+            } elseif ($experience->employment_category === EmploymentCategory::GOVERNMENT_OF_CANADA->name) {
                 /** @var Department | null $department */
                 $department = Department::find($experience->department_id);
                 $section->addTitle(
@@ -424,6 +422,11 @@ trait GeneratesUserDoc
                         $classification ? $classification->group.'-'.$classification->level : Lang::get('common.not_found', [], $this->lang),
                     );
                 }
+            } else {
+                // null case, so experiences prior to adding employment_category
+                $section->addTitle($experience->getTitle($this->lang), $headingRank);
+                $section->addText($experience->getDateRange($this->lang));
+                $this->addLabelText($section, $this->localize('experiences.team_group_division'), $experience->division);
             }
         }
 


### PR DESCRIPTION
🤖 Resolves #12250

## 👋 Introduction

Employment category will be non-null going forward, but so far all experiences will have it as null, the document needs to handle that case. 
Not sure what the bit about skills is referencing 
<!-- Describe what this PR is solving. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Have a user with work experiences missing the new fields
2. Test downloads


## 📸 Screenshot

![image](https://github.com/user-attachments/assets/0d604665-6dcd-4002-85df-2bbf038f33e4)

<!-- Add a screenshot (if possible). -->


