### PR TITLE
[Feature] Update French workstream name for `SECURITY`

### DIFF
--- a/api/database/migrations/2024_12_24_170232_rename_work_stream_security_name.php
+++ b/api/database/migrations/2024_12_24_170232_rename_work_stream_security_name.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('work_streams')
+            ->where('key', 'SECURITY')
+            ->update(['name->fr' => 'Sécurité']);
+    }
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('work_streams')
+            ->where('key', 'SECURITY')
+            ->update(['name->fr' => 'Sécurité de la TI']);
+    }
+};

--- a/api/database/migrations/2024_12_24_170232_rename_work_stream_security_name.php
+++ b/api/database/migrations/2024_12_24_170232_rename_work_stream_security_name.php
@@ -14,6 +14,7 @@ return new class extends Migration
             ->where('key', 'SECURITY')
             ->update(['name->fr' => 'Sécurité']);
     }
+
     /**
      * Reverse the migrations.
      */

--- a/api/lang/fr/pool_stream.php
+++ b/api/lang/fr/pool_stream.php
@@ -8,7 +8,7 @@ return [
     'infrastructure_operations' => 'Opérations d’infrastructure de la TI',
     'planning_and_reporting' => 'Planification et établissement de rapports en matière de TI',
     'project_portfolio_management' => 'Gestion de portefeuilles de projets de la TI',
-    'security' => 'Sécurité de la TI',
+    'security' => 'Sécurité',
     'software_solutions' => 'Solutions logicielles de la TI',
     'information_data_functions' => 'Fonctions d’information et de données',
     'executive_group' => 'Groupe de la direction',


### PR DESCRIPTION
🤖 Resolves #12375.

## 👋 Introduction

This PR updates the French workstream name for `SECURITY` in the database via a Laravel migration and updates the original pool stream lang file where it came from.

## 🧪 Testing

1. `make refresh-api`
2. `pnpm build:fresh`
3. Navigate to http://localhost:8000/fr/search
4. Verify option _Sécurité_ exists in _Volet_ select input
5. Create a process
6. Verify option _Sécurité_ exists in _Flux de travail_ select input

## 📸 Screenshots

<img width="673" alt="Screen Shot 2024-12-24 at 12 13 22" src="https://github.com/user-attachments/assets/3b758628-6def-41e6-93f1-5a88f3cd2741" />

<img width="1104" alt="Screen Shot 2024-12-24 at 12 14 57" src="https://github.com/user-attachments/assets/cdafc326-9e3a-452d-9ae5-48f756645b80" />

## 🚚 Deployment

This PR adds a migration that doesn't require any manual deployment action other than making sure the migration is run.
