### PR TITLE
[Feat] Shard playwright tests in CI

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -107,8 +107,9 @@ jobs:
     # Merge reports after playwright-tests, even if some shards have failed
     if: ${{ !cancelled() }}
     needs: [playwright]
-
     runs-on: ubuntu-latest
+    env:
+      PNPM_VERSION: "9.12.3"
     steps:
     - uses: pnpm/action-setup@v4
       with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -138,5 +138,5 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: html-report--attempt-${{ github.run_attempt }}
-        path: playwright-report
+        path: ./apps/playwright/playwright-report/
         retention-days: 14

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -83,7 +83,7 @@ jobs:
         if: always()
         with:
           name: blob-report-${{ matrix.shardIndex }}
-          path: ./apps/playwright/playwright-report/
+          path: blob-report
           retention-days: 1
 
   merge-reports:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -77,31 +77,14 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install chromium webkit --with-deps
 
-      - name: Run Chromium Tests
-        run: pnpm run e2e:playwright:chromium --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+      - name: Run Tests
+        run: pnpm run e2e:playwright --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: report-chromium-${{ matrix.shardIndex }}
+          name: blob-report-${{ matrix.shardIndex }}
           path: ./apps/playwright/playwright-report/
-          retention-days: 30
-
-      - name: Run Webkit Tests
-        run: pnpm run e2e:playwright:webkit --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: report-webkit-${{ matrix.shardIndex }}
-          path: ./apps/playwright/playwright-report/
-          retention-days: 30
-
-      - name: Check status of containers
-        if: failure()
-        run: docker compose ps
-
-      - name: "Check logs: web server container"
-        if: failure()
-        run: docker compose logs webserver
+          retention-days: 1
 
   merge-reports:
     # Merge reports after playwright-tests, even if some shards have failed
@@ -127,16 +110,16 @@ jobs:
     - name: Download blob reports from GitHub Actions Artifacts
       uses: actions/download-artifact@v4
       with:
-        path: ./all-reports
-        pattern: report-*
+        path: all-blob-reports
+        pattern: blob-report-*
         merge-multiple: true
 
     - name: Merge into HTML Report
-      run: npx playwright merge-reports --reporter html ./all-reports
+      run: npx playwright merge-reports --reporter html ./all-blob-reports
 
     - name: Upload HTML report
       uses: actions/upload-artifact@v4
       with:
         name: html-report--attempt-${{ github.run_attempt }}
-        path: ./playwright-report
+        path: playwright-report
         retention-days: 14

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: chromium-report-${{ matrix.shardIndex }}
+          name: report-chromium-${{ matrix.shardIndex }}
           path: ./apps/playwright/playwright-report/
           retention-days: 30
 
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: webkit-report-${{ matrix.shardIndex }}
+          name: report-webkit-${{ matrix.shardIndex }}
           path: ./apps/playwright/playwright-report/
           retention-days: 30
 
@@ -124,7 +124,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         path: all-reports
-        pattern: *-report-*
+        pattern: report-*
         merge-multiple: true
 
     - name: Merge into HTML Report

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -110,6 +110,9 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+    - uses: pnpm/action-setup@v4
+      with:
+        version: ${{ env.PNPM_VERSION }}
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -83,7 +83,7 @@ jobs:
         if: always()
         with:
           name: blob-report-${{ matrix.shardIndex }}
-          path: blob-report
+          path: ./apps/playwright/blob-report
           retention-days: 1
 
   merge-reports:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -127,7 +127,7 @@ jobs:
     - name: Download blob reports from GitHub Actions Artifacts
       uses: actions/download-artifact@v4
       with:
-        path: all-reports
+        path: ./all-reports
         pattern: report-*
         merge-multiple: true
 
@@ -138,5 +138,5 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: html-report--attempt-${{ github.run_attempt }}
-        path: ./apps/playwright/playwright-report/
+        path: ./playwright-report
         retention-days: 14

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -29,6 +29,11 @@ jobs:
   playwright:
     name: Playwright
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
     env:
       # Use native docker command within docker compose
       COMPOSE_DOCKER_CLI_BUILD: 1
@@ -70,20 +75,20 @@ jobs:
         run: npx playwright install chromium webkit --with-deps
 
       - name: Run Chromium Tests
-        run: pnpm run e2e:playwright:chromium
+        run: pnpm run e2e:playwright:chromium --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: chromium-report
+          name: chromium-report-${{ matrix.shardIndex }}
           path: ./apps/playwright/playwright-report/
           retention-days: 30
 
       - name: Run Webkit Tests
-        run: pnpm run e2e:playwright:webkit
+        run: pnpm run e2e:playwright:webkit --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: webkit-report
+          name: webkit-report-${{ matrix.shardIndex }}
           path: ./apps/playwright/playwright-report/
           retention-days: 30
 
@@ -94,3 +99,37 @@ jobs:
       - name: "Check logs: web server container"
         if: failure()
         run: docker compose logs webserver
+
+  merge-reports:
+    # Merge reports after playwright-tests, even if some shards have failed
+    if: ${{ !cancelled() }}
+    needs: [playwright]
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: ".nvmrc"
+        cache: pnpm
+
+    # Fix some issue with cache in setup-node
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
+
+    - name: Download blob reports from GitHub Actions Artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: all-reports
+        pattern: *-report-*
+        merge-multiple: true
+
+    - name: Merge into HTML Report
+      run: npx playwright merge-reports --reporter html ./all-reports
+
+    - name: Upload HTML report
+      uses: actions/upload-artifact@v4
+      with:
+        name: html-report--attempt-${{ github.run_attempt }}
+        path: playwright-report
+        retention-days: 14

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,7 +9,7 @@ on:
 
   pull_request:
     paths:
-      - .github/workflows/*lint*.yml
+      - .github/workflows/*playwright*.yml
       - apps/**
       - packages/**
       - api/**

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,8 +8,11 @@ on:
       - "**.md"
 
   pull_request:
-    paths-ignore:
-      - "**.md"
+    paths:
+      - .github/workflows/*lint*.yml
+      - apps/**
+      - packages/**
+      - api/**
   merge_group:
     branches: [main]
 # Concurrency is used to cancel other currently-running jobs, to preserve

--- a/apps/playwright/playwright.config.ts
+++ b/apps/playwright/playwright.config.ts
@@ -44,10 +44,10 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
 
-    {
-      name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
-    },
+    // {
+    //   name: "firefox",
+    //   use: { ...devices["Desktop Firefox"] },
+    // },
 
     {
       name: "webkit",

--- a/apps/playwright/playwright.config.ts
+++ b/apps/playwright/playwright.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : "25%",
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI
-    ? [["line"], ["html", { open: "never" }]]
+    ? "blob"
     : [["line"], ["html", { open: "on-failure" }]],
   timeout: Number(process.env.TEST_TIMEOUT ?? 60 * 1000), // 1 minute
   expect: { timeout: Number(process.env.EXPECT_TIMEOUT ?? 10000) }, // 10 seconds

--- a/apps/playwright/playwright.config.ts
+++ b/apps/playwright/playwright.config.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { defineConfig, devices } from "@playwright/test";
 import dotenv from "dotenv";
 
+// eslint-disable-next-line import/no-named-as-default-member
 dotenv.config({ path: path.resolve(__dirname, ".env") });
 
 /**


### PR DESCRIPTION
🤖 Resolves #12187 

## 👋 Introduction

Updates the playwright workflow to utilize shards, reducing the amount of time needed to run.

## 🕵️ Details

This makes a few crucial changes:

- Updates the report to blob (required to merge reports)
- Runs all the tests in a single command instead of separate for each browser (makes balancing shards more even)
- Shards the tests into 4 different matrices
- Merges all reports into a single html report at the end instead of having a report per browser

### Time savings

We have went for 44mins to 22mins for total run time which is  a 50% reduction in total runtime. We can probably squeeze some more savings if we [split some larger tests files up](https://github.com/GCTC-NTGC/gc-digital-talent/issues/12357) to better leverage parallelism.

## 🧪 Testing

1. Confirm playwright workflow runs as expected