### PR TITLE
[Fix] Getting started success toast always triggered

### DIFF
--- a/apps/web/src/pages/Auth/RegistrationPages/GettingStartedPage/GettingStartedPage.tsx
+++ b/apps/web/src/pages/Auth/RegistrationPages/GettingStartedPage/GettingStartedPage.tsx
@@ -410,7 +410,11 @@ const GettingStarted = () => {
             new Error(notificationResult.error?.toString()),
           );
         });
+      } else {
+        return Promise.reject(new Error(generalResult.error?.toString()));
       }
+
+      return null;
     });
 
   const onSubmit = async (


### PR DESCRIPTION
🤖 Resolves #12327 

## 👋 Introduction

Fixes and issue where the getting started form was always displaying the success message, even on failure.

## 🕵️ Details

Looks as though we were not rejecting the promise when there was an error on the main mutation, only in the mutation that occurs after. This lead to our error exchange showing an error toast and the success toast running regardless if there was an error.

## 🧪 Testing

> [!NOTE]
> On success, you may still see error toast but this is going to be expected if you selected "verify email" submit action and do not have a GC Notify API key set. Technically this is correct since account creation is successful and the error is sending the verification email.

1. Build the app `pnpm run dev:fresh`
2. Login as a new user
3. On the first step of account registration, set contact email to one that exists (`admin@test.com`)
4. Submit form
5. Confirm no success message happens
6. Update email to be on that has not been taken
7. Submit form
8. Confirm success toast