### PR TITLE
[Feature] Adds Application Insights User, Session cookie values to Freshdesk ticket

### DIFF
--- a/api/app/Http/Controllers/SupportController.php
+++ b/api/app/Http/Controllers/SupportController.php
@@ -52,6 +52,12 @@ class SupportController extends Controller
         if ($request->input('user_agent')) {
             $parameters['custom_fields']['cf_user_agent'] = (string) $request->input('user_agent');
         }
+        if ($request->cookie('ai_user')) {
+            $parameters['custom_fields']['cf_application_insights_user_id'] = (string) $request->cookie('ai_user');
+        }
+        if ($request->cookie('ai_session')) {
+            $parameters['custom_fields']['cf_application_insights_session_id'] = (string) $request->cookie('ai_session');
+        }
         if ($request->input('user_id')) {
             $parameters['unique_external_id'] = (string) $request->input('user_id');
         }

--- a/documentation/freshdesk.md
+++ b/documentation/freshdesk.md
@@ -9,6 +9,8 @@ Freshdesk is the customer service software used by GC Digital Talent for creatin
 3. Make note of the _domain_ upon account creation
 4. Create custom string field for the ticket object named `page_url` (https://_domain_.freshdesk.com/a/admin/ticket_fields)
 5. Create custom string field for the ticket object named `user_agent` (https://_domain_.freshdesk.com/a/admin/ticket_fields)
+6. Create custom string field for the ticket object named `application_insights_user_id` (https://_domain_.freshdesk.com/a/admin/ticket_fields)
+7. Create custom string field for the ticket object named `application_insights_session_id` (https://_domain_.freshdesk.com/a/admin/ticket_fields)
 
 ## Local setup
 


### PR DESCRIPTION
🤖 Resolves #11390.

## 👋 Introduction

This PR adds the Application Insights User ID and the Application Insights Session ID cookie value strings to new support tickets via to the `SupportController`.

## 📸 Screenshot

<img width="894" alt="Screen Shot 2024-12-27 at 10 40 57" src="https://github.com/user-attachments/assets/8f5ccc2f-87f8-4773-85f8-150ab1485a1d" />

## 🧪 Testing

> [!NOTE]  
> To test creating a support ticket, you will need to access to and [credentials for Freshdesk](https://github.com/GCTC-NTGC/gc-digital-talent/blob/main/documentation/freshdesk.md). The `APPLICATIONINSIGHTS_CONNECTION_STRING` in apps/web/index.html will also need to be manually set locally.

1. `make refresh-api; pnpm build`
2. Navigate to http://localhost:8000/en/support
3. Fill out the support form and submit
5. Verify Application Insights User ID field and Application Insights Session ID field in a newly created Freshdesk ticket has the appropriate values from `ai_user` and `ai_session` cookies
