### PR TITLE
[Tooling] Fixes `codecov-action` argument

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -68,6 +68,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: coverage.xml
+          files: coverage.xml
           flags: integrationtests
           fail_ci_if_error: false


### PR DESCRIPTION
🤖 Resolves #12389.

## 👋 Introduction

This PR fixes a deprecated argument from v.5.0.0 of `codecov-action`.

## 🧪 Testing

1. Let GitHub workflows finish
2. Verify no codecov warnings in CI for PHPUnit test workflow