### PR TITLE
[Fix] Storage permissions after optimize

### DIFF
--- a/infrastructure/bin/post_deployment.sh
+++ b/infrastructure/bin/post_deployment.sh
@@ -46,8 +46,6 @@ cd /home/site/wwwroot/api
 # Laravel local cache
 if
     mkdir --parents /tmp/bootstrap/cache /tmp/api/storage/framework/cache/data && \
-    chown www-data:www-data /tmp/bootstrap/cache && \
-    chown -R www-data:www-data /tmp/api/storage && \
     php artisan optimize && \
     chown www-data:www-data /tmp/bootstrap/cache && \
     chown -R www-data:www-data /tmp/api/storage;

--- a/infrastructure/bin/post_deployment.sh
+++ b/infrastructure/bin/post_deployment.sh
@@ -48,7 +48,9 @@ if
     mkdir --parents /tmp/bootstrap/cache /tmp/api/storage/framework/cache/data && \
     chown www-data:www-data /tmp/bootstrap/cache && \
     chown -R www-data:www-data /tmp/api/storage && \
-    php artisan optimize;
+    php artisan optimize && \
+    chown www-data:www-data /tmp/bootstrap/cache && \
+    chown -R www-data:www-data /tmp/api/storage;
 then
     add_section_block ":white_check_mark: Laravel cache setup *successful*."
 else


### PR DESCRIPTION
🤖 Resolves #12223 

## 👋 Introduction

Re-runs the permission after optimize command to hopefully fix them.

## 🕵️ Details

I think this lined up with the addition of `php artisan optimize` after changing permissions. I think that deletes and/or rewrites some files that could have modified permissions on them to something undesirable. Since the graphiql error seems to be permissions related, this was my best guess.

## 🧪 Testing

> [!NOTE]
> This requires a deployment, or at least running `post_deployment.sh`

1. Run `post_deployment.sh`
2. Confirm `/graphiql` loads correctly with no error