### PR TITLE
[Feature] Updates skill justification word limit

### DIFF
--- a/apps/web/src/components/ExperienceSkillFormDialog/ExperienceSkillForm.tsx
+++ b/apps/web/src/components/ExperienceSkillFormDialog/ExperienceSkillForm.tsx
@@ -19,7 +19,7 @@ import {
 import { useExperienceMutations } from "~/hooks/useExperienceMutations";
 import { FRENCH_WORDS_PER_ENGLISH_WORD } from "~/constants/talentSearchConstants";
 
-const TEXT_AREA_MAX_WORDS_EN = 160;
+const TEXT_AREA_MAX_WORDS_EN = 400;
 
 const getSkillArgs = (
   skillId: Scalars["ID"]["output"],

--- a/apps/web/src/components/SkillsInDetail/SkillsInDetail.tsx
+++ b/apps/web/src/components/SkillsInDetail/SkillsInDetail.tsx
@@ -8,21 +8,28 @@ import {
   getLocale,
   errorMessages,
   getLocalizedName,
+  Locales,
 } from "@gc-digital-talent/i18n";
 
 import type { FormSkills } from "~/types/experience";
+import { FRENCH_WORDS_PER_ENGLISH_WORD } from "~/constants/talentSearchConstants";
 
 interface SkillsInDetailProps {
   skills: FormSkills;
   onDelete: (id: string) => void;
 }
 
-const MAX_WORDS = 160;
+const TEXT_AREA_MAX_WORDS_EN = 400;
 
 const SkillsInDetail = ({ skills, onDelete }: SkillsInDetailProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
   const { register } = useForm();
+
+  const wordCountLimits: Record<Locales, number> = {
+    en: TEXT_AREA_MAX_WORDS_EN,
+    fr: Math.round(TEXT_AREA_MAX_WORDS_EN * FRENCH_WORDS_PER_ENGLISH_WORD),
+  } as const;
 
   return (
     <div
@@ -81,7 +88,7 @@ const SkillsInDetail = ({ skills, onDelete }: SkillsInDetailProps) => {
               <TextArea
                 id={`skill-in-detail-${id}`}
                 name={`skills.${index}.details`}
-                wordLimit={MAX_WORDS}
+                wordLimit={wordCountLimits[locale]}
                 aria-label={intl.formatMessage(
                   {
                     id: "Opn8nz",


### PR DESCRIPTION
🤖 Resolves #12163.

## 👋 Introduction

This PR updates the skill justification word limit in English and French.

## 🧪 Testing

1. `pnpm build`
2. Apply to a job advertisement
3. Navigate to Step 5 of 7
4. Connect a career timeline experience
5. Verify Describe how you used this skill field has a word limit of 400
6. Switch to French
7. Verify Décrivez comment vous avez utilisé cette compétence field has a word limit of 560
8. Navigate to http://localhost:8000/en/applicant/career-timeline/create
9. Select type Work experience
10. Click Add a skill button
11. Verify Describe how this skill featured in this role field has a word limit of 400
12. Switch to French
7. Verify Décrivez la façon dont cette compétence a été mise en valeur dans ce rôle field has a word limit of 560

## 📸 Screenshots
<img width="879" alt="Screen Shot 2024-12-30 at 12 18 47" src="https://github.com/user-attachments/assets/5eb26754-15e6-44f5-a12d-eea6c641954c" />
<img width="883" alt="Screen Shot 2024-12-30 at 12 19 20" src="https://github.com/user-attachments/assets/e8be0b44-2d9e-4eaa-b840-260ec4985a14" />
<img width="1191" alt="Screen Shot 2024-12-30 at 12 35 29" src="https://github.com/user-attachments/assets/210c7061-3ffd-4ad8-89ce-77c3ff4e4917" />
<img width="1247" alt="Screen Shot 2024-12-30 at 12 34 25" src="https://github.com/user-attachments/assets/c49b5d99-178c-465e-ab70-90051266dfb1" />