### PR TITLE
[Feature] Adds EX-03, EX-04 to `scopeAvailableInSearch`

### DIFF
--- a/api/app/Models/Classification.php
+++ b/api/app/Models/Classification.php
@@ -59,7 +59,7 @@ class Classification extends Model
 
     /**
      * Used to limit the results for the search page input
-     * to IT up to level 5 and PM up to level 6 and CR level 4
+     * to IT up to level 5; PM up to level 6; CR level 4; EX level 3, EX level 4.
      *
      * TODO: Update in #9483 to derive from new column
      */
@@ -75,6 +75,10 @@ class Classification extends Model
             $query->where('group', 'PM')->where('level', '<=', 6);
         })->orWhere(function ($query) {
             $query->where('group', 'CR')->where('level', '=', 4);
+        })->orWhere(function ($query) {
+            $query->where('group', 'EX')->where('level', '=', 3);
+        })->orWhere(function ($query) {
+            $query->where('group', 'EX')->where('level', '=', 4);
         });
     }
 }

--- a/api/database/seeders/ClassificationSeeder.php
+++ b/api/database/seeders/ClassificationSeeder.php
@@ -257,6 +257,14 @@ class ClassificationSeeder extends Seeder
                 ]
             ),
             array_merge(
+                $exGroup,
+                [
+                    'level' => 4,
+                    'min_salary' => 193896,
+                    'max_salary' => 228114,
+                ]
+            ),
+            array_merge(
                 $crGroup,
                 [
                     'level' => 4,

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1859,6 +1859,10 @@
     "defaultMessage": "artisanat confectionné à la main de fleurs et de feuilles perlées.",
     "description": "Description of a decorative image of some beaded artwork"
   },
+  "7dOILY": {
+    "defaultMessage": "EX-03 : Chef de file du numérique",
+    "description": "EX-03 classification label including titles"
+  },
   "7ejG4K": {
     "defaultMessage": "Vous avez le droit d’accéder à vos renseignements personnels, de les corriger et de les protéger en vertu de la Loi sur la protection des renseignements personnels et de déposer une plainte auprès du Commissariat à la protection de la vie privée du Canada quant à la façon dont vos renseignements personnels sont traités.",
     "description": "Paragraph for privacy policy page"
@@ -3267,6 +3271,10 @@
     "defaultMessage": "Vous avez obtenu un diplôme à l’extérieur du Canada? <foreignDegreeLink>Apprenez-en davantage sur les équivalences pour les diplômes étrangers.</foreignDegreeLink>",
     "description": "External link message for the EX graduation with degree requirement."
   },
+  "EbG039": {
+    "defaultMessage": "Chef de file du numérique E X 4",
+    "description": "EX-04 classification aria label including titles"
+  },
   "Ed+xy1": {
     "defaultMessage": "Décision disqualifiée",
     "description": "Disqualified decision input"
@@ -3706,6 +3714,10 @@
   "Gw0uTQ": {
     "defaultMessage": "Gérez vos demandes de talents et établissez votre profil de gestionnaire.",
     "description": "Subtitle for the 'Manager dashboard' page"
+  },
+  "GwhSUZ": {
+    "defaultMessage": "EX-04 : Chef de file du numérique",
+    "description": "EX-04 classification label including titles"
   },
   "H+83NU": {
     "defaultMessage": "Vous avez des questions? <link>Contactez-nous</link>.",
@@ -8317,6 +8329,10 @@
   "e4eYvU": {
     "defaultMessage": "Cote de sécurité",
     "description": "Label for pool advertisement security clearance requirement"
+  },
+  "e4nq4j": {
+    "defaultMessage": "Chef de file du numérique E X 3",
+    "description": "EX-03 classification aria label including titles"
   },
   "e5BoL+": {
     "defaultMessage": "Cette bibliothèque contient une série de modèles pour des emplois courants dans les collectivités soutenues par Talents numériques du GC. Les modèles comprennent des informations suggérées et des recommandations pour des éléments tels que le titre du poste, les tâches courantes, les compétences essentielles et les compétences optionnelles. Parcourez la liste complète ou utilisez la barre de recherche et les filtres pour trouver des modèles qui correspondent aux spécificités du poste.",

--- a/apps/web/src/pages/SearchRequests/SearchPage/labels.ts
+++ b/apps/web/src/pages/SearchRequests/SearchPage/labels.ts
@@ -62,6 +62,16 @@ export const classificationLabels: Record<string, MessageDescriptor> =
       id: "i7nfvV",
       description: "CR-04 classification label including titles",
     },
+    "EX-03": {
+      defaultMessage: "EX-03: Digital Leader",
+      id: "7dOILY",
+      description: "EX-03 classification label including titles",
+    },
+    "EX-04": {
+      defaultMessage: "EX-04: Digital Leader",
+      id: "GwhSUZ",
+      description: "EX-04 classification label including titles",
+    },
   });
 
 export const classificationAriaLabels: Record<string, MessageDescriptor> =
@@ -125,5 +135,15 @@ export const classificationAriaLabels: Record<string, MessageDescriptor> =
       defaultMessage: "Clerk C R 4",
       id: "UA37iG",
       description: "CR-04 classification aria label including titles",
+    },
+    "EX-03": {
+      defaultMessage: "Digital Leader E X 3",
+      id: "e4nq4j",
+      description: "EX-03 classification aria label including titles",
+    },
+    "EX-04": {
+      defaultMessage: "Digital Leader E X 4",
+      id: "EbG039",
+      description: "EX-04 classification aria label including titles",
     },
   });

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -499,6 +499,12 @@ export const getClassificationSalaryRangeUrl = (
         fr: "https://www.tbs-sct.canada.ca/agreements-conventions/view-visualiser-fra.aspx?id=15",
       };
       break;
+    case "EX":
+      localizedUrl = {
+        en: "https://www.canada.ca/en/treasury-board-secretariat/services/pay/rates-pay/rates-pay-unrepresented-senior-excluded-employees/ex.html#EXcurrent",
+        fr: "https://www.canada.ca/fr/secretariat-conseil-tresor/services/remuneration/taux-remuneration/taux-remuneration-employes-non-representes-exclus-niveaux-superieurs/ex.htm#EXcurrent",
+      };
+      break;
     default:
       break;
   }


### PR DESCRIPTION
🤖 Resolves #12251.

## 👋 Introduction

This PR adds EX-03 and EX-04 to `scopeAvailableInSearch` so that they are available as options in the classification filter of the search for talent form.

## 🕵️ Details

The EX salary range URLs (`getClassificationSalaryRangeUrl`) were also added as they were not previously in the codebase.

## 🧪 Testing

1. Navigate to http://localhost:8000/en/search
2. Verify EX-03 and EX-04 are options with English job titles in classification filter select
3. Switch to French
4. Verify EX-03 and EX-04 are options with French job titles in classification filter select

## 📸 Screenshots
<img width="1357" alt="Screen Shot 2024-12-23 at 16 21 59" src="https://github.com/user-attachments/assets/c40a1e3c-f67e-4071-816b-cabb491accba" />

<img width="1357" alt="Screen Shot 2024-12-23 at 16 22 16" src="https://github.com/user-attachments/assets/ccab2db8-6c5a-4af3-beb4-81a2c9bac6ff" />