### PR TITLE
[Copy] Change to sentence case; remove superfluous colons; update English and French copy

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/tableMessages.ts
+++ b/apps/web/src/components/PoolCandidatesTable/tableMessages.ts
@@ -7,8 +7,8 @@ const messages = defineMessages({
     id: "/LGiVB",
   },
   candidateName: {
-    defaultMessage: "Candidate Name",
-    id: "p/Qp/u",
+    defaultMessage: "Candidate name",
+    id: "awEvCF",
     description: "Title displayed on the Pool Candidates table name column.",
   },
   skillCount: {
@@ -23,10 +23,10 @@ const messages = defineMessages({
       "Title displayed on the Pool Candidates table Current Location column.",
   },
   dateReceived: {
-    defaultMessage: "Date Received",
-    id: "3eNQnt",
+    defaultMessage: "Date received",
+    id: "fI0idr",
     description:
-      "Title displayed on the Pool Candidates table Date Received column.",
+      "Title displayed on the Pool Candidates table Date received column.",
   },
   rowSelection: {
     defaultMessage: "Row Selection",

--- a/apps/web/src/components/SearchRequestFilters/FilterBlock.tsx
+++ b/apps/web/src/components/SearchRequestFilters/FilterBlock.tsx
@@ -59,9 +59,6 @@ const FilterBlock = ({ title, content }: FilterBlockProps) => {
         data-h2-font-weight="base(600)"
       >
         <span data-h2-display="base(inline)">{title}</span>
-        <span data-h2-display="base(none) p-tablet(inline)">
-          {intl.formatMessage(commonMessages.dividingColon)}
-        </span>
       </p>
       <FilterBlockContent content={content} />
     </div>

--- a/apps/web/src/components/SearchRequestFilters/FilterBlock.tsx
+++ b/apps/web/src/components/SearchRequestFilters/FilterBlock.tsx
@@ -5,8 +5,6 @@ import isArray from "lodash/isArray";
 import { ReactNode } from "react";
 
 import { Maybe } from "@gc-digital-talent/graphql";
-import { commonMessages } from "@gc-digital-talent/i18n";
-
 interface FilterBlockProps {
   title: string;
   content?: Maybe<string | ReactNode> | Maybe<string[]>;
@@ -49,8 +47,6 @@ const FilterBlockContent = ({
 };
 
 const FilterBlock = ({ title, content }: FilterBlockProps) => {
-  const intl = useIntl();
-
   return (
     <div data-h2-padding="base(0, 0, x1, 0)">
       <p

--- a/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -230,8 +230,8 @@ const ApplicantFilters = ({
           <FilterBlock
             title={intl.formatMessage({
               defaultMessage:
-                "Conditions of employment / Operational requirements",
-              id: "cMsRgt",
+                "Conditions of employment or operational requirements",
+              id: "SNxTm+",
               description:
                 "Title for operational requirements section on summary of filters section",
             })}
@@ -430,8 +430,8 @@ const SearchRequestFilters = ({
               <FilterBlock
                 title={intl.formatMessage({
                   defaultMessage:
-                    "Conditions of employment / Operational requirements",
-                  id: "cMsRgt",
+                    "Conditions of employment or operational requirements",
+                  id: "SNxTm+",
                   description:
                     "Title for operational requirements section on summary of filters section",
                 })}

--- a/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
@@ -330,8 +330,8 @@ const SearchRequestTable = ({ title }: SearchRequestTableProps) => {
         id: "requestedDate",
         enableColumnFilter: false,
         header: intl.formatMessage({
-          defaultMessage: "Date Received",
-          id: "r2gD/4",
+          defaultMessage: "Date received",
+          id: "m0Qcow",
           description:
             "Title displayed on the search request table requested date column.",
         }),

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2552,7 +2552,7 @@
     "description": "Placeholder text for user name input in the delete user dialog"
   },
   "B6SqfX": {
-    "defaultMessage": "Sauvegarder le changement d’état",
+    "defaultMessage": "Sauvegardez le changement d'état",
     "description": "Button label displayed that saves the users status selection."
   },
   "B6XXtf": {
@@ -5316,7 +5316,7 @@
     "description": "Title for the websites inclusivity and equity page"
   },
   "PD7anu": {
-    "defaultMessage": "Courriel du conseiller/ère en RH",
+    "defaultMessage": "Courriel du (de la) conseiller(-ère) en RH",
     "description": "Title for the HR advisor email block in the manager info section of the single search request view."
   },
   "PDGUT2": {
@@ -5400,7 +5400,7 @@
     "description": "Title for link to page to create a training opportunity (imperative in French)"
   },
   "Pe1kas": {
-    "defaultMessage": "Notes sur les demandes",
+    "defaultMessage": "Notes sur cette demande",
     "description": "Label displayed on the search request form request notes field."
   },
   "PerY/b": {
@@ -6623,7 +6623,7 @@
     "description": "Status for an application that has been hired with a term contract"
   },
   "VrLfLw": {
-    "defaultMessage": "Courriel du conseiller/ère en RH",
+    "defaultMessage": "Courriel du (de la) conseiller(-ère) en RH",
     "description": "Input label asking for the HR advisor's email address."
   },
   "Vs8wOD": {
@@ -7383,7 +7383,7 @@
     "description": "Link text to start a new talent request"
   },
   "ZNne50": {
-    "defaultMessage": "Enregistrer les notes",
+    "defaultMessage": "Enregistrez les notes",
     "description": "Button to save notes for a pool candidate on the view-user page"
   },
   "ZOEHxi": {
@@ -8731,7 +8731,7 @@
     "description": "Opening paragraph for accessibility statement"
   },
   "fzuAHN": {
-    "defaultMessage": "Enregistrer les notes",
+    "defaultMessage": "Enregistrez les notes",
     "description": "Button label displayed on the search request form which saves the users personal notes."
   },
   "g+JcDC": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5203,6 +5203,10 @@
     "defaultMessage": "Ajouter une compétence",
     "description": "Label for skill dialog trigger on experience skills section."
   },
+  "OgbLp1": {
+    "defaultMessage": "Ministère ou organisation d'embauche",
+    "description": "Label for department select input in the request form"
+  },
   "OgizOq": {
     "defaultMessage": "Vous êtes à l'aise de partager vos renseignements sur l'équité en matière d'emploi pour des possibilités de recrutement et à des fins de statistiques anonymisées.",
     "description": "Second condition for selecting an employment equity group"
@@ -5286,10 +5290,6 @@
   "P6jGb4": {
     "defaultMessage": "Veuillez préciser les exigences linguistiques",
     "description": "Label for _other official language requirement_ fieldset in the _digital services contracting questionnaire_"
-  },
-  "P7ItrT": {
-    "defaultMessage": "Ministère/organisation d’embauche",
-    "description": "Label for department select input in the request form"
   },
   "P9SZBZ": {
     "defaultMessage": "Sélectionnez les filtres",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -203,6 +203,10 @@
     "defaultMessage": "Sécurité de la TI",
     "description": "Label for the 'security' IT work stream"
   },
+  "/3mqz9": {
+    "defaultMessage": "Renseignements sur le gestionnaire",
+    "description": "Heading for the request information section of the single search request view."
+  },
   "/4z9lj": {
     "defaultMessage": "De la même manière que pour les compétences techniques essentielles, cette liste propose des recommandations concernant les compétences comportementales généralement requises dans le cadre de ce poste. Nous recommandons de limiter les compétences comportementales essentielles aux exigences exactes de votre poste ou de votre équipe afin d’aider les personnes candidates à mettre en évidence l’expérience la plus pertinente.",
     "description": "Description displayed on the job poster template 'essential behavioural skills' section."
@@ -1094,10 +1098,6 @@
   "3e965x": {
     "defaultMessage": "Lieu de travail",
     "description": "Title for work location section on summary of filters section"
-  },
-  "3eNQnt": {
-    "defaultMessage": "Date de réception",
-    "description": "Title displayed on the Pool Candidates table Date Received column."
   },
   "3eeKdd": {
     "defaultMessage": "De quelle façon avez-vous démontré cette compétence dans ce rôle?",
@@ -2379,10 +2379,6 @@
     "defaultMessage": "Mettre à jour l’expérience",
     "description": "Button to submit the link experience to skill form"
   },
-  "AAmd5G": {
-    "defaultMessage": "Demande de renseignements",
-    "description": "Heading for the request information section of the single search request view."
-  },
   "AAvLM5": {
     "defaultMessage": "Type d’études",
     "description": "Label displayed on Education form for education type input"
@@ -3143,10 +3139,6 @@
     "defaultMessage": "Changer la date",
     "description": "Command to change a date"
   },
-  "Duswz0": {
-    "defaultMessage": "Résultats du candidat",
-    "description": "Heading for the candidate results section of the single search request view."
-  },
   "DvmNR7": {
     "defaultMessage": "Inscrivez-vous dès maintenant",
     "description": "Button text to apply for program"
@@ -3730,6 +3722,10 @@
   "H/aUwM": {
     "defaultMessage": "Vous êtes un cadre supérieur de la collectivité du numérique du GC et vous êtes à la recherche de talents, contactez notre équipe afin d’obtenir des recommandations, une liste de candidats préqualifiés ainsi que leurs profils.",
     "description": "Description for the digital government executive talent search"
+  },
+  "H/zqKa": {
+    "defaultMessage": "Conditions d’emploi ou exigences opérationnelles",
+    "description": "Heading for operational requirements section of the search form."
   },
   "H0h1Vn": {
     "defaultMessage": "Anglais essentiel",
@@ -5015,10 +5011,6 @@
     "defaultMessage": "la création des fonctionnalités et des outils accessibles, comme le mode sombre",
     "description": "List item three, things designers consider for accessibility"
   },
-  "NeNnAP": {
-    "defaultMessage": "Nom du candidat",
-    "description": "Title displayed on the User table Candidate Name column."
-  },
   "NeR+6V": {
     "defaultMessage": "<strong>Contributeur individuel</strong> : Les conseillers principaux en <abbreviation>TI</abbreviation> (<abbreviation>IT-04</abbreviation>) fournissent des conseils techniques et une orientation stratégique d'experts dans leur domaine d'expertise en matière de fourniture de solutions et de services à des clients internes ou externes et à des intervenants.",
     "description": "IT-04 senior advisor description precursor to work stream list"
@@ -5991,6 +5983,10 @@
     "defaultMessage": "<strong>Ma situation concorde avec l’option d’expérience de travail appliquée</strong>",
     "description": "Radio group option for education requirement filter in application education form."
   },
+  "SNxTm+": {
+    "defaultMessage": "Conditions d’emploi ou exigences opérationnelles",
+    "description": "Title for operational requirements section on summary of filters section"
+  },
   "SP8yeX": {
     "defaultMessage": "Vous pouvez commencer par formuler une demande dans le cadre d’un processus de recrutement.",
     "description": "Message to user when no qualified recruitments have been attached to profile, paragraph two."
@@ -6339,10 +6335,6 @@
     "defaultMessage": "Bientôt, les postulants pourront présenter leur demande à l’aide d’un outil interactif en ligne qui sera disponible à partir du présent site Web. Voici ce sur quoi nous travaillons :",
     "description": "Description of how the indigenous talent portal will work"
   },
-  "UEsexn": {
-    "defaultMessage": "Renseignements sur le gestionnaire",
-    "description": "Heading for the manager info section of the single search request view."
-  },
   "UJ/rX1": {
     "defaultMessage": "<strong>Courriel :</strong> <chrcMailLink>Info.Com@chrc-ccdp.gc.ca</chrcMailLink>",
     "description": "Email contact info"
@@ -6617,10 +6609,6 @@
   "VitOoU": {
     "defaultMessage": "Ces renseignements sont automatiquement remplis pour vous en fonction de la classification sélectionnée pour l'occasion.",
     "description": "Null message for education requirement section"
-  },
-  "VkBcGJ": {
-    "defaultMessage": "Ces notes sont accessibles à tous les gestionnaires de ce bassin, mais pas aux candidats.",
-    "description": "Description for the notes about this request section of the single search request view."
   },
   "VlI6x0": {
     "defaultMessage": "membre d'une minorité visible.",
@@ -7654,6 +7642,10 @@
     "defaultMessage": "Groupe de compétences {skillFamilyId} non trouvé.",
     "description": "Message displayed for skillFamily not found."
   },
+  "awEvCF": {
+    "defaultMessage": "Nom du (de la) candidat(e)",
+    "description": "Title displayed on the Pool Candidates table name column."
+  },
   "axQDlj": {
     "defaultMessage": "Contactez-nous pour nous faire part de votre rétroaction ou d'un problème.",
     "description": "Subtitle for the Support page"
@@ -7733,6 +7725,10 @@
   "bOAF9o": {
     "defaultMessage": "Ajoutez une nouvelle expérience",
     "description": "Title for adding a new experience"
+  },
+  "bQ4iDW": {
+    "defaultMessage": "Résultats des candidates et candidats",
+    "description": "Heading for the candidate results section of the single search request view."
   },
   "bQtRF+": {
     "defaultMessage": "Réussite",
@@ -7930,10 +7926,6 @@
     "defaultMessage": "Développer un <link>ensemble de produits génériques en matière de RH</link> (accessibles uniquement sur le réseau du GC), tels que des descriptions d’emploi normalisées, pour la collectivité du numérique",
     "description": "An OCIO role in the _supporting the community_ section of the _digital services contracting questionnaire_"
   },
-  "cMsRgt": {
-    "defaultMessage": "Conditions d’emploi/Exigences opérationnelles",
-    "description": "Title for operational requirements section on summary of filters section"
-  },
   "cNXORI": {
     "defaultMessage": "Être âgé(e) d’au moins 16 ans",
     "description": "IAP Requirement list item three"
@@ -8085,10 +8077,6 @@
   "d3HIMV": {
     "defaultMessage": "Renseignez-vous sur CléGC et trouvez des liens vers des renseignements sur les comptes.",
     "description": "Introductory text displayed in login and authentication accordion."
-  },
-  "d3oN4p": {
-    "defaultMessage": "Courriel du gouvernement",
-    "description": "Title for the government email block in the manager info section of the single search request view."
   },
   "d4aLWc": {
     "defaultMessage": "Revenez ici pour recevoir des alertes sur une variété d’activités sur la plateforme, y compris des offres d’emploi, de nouvelles fonctionnalités et plus encore.",
@@ -8526,6 +8514,10 @@
     "defaultMessage": "Agent(e) subalterne P M 1",
     "description": "PM-01 classification aria label including titles"
   },
+  "eyR6B+": {
+    "defaultMessage": "Renseignements sur le gestionnaire",
+    "description": "Heading for the manager info section of the single search request view."
+  },
   "ezstJx": {
     "defaultMessage": "Exigences",
     "description": "Heading for the Requirements section on the digital services contracting questionnaire"
@@ -8565,6 +8557,10 @@
   "fHEsA5": {
     "defaultMessage": "Le BIA a pour mission d’intégrer les talents autochtones dans la main-d’œuvre des TI du GC et de simplifier le processus d’embauche pour vous.",
     "description": "Paragraph 1 for the 'Indigenous talent ready for IT apprenticeships' section"
+  },
+  "fI0idr": {
+    "defaultMessage": "Date de réception",
+    "description": "Title displayed on the Pool Candidates table Date received column."
   },
   "fK+EvE": {
     "defaultMessage": "Supprimer cette compétence",
@@ -9918,10 +9914,6 @@
     "defaultMessage": "Étapes à suivre pour créer votre compte CléGC",
     "description": "Subtitle for a section explaining the create steps"
   },
-  "laGCzG": {
-    "defaultMessage": "Conditions d’emploi/Exigences opérationnelles",
-    "description": "Heading for operational requirements section of the search form."
-  },
   "laYGvQ": {
     "defaultMessage": "de faire preuve de diligence raisonnable quant à l'exactitude du contenu reproduit",
     "description": "Non commercial reproduction list item"
@@ -9985,6 +9977,10 @@
   "m+411R": {
     "defaultMessage": "Exigences temporelles",
     "description": "Timing requirements contracting rationale"
+  },
+  "m0Qcow": {
+    "defaultMessage": "Date de réception",
+    "description": "Title displayed on the search request table requested date column."
   },
   "m1eQrS": {
     "defaultMessage": "Canada.ca",
@@ -10610,10 +10606,6 @@
     "defaultMessage": "Cela indiquera aux candidats que seuls les employés à niveau ou de niveau équivalent seront pris en considération pour cette possibilité.",
     "description": "Caption for the at-level-only selection limitation"
   },
-  "p/Qp/u": {
-    "defaultMessage": "Nom du candidat",
-    "description": "Title displayed on the Pool Candidates table name column."
-  },
   "p0KALn": {
     "defaultMessage": "Aucun processus de recrutement n’est actif dans votre profil en ce moment.",
     "description": "Message displayed in recruitment availability when the user is not in any valid pools"
@@ -10990,10 +10982,6 @@
     "defaultMessage": "Créer<hidden> une collectivité</hidden>",
     "description": "Breadcrumb title for the create community page link."
   },
-  "r2gD/4": {
-    "defaultMessage": "Date de réception",
-    "description": "Title displayed on the search request table requested date column."
-  },
   "r4IQ0h": {
     "defaultMessage": "Examiner une demande de talent",
     "description": "Title for the 'review talent request' dialog"
@@ -11354,6 +11342,10 @@
     "defaultMessage": "Intermédiaire <gray>– J'ai des compétences robustes en lecture, écriture et communication verbale.</gray>",
     "description": "Message for the intermediate language ability option"
   },
+  "t79/r1": {
+    "defaultMessage": "Ces notes sont uniquement disponibles ici et ne seront pas communiquées aux candidates et candidats.",
+    "description": "Description for the notes about this request section of the single search request view."
+  },
   "t7T/Zv": {
     "defaultMessage": "Montrer des exemples de « contrats de services numériques » où cette exigence s’applique",
     "description": "Button text to show a specific qualified recruitment cards's skill assessments"
@@ -11561,6 +11553,10 @@
   "uKD+km": {
     "defaultMessage": "(Ordre décroissant)",
     "description": "Message added to indicate a table column is sorted in descending order"
+  },
+  "uLncuU": {
+    "defaultMessage": "Nom du (de la) candidat(e)",
+    "description": "Title displayed on the User table Candidate name column."
   },
   "uMU2Yg": {
     "defaultMessage": "Votre incidence (français)",
@@ -11873,6 +11869,10 @@
   "wKXLmR": {
     "defaultMessage": "Ajoutez un rôle dans l'équipe",
     "description": "Label for the button to add a role to a user"
+  },
+  "wLVo1I": {
+    "defaultMessage": "Courriel du gouvernement",
+    "description": "Title for the government email block in the manager info section of the single search request view."
   },
   "wNJSJ7": {
     "defaultMessage": "En valorisant et en misant sur le potentiel d’une personne plutôt que sur son niveau de scolarité, le programme élimine l’un des plus grands obstacles qui existe en matière d’emploi dans l’économie numérique. Le programme a été élaboré par, avec et pour des personnes autochtones à travers le Canada. Il intègre les préférences et les besoins des apprenants autochtones tout en reconnaissant l’importance de la communauté.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -204,7 +204,7 @@
     "description": "Label for the 'security' IT work stream"
   },
   "/3mqz9": {
-    "defaultMessage": "Renseignements sur le gestionnaire",
+    "defaultMessage": "Renseignements sur la demande",
     "description": "Heading for the request information section of the single search request view."
   },
   "/4z9lj": {

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -473,8 +473,8 @@ export const RequestForm = ({
                 id="department"
                 name="department"
                 label={intl.formatMessage({
-                  defaultMessage: "Department / Hiring organization",
-                  id: "P7ItrT",
+                  defaultMessage: "Department or hiring organization",
+                  id: "OgbLp1",
                   description:
                     "Label for department select input in the request form",
                 })}

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/AdvancedFilters.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/AdvancedFilters.tsx
@@ -285,8 +285,8 @@ const AdvancedFilters = () => {
             >
               {intl.formatMessage({
                 defaultMessage:
-                  "Conditions of employment / Operational requirements",
-                id: "laGCzG",
+                  "Conditions of employment or operational requirements",
+                id: "H/zqKa",
                 description:
                   "Heading for operational requirements section of the search form.",
               })}

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/UpdateSearchRequest.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/UpdateSearchRequest.tsx
@@ -154,8 +154,8 @@ const UpdateSearchRequestForm = ({
             <p data-h2-padding="base(x.5, 0, x.5, 0)">
               {intl.formatMessage({
                 defaultMessage:
-                  "These notes are available to all managers of this pool, but not to candidates.",
-                id: "VkBcGJ",
+                  "These notes are only available here and will not be shared with the candidates.",
+                id: "t79/r1",
                 description:
                   "Description for the notes about this request section of the single search request view.",
               })}

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/ViewSearchRequest.tsx
@@ -57,8 +57,8 @@ const ManagerInfo = ({
     <>
       <Heading level="h2" size="h4" data-h2-margin-top="base(0)">
         {intl.formatMessage({
-          defaultMessage: "Manager Information",
-          id: "UEsexn",
+          defaultMessage: "Manager information",
+          id: "eyR6B+",
           description:
             "Heading for the manager info section of the single search request view.",
         })}
@@ -91,8 +91,8 @@ const ManagerInfo = ({
                 />
                 <FilterBlock
                   title={intl.formatMessage({
-                    defaultMessage: "Government Email",
-                    id: "d3oN4p",
+                    defaultMessage: "Government email",
+                    id: "wLVo1I",
                     description:
                       "Title for the government email block in the manager info section of the single search request view.",
                   })}
@@ -137,8 +137,8 @@ const ManagerInfo = ({
               >
                 <FilterBlock
                   title={intl.formatMessage({
-                    defaultMessage: "Date Received",
-                    id: "r2gD/4",
+                    defaultMessage: "Date received",
+                    id: "m0Qcow",
                     description:
                       "Title displayed on the search request table requested date column.",
                   })}
@@ -498,8 +498,8 @@ export const ViewSearchRequest = ({
         <div>
           <Heading level="h2" size="h4">
             {intl.formatMessage({
-              defaultMessage: "Request Information",
-              id: "AAmd5G",
+              defaultMessage: "Request information",
+              id: "/3mqz9",
               description:
                 "Heading for the request information section of the single search request view.",
             })}
@@ -563,8 +563,8 @@ export const ViewSearchRequest = ({
         <div>
           <Heading level="h2" size="h4">
             {intl.formatMessage({
-              defaultMessage: "Candidate Results",
-              id: "Duswz0",
+              defaultMessage: "Candidate results",
+              id: "bQ4iDW",
               description:
                 "Heading for the candidate results section of the single search request view.",
             })}

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
@@ -252,10 +252,10 @@ const UserTable = ({ title }: UserTableProps) => {
       {
         id: "candidateName",
         header: intl.formatMessage({
-          defaultMessage: "Candidate Name",
-          id: "NeNnAP",
+          defaultMessage: "Candidate name",
+          id: "uLncuU",
           description:
-            "Title displayed on the User table Candidate Name column.",
+            "Title displayed on the User table Candidate name column.",
         }),
         cell: ({ row: { original: user } }) =>
           getFullNameHtml(user.firstName, user.lastName, intl),


### PR DESCRIPTION
🤖 Resolves #12335.

## 👋 Introduction

This PR makes some copy fixes on the search request page and view request page, primarily issues of title case to sentence case, but also some other fixes to English copy and some French edits. It also removes all the colons from the labels in both languages (`FilterBlock` component) and updates some other text for consistency.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to Search request page
3. Verify English and French copy matches requested changes in linked issue
4. Navigate to View request page
5. Verify English and French copy matches requested changes in linked issue

## 📸 Screenshots

<details><summary>Search request page</summary>

### English
![localhost_8000_en_search_request](https://github.com/user-attachments/assets/47e9236e-f51b-437a-a5eb-bbb8edaf0351)

### French
![localhost_8000_fr_search_request](https://github.com/user-attachments/assets/870841fb-1acc-4b64-b6d7-8331697249f5)
</details> 

<details><summary>View request page</summary>

### English
![localhost_8000_en_admin_talent-requests_f32bf6c5-a890-4e8e-8326-57d9e38050c3](https://github.com/user-attachments/assets/47721237-5ec7-4ce8-96ae-7f7a152da91f)

### French
![localhost_8000_fr_admin_talent-requests_f32bf6c5-a890-4e8e-8326-57d9e38050c3](https://github.com/user-attachments/assets/4e366fd3-e643-4e54-bb71-86b3110f2e4e)
</details> 

<details><summary>Other</summary>
<img width="362" alt="Screen Shot 2024-12-24 at 13 53 49" src="https://github.com/user-attachments/assets/e53890eb-dd4e-42e5-846e-8c3bc08127f3" />
<img width="925" alt="Screen Shot 2024-12-24 at 13 55 00" src="https://github.com/user-attachments/assets/891172fc-2227-46d5-9bd8-ee5e18494558" />
<img width="565" alt="Screen Shot 2024-12-24 at 13 55 31" src="https://github.com/user-attachments/assets/b5a62fd0-3064-4bc4-b377-f35279a4dfdb" />
</details> 