### PR TITLE
[Feature] Ad hoc email command

### DIFF
--- a/api/app/Console/Commands/SendNotificationsAdHocEmail.php
+++ b/api/app/Console/Commands/SendNotificationsAdHocEmail.php
@@ -93,7 +93,7 @@ class SendNotificationsAdHocEmail extends Command implements PromptsForMissingIn
             ($notifyAllUsers ? 1 : 0);
 
         if ($optionTypesCount != 1) {
-            throw new \Error('Must filter users using exactly one of the option types');
+            throw new \InvalidArgumentException('Must filter users using exactly one of the option types');
         }
 
         if (count($emailAddresses) > 0) {
@@ -108,7 +108,7 @@ class SendNotificationsAdHocEmail extends Command implements PromptsForMissingIn
             return User::query();
         }
 
-        throw new \Error('Unexpected function end point for options: '.json_encode($options));
+        throw new \InvalidArgumentException('Unexpected function end point for options: '.json_encode($options));
     }
 
     private function builderFromEmailAddresses(array $requestedEmailAddresses): Builder
@@ -134,7 +134,7 @@ class SendNotificationsAdHocEmail extends Command implements PromptsForMissingIn
         $allNotificationFamilies = array_column(NotificationFamily::cases(), 'name');
         foreach ($notificationFamilies as $notificationFamily) {
             if (! in_array($notificationFamily, $allNotificationFamilies)) {
-                throw new \Error('Invalid notification family: '.$notificationFamily);
+                throw new \InvalidArgumentException('Invalid notification family: '.$notificationFamily);
             }
         }
 

--- a/api/app/Console/Commands/SendNotificationsAdHocEmail.php
+++ b/api/app/Console/Commands/SendNotificationsAdHocEmail.php
@@ -56,7 +56,7 @@ class SendNotificationsAdHocEmail extends Command implements PromptsForMissingIn
                         $user->notify($notification);
                         $successCount++;
                     } catch (\Throwable $e) {
-                        $this->error("Failed to send notification to user $user->id: ".$e->getMessage());
+                        $this->error("Failed to queue notification for user $user->id: ".$e->getMessage());
                         $failureCount++;
                     } finally {
                         $progressBar->advance();
@@ -65,7 +65,7 @@ class SendNotificationsAdHocEmail extends Command implements PromptsForMissingIn
             });
             $this->newLine();
 
-            $this->info("Success: $successCount Failure: $failureCount");
+            $this->info("Notifications queued.  Success: $successCount Failure: $failureCount");
             if ($failureCount > 0) {
                 return Command::FAILURE;
             } else {

--- a/api/app/Console/Commands/SendNotificationsAdHocEmail.php
+++ b/api/app/Console/Commands/SendNotificationsAdHocEmail.php
@@ -50,6 +50,7 @@ class SendNotificationsAdHocEmail extends Command implements PromptsForMissingIn
             $notification = new AdHocEmail($this->argument('templateIdEn'), $this->argument('templateIdFr'));
 
             $users->chunk(200, function (Collection $chunkOfUsers) use (&$successCount, &$failureCount, $progressBar, $notification) {
+                /** @var \App\Models\User $user */
                 foreach ($chunkOfUsers as $user) {
                     try {
                         $user->notify($notification);

--- a/api/app/Console/Commands/SendNotificationsAdHocEmail.php
+++ b/api/app/Console/Commands/SendNotificationsAdHocEmail.php
@@ -101,7 +101,7 @@ class SendNotificationsAdHocEmail extends Command implements PromptsForMissingIn
         }
 
         if (count($notificationFamilies) > 0) {
-            return $this->builderFromNotifictionFamilies($notificationFamilies);
+            return $this->builderFromNotificationFamilies($notificationFamilies);
         }
 
         if ($notifyAllUsers) {
@@ -128,7 +128,7 @@ class SendNotificationsAdHocEmail extends Command implements PromptsForMissingIn
         return $builder;
     }
 
-    private function builderFromNotifictionFamilies(array $notificationFamilies): Builder
+    private function builderFromNotificationFamilies(array $notificationFamilies): Builder
     {
         // Check for bad notification families
         $allNotificationFamilies = array_column(NotificationFamily::cases(), 'name');

--- a/api/app/Console/Commands/SendNotificationsAdHocEmail.php
+++ b/api/app/Console/Commands/SendNotificationsAdHocEmail.php
@@ -4,7 +4,7 @@ namespace App\Console\Commands;
 
 use App\Enums\NotificationFamily;
 use App\Models\User;
-use App\Notifications\AdHocGcNotifyEmail;
+use App\Notifications\AdHocEmail;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Database\Eloquent\Builder;
@@ -47,7 +47,7 @@ class SendNotificationsAdHocEmail extends Command implements PromptsForMissingIn
 
         if ($this->confirm('Do you wish to send notifications to '.$userCount.' users?')) {
             $progressBar = $this->output->createProgressBar($userCount);
-            $notification = new AdHocGcNotifyEmail($this->argument('templateIdEn'), $this->argument('templateIdFr'));
+            $notification = new AdHocEmail($this->argument('templateIdEn'), $this->argument('templateIdFr'));
 
             $users->chunk(200, function (Collection $chunkOfUsers) use (&$successCount, &$failureCount, $progressBar, $notification) {
                 foreach ($chunkOfUsers as $user) {

--- a/api/app/Console/Commands/SendNotificationsEmail.php
+++ b/api/app/Console/Commands/SendNotificationsEmail.php
@@ -94,7 +94,12 @@ class SendNotificationsEmail extends Command implements PromptsForMissingInput
         }
 
         if (count($notificationFamilies) > 0) {
-            return User::whereJsonContains('enabled_email_notifications', $notificationFamilies);
+            $builder = User::whereJsonContains('enabled_email_notifications', $notificationFamilies[0]);
+            for ($i = 1; $i < count($notificationFamilies); $i++) {
+                $builder->orWhereJsonContains('enabled_email_notifications', $notificationFamilies[$i]);
+            }
+
+            return $builder;
         }
 
         if ($notifyAllUsers) {

--- a/api/app/Console/Commands/SendNotificationsEmail.php
+++ b/api/app/Console/Commands/SendNotificationsEmail.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\PromptsForMissingInput;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+
+class SendNotificationsEmail extends Command implements PromptsForMissingInput
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'send-notifications:email
+                                {templateIdEn : The template ID for the English email message}
+                                {templateIdFr : The template ID for the French email message}
+                                {--emailAddress=* : The list of contact email addresses to send the notification to}
+                                {--notificationFamily=* : The list of notification families to send the notification to}
+                                {--notifyAllUsers : Send the notification to all users}
+    ';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send email notifications from given GC Notify templates';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $successCount = 0;
+        $failureCount = 0;
+
+        $users = $this->getUsersToSendNotificationTo();
+        $userCount = $users->count();
+
+        if ($this->confirm('Do you wish to send notifications to '.$userCount.' users?')) {
+
+            $progressBar = $this->output->createProgressBar($userCount);
+
+            $users->chunk(200, function (Collection $users) use (&$successCount, &$failureCount, $progressBar) {
+                foreach ($users as $user) {
+                    try {
+                        // $this->sendNotification($user, $successCount, $failureCount);
+                        $successCount++;
+                    } catch (\Throwable $e) {
+                        $this->error("Failed to send notification to user $user->id: ".$e->getMessage());
+                        $failureCount++;
+                    } finally {
+                        $progressBar->advance();
+                    }
+                }
+            });
+            $this->newLine();
+
+        }
+
+        $this->info("Success: $successCount Failure: $failureCount");
+        if ($failureCount > 0) {
+            return Command::FAILURE;
+        } else {
+            return Command::SUCCESS;
+        }
+    }
+
+    private function getUsersToSendNotificationTo(): Builder
+    {
+        $emailAddresses = $this->option('emailAddress');
+        $notificationFamilies = $this->option('notificationFamily');
+        $notifyAllUsers = $this->option('notifyAllUsers');
+
+        $options = $this->options();
+
+        $optionSelectedCount =
+            (count($emailAddresses) > 0 ? 1 : 0) +
+            (count($notificationFamilies) > 0 ? 1 : 0) +
+            ($notifyAllUsers ? 1 : 0);
+
+        if ($optionSelectedCount != 1) {
+            throw new \Error('Filter users using exactly one of the option types');
+        }
+
+        if (count($emailAddresses) > 0) {
+            return User::whereIn('email', $emailAddresses);
+        }
+
+        if (count($notificationFamilies) > 0) {
+            return User::whereJsonContains('enabled_email_notifications', $notificationFamilies);
+        }
+
+        if ($notifyAllUsers) {
+            return User::query();
+        }
+
+        throw new \Error('Unexpected function end point for options: '.json_encode($options));
+    }
+}

--- a/api/app/Notifications/AdHocEmail.php
+++ b/api/app/Notifications/AdHocEmail.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Enums\Language;
+use App\Models\User;
+use App\Notifications\Messages\GcNotifyEmailMessage;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+class AdHocEmail extends Notification implements CanBeSentViaGcNotifyEmail
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public string $templateIdEn,
+        public string $templateIdFr,
+    ) {}
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(): array
+    {
+        return [GcNotifyEmailChannel::class];
+    }
+
+    /**
+     * Get the GC Notify representation of the notification.
+     */
+    public function toGcNotifyEmail(User $notifiable): GcNotifyEmailMessage
+    {
+        $locale = $this->locale ?? $notifiable->preferredLocale();
+
+        if ($locale == Language::EN->value) {
+            // English notification
+            $message = new GcNotifyEmailMessage(
+                $this->templateIdEn,
+                $notifiable->email,
+                [
+                    'user' => $notifiable,
+                ]
+            );
+        } else {
+            // French notification
+            $message = new GcNotifyEmailMessage(
+                $this->templateIdFr,
+                $notifiable->email,
+                [
+                    'user' => $notifiable,
+                ]
+            );
+        }
+
+        return $message;
+    }
+}

--- a/api/app/Notifications/AdHocEmail.php
+++ b/api/app/Notifications/AdHocEmail.php
@@ -38,7 +38,8 @@ class AdHocEmail extends Notification implements CanBeSentViaGcNotifyEmail
         $locale = $this->locale ?? $notifiable->preferredLocale();
         $templateId = match ($locale) {
             Language::EN->value => $this->templateIdEn,
-            Language::FR->value => $this->templateIdFr
+            Language::FR->value => $this->templateIdFr,
+            default => throw new \InvalidArgumentException("Unsupported locale: $locale"),
         };
 
         $message = new GcNotifyEmailMessage(

--- a/api/app/Notifications/AdHocEmail.php
+++ b/api/app/Notifications/AdHocEmail.php
@@ -36,26 +36,19 @@ class AdHocEmail extends Notification implements CanBeSentViaGcNotifyEmail
     public function toGcNotifyEmail(User $notifiable): GcNotifyEmailMessage
     {
         $locale = $this->locale ?? $notifiable->preferredLocale();
+        $templateId = match ($locale) {
+            Language::EN->value => $this->templateIdEn,
+            Language::FR->value => $this->templateIdFr
+        };
 
-        if ($locale == Language::EN->value) {
-            // English notification
-            $message = new GcNotifyEmailMessage(
-                $this->templateIdEn,
-                $notifiable->email,
-                [
-                    'user' => $notifiable,
-                ]
-            );
-        } else {
-            // French notification
-            $message = new GcNotifyEmailMessage(
-                $this->templateIdFr,
-                $notifiable->email,
-                [
-                    'user' => $notifiable,
-                ]
-            );
-        }
+        $message = new GcNotifyEmailMessage(
+            $templateId,
+            $notifiable->email,
+            [
+                'first_name' => $notifiable->first_name,
+                'last_name' => $notifiable->last_name,
+            ]
+        );
 
         return $message;
     }


### PR DESCRIPTION
🤖 Resolves #11542 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Adds an Artisan command and Laravel notification for sending ad hoc emails with just the first name and last name.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->
The command will select users to notify by one of three criteria:
- specific email addresses
- specific notification families
- all users

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Update your api/.env file with the "team" api key
2. Rerun ./artisan optimize:clear
3. Start a queue worker
4. Update one user to have your GCNotify registered email address
5. Test various forms of the Artisan command

- [x] Can use email criteria
    `./artisan send-notifications:ad-hoc-email cdaa82f1-7f76-4d9e-a82e-328c41a6ab62 0831e036-8dfb-4f5e-8b31-867b2c526d77 --emailAddress=email1@example.org --emailAddress=email2@example.org`
- [x] Can use notification family criteria
    `./artisan send-notifications:ad-hoc-email cdaa82f1-7f76-4d9e-a82e-328c41a6ab62 0831e036-8dfb-4f5e-8b31-867b2c526d77 --notificationFamily=JOB_ALERT --notificationFamily=APPLICATION_UPDATE`
- [x] Can use notify all criteria (OR logic)
    `./artisan send-notifications:ad-hoc-email cdaa82f1-7f76-4d9e-a82e-328c41a6ab62 0831e036-8dfb-4f5e-8b31-867b2c526d77 --notifyAllUsers`
- [x] Respects language preferences
- [x] Can not use 0 or 2 or 3 criteria types
- [x] Warns of missing email addresses
- [x] Errors on invalid notification families
- [x] first and last name passed to GC Notify

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
![image](https://github.com/user-attachments/assets/34320fec-e411-4792-b63a-b3563f78daaf)

