### PR TITLE
[Fix] Add missing work email field in applicant query

### DIFF
--- a/apps/web/src/pages/Applications/fragment.ts
+++ b/apps/web/src/pages/Applications/fragment.ts
@@ -251,6 +251,8 @@ const Application_PoolCandidateFragment = graphql(/* GraphQL */ `
           endDate
         }
       }
+      workEmail
+      isWorkEmailVerified
     }
     pool {
       id


### PR DESCRIPTION
🤖 Resolves #12147 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Fixes a missing work email field in the query.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->


1. Rebuild app
2. Log in as a new user
3. In the create account flow, mark as a government employee and add a work email address
4. Start a new application

- [ ] In step 2 (review profile) confirm that the previously added work email is shown.

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
![image](https://github.com/user-attachments/assets/4a62d89b-4a7d-4761-8985-0ad2f7543898)
