### PR TITLE
[Fix] Account settings auth redirect

### DIFF
--- a/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPage.tsx
+++ b/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPage.tsx
@@ -12,18 +12,18 @@ import {
 } from "@gc-digital-talent/ui";
 import { graphql } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
+import { ROLE_NAME } from "@gc-digital-talent/auth";
 
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import useRoutes from "~/hooks/useRoutes";
 import SEO from "~/components/SEO/SEO";
 import Hero from "~/components/Hero";
 import profileMessages from "~/messages/profileMessages";
+import RequireAuth from "~/components/RequireAuth/RequireAuth";
 
 import AccountManagement from "./AccountManagement";
 import RecruitmentAvailability from "./RecruitmentAvailability";
 import NotificationSettings from "./NotificationSettings";
-import RequireAuth from "~/components/RequireAuth/RequireAuth";
-import { ROLE_NAME } from "@gc-digital-talent/auth";
 
 const AccountSettings_Query = graphql(/* GraphQL */ `
   query AccountSettings {

--- a/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPage.tsx
+++ b/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPage.tsx
@@ -22,6 +22,8 @@ import profileMessages from "~/messages/profileMessages";
 import AccountManagement from "./AccountManagement";
 import RecruitmentAvailability from "./RecruitmentAvailability";
 import NotificationSettings from "./NotificationSettings";
+import RequireAuth from "~/components/RequireAuth/RequireAuth";
+import { ROLE_NAME } from "@gc-digital-talent/auth";
 
 const AccountSettings_Query = graphql(/* GraphQL */ `
   query AccountSettings {
@@ -65,7 +67,7 @@ const inlineLink = (href: string, chunks: ReactNode) => (
   </Link>
 );
 
-export const Component = () => {
+const AccountSettingsPage = () => {
   const intl = useIntl();
   const paths = useRoutes();
 
@@ -238,12 +240,12 @@ export const Component = () => {
   );
 };
 
-// export const Component = () => (
-//   <RequireAuth roles={[ROLE_NAME.Applicant]}>
-//     <AccountSettingsPage />
-//   </RequireAuth>
-// );
+export const Component = () => (
+  <RequireAuth roles={[ROLE_NAME.Applicant]}>
+    <AccountSettingsPage />
+  </RequireAuth>
+);
 
 Component.displayName = "AccountSettingsPage";
 
-export default Component;
+export default AccountSettingsPage;


### PR DESCRIPTION
🤖 Resolves #12353 

## 👋 Introduction

Adds the `RequireAuth` wrapper to the account settings page for the redirect.

## 🧪 Testing

1. Build app `pnpm run dev:fresh`
2. Ensure you are not authenticated
3. Navigate to `/applicant/settings`
4. Confirm you are redirected to the login info page
5. Confirm completing the login takes you back to `/applicant/settings`