### PR TITLE
[Copy] Updates French Title for the instructor led training page

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6467,7 +6467,7 @@
     "description": "Submit button within the search filter dialog"
   },
   "V4W5oL": {
-    "defaultMessage": "Possibilités de formation dirigée par un instructeur ou une instructrice",
+    "defaultMessage": "Possibilités de formation dirigées par un instructeur ou une instructrice",
     "description": "Title for the instructor led training page"
   },
   "V6Y2Np": {


### PR DESCRIPTION
🤖 Resolves #12367.

## 👋 Introduction

This PR updates the French Title for the instructor led training page string.

## 🧪 Testing

1. `pnpm build`
2. Navigate to http://localhost:8000/fr/it-training-fund/instructor-led-training
3. Verify title of the document, heading title level 1, and breacrumb is _Possibilités de formation dirigées par un instructeur ou une instructrice_

## 📸 Screenshot

<img width="1432" alt="Screen Shot 2024-12-20 at 10 14 28" src="https://github.com/user-attachments/assets/00acb9de-1ff4-4aef-a2ae-ec3a0cb3baf7" />