### PR TITLE
[Feat] Add work stream to job poster templates

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -2085,6 +2085,7 @@ input CreateJobPosterTemplateInput @validator {
   name: LocalizedStringInput!
   description: LocalizedStringInput!
   supervisoryStatus: SupervisoryStatus! @rename(attribute: "supervisory_status")
+  stream: PoolStream!
   workStream: WorkStreamBelongsTo!
   workDescription: LocalizedStringInput @rename(attribute: "work_description")
   tasks: LocalizedStringInput!

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -780,7 +780,6 @@ type JobPosterTemplate {
   description: LocalizedString
   supervisoryStatus: LocalizedSupervisoryStatus
     @rename(attribute: "supervisory_status")
-  stream: LocalizedPoolStream
   workDescription: LocalizedString @rename(attribute: "work_description")
   tasks: LocalizedString
   keywords: LocalizedKeywords
@@ -792,6 +791,7 @@ type JobPosterTemplate {
     @rename(attribute: "nonessential_technical_skills_notes")
 
   classification: Classification @belongsTo
+  workStream: WorkStream @belongsTo
   skills: [JobPosterTemplateSkill!] @belongsToMany(model: "Skill")
 }
 
@@ -2085,7 +2085,7 @@ input CreateJobPosterTemplateInput @validator {
   name: LocalizedStringInput!
   description: LocalizedStringInput!
   supervisoryStatus: SupervisoryStatus! @rename(attribute: "supervisory_status")
-  stream: PoolStream!
+  workStream: WorkStreamBelongsTo!
   workDescription: LocalizedStringInput @rename(attribute: "work_description")
   tasks: LocalizedStringInput!
   keywords: LocalizedKeywordsInput
@@ -2105,7 +2105,7 @@ input UpdateJobPosterTemplateInput @validator {
   name: LocalizedStringInput
   description: LocalizedStringInput
   supervisoryStatus: SupervisoryStatus @rename(attribute: "supervisory_status")
-  stream: PoolStream
+  workStream: WorkStreamBelongsTo
   workDescription: LocalizedStringInput @rename(attribute: "work_description")
   tasks: LocalizedStringInput
   keywords: LocalizedStringInput

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -2086,6 +2086,7 @@ input CreateJobPosterTemplateInput {
   name: LocalizedStringInput!
   description: LocalizedStringInput!
   supervisoryStatus: SupervisoryStatus!
+  stream: PoolStream!
   workStream: WorkStreamBelongsTo!
   workDescription: LocalizedStringInput
   tasks: LocalizedStringInput!

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1138,7 +1138,6 @@ type JobPosterTemplate {
   name: LocalizedString
   description: LocalizedString
   supervisoryStatus: LocalizedSupervisoryStatus
-  stream: LocalizedPoolStream
   workDescription: LocalizedString
   tasks: LocalizedString
   keywords: LocalizedKeywords
@@ -1146,6 +1145,7 @@ type JobPosterTemplate {
   essentialBehaviouralSkillsNotes: LocalizedString
   nonessentialTechnicalSkillsNotes: LocalizedString
   classification: Classification
+  workStream: WorkStream
   skills: [JobPosterTemplateSkill!]
 }
 
@@ -2086,7 +2086,7 @@ input CreateJobPosterTemplateInput {
   name: LocalizedStringInput!
   description: LocalizedStringInput!
   supervisoryStatus: SupervisoryStatus!
-  stream: PoolStream!
+  workStream: WorkStreamBelongsTo!
   workDescription: LocalizedStringInput
   tasks: LocalizedStringInput!
   keywords: LocalizedKeywordsInput
@@ -2103,7 +2103,7 @@ input UpdateJobPosterTemplateInput {
   name: LocalizedStringInput
   description: LocalizedStringInput
   supervisoryStatus: SupervisoryStatus
-  stream: PoolStream
+  workStream: WorkStreamBelongsTo
   workDescription: LocalizedStringInput
   tasks: LocalizedStringInput
   keywords: LocalizedStringInput

--- a/api/tests/Feature/JobPosterTemplateTest.php
+++ b/api/tests/Feature/JobPosterTemplateTest.php
@@ -98,7 +98,7 @@ class JobPosterTemplateTest extends TestCase
             ->create();
     }
 
-    public function test_anonymous_users_can_view_any()
+    public function testAnonymousUsersCanViewAny()
     {
         $this->graphQL($this->queryOne, [
             'id' => $this->template->id,
@@ -121,21 +121,21 @@ class JobPosterTemplateTest extends TestCase
             ]);
     }
 
-    public function test_anonymous_user_cannot_create()
+    public function testAnonymousUserCannotCreate()
     {
         $this->graphQL($this->create, [
             'template' => $this->getCreateInput(),
         ])->assertGraphQLErrorMessage('Unauthenticated.');
     }
 
-    public function test_non_admin_user_cannot_create()
+    public function testNonAdminUserCannotCreate()
     {
         $this->actingAs($this->baseUser, 'api')->graphQL($this->create, [
             'template' => $this->getCreateInput(),
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function test_admin_can_create()
+    public function testAdminCanCreate()
     {
         $res = $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
             'template' => $this->getCreateInput(),
@@ -144,7 +144,7 @@ class JobPosterTemplateTest extends TestCase
         $this->assertNotNull($res['data']['createJobPosterTemplate']);
     }
 
-    public function test_anonymous_user_cannot_update()
+    public function testAnonymousUserCannotUpdate()
     {
         $this->graphQL($this->update, [
             'template' => [
@@ -154,7 +154,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Unauthenticated.');
     }
 
-    public function test_non_admin_user_cannot_update()
+    public function testNonAdminUserCannotUpdate()
     {
         $this->actingAs($this->baseUser, 'api')->graphQL($this->update, [
             'template' => [
@@ -164,7 +164,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function test_admin_can_update()
+    public function testAdminCanUpdate()
     {
         $this->actingAs($this->adminUser, 'api')->graphQL($this->update, [
             'template' => [
@@ -181,7 +181,7 @@ class JobPosterTemplateTest extends TestCase
         ]);
     }
 
-    public function test_non_admin_user_cannot_delete()
+    public function testNonAdminUserCannotDelete()
     {
         $template = JobPosterTemplate::factory()->create();
 
@@ -190,7 +190,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function test_admin_can_delete()
+    public function testAdminCanDelete()
     {
         $template = JobPosterTemplate::factory()->create();
 
@@ -205,7 +205,7 @@ class JobPosterTemplateTest extends TestCase
         ]);
     }
 
-    public function test_reference_id_is_unique()
+    public function testReferenceIdIsUnique()
     {
         $input = $this->getCreateInput();
         $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -216,7 +216,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Validation failed for the field [createJobPosterTemplate].');
     }
 
-    public function test_cannot_add_essential_skill_with_no_level()
+    public function testCannotAddEssentialSkillWithNoLevel()
     {
         $input = $this->getCreateInput();
         $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -235,7 +235,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Validation failed for the field [createJobPosterTemplate].');
     }
 
-    public function test_can_add_essential_skill_with_level()
+    public function testCanAddEssentialSkillWithLevel()
     {
         $input = $this->getCreateInput();
         $res = $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -256,7 +256,7 @@ class JobPosterTemplateTest extends TestCase
         $this->assertNotNull($res['data']['createJobPosterTemplate']);
     }
 
-    public function test_cannot_add_asset_skill_with_level()
+    public function testCannotAddAssetSkillWithLevel()
     {
         $input = $this->getCreateInput();
         $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -275,7 +275,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Validation failed for the field [createJobPosterTemplate].');
     }
 
-    public function test_can_add_asset_skill_with_no_level()
+    public function testCanAddAssetSkillWithNoLevel()
     {
         $input = $this->getCreateInput();
         $res = $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [

--- a/api/tests/Feature/JobPosterTemplateTest.php
+++ b/api/tests/Feature/JobPosterTemplateTest.php
@@ -98,7 +98,7 @@ class JobPosterTemplateTest extends TestCase
             ->create();
     }
 
-    public function testAnonymousUsersCanViewAny()
+    public function test_anonymous_users_can_view_any()
     {
         $this->graphQL($this->queryOne, [
             'id' => $this->template->id,
@@ -121,21 +121,21 @@ class JobPosterTemplateTest extends TestCase
             ]);
     }
 
-    public function testAnonymousUserCannotCreate()
+    public function test_anonymous_user_cannot_create()
     {
         $this->graphQL($this->create, [
             'template' => $this->getCreateInput(),
         ])->assertGraphQLErrorMessage('Unauthenticated.');
     }
 
-    public function testNonAdminUserCannotCreate()
+    public function test_non_admin_user_cannot_create()
     {
         $this->actingAs($this->baseUser, 'api')->graphQL($this->create, [
             'template' => $this->getCreateInput(),
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function testAdminCanCreate()
+    public function test_admin_can_create()
     {
         $res = $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
             'template' => $this->getCreateInput(),
@@ -144,7 +144,7 @@ class JobPosterTemplateTest extends TestCase
         $this->assertNotNull($res['data']['createJobPosterTemplate']);
     }
 
-    public function testAnonymousUserCannotUpdate()
+    public function test_anonymous_user_cannot_update()
     {
         $this->graphQL($this->update, [
             'template' => [
@@ -154,7 +154,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Unauthenticated.');
     }
 
-    public function testNonAdminUserCannotUpdate()
+    public function test_non_admin_user_cannot_update()
     {
         $this->actingAs($this->baseUser, 'api')->graphQL($this->update, [
             'template' => [
@@ -164,7 +164,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function testAdminCanUpdate()
+    public function test_admin_can_update()
     {
         $this->actingAs($this->adminUser, 'api')->graphQL($this->update, [
             'template' => [
@@ -181,7 +181,7 @@ class JobPosterTemplateTest extends TestCase
         ]);
     }
 
-    public function testNonAdminUserCannotDelete()
+    public function test_non_admin_user_cannot_delete()
     {
         $template = JobPosterTemplate::factory()->create();
 
@@ -190,7 +190,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
-    public function testAdminCanDelete()
+    public function test_admin_can_delete()
     {
         $template = JobPosterTemplate::factory()->create();
 
@@ -205,7 +205,7 @@ class JobPosterTemplateTest extends TestCase
         ]);
     }
 
-    public function testReferenceIdIsUnique()
+    public function test_reference_id_is_unique()
     {
         $input = $this->getCreateInput();
         $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -216,7 +216,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Validation failed for the field [createJobPosterTemplate].');
     }
 
-    public function testCannotAddEssentialSkillWithNoLevel()
+    public function test_cannot_add_essential_skill_with_no_level()
     {
         $input = $this->getCreateInput();
         $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -235,7 +235,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Validation failed for the field [createJobPosterTemplate].');
     }
 
-    public function testCanAddEssentialSkillWithLevel()
+    public function test_can_add_essential_skill_with_level()
     {
         $input = $this->getCreateInput();
         $res = $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -256,7 +256,7 @@ class JobPosterTemplateTest extends TestCase
         $this->assertNotNull($res['data']['createJobPosterTemplate']);
     }
 
-    public function testCannotAddAssetSkillWithLevel()
+    public function test_cannot_add_asset_skill_with_level()
     {
         $input = $this->getCreateInput();
         $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -275,7 +275,7 @@ class JobPosterTemplateTest extends TestCase
         ])->assertGraphQLErrorMessage('Validation failed for the field [createJobPosterTemplate].');
     }
 
-    public function testCanAddAssetSkillWithNoLevel()
+    public function test_can_add_asset_skill_with_no_level()
     {
         $input = $this->getCreateInput();
         $res = $this->actingAs($this->adminUser, 'api')->graphQL($this->create, [
@@ -314,6 +314,9 @@ class JobPosterTemplateTest extends TestCase
             'nonessentialTechnicalSkillsNotes' => Arr::only($template->nonessential_technical_skills_notes, ['en', 'fr']),
             'classification' => [
                 'connect' => $template->classification->id,
+            ],
+            'workStream' => [
+                'connect' => $template->workStream->id,
             ],
             'skills' => [
                 'connect' => $template->skills->map(function ($skill) {

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatePage/components/BasicDetails.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatePage/components/BasicDetails.tsx
@@ -29,8 +29,8 @@ const JobPosterTemplateBasicDetails_Fragment = graphql(/* GraphQL */ `
       group
       level
     }
-    stream {
-      label {
+    workStream {
+      name {
         en
         fr
       }
@@ -121,7 +121,7 @@ const BasicDetails = ({ jobPosterTemplateQuery }: BasicDetailsProps) => {
                 "Label displayed on the pool form stream/job title field.",
             })}
           >
-            {getLocalizedName(jobPosterTemplate.stream?.label, intl)}
+            {getLocalizedName(jobPosterTemplate.workStream?.name, intl)}
           </FieldDisplay>
           <FieldDisplay
             label={intl.formatMessage({

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -21,10 +21,9 @@ import {
 import {
   Classification,
   graphql,
-  LocalizedPoolStream,
   Maybe,
-  PoolStream,
   SupervisoryStatus,
+  WorkStream,
 } from "@gc-digital-talent/graphql";
 import {
   alphaSortOptions,
@@ -53,14 +52,14 @@ interface FormValues {
   keyword: string;
   classifications: string[];
   supervisoryStatuses: SupervisoryStatus[];
-  streams: PoolStream[];
+  workStreams: string[];
 }
 
 const defaultValues = {
   keyword: "",
   classifications: [],
   supervisoryStatuses: [],
-  streams: [],
+  workStreams: [],
 } satisfies FormValues;
 
 const JobPosterTemplates_Query = graphql(/* GraphQL */ `
@@ -77,18 +76,18 @@ const JobPosterTemplates_Query = graphql(/* GraphQL */ `
         fr
       }
     }
-    poolStreams: localizedEnumStrings(enumName: "PoolStream") {
-      value
-      label {
+    workStreams {
+      id
+      name {
         en
         fr
       }
     }
     jobPosterTemplates {
       id
-      stream {
-        value
-        label {
+      workStream {
+        id
+        name {
           en
           fr
         }
@@ -126,7 +125,7 @@ function assertIncludes(haystack: string[], needle?: Maybe<string>): boolean {
 function previewMetaData(
   intl: IntlShape,
   classification?: Maybe<Classification>,
-  stream?: Maybe<LocalizedPoolStream>,
+  workStream?: Maybe<WorkStream>,
 ): PreviewMetaData[] {
   const metaData = [];
   if (classification) {
@@ -137,11 +136,11 @@ function previewMetaData(
     } satisfies PreviewMetaData);
   }
 
-  if (stream) {
+  if (workStream) {
     metaData.push({
-      key: stream.value,
+      key: workStream.id,
       type: "text",
-      children: getLocalizedName(stream.label, intl),
+      children: getLocalizedName(workStream.name, intl),
     } satisfies PreviewMetaData);
   }
 
@@ -225,7 +224,7 @@ const JobPosterTemplatesPage = () => {
         );
       show =
         show &&
-        assertIncludes(formData.streams, jobPosterTemplate?.stream?.value);
+        assertIncludes(formData.workStreams, jobPosterTemplate?.workStream?.id);
 
       return show;
     });
@@ -256,7 +255,7 @@ const JobPosterTemplatesPage = () => {
     formData.keyword,
     formData.classifications,
     formData.supervisoryStatuses,
-    formData.streams,
+    formData.workStreams,
     locale,
     sortBy,
     intl,
@@ -374,13 +373,13 @@ const JobPosterTemplatesPage = () => {
                       })}
                     />
                     <Checklist
-                      idPrefix="streams"
-                      name="streams"
+                      idPrefix="workStreams"
+                      name="workStreams"
                       items={alphaSortOptions(
-                        localizedEnumToOptions(
-                          unpackMaybes(data?.poolStreams),
-                          intl,
-                        ),
+                        unpackMaybes(data?.workStreams).map((workStream) => ({
+                          value: workStream.id,
+                          label: getLocalizedName(workStream.name, intl),
+                        })),
                       )}
                       legend={intl.formatMessage({
                         defaultMessage: "Filter by work streams",
@@ -497,7 +496,7 @@ const JobPosterTemplatesPage = () => {
                             metaData={previewMetaData(
                               intl,
                               jobPosterTemplate.classification,
-                              jobPosterTemplate.stream,
+                              jobPosterTemplate.workStream,
                             )}
                           >
                             {jobPosterTemplate.description && (


### PR DESCRIPTION
🤖 Resolves #7574 

## 👋 Introduction

Updates the `JobPosterTemplate` grpahql type to use the `WorkStream` relationship.

## 🧪 Testing

1. Build the app `pnpm run dev:fresh`
2. Login as admin `admin@test.com`
3. Navigate to the index page for job poster templates `/job-templates`
4. Filter by work stream and confirm it functions as expected
5. Open a template
6. Confirm the stream is displayed properly