### PR TITLE
[Copy] Replaces "Job templates library" in resources section on admin dashboard

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -147,6 +147,10 @@
     "defaultMessage": "Demande d’état mise à jour!",
     "description": "Message displayed to user after the request status is successfully updated."
   },
+  "+nQpv5": {
+    "defaultMessage": "Modèles d'offres d'emploi",
+    "description": "Title for the page showing list of job advertisement templates"
+  },
   "+o1lWq": {
     "defaultMessage": "Ce poste requiert de pouvoir travailler en français. Il incombe au gestionnaire de l’embauche de déterminer si vous répondez à cette exigence linguistique.",
     "description": "French essential language requirement description"
@@ -4786,10 +4790,6 @@
   "Mxu+IY": {
     "defaultMessage": "Inconnu",
     "description": "Contract start timeframe is unknown"
-  },
-  "MySfL/": {
-    "defaultMessage": "Bibliothèque de modèles d'emplois",
-    "description": "Label for link to job templates library"
   },
   "Myfw+L": {
     "defaultMessage": "Bassins",

--- a/apps/web/src/messages/pageTitles.ts
+++ b/apps/web/src/messages/pageTitles.ts
@@ -76,4 +76,10 @@ export default defineMessages({
     id: "V95g4E",
     description: "Title for the index training opportunities page",
   },
+  jobAdvertisementTemplates: {
+    defaultMessage: "Job advertisement templates",
+    id: "+nQpv5",
+    description:
+      "Title for the page showing list of job advertisement templates",
+  },
 });

--- a/apps/web/src/pages/AdminDashboardPage/AdminDashboard.test.tsx
+++ b/apps/web/src/pages/AdminDashboardPage/AdminDashboard.test.tsx
@@ -64,7 +64,7 @@ describe("Render dashboard page", () => {
     // resources links
     expect(
       screen.getByRole("link", {
-        name: "Job templates library",
+        name: "Job advertisement templates",
       }),
     ).toBeInTheDocument();
     expect(
@@ -145,7 +145,7 @@ describe("Render dashboard page", () => {
     // resources links
     expect(
       screen.getByRole("link", {
-        name: "Job templates library",
+        name: "Job advertisement templates",
       }),
     ).toBeInTheDocument();
     expect(
@@ -226,7 +226,7 @@ describe("Render dashboard page", () => {
     // resources links
     expect(
       screen.getByRole("link", {
-        name: "Job templates library",
+        name: "Job advertisement templates",
       }),
     ).toBeInTheDocument();
     expect(
@@ -307,7 +307,7 @@ describe("Render dashboard page", () => {
     // resources links
     expect(
       screen.getByRole("link", {
-        name: "Job templates library",
+        name: "Job advertisement templates",
       }),
     ).toBeInTheDocument();
     expect(

--- a/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
+++ b/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
@@ -134,11 +134,7 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
       roles: [],
     },
     {
-      label: intl.formatMessage({
-        defaultMessage: "Job templates library",
-        id: "MySfL/",
-        description: "Label for link to job templates library",
-      }),
+      label: intl.formatMessage(navigationMessages.jobAdvertisementTemplates),
       href: adminRoutes.jobPosterTemplates(),
       roles: [],
     },

--- a/apps/web/src/pages/CommunityDashboardPage/CommunityDashboardPage.tsx
+++ b/apps/web/src/pages/CommunityDashboardPage/CommunityDashboardPage.tsx
@@ -134,11 +134,7 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
       roles: [],
     },
     {
-      label: intl.formatMessage({
-        defaultMessage: "Job templates library",
-        id: "MySfL/",
-        description: "Label for link to job templates library",
-      }),
+      label: intl.formatMessage(navigationMessages.jobAdvertisementTemplates),
       href: adminRoutes.jobPosterTemplates(),
       roles: [],
     },

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -827,6 +827,10 @@
     "defaultMessage": "Ajouter le lien",
     "description": "Button text for adding a link in the rich text editor"
   },
+  "ZhOciS": {
+    "defaultMessage": "Modèles d'offres d'emploi",
+    "description": "Name of job advertisement templates page"
+  },
   "ZhQEUx": {
     "defaultMessage": "Ce champ requiert des dates ultérieures seulement.",
     "description": "Error message that the provided date must be in the future."

--- a/packages/i18n/src/messages/navigationMessages.ts
+++ b/packages/i18n/src/messages/navigationMessages.ts
@@ -141,6 +141,11 @@ const navigationMessages = defineMessages({
     id: "dK8pdO",
     description: "Name of job template page",
   },
+  jobAdvertisementTemplates: {
+    defaultMessage: "Job advertisement templates",
+    id: "ZhOciS",
+    description: "Name of job advertisement templates page",
+  },
   announcements: {
     defaultMessage: "Announcements",
     id: "Md1J9+",


### PR DESCRIPTION
🤖 Resolves #11999.

## 👋 Introduction

This PR replaces "Job templates library" in resources section on admin dashboard.

## 🧪 Testing

1. `pnpm build`
2. Navigate to http://localhost:8000/en/admin
3. Verify "Job advertisements templates" link renders in resources section

## 📸 Screenshots

<img width="1362" alt="Screen Shot 2024-12-30 at 11 24 37" src="https://github.com/user-attachments/assets/b1e2dbb7-14df-4420-b8d0-287a01b40e42" />
<img width="1360" alt="Screen Shot 2024-12-30 at 11 24 53" src="https://github.com/user-attachments/assets/de54bafd-b437-4e3a-89cf-d148a2118110" />