### PR TITLE
[A11y] Add context to dashboard page titles

### DIFF
--- a/apps/playwright/tests/admin/auth.spec.ts
+++ b/apps/playwright/tests/admin/auth.spec.ts
@@ -326,7 +326,7 @@ test.describe("Login", () => {
     await appPage.waitForGraphqlResponse("AdminDashboard_Query");
     await expect(
       appPage.page.getByRole("heading", {
-        name: /welcome back, dale monroe/i,
+        name: /welcome back/i,
       }),
     ).toBeVisible();
   });

--- a/apps/playwright/tests/login-logout.spec.ts
+++ b/apps/playwright/tests/login-logout.spec.ts
@@ -337,7 +337,7 @@ test.describe("Login and logout", () => {
     // confirm login in first page context
     await expect(
       pageOne.getByRole("heading", {
-        name: "Welcome back, Gul",
+        name: /welcome back/i,
         level: 1,
       }),
     ).toBeVisible();

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -811,6 +811,10 @@
     "defaultMessage": "Apprentissage en cours d’emploi",
     "description": "Experience requirement, On the job."
   },
+  "2FrqUn": {
+    "defaultmessage": "Bon retour<hidden> sur votre tableau de bord de la collectivité</hidden>, {name}",
+    "description": "title for community dashboard on the talent cloud admin portal."
+  },
   "2HGCCF": {
     "defaultMessage": "Nous utilisons également cette information pour vous offrir une expérience plus contextualisée, y compris des recommandations de possibilités fondées sur votre situation de l'emploi, votre classification, et plus encore.",
     "description": "Message after main heading in employee information page - paragraph 2."
@@ -7706,6 +7710,10 @@
     "defaultMessage": "<strong>Veuillez sélectionner un niveau approprié de maîtrise de la deuxième langue sur la base des définitions fournies.</strong>",
     "description": "Text requesting language levels given from bilingual evaluation in language information form"
   },
+  "bw4CAS": {
+    "defaultmessage": "Bon retour<hidden> sur votre tableau de bord de la candidate ou du candidat</hidden>, {name}",
+    "description": "title for applicant dashboard on the talent cloud admin portal."
+  },
   "bwoJyk": {
     "defaultMessage": "Informations sur la possibilité de formation",
     "description": "Heading for the opportunity form information section"
@@ -11397,6 +11405,10 @@
   "utLdbN": {
     "defaultMessage": "Vise à lancer le programme au début de 2024.",
     "description": "Talent portal strategy item 4 content"
+  },
+  "utS0s1": {
+    "defaultmessage": "Bon retour<hidden> sur votre tableau de bord de l'administrateur</hidden>, {name}",
+    "description": "title for admin dashboard on the talent cloud admin portal."
   },
   "utl6O/": {
     "defaultMessage": "Gérer le recrutement {title}",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -812,8 +812,8 @@
     "description": "Experience requirement, On the job."
   },
   "2FrqUn": {
-    "defaultmessage": "Bon retour<hidden> sur votre tableau de bord de la collectivité</hidden>, {name}",
-    "description": "title for community dashboard on the talent cloud admin portal."
+    "defaultMessage": "Bon retour<hidden> sur votre tableau de bord de la collectivité</hidden>, {name}",
+    "description": "Title for community dashboard on the talent cloud admin portal."
   },
   "2HGCCF": {
     "defaultMessage": "Nous utilisons également cette information pour vous offrir une expérience plus contextualisée, y compris des recommandations de possibilités fondées sur votre situation de l'emploi, votre classification, et plus encore.",
@@ -7711,8 +7711,8 @@
     "description": "Text requesting language levels given from bilingual evaluation in language information form"
   },
   "bw4CAS": {
-    "defaultmessage": "Bon retour<hidden> sur votre tableau de bord de la candidate ou du candidat</hidden>, {name}",
-    "description": "title for applicant dashboard on the talent cloud admin portal."
+    "defaultMessage": "Bon retour<hidden> sur votre tableau de bord de la candidate ou du candidat</hidden>, {name}",
+    "description": "Title for applicant dashboard on the talent cloud admin portal."
   },
   "bwoJyk": {
     "defaultMessage": "Informations sur la possibilité de formation",
@@ -11407,8 +11407,8 @@
     "description": "Talent portal strategy item 4 content"
   },
   "utS0s1": {
-    "defaultmessage": "Bon retour<hidden> sur votre tableau de bord de l'administrateur</hidden>, {name}",
-    "description": "title for admin dashboard on the talent cloud admin portal."
+    "defaultMessage": "Bon retour<hidden> sur votre tableau de bord de l'administrateur</hidden>, {name}",
+    "description": "Title for admin dashboard on the talent cloud admin portal."
   },
   "utl6O/": {
     "defaultMessage": "Gérer le recrutement {title}",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -9682,10 +9682,6 @@
     "defaultMessage": "Évaluer",
     "description": "Talent portal strategy item 3 heading"
   },
-  "lIwJp4": {
-    "defaultMessage": "Bon retour, {name}",
-    "description": "Title for dashboard on the talent cloud admin portal."
-  },
   "lKoKu0": {
     "defaultMessage": "42 postes de cadres supérieurs et autres postes de dirigeants ont été pourvus au cours de cet exercice, ce qui a permis de doubler les affectations réalisées au cours de l’exercice financier précédent (2022-2023) et de promouvoir la gestion des talents numériques. Veuillez prendre note que les talents numériques sont ciblés lors des tables rondes annuelles interministérielles sur la gestion des talents.",
     "description": "Description of executive referral services"

--- a/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
+++ b/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
@@ -221,10 +221,11 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
       <Hero
         title={intl.formatMessage(
           {
-            defaultMessage: "Welcome back, {name}",
-            id: "lIwJp4",
+            defaultMessage:
+              "Welcome back<hidden> to your admin dashboard</hidden>, {name}",
+            id: "utS0s1",
             description:
-              "Title for dashboard on the talent cloud admin portal.",
+              "Title for admin dashboard on the talent cloud admin portal.",
           },
           {
             name: currentUser

--- a/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.tsx
@@ -25,10 +25,11 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
       <Hero
         title={intl.formatMessage(
           {
-            defaultMessage: "Welcome back, {name}",
-            id: "lIwJp4",
+            defaultMessage:
+              "Welcome back<hidden> to your applicant dashboard</hidden>, {name}",
+            id: "bw4CAS",
             description:
-              "Title for dashboard on the talent cloud admin portal.",
+              "Title for applicant dashboard on the talent cloud admin portal.",
           },
           {
             name: currentUser

--- a/apps/web/src/pages/CommunityDashboardPage/CommunityDashboardPage.tsx
+++ b/apps/web/src/pages/CommunityDashboardPage/CommunityDashboardPage.tsx
@@ -221,10 +221,11 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
       <AdminHero
         title={intl.formatMessage(
           {
-            defaultMessage: "Welcome back, {name}",
-            id: "lIwJp4",
+            defaultMessage:
+              "Welcome back<hidden> to your community dashboard</hidden>, {name}",
+            id: "2FrqUn",
             description:
-              "Title for dashboard on the talent cloud admin portal.",
+              "Title for community dashboard on the talent cloud admin portal.",
           },
           {
             name: currentUser

--- a/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
+++ b/apps/web/src/pages/ProfileAndApplicationsPage/components/ProfileAndApplicationsHeading.tsx
@@ -247,13 +247,14 @@ const DashboardHeading = ({ userQuery }: DashboardHeadingProps) => {
     <Hero
       title={intl.formatMessage(
         {
-          defaultMessage: "Welcome back, {firstName}",
-          id: "Q/f5AF",
+          defaultMessage:
+            "Welcome back<hidden> to your applicant dashboard</hidden>, {name}",
+          id: "bw4CAS",
           description:
-            "Title displayed in the hero section of the Search page.",
+            "Title for applicant dashboard on the talent cloud admin portal.",
         },
         {
-          firstName: user.firstName,
+          name: user.firstName,
         },
       )}
       subtitle={intl.formatMessage(


### PR DESCRIPTION
🤖 Resolves #11978 

## 👋 Introduction

Adds hidden text to the dashboard titles to improve context for non-visual users.

## 🕵️ Details

Hopefully we find a more permanent solution as this is a stop gap since:

- We know we have issues with hidden text in voiceover
- They still lack context for visual users

## 🧪 Testing

1. Build the app `pnpm run dev:fresh`
2. Login as admin `admin@test.com`
3. Navigate to the applicant dashboard `/applicant`
4. Confirm the `h1` indicates the page you are on in hidden text
5. Repeat step 4 on the admin dashboard `/admin`
6. Login as the community admin `community@test.com`
7. Repeat step 4 onm the community dashboard `/community`
