### PR TITLE
[Feature] Opt into search placed candidates backend

### DIFF
--- a/api/app/Console/Commands/SuspendPlacedCandidates.php
+++ b/api/app/Console/Commands/SuspendPlacedCandidates.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\PoolCandidateStatus;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class SuspendPlacedCandidates extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:suspend-placed-candidates';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Set suspended at date to now() for placed term and indeterminate candidates';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $dateNow = Carbon::now();
+        $applicableStatuses = [PoolCandidateStatus::PLACED_TERM->name, PoolCandidateStatus::PLACED_INDETERMINATE->name];
+
+        DB::beginTransaction();
+        try {
+            DB::table('pool_candidates')
+                ->whereIn('pool_candidate_status', $applicableStatuses)
+                ->whereNull('suspended_at')
+                ->update(['suspended_at' => $dateNow]);
+            DB::commit();
+        } catch (\Throwable $error) {
+            DB::rollBack();
+            throw $error;
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/api/app/Enums/PoolCandidateStatus.php
+++ b/api/app/Enums/PoolCandidateStatus.php
@@ -28,12 +28,15 @@ enum PoolCandidateStatus
     case EXPIRED;
     case REMOVED;
 
+    // searchable candidates, so the available status and others treated as available for search purposes
     public static function qualifiedEquivalentGroup(): array
     {
         return [
             PoolCandidateStatus::QUALIFIED_AVAILABLE->name,
             PoolCandidateStatus::PLACED_TENTATIVE->name,
             PoolCandidateStatus::PLACED_CASUAL->name,
+            PoolCandidateStatus::PLACED_TERM->name,
+            PoolCandidateStatus::PLACED_INDETERMINATE->name,
         ];
     }
 

--- a/api/app/GraphQL/Mutations/PlaceCandidate.php
+++ b/api/app/GraphQL/Mutations/PlaceCandidate.php
@@ -2,6 +2,7 @@
 
 namespace App\GraphQL\Mutations;
 
+use App\Enums\PlacementType;
 use App\Models\PoolCandidate;
 use Carbon\Carbon;
 
@@ -24,6 +25,12 @@ final class PlaceCandidate
         $finalDecision = $candidate->computeFinalDecision();
         $candidate->computed_final_decision = $finalDecision['decision'];
         $candidate->computed_final_decision_weight = $finalDecision['weight'];
+
+        if ($placementType === PlacementType::PLACED_TERM->name || $placementType === PlacementType::PLACED_INDETERMINATE->name) {
+            $candidate->suspended_at = $now;
+        } else {
+            $candidate->suspended_at = null;
+        }
 
         $candidate->save();
 

--- a/api/app/GraphQL/Mutations/RevertPlaceCandidate.php
+++ b/api/app/GraphQL/Mutations/RevertPlaceCandidate.php
@@ -17,6 +17,7 @@ final class RevertPlaceCandidate
         $candidate->pool_candidate_status = PoolCandidateStatus::QUALIFIED_AVAILABLE->name;
         $candidate->placed_at = null;
         $candidate->placed_department_id = null;
+        $candidate->suspended_at = null;
 
         $candidate->save();
 

--- a/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
+++ b/api/app/GraphQL/Queries/CountPoolCandidatesByPool.php
@@ -33,7 +33,7 @@ final class CountPoolCandidatesByPool
             }
         });
 
-        // available candidates scope (scope CANDIDATE_STATUS_QUALIFIED_AVAILABLE or CANDIDATE_STATUS_PLACED_CASUAL, or PLACED_TENTATIVE)
+        // available candidates scope (qualifiedEquivalentGroup, not expired, not suspended)
         PoolCandidate::scopeAvailable($queryBuilder);
 
         // Only display IT & OTHER publishing group candidates

--- a/api/tests/Feature/PoolCandidateUpdateTest.php
+++ b/api/tests/Feature/PoolCandidateUpdateTest.php
@@ -160,6 +160,7 @@ class PoolCandidateUpdateTest extends TestCase
                 placedDepartment {
                     id
                 }
+                suspendedAt
             }
         }
     ';
@@ -175,6 +176,7 @@ class PoolCandidateUpdateTest extends TestCase
                 placedDepartment {
                     id
                 }
+                suspendedAt
             }
         }
     ';
@@ -502,12 +504,66 @@ class PoolCandidateUpdateTest extends TestCase
         assertSame($response['placedDepartment']['id'], $department->id);
     }
 
+    // placing candidates sets suspended_at automatically or keeps/makes it null appropriately
+    public function testPlaceCandidateMutationSuspensionLogic(): void
+    {
+        $department = Department::factory()->create();
+        $this->poolCandidate->pool_candidate_status = PoolCandidateStatus::QUALIFIED_AVAILABLE->name;
+        $this->poolCandidate->placed_at = null;
+        $this->poolCandidate->save();
+        $placedDoNotSuspend = [
+            PlacementType::PLACED_TENTATIVE->name,
+            PlacementType::PLACED_CASUAL->name,
+        ];
+        $placedDoSuspend = [
+            PlacementType::PLACED_TERM->name,
+            PlacementType::PLACED_INDETERMINATE->name,
+        ];
+
+        foreach ($placedDoNotSuspend as $value) {
+            $response = $this->actingAs($this->poolOperatorUser, 'api')
+                ->graphQL(
+                    $this->placeCandidateMutation,
+                    [
+                        'id' => $this->poolCandidate->id,
+                        'placeCandidate' => [
+                            'placementType' => $value,
+                            'departmentId' => $department->id,
+                        ],
+                    ]
+                )->json('data.placeCandidate');
+
+            assertSame($response['status']['value'], $value);
+            assertNotNull($response['placedAt']);
+            assertNull($response['suspendedAt']);
+        }
+
+        foreach ($placedDoSuspend as $value) {
+            $response = $this->actingAs($this->poolOperatorUser, 'api')
+                ->graphQL(
+                    $this->placeCandidateMutation,
+                    [
+                        'id' => $this->poolCandidate->id,
+                        'placeCandidate' => [
+                            'placementType' => $value,
+                            'departmentId' => $department->id,
+                        ],
+                    ]
+                )->json('data.placeCandidate');
+
+            assertSame($response['status']['value'], $value);
+            assertNotNull($response['placedAt']);
+            assertNotNull($response['suspendedAt']);
+        }
+    }
+
     public function testRevertPlaceCandidateMutation(): void
     {
         $department = Department::factory()->create();
         $this->poolCandidate->pool_candidate_status = PoolCandidateStatus::NEW_APPLICATION->name;
         $this->poolCandidate->placed_department_id = $department->id;
         $this->poolCandidate->placed_at = config('constants.far_past_date');
+        $this->poolCandidate->suspended_at = config('constants.far_past_date');
         $this->poolCandidate->save();
 
         // cannot execute mutation due to candidate not being placed
@@ -535,6 +591,7 @@ class PoolCandidateUpdateTest extends TestCase
         assertSame($response['status']['value'], PoolCandidateStatus::QUALIFIED_AVAILABLE->name);
         assertNull($response['placedAt']);
         assertNull($response['placedDepartment']);
+        assertNull($response['suspendedAt']);
     }
 
     public function testQualifyCandidateMutation(): void

--- a/api/tests/Feature/UserTest.php
+++ b/api/tests/Feature/UserTest.php
@@ -1771,11 +1771,12 @@ class UserTest extends TestCase
                 'looking_for_bilingual' => false,
             ]),
         ]);
-        // Already placed - should not appear in searches
+        // Already placed - should appear in searches
         PoolCandidate::factory()->create([
             'pool_id' => $pool1['id'],
             'expiry_date' => config('constants.far_future_date'),
             'pool_candidate_status' => PoolCandidateStatus::PLACED_TERM->name,
+            'suspended_at' => null,
             'user_id' => User::factory([
                 'looking_for_english' => true,
                 'looking_for_french' => false,
@@ -1812,7 +1813,7 @@ class UserTest extends TestCase
         );
         $response->assertJson([
             'data' => [
-                'countApplicants' => 14, // including base admin user
+                'countApplicants' => 15, // including base admin user
             ],
         ]);
 
@@ -1834,7 +1835,7 @@ class UserTest extends TestCase
             ]
         )->assertJson([
             'data' => [
-                'countApplicants' => 9, //including base admin user
+                'countApplicants' => 10, //including base admin user
             ],
         ]);
     }


### PR DESCRIPTION
🤖 Resolves #12212 

## 👋 Introduction

Handles some of the backend work needed as well as introduces an Artisan command. 

## 🕵️ Details

The command will update placed term and indeterminate candidates to have suspended dates. 
Placement mutations will touch the suspended date field, and search accounts for the two statuses as well. 

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Test Artisan command 
2. Place/revert candidates, assert field updated in database client
3. Test placed candidate searchable or not based off suspended value, such as from `/en/search`

## 🚚 Deployment

Run 
`php artisan app:suspend-placed-candidates`