### PR TITLE
[Feat] Return locale aware string from `LocalizedString`

### DIFF
--- a/api/app/Casts/LocalizedString.php
+++ b/api/app/Casts/LocalizedString.php
@@ -20,10 +20,11 @@ class LocalizedString implements CastsAttributes
         }
 
         $decodedValue = is_array($value) ? $value : json_decode($value, true);
+        $locale = App::getLocale() ?? 'en';
 
         return [
             ...$decodedValue,
-            'localized' => $decodedValue[App::getLocale()] ?? null,
+            'localized' => $decodedValue[$locale] ?? null,
         ];
     }
 

--- a/api/app/Casts/LocalizedString.php
+++ b/api/app/Casts/LocalizedString.php
@@ -15,11 +15,11 @@ class LocalizedString implements CastsAttributes
      */
     public function get(Model $model, string $key, mixed $value, array $attributes): mixed
     {
-        if (is_null($value) || $value === '') {
+        if (is_null($value) || $value === '' || $value === 'null') {
             return null;
         }
 
-        $decodedValue = json_decode($value, true);
+        $decodedValue = is_array($value) ? $value : json_decode($value, true);
 
         return [
             ...$decodedValue,

--- a/api/app/Casts/LocalizedString.php
+++ b/api/app/Casts/LocalizedString.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\App;
+
+class LocalizedString implements CastsAttributes
+{
+    /**
+     * Cast the given value.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function get(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        if (is_null($value) || $value === '') {
+            return null;
+        }
+
+        $decodedValue = json_decode($value, true);
+
+        return [
+            ...$decodedValue,
+            'localized' => $decodedValue[App::getLocale()] ?? null,
+        ];
+    }
+
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function set(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        return json_encode($value);
+    }
+}

--- a/api/app/Models/AssessmentStep.php
+++ b/api/app/Models/AssessmentStep.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Casts\LocalizedString;
 use App\Enums\AssessmentStepType;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -33,7 +34,7 @@ class AssessmentStep extends Model
      * The attributes that should be cast.
      */
     protected $casts = [
-        'title' => 'array',
+        'title' => LocalizedString::class,
     ];
 
     /**

--- a/api/app/Models/Classification.php
+++ b/api/app/Models/Classification.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Casts\LocalizedString;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -35,7 +36,7 @@ class Classification extends Model
      * The attributes that should be cast.
      */
     protected $casts = [
-        'name' => 'array',
+        'name' => LocalizedString::class,
     ];
 
     /** @return HasMany<GenericJobTitle, $this> */

--- a/api/app/Models/Community.php
+++ b/api/app/Models/Community.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Casts\LocalizedString;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -26,9 +27,9 @@ class Community extends Model
     protected $keyType = 'string';
 
     protected $casts = [
-        'name' => 'array',
-        'description' => 'array',
-        'mandate_authority' => 'array',
+        'name' => LocalizedString::class,
+        'description' => LocalizedString::class,
+        'mandate_authority' => LocalizedString::class,
     ];
 
     protected $fillable = [

--- a/api/app/Models/Department.php
+++ b/api/app/Models/Department.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Casts\LocalizedString;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -32,7 +33,7 @@ class Department extends Model
      * The attributes that should be case.
      */
     protected $casts = [
-        'name' => 'array',
+        'name' => LocalizedString::class,
     ];
 
     /** @return HasMany<PoolCandidateSearchRequest, $this> */

--- a/api/app/Models/GeneralQuestion.php
+++ b/api/app/Models/GeneralQuestion.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Casts\LocalizedString;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -30,7 +31,7 @@ class GeneralQuestion extends Model
      * The attributes that should be cast.
      */
     protected $casts = [
-        'question' => 'array',
+        'question' => LocalizedString::class,
     ];
 
     /**

--- a/api/app/Models/GenericJobTitle.php
+++ b/api/app/Models/GenericJobTitle.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Casts\LocalizedString;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -28,7 +29,7 @@ class GenericJobTitle extends Model
      * The attributes that should be cast.
      */
     protected $casts = [
-        'name' => 'array',
+        'name' => LocalizedString::class,
 
     ];
 

--- a/api/app/Models/JobPosterTemplate.php
+++ b/api/app/Models/JobPosterTemplate.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Casts\LocalizedString;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -36,14 +37,14 @@ class JobPosterTemplate extends Model
      * The attributes that should be cast.
      */
     protected $casts = [
-        'name' => 'array',
-        'description' => 'array',
-        'work_description' => 'array',
-        'tasks' => 'array',
-        'keywords' => 'array',
-        'essential_technical_skills_notes' => 'array',
-        'essential_behavioural_skills_notes' => 'array',
-        'nonessential_technical_skills_notes' => 'array',
+        'name' => LocalizedString::class,
+        'description' => LocalizedString::class,
+        'work_description' => LocalizedString::class,
+        'tasks' => LocalizedString::class,
+        'keywords' => LocalizedString::class,
+        'essential_technical_skills_notes' => LocalizedString::class,
+        'essential_behavioural_skills_notes' => LocalizedString::class,
+        'nonessential_technical_skills_notes' => LocalizedString::class,
     ];
 
     /**

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Builders\PoolBuilder;
+use App\Casts\LocalizedString;
 use App\Enums\AssessmentStepType;
 use App\Enums\PoolSkillType;
 use App\Enums\PoolStatus;
@@ -70,15 +71,15 @@ class Pool extends Model
      * The attributes that should be cast.
      */
     protected $casts = [
-        'name' => 'array',
+        'name' => LocalizedString::class,
         'operational_requirements' => 'array',
-        'key_tasks' => 'array',
-        'advertisement_location' => 'array',
-        'your_impact' => 'array',
-        'what_to_expect' => 'array',
-        'special_note' => 'array',
-        'what_to_expect_admission' => 'array',
-        'about_us' => 'array',
+        'key_tasks' => LocalizedString::class,
+        'advertisement_location' => LocalizedString::class,
+        'your_impact' => LocalizedString::class,
+        'what_to_expect' => LocalizedString::class,
+        'special_note' => LocalizedString::class,
+        'what_to_expect_admission' => LocalizedString::class,
+        'about_us' => LocalizedString::class,
         'closing_date' => 'datetime',
         'published_at' => 'datetime',
         'is_remote' => 'boolean',

--- a/api/app/Models/Role.php
+++ b/api/app/Models/Role.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Casts\LocalizedString;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Laratrust\Models\Role as LaratrustRole;
@@ -24,8 +25,8 @@ class Role extends LaratrustRole
     protected $keyType = 'string';
 
     protected $casts = [
-        'display_name' => 'array',
-        'description' => 'array',
+        'display_name' => LocalizedString::class,
+        'description' => LocalizedString::class,
     ];
 
     protected $fillable = [

--- a/api/app/Models/ScreeningQuestion.php
+++ b/api/app/Models/ScreeningQuestion.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Casts\LocalizedString;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -31,7 +32,7 @@ class ScreeningQuestion extends Model
      * The attributes that should be cast.
      */
     protected $casts = [
-        'question' => 'array',
+        'question' => LocalizedString::class,
     ];
 
     /**

--- a/api/app/Models/Skill.php
+++ b/api/app/Models/Skill.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Casts\LocalizedString;
 use App\Enums\PoolSkillType;
 use App\Enums\SkillCategory;
 use Illuminate\Database\Eloquent\Builder;
@@ -36,8 +37,8 @@ class Skill extends Model
      * The attributes that should be cast.
      */
     protected $casts = [
-        'name' => 'array',
-        'description' => 'array',
+        'name' => LocalizedString::class,
+        'description' => LocalizedString::class,
         'keywords' => 'array',
     ];
 

--- a/api/app/Models/SkillFamily.php
+++ b/api/app/Models/SkillFamily.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Casts\LocalizedString;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -28,8 +29,8 @@ class SkillFamily extends Model
      * The attributes that should be cast.
      */
     protected $casts = [
-        'name' => 'array',
-        'description' => 'array',
+        'name' => LocalizedString::class,
+        'description' => LocalizedString::class,
     ];
 
     /** @return BelongsToMany<Skill, $this> */

--- a/api/app/Models/Team.php
+++ b/api/app/Models/Team.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Casts\LocalizedString;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -27,8 +28,8 @@ class Team extends LaratrustTeam
     protected $keyType = 'string';
 
     protected $casts = [
-        'display_name' => 'array',
-        'description' => 'array',
+        'display_name' => LocalizedString::class,
+        'description' => LocalizedString::class,
     ];
 
     protected $fillable = [

--- a/api/app/Models/TrainingOpportunity.php
+++ b/api/app/Models/TrainingOpportunity.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Casts\LocalizedString;
 use App\Enums\CourseLanguage;
 use App\Enums\DeadlineStatus;
 use Illuminate\Database\Eloquent\Builder;
@@ -34,12 +35,12 @@ class TrainingOpportunity extends Model
      * The attributes that should be cast.
      */
     protected $casts = [
-        'title' => 'array',
+        'title' => LocalizedString::class,
         'registration_deadline' => 'date',
         'training_start' => 'date',
         'training_end' => 'date',
-        'description' => 'array',
-        'application_url' => 'array',
+        'description' => LocalizedString::class,
+        'application_url' => LocalizedString::class,
     ];
 
     /**

--- a/api/app/Models/WorkStream.php
+++ b/api/app/Models/WorkStream.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Casts\LocalizedString;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -24,8 +25,8 @@ class WorkStream extends Model
     protected $keyType = 'string';
 
     protected $casts = [
-        'name' => 'array',
-        'plain_language_name' => 'array',
+        'name' => LocalizedString::class,
+        'plain_language_name' => LocalizedString::class,
     ];
 
     protected $fillable = [

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -23,6 +23,7 @@ scalar UUID @scalar(class: "UUID")
 type LocalizedString {
   en: String
   fr: String
+  localized: String
 }
 
 type LocalizedEnumString {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -540,6 +540,7 @@ scalar UUID
 type LocalizedString {
   en: String
   fr: String
+  localized: String
 }
 
 type LocalizedEnumString {

--- a/api/tests/Feature/ApplicantFilterTest.php
+++ b/api/tests/Feature/ApplicantFilterTest.php
@@ -131,7 +131,7 @@ class ApplicantFilterTest extends TestCase
      *
      * @return void
      */
-    public function testQueryApplicantFilter()
+    public function test_query_applicant_filter()
     {
         $filter = ApplicantFilter::factory()->create();
         $request = PoolCandidateSearchRequest::factory()->create([
@@ -212,7 +212,7 @@ class ApplicantFilterTest extends TestCase
     /**
      * Test that factory creates relationships correctly.
      */
-    public function testFactoryRelationships()
+    public function test_factory_relationships()
     {
 
         // Before we add relationships, we need to seed the related values
@@ -245,7 +245,7 @@ class ApplicantFilterTest extends TestCase
     /**
      * Test that queried ApplicantFilter has the correct relationships.
      */
-    public function testQueryRelationships()
+    public function test_query_relationships()
     {
         // Before we add relationships, we need to seed the related values
         $this->seed([
@@ -273,6 +273,7 @@ class ApplicantFilterTest extends TestCase
                             name {
                                 en
                                 fr
+                                localized
                             }
                         }
                         pools {
@@ -280,6 +281,7 @@ class ApplicantFilterTest extends TestCase
                             name {
                                 en
                                 fr
+                                localized
                             }
                         }
                         qualifiedStreams { value }
@@ -288,6 +290,7 @@ class ApplicantFilterTest extends TestCase
                             name {
                                 en
                                 fr
+                                localized
                             }
                         }
                         community {
@@ -331,7 +334,7 @@ class ApplicantFilterTest extends TestCase
     /**
      * Test that a PoolCandidateSearchRequest can be created, containing an ApplicantFilter
      */
-    public function testCanCreateARequest()
+    public function test_can_create_a_request()
     {
         // Seed everything required
         $this->seed(CommunitySeeder::class);
@@ -412,7 +415,7 @@ class ApplicantFilterTest extends TestCase
     /**
      * Test that we can use an ApplicantFilter in a search, save it as part of a PoolCandidateSearchRequest, retrieve it, and get the same results again.
      */
-    public function testFilterCanBeStoredAndRetrievedWithoutChangingResults()
+    public function test_filter_can_be_stored_and_retrieved_without_changing_results()
     {
         // Seed everything used in generating Users
         $this->seed([

--- a/api/tests/Feature/ApplicantFilterTest.php
+++ b/api/tests/Feature/ApplicantFilterTest.php
@@ -131,7 +131,7 @@ class ApplicantFilterTest extends TestCase
      *
      * @return void
      */
-    public function test_query_applicant_filter()
+    public function testQueryApplicantFilter()
     {
         $filter = ApplicantFilter::factory()->create();
         $request = PoolCandidateSearchRequest::factory()->create([
@@ -212,7 +212,7 @@ class ApplicantFilterTest extends TestCase
     /**
      * Test that factory creates relationships correctly.
      */
-    public function test_factory_relationships()
+    public function testFactoryRelationships()
     {
 
         // Before we add relationships, we need to seed the related values
@@ -245,7 +245,7 @@ class ApplicantFilterTest extends TestCase
     /**
      * Test that queried ApplicantFilter has the correct relationships.
      */
-    public function test_query_relationships()
+    public function testQueryRelationships()
     {
         // Before we add relationships, we need to seed the related values
         $this->seed([
@@ -334,7 +334,7 @@ class ApplicantFilterTest extends TestCase
     /**
      * Test that a PoolCandidateSearchRequest can be created, containing an ApplicantFilter
      */
-    public function test_can_create_a_request()
+    public function testCanCreateARequest()
     {
         // Seed everything required
         $this->seed(CommunitySeeder::class);
@@ -415,7 +415,7 @@ class ApplicantFilterTest extends TestCase
     /**
      * Test that we can use an ApplicantFilter in a search, save it as part of a PoolCandidateSearchRequest, retrieve it, and get the same results again.
      */
-    public function test_filter_can_be_stored_and_retrieved_without_changing_results()
+    public function testFilterCanBeStoredAndRetrievedWithoutChangingResults()
     {
         // Seed everything used in generating Users
         $this->seed([

--- a/api/tests/Feature/CommunityTest.php
+++ b/api/tests/Feature/CommunityTest.php
@@ -84,7 +84,7 @@ class CommunityTest extends TestCase
             ]);
     }
 
-    public function test_all_communities_query(): void
+    public function testAllCommunitiesQuery(): void
     {
         // Assert all communities query contains expected results.
         $query = $this->actingAs($this->admin, 'api')
@@ -111,7 +111,7 @@ class CommunityTest extends TestCase
         $query->assertJsonFragment(['id' => $this->community3->id]);
     }
 
-    public function test_community_create_mutation(): void
+    public function testCommunityCreateMutation(): void
     {
 
         // Assert null key causes failure.
@@ -206,7 +206,7 @@ class CommunityTest extends TestCase
         );
     }
 
-    public function test_community_update_mutation(): void
+    public function testCommunityUpdateMutation(): void
     {
         // Assert community update successful across all input fields.
         $this->actingAs($this->admin, 'api')->graphQL(
@@ -257,7 +257,7 @@ class CommunityTest extends TestCase
         ]);
     }
 
-    public function test_view_community_members(): void
+    public function testViewCommunityMembers(): void
     {
         $this->community1->addCommunityRecruiters([$this->communityRecruiter1->id, $this->communityRecruiter2->id]);
         $this->community2->addCommunityRecruiters([$this->communityRecruiter3->id]);

--- a/api/tests/Feature/CommunityTest.php
+++ b/api/tests/Feature/CommunityTest.php
@@ -47,11 +47,10 @@ class CommunityTest extends TestCase
 
         // Create communities.
         $this->toBeDeletedUUID = $this->faker->UUID();
-        $this->community1 = Community::factory()->create(['name' => 'community1']);
-        $this->community2 = Community::factory()->create(['name' => 'community2']);
+        $this->community1 = Community::factory()->create();
+        $this->community2 = Community::factory()->create();
         $this->community3 = Community::factory()->create([
             'id' => $this->toBeDeletedUUID, // need specific ID for delete community testing.
-            'name' => 'community3',
         ]);
 
         // Create users.
@@ -85,7 +84,7 @@ class CommunityTest extends TestCase
             ]);
     }
 
-    public function testAllCommunitiesQuery(): void
+    public function test_all_communities_query(): void
     {
         // Assert all communities query contains expected results.
         $query = $this->actingAs($this->admin, 'api')
@@ -112,7 +111,7 @@ class CommunityTest extends TestCase
         $query->assertJsonFragment(['id' => $this->community3->id]);
     }
 
-    public function testCommunityCreateMutation(): void
+    public function test_community_create_mutation(): void
     {
 
         // Assert null key causes failure.
@@ -207,7 +206,7 @@ class CommunityTest extends TestCase
         );
     }
 
-    public function testCommunityUpdateMutation(): void
+    public function test_community_update_mutation(): void
     {
         // Assert community update successful across all input fields.
         $this->actingAs($this->admin, 'api')->graphQL(
@@ -258,7 +257,7 @@ class CommunityTest extends TestCase
         ]);
     }
 
-    public function testViewCommunityMembers(): void
+    public function test_view_community_members(): void
     {
         $this->community1->addCommunityRecruiters([$this->communityRecruiter1->id, $this->communityRecruiter2->id]);
         $this->community2->addCommunityRecruiters([$this->communityRecruiter3->id]);

--- a/api/tests/Feature/JobPosterTemplateTest.php
+++ b/api/tests/Feature/JobPosterTemplateTest.php
@@ -98,7 +98,7 @@ class JobPosterTemplateTest extends TestCase
             ->create();
     }
 
-    public function test_anonymous_users_can_view_any()
+    public function testAnonymousUsersCanViewAny()
     {
         $this->graphQL($this->queryOne, [
             'id' => $this->template->id,
@@ -121,21 +121,21 @@ class JobPosterTemplateTest extends TestCase
             ]);
     }
 
-    public function test_anonymous_user_cannot_create()
+    public function testAnonymousUserCannotCreate()
     {
         $this->graphQL($this->create, [
             'template' => $this->getCreateInput(),
         ])->assertGraphQLErrorMessage('Unauthenticated.');
     }
 
-    public function test_non_admin_user_cannot_create()
+    public function testNonAdminUserCannotCreate()
     {
         $this->actingAs($this->baseUser, 'api')->graphQL($this->create, [
             'template' => $this->getCreateInput(),
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function test_admin_can_create()
+    public function testAdminCanCreate()
     {
         $res = $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
             'template' => $this->getCreateInput(),
@@ -144,7 +144,7 @@ class JobPosterTemplateTest extends TestCase
         $this->assertNotNull($res['data']['createJobPosterTemplate']);
     }
 
-    public function test_anonymous_user_cannot_update()
+    public function testAnonymousUserCannotUpdate()
     {
         $this->graphQL($this->update, [
             'template' => [
@@ -154,7 +154,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Unauthenticated.');
     }
 
-    public function test_non_admin_user_cannot_update()
+    public function testNonAdminUserCannotUpdate()
     {
         $this->actingAs($this->baseUser, 'api')->graphQL($this->update, [
             'template' => [
@@ -164,7 +164,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function test_admin_can_update()
+    public function testAdminCanUpdate()
     {
         $this->actingAs($this->adminUser, 'api')->graphQL($this->update, [
             'template' => [
@@ -181,7 +181,7 @@ class JobPosterTemplateTest extends TestCase
         ]);
     }
 
-    public function test_non_admin_user_cannot_delete()
+    public function testNonAdminUserCannotDelete()
     {
         $template = JobPosterTemplate::factory()->create();
 
@@ -190,7 +190,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function test_admin_can_delete()
+    public function testAdminCanDelete()
     {
         $template = JobPosterTemplate::factory()->create();
 
@@ -205,7 +205,7 @@ class JobPosterTemplateTest extends TestCase
         ]);
     }
 
-    public function test_reference_id_is_unique()
+    public function testReferenceIdIsUnique()
     {
         $input = $this->getCreateInput();
         $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -216,7 +216,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Validation failed for the field [createJobPosterTemplate].');
     }
 
-    public function test_cannot_add_essential_skill_with_no_level()
+    public function testCannotAddEssentialSkillWithNoLevel()
     {
         $input = $this->getCreateInput();
         $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -235,7 +235,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Validation failed for the field [createJobPosterTemplate].');
     }
 
-    public function test_can_add_essential_skill_with_level()
+    public function testCanAddEssentialSkillWithLevel()
     {
         $input = $this->getCreateInput();
         $res = $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -256,7 +256,7 @@ class JobPosterTemplateTest extends TestCase
         $this->assertNotNull($res['data']['createJobPosterTemplate']);
     }
 
-    public function test_cannot_add_asset_skill_with_level()
+    public function testCannotAddAssetSkillWithLevel()
     {
         $input = $this->getCreateInput();
         $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -275,7 +275,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Validation failed for the field [createJobPosterTemplate].');
     }
 
-    public function test_can_add_asset_skill_with_no_level()
+    public function testCanAddAssetSkillWithNoLevel()
     {
         $input = $this->getCreateInput();
         $res = $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [

--- a/api/tests/Feature/JobPosterTemplateTest.php
+++ b/api/tests/Feature/JobPosterTemplateTest.php
@@ -13,6 +13,7 @@ use Database\Seeders\SkillFamilySeeder;
 use Database\Seeders\SkillSeeder;
 use Database\Seeders\WorkStreamSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Arr;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
@@ -97,7 +98,7 @@ class JobPosterTemplateTest extends TestCase
             ->create();
     }
 
-    public function testAnonymousUsersCanViewAny()
+    public function test_anonymous_users_can_view_any()
     {
         $this->graphQL($this->queryOne, [
             'id' => $this->template->id,
@@ -120,21 +121,21 @@ class JobPosterTemplateTest extends TestCase
             ]);
     }
 
-    public function testAnonymousUserCannotCreate()
+    public function test_anonymous_user_cannot_create()
     {
         $this->graphQL($this->create, [
             'template' => $this->getCreateInput(),
         ])->assertGraphQLErrorMessage('Unauthenticated.');
     }
 
-    public function testNonAdminUserCannotCreate()
+    public function test_non_admin_user_cannot_create()
     {
         $this->actingAs($this->baseUser, 'api')->graphQL($this->create, [
             'template' => $this->getCreateInput(),
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function testAdminCanCreate()
+    public function test_admin_can_create()
     {
         $res = $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
             'template' => $this->getCreateInput(),
@@ -143,7 +144,7 @@ class JobPosterTemplateTest extends TestCase
         $this->assertNotNull($res['data']['createJobPosterTemplate']);
     }
 
-    public function testAnonymousUserCannotUpdate()
+    public function test_anonymous_user_cannot_update()
     {
         $this->graphQL($this->update, [
             'template' => [
@@ -153,7 +154,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Unauthenticated.');
     }
 
-    public function testNonAdminUserCannotUpdate()
+    public function test_non_admin_user_cannot_update()
     {
         $this->actingAs($this->baseUser, 'api')->graphQL($this->update, [
             'template' => [
@@ -163,7 +164,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function testAdminCanUpdate()
+    public function test_admin_can_update()
     {
         $this->actingAs($this->adminUser, 'api')->graphQL($this->update, [
             'template' => [
@@ -180,7 +181,7 @@ class JobPosterTemplateTest extends TestCase
         ]);
     }
 
-    public function testNonAdminUserCannotDelete()
+    public function test_non_admin_user_cannot_delete()
     {
         $template = JobPosterTemplate::factory()->create();
 
@@ -189,7 +190,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function testAdminCanDelete()
+    public function test_admin_can_delete()
     {
         $template = JobPosterTemplate::factory()->create();
 
@@ -204,7 +205,7 @@ class JobPosterTemplateTest extends TestCase
         ]);
     }
 
-    public function testReferenceIdIsUnique()
+    public function test_reference_id_is_unique()
     {
         $input = $this->getCreateInput();
         $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -215,7 +216,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Validation failed for the field [createJobPosterTemplate].');
     }
 
-    public function testCannotAddEssentialSkillWithNoLevel()
+    public function test_cannot_add_essential_skill_with_no_level()
     {
         $input = $this->getCreateInput();
         $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -234,7 +235,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Validation failed for the field [createJobPosterTemplate].');
     }
 
-    public function testCanAddEssentialSkillWithLevel()
+    public function test_can_add_essential_skill_with_level()
     {
         $input = $this->getCreateInput();
         $res = $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -255,7 +256,7 @@ class JobPosterTemplateTest extends TestCase
         $this->assertNotNull($res['data']['createJobPosterTemplate']);
     }
 
-    public function testCannotAddAssetSkillWithLevel()
+    public function test_cannot_add_asset_skill_with_level()
     {
         $input = $this->getCreateInput();
         $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -274,7 +275,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Validation failed for the field [createJobPosterTemplate].');
     }
 
-    public function testCanAddAssetSkillWithNoLevel()
+    public function test_can_add_asset_skill_with_no_level()
     {
         $input = $this->getCreateInput();
         $res = $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -301,16 +302,16 @@ class JobPosterTemplateTest extends TestCase
 
         return [
             'referenceId' => $template->reference_id,
-            'name' => $template->name,
-            'description' => $template->description,
+            'name' => Arr::only($template->name, ['en', 'fr']),
+            'description' => Arr::only($template->description, ['en', 'fr']),
             'supervisoryStatus' => $template->supervisory_status,
             'stream' => $template->stream,
-            'tasks' => $template->tasks,
-            'workDescription' => $template->work_description,
-            'keywords' => $template->keywords,
-            'essentialBehaviouralSkillsNotes' => $template->essential_behavioural_skills_notes,
-            'essentialTechnicalSkillsNotes' => $template->essential_technical_skills_notes,
-            'nonessentialTechnicalSkillsNotes' => $template->nonessential_technical_skills_notes,
+            'tasks' => Arr::only($template->tasks, ['en', 'fr']),
+            'workDescription' => Arr::only($template->work_description, ['en', 'fr']),
+            'keywords' => Arr::only($template->keywords, ['en', 'fr']),
+            'essentialBehaviouralSkillsNotes' => Arr::only($template->essential_behavioural_skills_notes, ['en', 'fr']),
+            'essentialTechnicalSkillsNotes' => Arr::only($template->essential_technical_skills_notes, ['en', 'fr']),
+            'nonessentialTechnicalSkillsNotes' => Arr::only($template->nonessential_technical_skills_notes, ['en', 'fr']),
             'classification' => [
                 'connect' => $template->classification->id,
             ],

--- a/api/tests/Feature/PoolCandidateTest.php
+++ b/api/tests/Feature/PoolCandidateTest.php
@@ -102,7 +102,7 @@ class PoolCandidateTest extends TestCase
             ]);
     }
 
-    public function test_pool_candidate_status_accessor(): void
+    public function testPoolCandidateStatusAccessor(): void
     {
         $query =
             /** @lang GraphQL */
@@ -248,7 +248,7 @@ class PoolCandidateTest extends TestCase
             ]);
     }
 
-    public function test_skill_count(): void
+    public function testSkillCount(): void
     {
         $query =
             /** @lang GraphQL */
@@ -422,7 +422,7 @@ class PoolCandidateTest extends TestCase
             ]);
     }
 
-    public function test_notes_access(): void
+    public function testNotesAccess(): void
     {
         $candidate = PoolCandidate::factory()->create([
             'pool_candidate_status' => PoolCandidateStatus::NEW_APPLICATION->name,
@@ -503,7 +503,7 @@ class PoolCandidateTest extends TestCase
             ->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function test_notes_update(): void
+    public function testNotesUpdate(): void
     {
         $candidate = PoolCandidate::factory()->create([
             'pool_candidate_status' => PoolCandidateStatus::NEW_APPLICATION->name,
@@ -546,7 +546,7 @@ class PoolCandidateTest extends TestCase
     /**
      * Status access permissions are similar to notes, except a candidate can see their own status
      */
-    public function test_status_access(): void
+    public function testStatusAccess(): void
     {
         $candidate = PoolCandidate::factory()->create([
             'pool_candidate_status' => PoolCandidateStatus::NEW_APPLICATION->name,
@@ -623,7 +623,7 @@ class PoolCandidateTest extends TestCase
             ->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function test_order_by_pool_name(): void
+    public function testOrderByPoolName(): void
     {
         $query =
             /** @lang GraphQL */
@@ -791,7 +791,7 @@ class PoolCandidateTest extends TestCase
 
     }
 
-    public function test_scope_candidates_in_community(): void
+    public function testScopeCandidatesInCommunity(): void
     {
         $query =
         /** @lang GraphQL */

--- a/api/tests/Feature/PoolCandidateTest.php
+++ b/api/tests/Feature/PoolCandidateTest.php
@@ -102,7 +102,7 @@ class PoolCandidateTest extends TestCase
             ]);
     }
 
-    public function testPoolCandidateStatusAccessor(): void
+    public function test_pool_candidate_status_accessor(): void
     {
         $query =
             /** @lang GraphQL */
@@ -248,7 +248,7 @@ class PoolCandidateTest extends TestCase
             ]);
     }
 
-    public function testSkillCount(): void
+    public function test_skill_count(): void
     {
         $query =
             /** @lang GraphQL */
@@ -422,7 +422,7 @@ class PoolCandidateTest extends TestCase
             ]);
     }
 
-    public function testNotesAccess(): void
+    public function test_notes_access(): void
     {
         $candidate = PoolCandidate::factory()->create([
             'pool_candidate_status' => PoolCandidateStatus::NEW_APPLICATION->name,
@@ -503,7 +503,7 @@ class PoolCandidateTest extends TestCase
             ->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function testNotesUpdate(): void
+    public function test_notes_update(): void
     {
         $candidate = PoolCandidate::factory()->create([
             'pool_candidate_status' => PoolCandidateStatus::NEW_APPLICATION->name,
@@ -546,7 +546,7 @@ class PoolCandidateTest extends TestCase
     /**
      * Status access permissions are similar to notes, except a candidate can see their own status
      */
-    public function testStatusAccess(): void
+    public function test_status_access(): void
     {
         $candidate = PoolCandidate::factory()->create([
             'pool_candidate_status' => PoolCandidateStatus::NEW_APPLICATION->name,
@@ -623,7 +623,7 @@ class PoolCandidateTest extends TestCase
             ->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function testOrderByPoolName(): void
+    public function test_order_by_pool_name(): void
     {
         $query =
             /** @lang GraphQL */
@@ -639,6 +639,7 @@ class PoolCandidateTest extends TestCase
                                 name {
                                     en
                                     fr
+                                    localized
                                 }
                             }
                         }
@@ -790,7 +791,7 @@ class PoolCandidateTest extends TestCase
 
     }
 
-    public function testScopeCandidatesInCommunity(): void
+    public function test_scope_candidates_in_community(): void
     {
         $query =
         /** @lang GraphQL */

--- a/api/tests/Feature/PoolTest.php
+++ b/api/tests/Feature/PoolTest.php
@@ -86,7 +86,7 @@ class PoolTest extends TestCase
         $this->baseUser = User::factory()->create();
     }
 
-    public function test_pool_accessor(): void
+    public function testPoolAccessor(): void
     {
         // Create new pools and attach to new pool candidates.
         $pool1 = Pool::factory()->create([
@@ -217,7 +217,7 @@ class PoolTest extends TestCase
         ]);
     }
 
-    public function test_pool_accessor_time(): void
+    public function testPoolAccessorTime(): void
     {
         // test that expiry on day of functions as expected, that soon to expire can be applied to and just expired is longer open for application
         $expireInHour = date('Y-m-d H:i:s', strtotime('+1 hour'));
@@ -276,7 +276,7 @@ class PoolTest extends TestCase
     }
 
     // The publishedPools query should only return pools that have been published, not draft
-    public function test_published_pool_query_does_not_return_draft(): void
+    public function testPublishedPoolQueryDoesNotReturnDraft(): void
     {
         // this pool has been published so it should be returned in the publishedPool query
         $publishedPool = Pool::factory()->create([
@@ -309,7 +309,7 @@ class PoolTest extends TestCase
     }
 
     // The publishedPools query should only return pools that have been published, not archived
-    public function test_published_pool_query_does_not_return_archived(): void
+    public function testPublishedPoolQueryDoesNotReturnArchived(): void
     {
         // this pool has been published so it should be returned in the publishedPool query
         $publishedPool = Pool::factory()->create([
@@ -339,7 +339,7 @@ class PoolTest extends TestCase
         ]);
     }
 
-    public function test_list_pools_does_not_return_draft_as_anon(): void
+    public function testListPoolsDoesNotReturnDraftAsAnon(): void
     {
         $publishedPool = Pool::factory()->create([
             'published_at' => config('constants.past_date'),
@@ -364,7 +364,7 @@ class PoolTest extends TestCase
             ->assertJsonFragment(['id' => $publishedPool->id]);
     }
 
-    public function test_list_pools_does_not_return_archived_as_anon(): void
+    public function testListPoolsDoesNotReturnArchivedAsAnon(): void
     {
         $publishedPool = Pool::factory()->create([
             'published_at' => config('constants.past_date'),
@@ -387,7 +387,7 @@ class PoolTest extends TestCase
             ->assertJsonFragment(['id' => $publishedPool->id]);
     }
 
-    public function test_list_pools_returns_only_published_as_base_role_user(): void
+    public function testListPoolsReturnsOnlyPublishedAsBaseRoleUser(): void
     {
         $publishedPool = Pool::factory()
             ->published()
@@ -412,7 +412,7 @@ class PoolTest extends TestCase
             ->assertJsonFragment(['id' => $publishedPool->id]);
     }
 
-    public function test_list_pools_returns_only_published_as_guest_role_user(): void
+    public function testListPoolsReturnsOnlyPublishedAsGuestRoleUser(): void
     {
         $publishedPool = Pool::factory()->create([
             'published_at' => config('constants.past_date'),
@@ -438,7 +438,7 @@ class PoolTest extends TestCase
     }
 
     // test filtering closing_date on publishedPools
-    public function test_pool_query_closing_date(): void
+    public function testPoolQueryClosingDate(): void
     {
         Pool::factory()->create([
             'published_at' => null,
@@ -487,7 +487,7 @@ class PoolTest extends TestCase
         assertSame(2, $response2Count);
     }
 
-    public function test_can_archive_closed(): void
+    public function testCanArchiveClosed(): void
     {
         $pool = Pool::factory()->closed()->create(['team_id' => $this->team->id]);
 
@@ -507,7 +507,7 @@ class PoolTest extends TestCase
             ->assertJsonFragment(['status' => ['value' => PoolStatus::ARCHIVED->name]]);
     }
 
-    public function test_cant_archive_active(): void
+    public function testCantArchiveActive(): void
     {
         $pool = Pool::factory()->published()->create(['team_id' => $this->team->id]);
 
@@ -527,7 +527,7 @@ class PoolTest extends TestCase
             ->assertGraphQLErrorMessage('ArchivePoolInvalidStatus');
     }
 
-    public function test_can_unarchive_archived(): void
+    public function testCanUnarchiveArchived(): void
     {
         $pool = Pool::factory()->archived()->create(['team_id' => $this->team->id]);
 
@@ -549,7 +549,7 @@ class PoolTest extends TestCase
             ]]);
     }
 
-    public function test_cant_unarchive_closed(): void
+    public function testCantUnarchiveClosed(): void
     {
         $pool = Pool::factory()->closed()->create(['team_id' => $this->team->id]);
 
@@ -569,7 +569,7 @@ class PoolTest extends TestCase
             ->assertGraphQLErrorMessage('UnarchivePoolInvalidStatus');
     }
 
-    public function test_cannot_publish_with_deleted_skill(): void
+    public function testCannotPublishWithDeletedSkill(): void
     {
         // create complete but unpublished pool with a deleted skill
         $pool = Pool::factory()
@@ -617,7 +617,7 @@ class PoolTest extends TestCase
             ->assertSuccessful();
     }
 
-    public function test_cannot_reopen_with_deleted_skill(): void
+    public function testCannotReopenWithDeletedSkill(): void
     {
         $pool = Pool::factory()->published()->closed()->create(['team_id' => $this->team->id]);
         $skill1 = Skill::factory()->create();
@@ -665,7 +665,7 @@ class PoolTest extends TestCase
             ->assertSuccessful();
     }
 
-    public function test_pool_scope_currently_active(): void
+    public function testPoolScopeCurrentlyActive(): void
     {
         Pool::factory()->create([
             'published_at' => null,
@@ -687,7 +687,7 @@ class PoolTest extends TestCase
         assertSame(count($activePools), 4); // assert 7 pools present but only 4 are considered "active"
     }
 
-    public function test_pool_is_complete_accessor(): void
+    public function testPoolIsCompleteAccessor(): void
     {
         $queryPool =
             /** @lang GraphQL */
@@ -741,7 +741,7 @@ class PoolTest extends TestCase
             ->assertJsonFragment(['isComplete' => false]);
     }
 
-    public function test_pool_is_complete_accessor_skill_level(): void
+    public function testPoolIsCompleteAccessorSkillLevel(): void
     {
         $queryPool =
             /** @lang GraphQL */
@@ -786,7 +786,7 @@ class PoolTest extends TestCase
             ->assertJsonFragment(['isComplete' => false]);
     }
 
-    public function test_assessment_step_validation(): void
+    public function testAssessmentStepValidation(): void
     {
         Classification::factory()->create();
         Skill::factory()->count(5)->create([
@@ -903,7 +903,7 @@ class PoolTest extends TestCase
             ->assertJsonFragment(['id' => $completePool->id]);
     }
 
-    public function test_pool_skill_validation(): void
+    public function testPoolSkillValidation(): void
     {
 
         Classification::factory()->create();
@@ -1054,7 +1054,7 @@ class PoolTest extends TestCase
     }
 
     // a pool operator can successfully delete a pool that they created but is still in draft
-    public function test_can_delete_draft_pool(): void
+    public function testCanDeleteDraftPool(): void
     {
         $pool = Pool::factory()
             ->for($this->poolOperator)
@@ -1081,7 +1081,7 @@ class PoolTest extends TestCase
     /**
      * @group paginated
      */
-    public function test_pool_name_scope(): void
+    public function testPoolNameScope(): void
     {
         $toBeFound = Pool::factory()->published()
             ->create([
@@ -1116,7 +1116,7 @@ class PoolTest extends TestCase
     /**
      * @group paginated
      */
-    public function test_pool_team_scope(): void
+    public function testPoolTeamScope(): void
     {
         $toBeFound = Pool::factory()->published()->create([
             'team_id' => $this->team,
@@ -1157,7 +1157,7 @@ class PoolTest extends TestCase
     /**
      * @group paginated
      */
-    public function test_pool_streams_scope(): void
+    public function testPoolStreamsScope(): void
     {
         $ATIP = Pool::factory()->published()->create([
             'stream' => PoolStream::ACCESS_INFORMATION_PRIVACY->name,
@@ -1214,7 +1214,7 @@ class PoolTest extends TestCase
     /**
      * @group paginated
      */
-    public function test_publishing_groups_scope(): void
+    public function testPublishingGroupsScope(): void
     {
         $IT = Pool::factory()->published()->create([
             'publishing_group' => PublishingGroup::IT_JOBS->name,
@@ -1271,7 +1271,7 @@ class PoolTest extends TestCase
     /**
      * @group paginated
      */
-    public function test_pool_status_scope(): void
+    public function testPoolStatusScope(): void
     {
         $closed = Pool::factory()->closed()->create();
         $published = Pool::factory()->published()->create();
@@ -1394,7 +1394,7 @@ class PoolTest extends TestCase
     /**
      * @group paginated
      */
-    public function test_classification_scope(): void
+    public function testClassificationScope(): void
     {
         $AA1 = Pool::factory()->published()->create([
             'classification_id' => Classification::factory()->create([
@@ -1474,7 +1474,7 @@ class PoolTest extends TestCase
     /**
      * @group paginated
      */
-    public function test_can_admin_scope(): void
+    public function testCanAdminScope(): void
     {
         // two published pools
         $teamPool = Pool::factory()->published()->create([
@@ -1560,7 +1560,7 @@ class PoolTest extends TestCase
      *
      * @group editing
      */
-    public function test_published_pool_editing(): void
+    public function testPublishedPoolEditing(): void
     {
 
         $pool = Pool::factory()
@@ -1627,7 +1627,7 @@ class PoolTest extends TestCase
     /**
      * @group paginated
      */
-    public function test_pool_bookmarks_scope(): void
+    public function testPoolBookmarksScope(): void
     {
         $pool1 = Pool::factory(['created_at' => config('constants.past_date')])->create();
         $pool2 = Pool::factory(['created_at' => config('constants.past_date')])->withBookmark($this->adminUser->id)->create();
@@ -1693,7 +1693,7 @@ class PoolTest extends TestCase
             ]);
     }
 
-    public function test_can_view_department()
+    public function testCanViewDepartment()
     {
         $department = Department::factory()->create();
 
@@ -1724,7 +1724,7 @@ class PoolTest extends TestCase
     }
 
     // test mutation createPool(...)
-    public function test_create_pool()
+    public function testCreatePool()
     {
         $community = Community::factory()->create();
         $classification = Classification::factory()->create();
@@ -1782,7 +1782,7 @@ class PoolTest extends TestCase
         ]);
     }
 
-    public function test_duplicate_pool()
+    public function testDuplicatePool()
     {
         $this->seed([
             SkillFamilySeeder::class,

--- a/api/tests/Feature/PoolTest.php
+++ b/api/tests/Feature/PoolTest.php
@@ -86,7 +86,7 @@ class PoolTest extends TestCase
         $this->baseUser = User::factory()->create();
     }
 
-    public function testPoolAccessor(): void
+    public function test_pool_accessor(): void
     {
         // Create new pools and attach to new pool candidates.
         $pool1 = Pool::factory()->create([
@@ -217,7 +217,7 @@ class PoolTest extends TestCase
         ]);
     }
 
-    public function testPoolAccessorTime(): void
+    public function test_pool_accessor_time(): void
     {
         // test that expiry on day of functions as expected, that soon to expire can be applied to and just expired is longer open for application
         $expireInHour = date('Y-m-d H:i:s', strtotime('+1 hour'));
@@ -276,7 +276,7 @@ class PoolTest extends TestCase
     }
 
     // The publishedPools query should only return pools that have been published, not draft
-    public function testPublishedPoolQueryDoesNotReturnDraft(): void
+    public function test_published_pool_query_does_not_return_draft(): void
     {
         // this pool has been published so it should be returned in the publishedPool query
         $publishedPool = Pool::factory()->create([
@@ -309,7 +309,7 @@ class PoolTest extends TestCase
     }
 
     // The publishedPools query should only return pools that have been published, not archived
-    public function testPublishedPoolQueryDoesNotReturnArchived(): void
+    public function test_published_pool_query_does_not_return_archived(): void
     {
         // this pool has been published so it should be returned in the publishedPool query
         $publishedPool = Pool::factory()->create([
@@ -339,7 +339,7 @@ class PoolTest extends TestCase
         ]);
     }
 
-    public function testListPoolsDoesNotReturnDraftAsAnon(): void
+    public function test_list_pools_does_not_return_draft_as_anon(): void
     {
         $publishedPool = Pool::factory()->create([
             'published_at' => config('constants.past_date'),
@@ -364,7 +364,7 @@ class PoolTest extends TestCase
             ->assertJsonFragment(['id' => $publishedPool->id]);
     }
 
-    public function testListPoolsDoesNotReturnArchivedAsAnon(): void
+    public function test_list_pools_does_not_return_archived_as_anon(): void
     {
         $publishedPool = Pool::factory()->create([
             'published_at' => config('constants.past_date'),
@@ -387,7 +387,7 @@ class PoolTest extends TestCase
             ->assertJsonFragment(['id' => $publishedPool->id]);
     }
 
-    public function testListPoolsReturnsOnlyPublishedAsBaseRoleUser(): void
+    public function test_list_pools_returns_only_published_as_base_role_user(): void
     {
         $publishedPool = Pool::factory()
             ->published()
@@ -412,7 +412,7 @@ class PoolTest extends TestCase
             ->assertJsonFragment(['id' => $publishedPool->id]);
     }
 
-    public function testListPoolsReturnsOnlyPublishedAsGuestRoleUser(): void
+    public function test_list_pools_returns_only_published_as_guest_role_user(): void
     {
         $publishedPool = Pool::factory()->create([
             'published_at' => config('constants.past_date'),
@@ -438,7 +438,7 @@ class PoolTest extends TestCase
     }
 
     // test filtering closing_date on publishedPools
-    public function testPoolQueryClosingDate(): void
+    public function test_pool_query_closing_date(): void
     {
         Pool::factory()->create([
             'published_at' => null,
@@ -487,7 +487,7 @@ class PoolTest extends TestCase
         assertSame(2, $response2Count);
     }
 
-    public function testCanArchiveClosed(): void
+    public function test_can_archive_closed(): void
     {
         $pool = Pool::factory()->closed()->create(['team_id' => $this->team->id]);
 
@@ -507,7 +507,7 @@ class PoolTest extends TestCase
             ->assertJsonFragment(['status' => ['value' => PoolStatus::ARCHIVED->name]]);
     }
 
-    public function testCantArchiveActive(): void
+    public function test_cant_archive_active(): void
     {
         $pool = Pool::factory()->published()->create(['team_id' => $this->team->id]);
 
@@ -527,7 +527,7 @@ class PoolTest extends TestCase
             ->assertGraphQLErrorMessage('ArchivePoolInvalidStatus');
     }
 
-    public function testCanUnarchiveArchived(): void
+    public function test_can_unarchive_archived(): void
     {
         $pool = Pool::factory()->archived()->create(['team_id' => $this->team->id]);
 
@@ -549,7 +549,7 @@ class PoolTest extends TestCase
             ]]);
     }
 
-    public function testCantUnarchiveClosed(): void
+    public function test_cant_unarchive_closed(): void
     {
         $pool = Pool::factory()->closed()->create(['team_id' => $this->team->id]);
 
@@ -569,7 +569,7 @@ class PoolTest extends TestCase
             ->assertGraphQLErrorMessage('UnarchivePoolInvalidStatus');
     }
 
-    public function testCannotPublishWithDeletedSkill(): void
+    public function test_cannot_publish_with_deleted_skill(): void
     {
         // create complete but unpublished pool with a deleted skill
         $pool = Pool::factory()
@@ -617,7 +617,7 @@ class PoolTest extends TestCase
             ->assertSuccessful();
     }
 
-    public function testCannotReopenWithDeletedSkill(): void
+    public function test_cannot_reopen_with_deleted_skill(): void
     {
         $pool = Pool::factory()->published()->closed()->create(['team_id' => $this->team->id]);
         $skill1 = Skill::factory()->create();
@@ -665,7 +665,7 @@ class PoolTest extends TestCase
             ->assertSuccessful();
     }
 
-    public function testPoolScopeCurrentlyActive(): void
+    public function test_pool_scope_currently_active(): void
     {
         Pool::factory()->create([
             'published_at' => null,
@@ -687,7 +687,7 @@ class PoolTest extends TestCase
         assertSame(count($activePools), 4); // assert 7 pools present but only 4 are considered "active"
     }
 
-    public function testPoolIsCompleteAccessor(): void
+    public function test_pool_is_complete_accessor(): void
     {
         $queryPool =
             /** @lang GraphQL */
@@ -741,7 +741,7 @@ class PoolTest extends TestCase
             ->assertJsonFragment(['isComplete' => false]);
     }
 
-    public function testPoolIsCompleteAccessorSkillLevel(): void
+    public function test_pool_is_complete_accessor_skill_level(): void
     {
         $queryPool =
             /** @lang GraphQL */
@@ -786,7 +786,7 @@ class PoolTest extends TestCase
             ->assertJsonFragment(['isComplete' => false]);
     }
 
-    public function testAssessmentStepValidation(): void
+    public function test_assessment_step_validation(): void
     {
         Classification::factory()->create();
         Skill::factory()->count(5)->create([
@@ -903,7 +903,7 @@ class PoolTest extends TestCase
             ->assertJsonFragment(['id' => $completePool->id]);
     }
 
-    public function testPoolSkillValidation(): void
+    public function test_pool_skill_validation(): void
     {
 
         Classification::factory()->create();
@@ -1054,7 +1054,7 @@ class PoolTest extends TestCase
     }
 
     // a pool operator can successfully delete a pool that they created but is still in draft
-    public function testCanDeleteDraftPool(): void
+    public function test_can_delete_draft_pool(): void
     {
         $pool = Pool::factory()
             ->for($this->poolOperator)
@@ -1081,7 +1081,7 @@ class PoolTest extends TestCase
     /**
      * @group paginated
      */
-    public function testPoolNameScope(): void
+    public function test_pool_name_scope(): void
     {
         $toBeFound = Pool::factory()->published()
             ->create([
@@ -1099,7 +1099,7 @@ class PoolTest extends TestCase
                     poolsPaginated(where: $where) {
                         data {
                             id
-                            name { en fr }
+                            name { en fr localized }
                         }
                     }
                 }
@@ -1116,7 +1116,7 @@ class PoolTest extends TestCase
     /**
      * @group paginated
      */
-    public function testPoolTeamScope(): void
+    public function test_pool_team_scope(): void
     {
         $toBeFound = Pool::factory()->published()->create([
             'team_id' => $this->team,
@@ -1157,7 +1157,7 @@ class PoolTest extends TestCase
     /**
      * @group paginated
      */
-    public function testPoolStreamsScope(): void
+    public function test_pool_streams_scope(): void
     {
         $ATIP = Pool::factory()->published()->create([
             'stream' => PoolStream::ACCESS_INFORMATION_PRIVACY->name,
@@ -1214,7 +1214,7 @@ class PoolTest extends TestCase
     /**
      * @group paginated
      */
-    public function testPublishingGroupsScope(): void
+    public function test_publishing_groups_scope(): void
     {
         $IT = Pool::factory()->published()->create([
             'publishing_group' => PublishingGroup::IT_JOBS->name,
@@ -1271,7 +1271,7 @@ class PoolTest extends TestCase
     /**
      * @group paginated
      */
-    public function testPoolStatusScope(): void
+    public function test_pool_status_scope(): void
     {
         $closed = Pool::factory()->closed()->create();
         $published = Pool::factory()->published()->create();
@@ -1394,7 +1394,7 @@ class PoolTest extends TestCase
     /**
      * @group paginated
      */
-    public function testClassificationScope(): void
+    public function test_classification_scope(): void
     {
         $AA1 = Pool::factory()->published()->create([
             'classification_id' => Classification::factory()->create([
@@ -1474,7 +1474,7 @@ class PoolTest extends TestCase
     /**
      * @group paginated
      */
-    public function testCanAdminScope(): void
+    public function test_can_admin_scope(): void
     {
         // two published pools
         $teamPool = Pool::factory()->published()->create([
@@ -1560,7 +1560,7 @@ class PoolTest extends TestCase
      *
      * @group editing
      */
-    public function testPublishedPoolEditing(): void
+    public function test_published_pool_editing(): void
     {
 
         $pool = Pool::factory()
@@ -1627,7 +1627,7 @@ class PoolTest extends TestCase
     /**
      * @group paginated
      */
-    public function testPoolBookmarksScope(): void
+    public function test_pool_bookmarks_scope(): void
     {
         $pool1 = Pool::factory(['created_at' => config('constants.past_date')])->create();
         $pool2 = Pool::factory(['created_at' => config('constants.past_date')])->withBookmark($this->adminUser->id)->create();
@@ -1693,7 +1693,7 @@ class PoolTest extends TestCase
             ]);
     }
 
-    public function testCanViewDepartment()
+    public function test_can_view_department()
     {
         $department = Department::factory()->create();
 
@@ -1724,7 +1724,7 @@ class PoolTest extends TestCase
     }
 
     // test mutation createPool(...)
-    public function testCreatePool()
+    public function test_create_pool()
     {
         $community = Community::factory()->create();
         $classification = Classification::factory()->create();
@@ -1782,7 +1782,7 @@ class PoolTest extends TestCase
         ]);
     }
 
-    public function testDuplicatePool()
+    public function test_duplicate_pool()
     {
         $this->seed([
             SkillFamilySeeder::class,

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -44,7 +44,7 @@ class SnapshotTest extends TestCase
      *
      * @return void
      */
-    public function testCreateSnapshot()
+    public function test_create_snapshot()
     {
         $snapshotQuery = file_get_contents(base_path('app/GraphQL/Mutations/PoolCandidateSnapshot.graphql'), true);
         $user = User::factory()
@@ -88,6 +88,7 @@ class SnapshotTest extends TestCase
         )->json('data.poolCandidate.profileSnapshot');
 
         $decodedActual = json_decode($actualSnapshot, true);
+        unset($decodedActual['pool']['department']['name']['localized']);
 
         // Add version number
         $expectedSnapshot['version'] = ProfileSnapshot::$VERSION;
@@ -107,7 +108,7 @@ class SnapshotTest extends TestCase
         assertEquals($expectedSnapshot, $decodedActual);
     }
 
-    public function testSnapshotSkillFiltering()
+    public function test_snapshot_skill_filtering()
     {
         Skill::factory(20)->create();
 
@@ -166,7 +167,7 @@ class SnapshotTest extends TestCase
         assertEquals($intersectedArrayLength, 0);
     }
 
-    public function testSetApplicationSnapshotDoesNotOverwrite()
+    public function test_set_application_snapshot_does_not_overwrite()
     {
         // non-null snapshot value set
         $user = User::factory()
@@ -188,7 +189,7 @@ class SnapshotTest extends TestCase
         assertSame(['snapshot' => 'set'], $snapshot);
     }
 
-    public function testLocalizingLegacyEnums()
+    public function test_localizing_legacy_enums()
     {
         // non-null snapshot value set
         $user = User::factory()

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -44,7 +44,7 @@ class SnapshotTest extends TestCase
      *
      * @return void
      */
-    public function test_create_snapshot()
+    public function testCreateSnapshot()
     {
         $snapshotQuery = file_get_contents(base_path('app/GraphQL/Mutations/PoolCandidateSnapshot.graphql'), true);
         $user = User::factory()
@@ -108,7 +108,7 @@ class SnapshotTest extends TestCase
         assertEquals($expectedSnapshot, $decodedActual);
     }
 
-    public function test_snapshot_skill_filtering()
+    public function testSnapshotSkillFiltering()
     {
         Skill::factory(20)->create();
 
@@ -167,7 +167,7 @@ class SnapshotTest extends TestCase
         assertEquals($intersectedArrayLength, 0);
     }
 
-    public function test_set_application_snapshot_does_not_overwrite()
+    public function testSetApplicationSnapshotDoesNotOverwrite()
     {
         // non-null snapshot value set
         $user = User::factory()
@@ -189,7 +189,7 @@ class SnapshotTest extends TestCase
         assertSame(['snapshot' => 'set'], $snapshot);
     }
 
-    public function test_localizing_legacy_enums()
+    public function testLocalizingLegacyEnums()
     {
         // non-null snapshot value set
         $user = User::factory()

--- a/api/tests/Unit/PoolCandidatePolicyTest.php
+++ b/api/tests/Unit/PoolCandidatePolicyTest.php
@@ -159,7 +159,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_view_any()
+    public function testViewAny()
     {
         $this->assertFalse($this->guestUser->can('viewAny', PoolCandidate::class));
         $this->assertFalse($this->applicantUser->can('viewAny', PoolCandidate::class));
@@ -179,7 +179,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_view_draft()
+    public function testViewDraft()
     {
         $this->poolCandidate->submitted_at = null;
         $this->poolCandidate->save();
@@ -205,7 +205,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_view_submitted()
+    public function testViewSubmitted()
     {
         $this->poolCandidate->submitted_at = config('constants.past_date');
         $this->poolCandidate->save();
@@ -234,7 +234,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_create_draft()
+    public function testCreateDraft()
     {
         $this->assertTrue($this->candidateUser->can('createDraft', PoolCandidate::class));
         $this->assertTrue($this->applicantUser->can('createDraft', PoolCandidate::class));
@@ -254,7 +254,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_create()
+    public function testCreate()
     {
         $this->assertTrue($this->adminUser->can('create', PoolCandidate::class));
 
@@ -275,7 +275,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_update_status()
+    public function testUpdateStatus()
     {
         // Ensure candidate is not draft
         $this->poolCandidate->submitted_at = config('constants.past_date');
@@ -299,7 +299,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_update()
+    public function testUpdate()
     {
         // Ensure candidate is not draft
         $this->poolCandidate->submitted_at = config('constants.past_date');
@@ -340,7 +340,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_submit()
+    public function testSubmit()
     {
         $this->assertTrue($this->candidateUser->can('submit', $this->poolCandidate));
 
@@ -361,7 +361,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_archive()
+    public function testArchive()
     {
         $this->assertTrue($this->candidateUser->can('archive', $this->poolCandidate));
 
@@ -382,7 +382,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_delete()
+    public function testDelete()
     {
         $this->assertTrue($this->candidateUser->can('delete', $this->poolCandidate));
 
@@ -403,7 +403,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_suspend()
+    public function testSuspend()
     {
         $this->assertTrue($this->candidateUser->can('suspend', $this->poolCandidate));
 
@@ -424,7 +424,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_count()
+    public function testCount()
     {
         $this->assertTrue($this->candidateUser->can('count', $this->poolCandidate));
         $this->assertTrue($this->guestUser->can('count', $this->poolCandidate));
@@ -446,7 +446,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_update_bookmark()
+    public function testUpdateBookmark()
     {
         $this->assertTrue($this->poolOperatorUser->can('updateBookmark', $this->poolCandidate));
         $this->assertTrue($this->requestResponderUser->can('updateBookmark', $this->poolCandidate));
@@ -474,7 +474,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_view_notes()
+    public function testViewNotes()
     {
         $this->assertTrue($this->poolOperatorUser->can('viewNotes', $this->poolCandidate));
         $this->assertTrue($this->requestResponderUser->can('viewNotes', $this->poolCandidate));
@@ -502,7 +502,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_update_notes()
+    public function testUpdateNotes()
     {
         $this->assertTrue($this->poolOperatorUser->can('updateNotes', $this->poolCandidate));
         $this->assertTrue($this->requestResponderUser->can('updateNotes', $this->poolCandidate));
@@ -530,7 +530,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_view_assessment()
+    public function testViewAssessment()
     {
         $this->assertTrue($this->poolOperatorUser->can('viewAssessment', $this->poolCandidate));
         $this->assertTrue($this->requestResponderUser->can('viewAssessment', $this->poolCandidate));
@@ -558,7 +558,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_update_assessment()
+    public function testUpdateAssessment()
     {
         $this->assertTrue($this->poolOperatorUser->can('updateAssessment', $this->poolCandidate));
         $this->assertTrue($this->requestResponderUser->can('updateAssessment', $this->poolCandidate));
@@ -586,7 +586,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_view_decision()
+    public function testViewDecision()
     {
         $this->assertTrue($this->poolOperatorUser->can('viewDecision', $this->poolCandidate));
         $this->assertTrue($this->requestResponderUser->can('viewDecision', $this->poolCandidate));
@@ -614,7 +614,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_update_decision()
+    public function testUpdateDecision()
     {
         $this->assertTrue($this->poolOperatorUser->can('updateDecision', $this->poolCandidate));
         $this->assertTrue($this->requestResponderUser->can('updateDecision', $this->poolCandidate));
@@ -642,7 +642,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_view_placement()
+    public function testViewPlacement()
     {
         $this->assertTrue($this->poolOperatorUser->can('viewPlacement', $this->poolCandidate));
         $this->assertTrue($this->requestResponderUser->can('viewPlacement', $this->poolCandidate));
@@ -670,7 +670,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_update_placement()
+    public function testUpdatePlacement()
     {
         $this->assertTrue($this->poolOperatorUser->can('updatePlacement', $this->poolCandidate));
         $this->assertTrue($this->requestResponderUser->can('updatePlacement', $this->poolCandidate));

--- a/api/tests/Unit/PoolCandidatePolicyTest.php
+++ b/api/tests/Unit/PoolCandidatePolicyTest.php
@@ -73,8 +73,8 @@ class PoolCandidatePolicyTest extends TestCase
             ]);
 
         $this->team = Team::factory()->create(['name' => 'test-team']);
-        $this->community = Community::factory()->create(['name' => 'test-team']);
-        $this->otherCommunity = Community::factory()->create(['name' => 'suspicious-team']);
+        $this->community = Community::factory()->create(['name' => ['en' => 'test-team EN', 'fr' => 'test-team FR']]);
+        $this->otherCommunity = Community::factory()->create(['name' => ['en' => 'suspicious-team EN', 'fr' => 'suspicious-team FR']]);
 
         $this->poolOperatorUser = User::factory()
             ->asPoolOperator($this->team->name)
@@ -159,7 +159,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testViewAny()
+    public function test_view_any()
     {
         $this->assertFalse($this->guestUser->can('viewAny', PoolCandidate::class));
         $this->assertFalse($this->applicantUser->can('viewAny', PoolCandidate::class));
@@ -179,7 +179,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testViewDraft()
+    public function test_view_draft()
     {
         $this->poolCandidate->submitted_at = null;
         $this->poolCandidate->save();
@@ -205,7 +205,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testViewSubmitted()
+    public function test_view_submitted()
     {
         $this->poolCandidate->submitted_at = config('constants.past_date');
         $this->poolCandidate->save();
@@ -234,7 +234,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testCreateDraft()
+    public function test_create_draft()
     {
         $this->assertTrue($this->candidateUser->can('createDraft', PoolCandidate::class));
         $this->assertTrue($this->applicantUser->can('createDraft', PoolCandidate::class));
@@ -254,7 +254,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testCreate()
+    public function test_create()
     {
         $this->assertTrue($this->adminUser->can('create', PoolCandidate::class));
 
@@ -275,7 +275,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testUpdateStatus()
+    public function test_update_status()
     {
         // Ensure candidate is not draft
         $this->poolCandidate->submitted_at = config('constants.past_date');
@@ -299,7 +299,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testUpdate()
+    public function test_update()
     {
         // Ensure candidate is not draft
         $this->poolCandidate->submitted_at = config('constants.past_date');
@@ -340,7 +340,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testSubmit()
+    public function test_submit()
     {
         $this->assertTrue($this->candidateUser->can('submit', $this->poolCandidate));
 
@@ -361,7 +361,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testArchive()
+    public function test_archive()
     {
         $this->assertTrue($this->candidateUser->can('archive', $this->poolCandidate));
 
@@ -382,7 +382,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testDelete()
+    public function test_delete()
     {
         $this->assertTrue($this->candidateUser->can('delete', $this->poolCandidate));
 
@@ -403,7 +403,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testSuspend()
+    public function test_suspend()
     {
         $this->assertTrue($this->candidateUser->can('suspend', $this->poolCandidate));
 
@@ -424,7 +424,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testCount()
+    public function test_count()
     {
         $this->assertTrue($this->candidateUser->can('count', $this->poolCandidate));
         $this->assertTrue($this->guestUser->can('count', $this->poolCandidate));
@@ -446,7 +446,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testUpdateBookmark()
+    public function test_update_bookmark()
     {
         $this->assertTrue($this->poolOperatorUser->can('updateBookmark', $this->poolCandidate));
         $this->assertTrue($this->requestResponderUser->can('updateBookmark', $this->poolCandidate));
@@ -474,7 +474,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testViewNotes()
+    public function test_view_notes()
     {
         $this->assertTrue($this->poolOperatorUser->can('viewNotes', $this->poolCandidate));
         $this->assertTrue($this->requestResponderUser->can('viewNotes', $this->poolCandidate));
@@ -502,7 +502,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testUpdateNotes()
+    public function test_update_notes()
     {
         $this->assertTrue($this->poolOperatorUser->can('updateNotes', $this->poolCandidate));
         $this->assertTrue($this->requestResponderUser->can('updateNotes', $this->poolCandidate));
@@ -530,7 +530,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testViewAssessment()
+    public function test_view_assessment()
     {
         $this->assertTrue($this->poolOperatorUser->can('viewAssessment', $this->poolCandidate));
         $this->assertTrue($this->requestResponderUser->can('viewAssessment', $this->poolCandidate));
@@ -558,7 +558,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testUpdateAssessment()
+    public function test_update_assessment()
     {
         $this->assertTrue($this->poolOperatorUser->can('updateAssessment', $this->poolCandidate));
         $this->assertTrue($this->requestResponderUser->can('updateAssessment', $this->poolCandidate));
@@ -586,7 +586,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testViewDecision()
+    public function test_view_decision()
     {
         $this->assertTrue($this->poolOperatorUser->can('viewDecision', $this->poolCandidate));
         $this->assertTrue($this->requestResponderUser->can('viewDecision', $this->poolCandidate));
@@ -614,7 +614,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testUpdateDecision()
+    public function test_update_decision()
     {
         $this->assertTrue($this->poolOperatorUser->can('updateDecision', $this->poolCandidate));
         $this->assertTrue($this->requestResponderUser->can('updateDecision', $this->poolCandidate));
@@ -642,7 +642,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testViewPlacement()
+    public function test_view_placement()
     {
         $this->assertTrue($this->poolOperatorUser->can('viewPlacement', $this->poolCandidate));
         $this->assertTrue($this->requestResponderUser->can('viewPlacement', $this->poolCandidate));
@@ -670,7 +670,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testUpdatePlacement()
+    public function test_update_placement()
     {
         $this->assertTrue($this->poolOperatorUser->can('updatePlacement', $this->poolCandidate));
         $this->assertTrue($this->requestResponderUser->can('updatePlacement', $this->poolCandidate));

--- a/api/tests/Unit/PoolPolicyTest.php
+++ b/api/tests/Unit/PoolPolicyTest.php
@@ -67,8 +67,8 @@ class PoolPolicyTest extends TestCase
             ]);
 
         $this->team = Team::factory()->create(['name' => 'test-team']);
-        $this->community = Community::factory()->create(['name' => 'test-team']);
-        $this->otherCommunity = Community::factory()->create(['name' => 'suspicious-team']);
+        $this->community = Community::factory()->create();
+        $this->otherCommunity = Community::factory()->create();
 
         $this->poolOperatorUser = User::factory()
             ->asApplicant()
@@ -142,7 +142,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function testViewAny()
+    public function test_view_any()
     {
         $this->assertTrue($this->adminUser->can('viewAny', Pool::class));
         $this->assertTrue($this->communityManagerUser->can('viewAny', Pool::class));
@@ -161,7 +161,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function testViewAnyPublishedPools()
+    public function test_view_any_published_pools()
     {
         $this->assertTrue($this->guestUser->can('viewAnyPublished', Pool::class));
         $this->assertTrue($this->applicantUser->can('viewAnyPublished', Pool::class));
@@ -182,7 +182,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function testView()
+    public function test_view()
     {
         $this->teamPool->published_at = null;
         $this->teamPool->save();
@@ -234,7 +234,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function testViewDraftPool()
+    public function test_view_draft_pool()
     {
         $this->teamPool->published_at = null;
         $this->teamPool->save();
@@ -259,7 +259,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function testViewPublishedPool()
+    public function test_view_published_pool()
     {
         $this->teamPool->published_at = config('constants.past_date');
         $this->teamPool->save();
@@ -280,7 +280,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function testCreate()
+    public function test_create()
     {
         $createPoolInput = [
             'team_id' => $this->team->id,
@@ -313,7 +313,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function testDuplicate()
+    public function test_duplicate()
     {
         $this->assertTrue($this->poolOperatorUser->can('duplicate', $this->teamPool));
         $this->assertTrue($this->communityRecruiterUser->can('duplicate', $this->teamPool));
@@ -337,7 +337,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function testUpdateDraft()
+    public function test_update_draft()
     {
         $this->teamPool->published_at = null;
         $this->teamPool->save();
@@ -368,7 +368,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function testPublish()
+    public function test_publish()
     {
         $this->teamPool->published_at = null;
         $this->teamPool->closing_date = config('constants.far_future_date');
@@ -400,7 +400,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function testChangeClosingDate()
+    public function test_change_closing_date()
     {
         $this->assertTrue($this->communityManagerUser->can('changePoolClosingDate', $this->teamPool));
         $this->assertTrue($this->communityAdminUser->can('changePoolClosingDate', $this->teamPool));
@@ -425,7 +425,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function testUpdatePublished()
+    public function test_update_published()
     {
         $this->teamPool->published_at = null;
         $this->teamPool->save();
@@ -462,7 +462,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function testClosePool()
+    public function test_close_pool()
     {
         $this->assertTrue($this->communityManagerUser->can('closePool', $this->teamPool));
         $this->assertTrue($this->communityAdminUser->can('closePool', $this->teamPool));
@@ -487,7 +487,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function testDeleteDraft()
+    public function test_delete_draft()
     {
         $this->teamPool->published_at = null;
         $this->teamPool->save();
@@ -517,7 +517,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function testDeletePublished()
+    public function test_delete_published()
     {
         $this->teamPool->published_at = config('constants.past_date');
         $this->teamPool->save();
@@ -538,7 +538,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function testArchiveAndUnarchive()
+    public function test_archive_and_unarchive()
     {
         $this->assertTrue($this->poolOperatorUser->can('archiveAndUnarchive', $this->teamPool));
         $this->assertTrue($this->communityRecruiterUser->can('archiveAndUnarchive', $this->teamPool));
@@ -563,7 +563,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function testViewAssessmentPlan()
+    public function test_view_assessment_plan()
     {
         $this->assertTrue($this->requestResponderUser->can('viewAssessmentPlan', $this->teamPool));
         $this->assertTrue($this->adminUser->can('viewAssessmentPlan', $this->teamPool));
@@ -588,7 +588,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function testViewTeamMembers()
+    public function test_view_team_members()
     {
         $this->assertTrue($this->adminUser->can('viewTeamMembers', $this->teamPool));
         $this->assertTrue($this->communityManagerUser->can('viewTeamMembers', $this->teamPool));

--- a/api/tests/Unit/PoolPolicyTest.php
+++ b/api/tests/Unit/PoolPolicyTest.php
@@ -142,7 +142,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_view_any()
+    public function testViewAny()
     {
         $this->assertTrue($this->adminUser->can('viewAny', Pool::class));
         $this->assertTrue($this->communityManagerUser->can('viewAny', Pool::class));
@@ -161,7 +161,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_view_any_published_pools()
+    public function testViewAnyPublishedPools()
     {
         $this->assertTrue($this->guestUser->can('viewAnyPublished', Pool::class));
         $this->assertTrue($this->applicantUser->can('viewAnyPublished', Pool::class));
@@ -182,7 +182,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_view()
+    public function testView()
     {
         $this->teamPool->published_at = null;
         $this->teamPool->save();
@@ -234,7 +234,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_view_draft_pool()
+    public function testViewDraftPool()
     {
         $this->teamPool->published_at = null;
         $this->teamPool->save();
@@ -259,7 +259,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_view_published_pool()
+    public function testViewPublishedPool()
     {
         $this->teamPool->published_at = config('constants.past_date');
         $this->teamPool->save();
@@ -280,7 +280,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_create()
+    public function testCreate()
     {
         $createPoolInput = [
             'team_id' => $this->team->id,
@@ -313,7 +313,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_duplicate()
+    public function testDuplicate()
     {
         $this->assertTrue($this->poolOperatorUser->can('duplicate', $this->teamPool));
         $this->assertTrue($this->communityRecruiterUser->can('duplicate', $this->teamPool));
@@ -337,7 +337,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_update_draft()
+    public function testUpdateDraft()
     {
         $this->teamPool->published_at = null;
         $this->teamPool->save();
@@ -368,7 +368,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_publish()
+    public function testPublish()
     {
         $this->teamPool->published_at = null;
         $this->teamPool->closing_date = config('constants.far_future_date');
@@ -400,7 +400,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_change_closing_date()
+    public function testChangeClosingDate()
     {
         $this->assertTrue($this->communityManagerUser->can('changePoolClosingDate', $this->teamPool));
         $this->assertTrue($this->communityAdminUser->can('changePoolClosingDate', $this->teamPool));
@@ -425,7 +425,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_update_published()
+    public function testUpdatePublished()
     {
         $this->teamPool->published_at = null;
         $this->teamPool->save();
@@ -462,7 +462,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_close_pool()
+    public function testClosePool()
     {
         $this->assertTrue($this->communityManagerUser->can('closePool', $this->teamPool));
         $this->assertTrue($this->communityAdminUser->can('closePool', $this->teamPool));
@@ -487,7 +487,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_delete_draft()
+    public function testDeleteDraft()
     {
         $this->teamPool->published_at = null;
         $this->teamPool->save();
@@ -517,7 +517,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_delete_published()
+    public function testDeletePublished()
     {
         $this->teamPool->published_at = config('constants.past_date');
         $this->teamPool->save();
@@ -538,7 +538,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_archive_and_unarchive()
+    public function testArchiveAndUnarchive()
     {
         $this->assertTrue($this->poolOperatorUser->can('archiveAndUnarchive', $this->teamPool));
         $this->assertTrue($this->communityRecruiterUser->can('archiveAndUnarchive', $this->teamPool));
@@ -563,7 +563,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_view_assessment_plan()
+    public function testViewAssessmentPlan()
     {
         $this->assertTrue($this->requestResponderUser->can('viewAssessmentPlan', $this->teamPool));
         $this->assertTrue($this->adminUser->can('viewAssessmentPlan', $this->teamPool));
@@ -588,7 +588,7 @@ class PoolPolicyTest extends TestCase
      *
      * @return void
      */
-    public function test_view_team_members()
+    public function testViewTeamMembers()
     {
         $this->assertTrue($this->adminUser->can('viewTeamMembers', $this->teamPool));
         $this->assertTrue($this->communityManagerUser->can('viewTeamMembers', $this->teamPool));


### PR DESCRIPTION
🤖 Resolves #11341 

## 👋 Introduction

Updates the grpahql type for `LocalizedString` to return the localized string based on the app locale.

## 🕵️ Details

This is adding a custom cast that includes the current localized string along with both languages for the `LocalizedString` type. This does not update the frontend to use this new field.

## 🧪 Testing

1. Open graphqil `/graphiql`
2. Query for the models affected
3. Confirm `localized` is added to the return type
4. Switch the locale with the header `Accept-Language en|fr`
5. Confirm the localized message switches between the current locale as expected
6. Confirm setting values still functions

## 📸 Screenshot

![2024-12-12_14-41](https://github.com/user-attachments/assets/797ca626-86ad-4082-a81b-e536e30507a7)
![2024-12-12_14-41_1](https://github.com/user-attachments/assets/1e35f0f6-bce0-41b0-8f5f-e7bdefd7b39f)
