### PR TITLE
[Feat] Populate support form from search params

### DIFF
--- a/apps/playwright/tests/support-page.spec.ts
+++ b/apps/playwright/tests/support-page.spec.ts
@@ -16,6 +16,21 @@ test.describe("Support page", () => {
       const accessibilityScanResults = await makeAxeBuilder().analyze();
       expect(accessibilityScanResults.violations).toEqual([]);
     });
+    test("populates from search param", async ({ page }) => {
+      await page.goto("/en/support?subject=bug&description=test");
+      await expect(
+        page.getByRole("combobox", { name: /looking to/i }),
+      ).toHaveValue("bug");
+      await expect(page.getByRole("textbox", { name: /details/i })).toHaveValue(
+        "test",
+      );
+    });
+    test("does not populate invalid subject param", async ({ page }) => {
+      await page.goto("/en/support?subject=invalid");
+      await expect(
+        page.getByRole("combobox", { name: /looking to/i }),
+      ).toHaveValue("");
+    });
   });
   test.describe("Support form", () => {
     test("send POST request to existing API endpoint", async ({ request }) => {

--- a/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
+++ b/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
@@ -2,7 +2,7 @@
 // Note: Disable camelcase since variables are being used by API
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { defineMessage, useIntl } from "react-intl";
-import { useLocation, Location } from "react-router";
+import { useLocation, Location, useSearchParams } from "react-router";
 import { useQuery } from "urql";
 import { ReactNode, useState } from "react";
 
@@ -49,6 +49,15 @@ const anchorTag = (chunks: ReactNode) => (
   // eslint-disable-next-line react/forbid-elements
   <a href={`mailto:${TALENTSEARCH_SUPPORT_EMAIL}`}>{chunks}</a>
 );
+
+const availableSubjects = ["bug", "feedback", "question"];
+function defaultSubject(subject?: string | null): string {
+  if (subject && availableSubjects.includes(subject)) {
+    return subject;
+  }
+
+  return "";
+}
 
 const SupportFormSuccess = ({ onFormToggle }: SupportFormSuccessProps) => {
   const intl = useIntl();
@@ -118,10 +127,13 @@ const SupportForm = ({
 }: SupportFormProps) => {
   const intl = useIntl();
   const location = useLocation() as Location<LocationState>;
+  const [params] = useSearchParams();
   const previousUrl = location?.state?.referrer ?? document?.referrer ?? "";
   const userAgent = window?.navigator.userAgent ?? "";
   const methods = useForm<FormValues>({
     defaultValues: {
+      subject: defaultSubject(params.get("subject")),
+      description: params.get("description") ?? "",
       user_id: currentUser?.id ?? "",
       name: currentUser
         ? getFullNameLabel(currentUser.firstName, currentUser.lastName, intl)


### PR DESCRIPTION
🤖 Resolves #12215 

## 👋 Introduction

Uses search params to pre-populate the support form `subject` and `description` fields.

## 🧪 Testing

> [!TIP]
> When adding search params, make sure they are encoded for URIs.

1. Build the app `pnpm run dev:fresh`
2. Navigate to `/support`
3. Confirm the form is empty
4. Add search params for `subject` (only "bug", "feedback" and "question" are supported values) and `description`
5. Confirm the form is populated
6. Confirm unsupported subject fields leads to an empty "I'm looking to..." field
7. Confirm unsafe input to the `description` param is sanitized (i.e `<script>alert('unsafe');</script>` does nothing)

## 📸 Screenshot

![2024-12-16_14-41](https://github.com/user-attachments/assets/54cdbf5c-82c2-4c86-a81a-a57f7d2e58e6)
