### PR TITLE
[Feat] Add locale aware label to localized enums

### DIFF
--- a/api/app/Traits/HasLocalization.php
+++ b/api/app/Traits/HasLocalization.php
@@ -24,6 +24,7 @@ trait HasLocalization
         return [
             'en' => Lang::get($key, [], 'en'),
             'fr' => Lang::get($key, [], 'fr'),
+            'localized' => __($key),
         ];
     }
 

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -44,7 +44,7 @@ class SnapshotTest extends TestCase
      *
      * @return void
      */
-    public function test_create_snapshot()
+    public function testCreateSnapshot()
     {
         $snapshotQuery = file_get_contents(base_path('app/GraphQL/Mutations/PoolCandidateSnapshot.graphql'), true);
         $user = User::factory()
@@ -108,7 +108,7 @@ class SnapshotTest extends TestCase
         assertEquals($expectedSnapshot, $decodedActual);
     }
 
-    public function test_snapshot_skill_filtering()
+    public function testSnapshotSkillFiltering()
     {
         Skill::factory(20)->create();
 
@@ -167,7 +167,7 @@ class SnapshotTest extends TestCase
         assertEquals($intersectedArrayLength, 0);
     }
 
-    public function test_set_application_snapshot_does_not_overwrite()
+    public function testSetApplicationSnapshotDoesNotOverwrite()
     {
         // non-null snapshot value set
         $user = User::factory()
@@ -189,7 +189,7 @@ class SnapshotTest extends TestCase
         assertSame(['snapshot' => 'set'], $snapshot);
     }
 
-    public function test_localizing_legacy_enums()
+    public function testLocalizingLegacyEnums()
     {
         // non-null snapshot value set
         $user = User::factory()


### PR DESCRIPTION
🤖 Resolves #11338 

## 👋 Introduction

Adds the locale aware label for localized enums in the graphql schema.

## 🧪 Testing

1. Navigate to `/graphiql`
2. Query for a localized enum
3. Confirm the new `label.localized` field appears
4. Update the `Accept-Language` header to `fr`
5. Re-run the query in step 2
6. Confirm the field updates to French

```graphql
query {
  localizedEnumStrings(enumName: "ArmedForcesStatus") {
    label {
      en
      fr
      localized
    }
  }
}
```