### PR TITLE
[Feature] Adds certification exam vouchers page

### DIFF
--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -536,6 +536,13 @@ const createRoute = (locale: Locales) =>
                       "../pages/InstructorLedTrainingPage/InstructorLedTrainingPage"
                     ),
                 },
+                {
+                  path: "certification-exam-vouchers",
+                  lazy: () =>
+                    import(
+                      "../pages/CertificationExamVouchersPage/CertificationExamVouchersPage"
+                    ),
+                },
               ],
             },
             {

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -315,6 +315,8 @@ const getRoutes = (lang: Locales) => {
     itTrainingFund: () => [baseUrl, "it-training-fund"].join("/"),
     instructorLedTraining: () =>
       [baseUrl, "it-training-fund", "instructor-led-training"].join("/"),
+    certificationExamVouchers: () =>
+      [baseUrl, "it-training-fund", "certification-exam-vouchers"].join("/"),
 
     // Training Opportunities (Admin)
     trainingOpportunitiesIndex: () =>

--- a/apps/web/src/lang/__snapshots__/lang.test.ts.snap
+++ b/apps/web/src/lang/__snapshots__/lang.test.ts.snap
@@ -101,6 +101,13 @@ exports[`message files should have no changes to duplicate strings 1`] = `
     ]
   },
   {
+    "en": "Request a voucher",
+    "fr": [
+      "Demander un bon",
+      "Demandez un bon"
+    ]
+  },
+  {
     "en": "Skill requirements",
     "fr": [
       "Exigences relatives aux compétences",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7634,10 +7634,6 @@
     "defaultMessage": "Date de fin de la formation",
     "description": "The training end date of the training opportunity"
   },
-  "bjcr+t": {
-    "defaultMessage": "S’inscrire aux mises à jour<hidden> sur les bons pour examens de certification</hidden>",
-    "description": "A link to sign up for updates"
-  },
   "bjwTpe": {
     "defaultMessage": "Si vous souhaitez suivre une formation, rendez-vous d'abord sur la plateforme Talents numériques du GC pour créer ou mettre à jour votre profil, lequel nous permet de confirmer votre situation d'emploi, votre classification, votre appartenance à un groupe visé par l'équité en matière d'emploi et l'expérience requise. Ensuite, remplissez le formulaire de demande et acceptez de partager votre profil.",
     "description": "First paragraph of apply and share section"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2775,10 +2775,6 @@
     "defaultMessage": "Supprimer la demande<hidden> ({name})</hidden>",
     "description": "Link text to delete a specific application"
   },
-  "CHIy5L": {
-    "defaultMessage": "Le <link>Fonds de formation et de perfectionnement de la collectivité de la TI</link> peut vous aider à acquérir la certification en payant le coût des examens.",
-    "description": "Second paragraph of certification exam vouchers section"
-  },
   "CKsQyK": {
     "defaultMessage": "Accessibilité et mesures d’adaptation",
     "description": "Title of the accessibility and accommodations information dialog"
@@ -8725,6 +8721,10 @@
   "gImGmr": {
     "defaultMessage": "Téléphone textuel (TTY/ATS)",
     "description": "GCKey answer for who to contact about GCKey, text telephone title"
+  },
+  "gIvlZk": {
+    "defaultMessage": "Le <link>Fonds de formation et de perfectionnement de la collectivité de la TI</link> peut vous aider à acquérir la certification en payant le coût des examens.",
+    "description": "Second paragraph of certification exam vouchers section"
   },
   "gIzUDr": {
     "defaultMessage": "Modifier les questions générales",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -39,10 +39,6 @@
     "defaultMessage": "Certificat numérique",
     "description": "Title of the 'Digital certificate credential' subsection"
   },
-  "+BeD0v": {
-    "defaultMessage": "l'analyse opérationnelle;",
-    "description": "Second item in list of certification topics section"
-  },
   "+C20lR": {
     "defaultMessage": "Vous n’avez pas de besoins en matière de personnel.",
     "description": "Message that appears when there are no screening messages for a pool"
@@ -94,6 +90,10 @@
   "+SoiCw": {
     "defaultMessage": "Endroits exclus",
     "description": "Location specifics label"
+  },
+  "+UjXSM": {
+    "defaultMessage": "le réseautage.",
+    "description": "Seventh item in list of certification topics section"
   },
   "+Xn2ke": {
     "defaultMessage": "Résultats de l’évaluation",
@@ -2315,6 +2315,10 @@
     "defaultMessage": "Hors site, quel que soit le lieu",
     "description": "Any offsite personnel work location"
   },
+  "9oUpdh": {
+    "defaultMessage": "la cybersécurité;",
+    "description": "Fourth item in list of certification topics section"
+  },
   "9pYlYz": {
     "defaultMessage": "Volet",
     "description": "Label for a process' stream"
@@ -3694,10 +3698,6 @@
   "GwhSUZ": {
     "defaultMessage": "EX-04 : Chef de file du numérique",
     "description": "EX-04 classification label including titles"
-  },
-  "GxrfIv": {
-    "defaultMessage": "l'architecture intégrée;",
-    "description": "Fifth item in list of certification topics section"
   },
   "H+83NU": {
     "defaultMessage": "Vous avez des questions? <link>Contactez-nous</link>.",
@@ -7570,6 +7570,10 @@
     "defaultMessage": "Nom du (de la) candidat(e)",
     "description": "Title displayed on the Pool Candidates table name column."
   },
+  "awyksR": {
+    "defaultMessage": "l'analyse opérationnelle;",
+    "description": "Second item in list of certification topics section"
+  },
   "axQDlj": {
     "defaultMessage": "Contactez-nous pour nous faire part de votre rétroaction ou d'un problème.",
     "description": "Subtitle for the Support page"
@@ -8229,10 +8233,6 @@
   "e5xrSy": {
     "defaultMessage": "Embauché à titre d’employé pour une période déterminée",
     "description": "Title of the 'Hired as a term employee' subsection"
-  },
-  "e6PlO0": {
-    "defaultMessage": "l'informatique en nuage;",
-    "description": "Third item in list of certification topics section"
   },
   "e6hj69": {
     "defaultMessage": "Trouvez des talents préqualifiés pour votre équipe ou planifiez votre prochaine évolution de carrière.",
@@ -8989,10 +8989,6 @@
   "hSmKjD": {
     "defaultMessage": "Absolument! Votre temps est précieux. Les apprentis recevront une rémunération et des avantages sociaux à titre d’employés du gouvernement du Canada. Au départ, les apprenti(e)s gagneront entre 29 $ et 33 $ de l’heure. Le salaire exact est déterminé au moment de l’embauche, et dépend de la convention collective en vigueur au sein de l’organisation qui les embauche. Les apprentis seront employés à temps plein, pour un total de 37,5 heures par semaine.",
     "description": "Learn more dialog question four paragraph one"
-  },
-  "hSoZzH": {
-    "defaultMessage": "la cybersécurité;",
-    "description": "Fourth item in list of certification topics section"
   },
   "hTJgV2": {
     "defaultMessage": "Tous les champs obligatoires sont remplis. Vous pouvez maintenant modifier votre statut.",
@@ -10434,10 +10430,6 @@
     "defaultMessage": "Si vous avez déjà un compte de CléGC, vous pouvez ouvrir une session dans votre profil sur la plateforme Talents numériques du GC à l'aide de votre CléGC, même si vous n'avez jamais utilisé cette plateforme avant. Si vous ne savez pas si vous avez déjà un compte de CléGC, continuez vers le site Web et essayez d'ouvrir une session. Si vous ne vous souvenez pas de votre mot de passe, c'est là que vous pourrez aussi le réinitialiser.",
     "description": "GCKey answer for when user already has an account"
   },
-  "okQrE7": {
-    "defaultMessage": "le réseautage.",
-    "description": "Seventh item in list of certification topics section"
-  },
   "okRYhl": {
     "defaultMessage": "Ce que nous entendons",
     "description": "Title of a quotes section"
@@ -11610,6 +11602,10 @@
     "defaultMessage": "Ce guide de mise en œuvre est conçu pour aider les gestionnaires et les responsables de l’initiative numérique à assumer leurs responsabilités au titre de la <cite>Directive sur les talents numériques</cite>. Il explique pourquoi la Directive est nécessaire et ce qu’elle exige.",
     "description": "Body message for digital initiative managers section."
   },
+  "vYigGH": {
+    "defaultMessage": "l'informatique en nuage;",
+    "description": "Third item in list of certification topics section"
+  },
   "vbEXnp": {
     "defaultMessage": "Gestion de bases de données de la <abbreviation>TI</abbreviation>",
     "description": "Title for the 'database management' IT work stream"
@@ -12105,6 +12101,10 @@
   "yNPkM8": {
     "defaultMessage": "Téléchargez le guide de mise en œuvre pour les gestionnaires",
     "description": "Aria label for download guidance for managers plain text link."
+  },
+  "yOii5k": {
+    "defaultMessage": "l'architecture intégrée;",
+    "description": "Fifth item in list of certification topics section"
   },
   "yUSG9Z": {
     "defaultMessage": "Non, je ne suis pas un(e) employé(e) du gouvernement du Canada.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -39,6 +39,10 @@
     "defaultMessage": "Certificat numérique",
     "description": "Title of the 'Digital certificate credential' subsection"
   },
+  "+BeD0v": {
+    "defaultMessage": "l'analyse opérationnelle;",
+    "description": "Second item in list of certification topics section"
+  },
   "+C20lR": {
     "defaultMessage": "Vous n’avez pas de besoins en matière de personnel.",
     "description": "Message that appears when there are no screening messages for a pool"
@@ -607,6 +611,10 @@
     "defaultMessage": "Compétences sélectionnées ({numOfSkills})",
     "description": "Title for skills section on summary of filters section"
   },
+  "15nKPJ": {
+    "defaultMessage": "Vous pouvez demander un bon pour de nombreux domaines de certification des TI, notamment :",
+    "description": "First paragraph of certification topics section"
+  },
   "16iCWc": {
     "defaultMessage": "Vétéran",
     "description": "Label for veteran chip on view candidate page"
@@ -759,6 +767,10 @@
     "defaultMessage": "<strong>{role}</strong> à {group}",
     "description": "Role with group, HTML"
   },
+  "1uoeR6": {
+    "defaultMessage": "Pour obtenir un bon, vous devez remplir le formulaire de demande. Votre profil sur Talents numériques du GC nous permettra de vérifier si vous êtes admissible. Avant de présenter votre demande, prenez le temps de revoir et de mettre à jour les renseignements dans votre profil, ou de vous en créer un si vous ne l'avez pas déjà fait. ",
+    "description": "First paragraph of apply and complete your profile section"
+  },
   "1xI8uo": {
     "defaultMessage": "Utilisez le bouton « Ajoutez un rôle individuel » pour commencer.",
     "description": "Instructions for adding a role to a user."
@@ -806,6 +818,10 @@
   "29o8/W": {
     "defaultMessage": "Un engagement en faveur de la diversité des talents numériques",
     "description": "Title of the 'A commitment to diverse digital talent' section"
+  },
+  "2B+d2V": {
+    "defaultMessage": "Vous avez un profil sur Talents numériques du GC.",
+    "description": "Second item in list of eligibility requirements section"
   },
   "2FBdeQ": {
     "defaultMessage": "Apprentissage en cours d’emploi",
@@ -1294,6 +1310,10 @@
   "4cN/oN": {
     "defaultMessage": "Pour la raison suivante",
     "description": "Lead in text for a decisions reason"
+  },
+  "4ddL8K": {
+    "defaultMessage": "Vous avez un compte Navigar actif.",
+    "description": "Third item in list of eligibility requirements section"
   },
   "4f9Xsc": {
     "defaultMessage": "Les renseignements que vous fournissez peuvent également être utilisés à des fins statistiques et de recherche, et ils peuvent être communiqués à la<publicServiceLink>Direction des enquêtes de la Commission de la fonction publique</publicServiceLink> au besoin.",
@@ -2087,6 +2107,10 @@
     "defaultMessage": "* La préférence sera accordée aux personnes employées par les ministères ou agences (ministère) suivants : {department}.",
     "description": "Fine print of a note describing that a pool is only open to employees with departmental preference"
   },
+  "8umYON": {
+    "defaultMessage": "Prochaines étapes",
+    "description": "Title for what to expect section"
+  },
   "8v/v3u": {
     "defaultMessage": "Compétences requises",
     "description": "Label for _qualification requirement_ textbox in the _digital services contracting questionnaire_"
@@ -2258,6 +2282,10 @@
   "9g11GN": {
     "defaultMessage": "Créer une classification",
     "description": "Page title for the classification creation page"
+  },
+  "9gU2in": {
+    "defaultMessage": "Nous répondrons à votre demande dans les sept jours ouvrables. Si votre demande est approuvée, nous vous ferons parvenir un code pour le bon que vous pourrez utiliser pour réserver une date d'examen sur la plateforme du fournisseur.",
+    "description": "First paragraph of what to expect section"
   },
   "9gpVCX": {
     "defaultMessage": "Prêt à être embauché",
@@ -2742,6 +2770,10 @@
   "CH6FQA": {
     "defaultMessage": "Supprimer la demande<hidden> ({name})</hidden>",
     "description": "Link text to delete a specific application"
+  },
+  "CHIy5L": {
+    "defaultMessage": "Le <link>Fonds de formation et de perfectionnement de la collectivité de la TI</link> peut vous aider à acquérir la certification en payant le coût des examens.",
+    "description": "Second paragraph of certification exam vouchers section"
   },
   "CKsQyK": {
     "defaultMessage": "Accessibilité et mesures d’adaptation",
@@ -3663,6 +3695,10 @@
     "defaultMessage": "EX-04 : Chef de file du numérique",
     "description": "EX-04 classification label including titles"
   },
+  "GxrfIv": {
+    "defaultMessage": "l'architecture intégrée;",
+    "description": "Fifth item in list of certification topics section"
+  },
   "H+83NU": {
     "defaultMessage": "Vous avez des questions? <link>Contactez-nous</link>.",
     "description": "Fourth paragraph for pool deadlines dialog"
@@ -3826,6 +3862,10 @@
   "I2CtZJ": {
     "defaultMessage": "Les commentaires ou les contributions seront supprimés s’ils :",
     "description": "Comments or contributions list title"
+  },
+  "I2kLuc": {
+    "defaultMessage": "Pour toute question concernant les bons pour examens de certification, veuillez contacter <mailLink>icommunity-icollectivite@tbs-sct.gc.ca<mailLink>.",
+    "description": "Second paragraph of what to expect section"
   },
   "I5q1n6": {
     "defaultMessage": "Soumettre aux fins de publication",
@@ -4098,6 +4138,10 @@
   "JH2+tK": {
     "defaultMessage": "Instantané de profil non trouvé.",
     "description": "Message displayed for profile snapshot not found."
+  },
+  "JIvR0C": {
+    "defaultMessage": "Bons pour examens de certification",
+    "description": "Title for the certification exam vouchers page"
   },
   "JO2yLA": {
     "defaultMessage": "Lieu de travail",
@@ -5575,6 +5619,10 @@
     "defaultMessage": "Appuyez le cheminement de carrière des peuples des Premières Nations, des Inuit et des Métis, qui sont passionnés par les TI, et contribuez à créer une fonction publique diversifiée, équitable et inclusive. Embauchez par le biais du Programme d'apprentissage en TI pour les personnes autochtones.",
     "description": "Description for the IT Apprenticehip program for Indigenous peoples"
   },
+  "Qn8C+Z": {
+    "defaultMessage": "Domaines de certification",
+    "description": "Title for certification topics section"
+  },
   "QnfjbI": {
     "defaultMessage": "constituent de l’usurpation d’identité, de la publicité ou un pourriel",
     "description": "Comments or contributions list item"
@@ -6142,6 +6190,10 @@
   "TiutAx": {
     "defaultMessage": "Raison de l’octroi de contrats",
     "description": "Label for _rationale for contracting_ section in the _digital services contracting questionnaire_"
+  },
+  "Tj1iyN": {
+    "defaultMessage": "S’inscrire aux mises à jour<hidden> sur les cours et camps d'entrainement dirigés par un instructeur ou une instructrice</hidden>",
+    "description": "A link to sign up for updates"
   },
   "Tjd942": {
     "defaultMessage": "Solutions logicielles de la <abbreviation>TI</abbreviation>",
@@ -7078,6 +7130,10 @@
     "defaultMessage": "Avant de conclure qu’une pénurie de talents numériques disponibles ou qualifiés est la principale raison de l’approvisionnement, le chef opérationnel doit confirmer avec le BDPI qu’il n’y a pas de talents préqualifiés disponibles dans une <link>bassin de talents coordonnée par le BDPI</link> qui pourrait répondre au besoin dans le délai imparti.",
     "description": "Paragraph two of the _requirements_ section of the _digital services contracting questionnaire_"
   },
+  "YZtE49": {
+    "defaultMessage": "Obtenez une attestation de vos compétences liées à des domaines clés des TI.",
+    "description": "Page subtitle for certification exam vouchers page"
+  },
   "YaDJN+": {
     "defaultMessage": "Supprimer la notification",
     "description": "Button text to confirm deleting a notification"
@@ -7194,6 +7250,10 @@
     "defaultMessage": "Cette compétence sera aussi ajoutée à votre portfolio de compétences si elle ne s'y trouve pas déjà.",
     "description": "Subtitle for the find a skill dialog within an experience"
   },
+  "Z8uO3k": {
+    "defaultMessage": "Les bons pour examens",
+    "description": "Title for certification exam vouchers section"
+  },
   "Z9W+O2": {
     "defaultMessage": "Postulez dès aujourd'hui pour entamer votre parcours de carrière en TI.",
     "description": "Meta tag description for IT Apprenticeship Program for Indigenous Peoples site"
@@ -7293,6 +7353,10 @@
   "ZgeBBn": {
     "defaultMessage": "La <relationsLink>Commission des relations de travail et de l’emploi dans le secteur public fédéral</relationsLink> traite les plaintes de certains employés de la fonction publique fédérale, membres de la Gendarmerie royale du Canada et employés du Parlement.",
     "description": "Description of complaints to the Federal Public Sector Labour Relations and Employment Board<"
+  },
+  "ZiCXd1": {
+    "defaultMessage": "la gestion de projets de TI;",
+    "description": "First item in list of certification topics section"
   },
   "ZoZNDf": {
     "defaultMessage": "Trouvez une nouvelle compétence et ajoutez-la à votre portfolio",
@@ -8166,6 +8230,10 @@
     "defaultMessage": "Embauché à titre d’employé pour une période déterminée",
     "description": "Title of the 'Hired as a term employee' subsection"
   },
+  "e6PlO0": {
+    "defaultMessage": "l'informatique en nuage;",
+    "description": "Third item in list of certification topics section"
+  },
   "e6hj69": {
     "defaultMessage": "Trouvez des talents préqualifiés pour votre équipe ou planifiez votre prochaine évolution de carrière.",
     "description": "Paragraph one, description of the managers community"
@@ -8233,6 +8301,10 @@
   "eP8dfW": {
     "defaultMessage": "Voir l’utilisateur",
     "description": "Title for the user information page"
+  },
+  "eQkmhS": {
+    "defaultMessage": "Vous êtes actuellement un membre du personnel du gouvernement du Canada du groupe TI représenté par l'Institut professionnel de la fonction publique du Canada (IPFPC).",
+    "description": "First item in list of eligibility requirements section"
   },
   "eRbVle": {
     "defaultMessage": "Cette adresse courriel sera utilisée pour la communication et les notifications. À l'étape suivante, nous vous demanderons de vérifier cette adresse courriel en utilisant un code que nous vous enverrons dans votre boîte de réception.",
@@ -8333,6 +8405,10 @@
   "eqX3mk": {
     "defaultMessage": "Retirer {skillName}",
     "description": "Remove a skill"
+  },
+  "erzpFY": {
+    "defaultMessage": "Demander un bon",
+    "description": "Link text to request a voucher (infinitive)"
   },
   "evxvnW": {
     "defaultMessage": "L'utilisateur a été mis à jour avec succès!",
@@ -8549,6 +8625,10 @@
   "fxPLAl": {
     "defaultMessage": "Modification du profil linguistique",
     "description": "Button text to start editing language profile"
+  },
+  "fxhdQd": {
+    "defaultMessage": "Formulaire de demande et profil",
+    "description": "Title for apply and complete your profile section"
   },
   "fyidgo": {
     "defaultMessage": "Retirer le rôle<hidden> {role}</hidden>",
@@ -8909,6 +8989,10 @@
   "hSmKjD": {
     "defaultMessage": "Absolument! Votre temps est précieux. Les apprentis recevront une rémunération et des avantages sociaux à titre d’employés du gouvernement du Canada. Au départ, les apprenti(e)s gagneront entre 29 $ et 33 $ de l’heure. Le salaire exact est déterminé au moment de l’embauche, et dépend de la convention collective en vigueur au sein de l’organisation qui les embauche. Les apprentis seront employés à temps plein, pour un total de 37,5 heures par semaine.",
     "description": "Learn more dialog question four paragraph one"
+  },
+  "hSoZzH": {
+    "defaultMessage": "la cybersécurité;",
+    "description": "Fourth item in list of certification topics section"
   },
   "hTJgV2": {
     "defaultMessage": "Tous les champs obligatoires sont remplis. Vous pouvez maintenant modifier votre statut.",
@@ -9954,6 +10038,10 @@
     "defaultMessage": "Pas certain",
     "description": "The unsure option to answer a question"
   },
+  "mcibCA": {
+    "defaultMessage": "Conditions d'admissibilité",
+    "description": "Title for eligibility requirements section"
+  },
   "md/sEi": {
     "defaultMessage": "Choisissez parmi une variété de compétences et déterminez le niveau requis des candidats",
     "description": "Subtitle for the find a skill dialog within a pool"
@@ -10318,6 +10406,10 @@
     "defaultMessage": "3. Saisissez votre <strong>code unique à six chiffres</strong> à partir de votre <strong>application d'authentification</strong> dans la barre de vérification.",
     "description": "Text for third sign in step."
   },
+  "oc4iCB": {
+    "defaultMessage": "Vous avez terminé votre préparation, notamment les modules de formation préalable, et vous êtes prêt ou prête à faire l'examen.",
+    "description": "Fourth item in list of eligibility requirements section"
+  },
   "ocTGYr": {
     "defaultMessage": "Informations sur la collectivité",
     "description": "Heading for the 'create a community' form"
@@ -10341,6 +10433,10 @@
   "oiaUxW": {
     "defaultMessage": "Si vous avez déjà un compte de CléGC, vous pouvez ouvrir une session dans votre profil sur la plateforme Talents numériques du GC à l'aide de votre CléGC, même si vous n'avez jamais utilisé cette plateforme avant. Si vous ne savez pas si vous avez déjà un compte de CléGC, continuez vers le site Web et essayez d'ouvrir une session. Si vous ne vous souvenez pas de votre mot de passe, c'est là que vous pourrez aussi le réinitialiser.",
     "description": "GCKey answer for when user already has an account"
+  },
+  "okQrE7": {
+    "defaultMessage": "le réseautage.",
+    "description": "Seventh item in list of certification topics section"
   },
   "okRYhl": {
     "defaultMessage": "Ce que nous entendons",
@@ -10853,6 +10949,10 @@
   "rVgBGi": {
     "defaultMessage": "La soumission de votre demande est réussie.",
     "description": "Subtitle for the request confirmation page."
+  },
+  "rYYqbv": {
+    "defaultMessage": "Les fonctionnaires du gouvernement du Canada travaillant en TI pourraient profiter des bons pour examens de certification attestant les compétences reconnues par l'industrie. Ces bons vous aideront à accroître vos qualifications et à faire progresser votre carrière.",
+    "description": "First paragraph of certification exam vouchers section"
   },
   "rZ0GyE": {
     "defaultMessage": "Modifications apportées aux procédures obligatoires en 2024",
@@ -11958,6 +12058,10 @@
     "defaultMessage": "Création du ministère réussie!",
     "description": "Message displayed to user after department is created successfully."
   },
+  "yGtIgV": {
+    "defaultMessage": "Demandez un bon",
+    "description": "Link text to request a voucher"
+  },
   "yGwPBd": {
     "defaultMessage": "Afin d’améliorer la fonctionnalité des sites Web du gouvernement du Canada, certains fichiers (tels que les bibliothèques à code source ouvert, les images et les scripts) peuvent être téléchargés automatiquement vers votre navigateur à l’aide d’un serveur tiers ou d’un réseau de diffusion de contenu de confiance. La diffusion de ces fichiers vise à offrir une expérience utilisateur transparente en diminuant les temps de réponse et en évitant le téléchargement de ces fichiers par chaque visiteur. Le cas échéant, les énoncés de protection des renseignements personnels traitant spécifiquement de ces fichiers se trouvent dans notre <privacyPolicyLink>Avis de confidentialité</privacyPolicyLink>.",
     "description": "Paragraph describing using files section"
@@ -12094,6 +12198,10 @@
     "defaultMessage": "La « clé » est une chaîne qui identifie de manière unique un groupe de compétences. Elle devrait être fondée sur le nom anglais du groupe de compétences et devrait être concise. Un bon exemple serait « information_management ». Elle peut être utilisée dans le code pour faire référence à cette compétence particulière, et ne peut donc pas être modifiée ultérieurement.",
     "description": "Additional context describing the purpose of the skill families 'key' field."
   },
+  "yu4wqa": {
+    "defaultMessage": "Dites-nous quel examen vous aimeriez passer et nous évaluerons votre demande.",
+    "description": "Second paragraph of certification topics section"
+  },
   "ywkgJx": {
     "defaultMessage": "Détails",
     "description": "Support form details field label"
@@ -12217,6 +12325,10 @@
   "zdeoxH": {
     "defaultMessage": "Diplôme d’études secondaires",
     "description": "Heading for the education requirement option secondary school diploma."
+  },
+  "zeLVU6": {
+    "defaultMessage": "DevOps;",
+    "description": "Sixth item in list of certification topics section"
   },
   "zejtvd": {
     "defaultMessage": "L'utilisateur perdra tous les rôles suivants dans le processus",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8810,10 +8810,6 @@
     "defaultMessage": "Talents numériques du <abbreviation>GC</abbreviation> n’est qu’une des nombreuses initiatives menées par le bureau du dirigeant principal de l'information du Canada (BDPI). Apprenez-en davantage sur le rôle du BDPI au sein du gouvernement du Canada. Consultez l’Ambition numérique du Canada 2022 pour connaître la direction future du BDPI.",
     "description": "Description of the Office of the Chief Information Officer"
   },
-  "h7f4Om": {
-    "defaultMessage": "Hiver 2024‑2025",
-    "description": "Statement that something will be available in the future"
-  },
   "h8BHov": {
     "defaultMessage": "Étape {stepOrdinal} (Intro)",
     "description": "Breadcrumb link text for a numbered application step introduction page"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3864,7 +3864,7 @@
     "description": "Comments or contributions list title"
   },
   "I2kLuc": {
-    "defaultMessage": "Pour toute question concernant les bons pour examens de certification, veuillez contacter <mailLink>icommunity-icollectivite@tbs-sct.gc.ca<mailLink>.",
+    "defaultMessage": "Pour toute question concernant les bons pour examens de certification, veuillez contacter <mailLink>icommunity-icollectivite@tbs-sct.gc.ca</mailLink>.",
     "description": "Second paragraph of what to expect section"
   },
   "I5q1n6": {

--- a/apps/web/src/messages/pageTitles.ts
+++ b/apps/web/src/messages/pageTitles.ts
@@ -76,6 +76,11 @@ export default defineMessages({
     id: "V95g4E",
     description: "Title for the index training opportunities page",
   },
+  certificationExamVouchers: {
+    defaultMessage: "Certification exam vouchers",
+    id: "JIvR0C",
+    description: "Title for the certification exam vouchers page",
+  },
   jobAdvertisementTemplates: {
     defaultMessage: "Job advertisement templates",
     id: "+nQpv5",

--- a/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
+++ b/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
@@ -1,0 +1,348 @@
+import { defineMessage, useIntl } from "react-intl";
+import { ReactNode } from "react";
+import InformationCircleIcon from "@heroicons/react/24/outline/InformationCircleIcon";
+import LightBulbIcon from "@heroicons/react/24/outline/LightBulbIcon";
+import ClipboardIcon from "@heroicons/react/24/outline/ClipboardIcon";
+import UserCircleIcon from "@heroicons/react/24/outline/UserCircleIcon";
+import QuestionMarkCircleIcon from "@heroicons/react/24/outline/QuestionMarkCircleIcon";
+import ChatBubbleLeftEllipsisIcon from "@heroicons/react/24/outline/ChatBubbleLeftEllipsisIcon";
+import TicketIcon from "@heroicons/react/24/outline/TicketIcon";
+
+import { Heading, Link } from "@gc-digital-talent/ui";
+import { getLocale } from "@gc-digital-talent/i18n";
+
+import useRoutes from "~/hooks/useRoutes";
+import SEO from "~/components/SEO/SEO";
+import Hero from "~/components/Hero";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
+import pageTitles from "~/messages/pageTitles";
+import hero4Landscape from "~/assets/img/hero-4-landscape.webp";
+
+const itLink = (href: string, chunks: ReactNode) => {
+  return (
+    <Link href={href} color="secondary" data-h2-font-weight="base(bold)">
+      {chunks}
+    </Link>
+  );
+};
+
+const mailLink = (chunks: ReactNode) => (
+  <Link href="mailto:icommunity-icollectivite@tbs-sct.gc.ca">{chunks}</Link>
+);
+
+const requestAVoucherUrl = {
+  en: "https://forms-formulaires.alpha.canada.ca/en/id/cm5b73nug00hmaxdu1dqpit6m",
+  fr: "https://forms-formulaires.alpha.canada.ca/fr/id/cm5b73nug00hmaxdu1dqpit6m",
+} as const;
+
+const pageSubtitle = defineMessage({
+  defaultMessage: "Validate your skills in key IT areas by becoming certified.",
+  id: "YZtE49",
+  description: "Page subtitle for certification exam vouchers page",
+});
+
+export const Component = () => {
+  const intl = useIntl();
+  const locale = getLocale(intl);
+  const paths = useRoutes();
+
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(pageTitles.itTrainingFund),
+        url: paths.itTrainingFund(),
+      },
+      {
+        label: intl.formatMessage(pageTitles.certificationExamVouchers),
+        url: paths.certificationExamVouchers(),
+      },
+    ],
+  });
+
+  return (
+    <>
+      <SEO
+        title={intl.formatMessage(pageTitles.certificationExamVouchers)}
+        description={intl.formatMessage(pageSubtitle)}
+      />
+      <Hero
+        title={intl.formatMessage(pageTitles.certificationExamVouchers)}
+        subtitle={intl.formatMessage(pageSubtitle)}
+        crumbs={crumbs}
+        buttonLinks={[
+          {
+            icon: TicketIcon,
+            text: intl.formatMessage({
+              defaultMessage: "Request a voucher",
+              id: "yGtIgV",
+              description: "Link text to request a voucher",
+            }),
+            url: requestAVoucherUrl[locale],
+            color: "quaternary",
+          },
+        ]}
+        imgPath={hero4Landscape}
+      />
+      <div data-h2-padding="base(x3, 0)">
+        <div data-h2-wrapper="base(center, large, x1) p-tablet(center, large, x2)">
+          <div data-h2-margin-bottom="base(x3)">
+            <Heading
+              size="h3"
+              Icon={InformationCircleIcon}
+              color="primary"
+              data-h2-margin-bottom="base(x1)"
+            >
+              {intl.formatMessage({
+                defaultMessage: "About the certification exam vouchers",
+                id: "Z8uO3k",
+                description: "Title for certification exam vouchers section",
+              })}
+            </Heading>
+            <p data-h2-margin-bottom="base(x.5)">
+              {intl.formatMessage({
+                defaultMessage:
+                  "Take advantage of available vouchers for industry-recognized certification exams intended for eligible Government of Canada IT employees. These vouchers help you enhance your qualifications and advance your career.",
+                id: "rYYqbv",
+                description:
+                  "First paragraph of certification exam vouchers section",
+              })}
+            </p>
+            <p>
+              {intl.formatMessage(
+                {
+                  defaultMessage:
+                    "<link>The IT Community Training and Development Fund</link> helps you become certified by paying for your certification exams.",
+                  id: "CHIy5L",
+                  description:
+                    "Second paragraph of certification exam vouchers section",
+                },
+                {
+                  link: (chunks: ReactNode) =>
+                    itLink(paths.itTrainingFund(), chunks),
+                },
+              )}
+            </p>
+          </div>
+          <div data-h2-margin-bottom="base(x3)">
+            <Heading
+              size="h3"
+              Icon={LightBulbIcon}
+              color="secondary"
+              data-h2-margin-bottom="base(x1)"
+            >
+              {intl.formatMessage({
+                defaultMessage: "Certification topics",
+                id: "Qn8C+Z",
+                description: "Title for certification topics section",
+              })}
+            </Heading>
+            <p data-h2-margin-bottom="base(x.5)">
+              {intl.formatMessage({
+                defaultMessage:
+                  "You can request vouchers for many IT certifications. Here are some examples of certifications for which you can get a voucher:",
+                id: "15nKPJ",
+                description: "First paragraph of certification topics section",
+              })}
+            </p>
+            <p data-h2-margin-bottom="base(x.5)">
+              <ul>
+                <li>
+                  {intl.formatMessage({
+                    defaultMessage: "IT project management",
+                    id: "ZiCXd1",
+                    description:
+                      "First item in list of certification topics section",
+                  })}
+                </li>
+                <li>
+                  {intl.formatMessage({
+                    defaultMessage: "Business analysis",
+                    id: "+BeD0v",
+                    description:
+                      "Second item in list of certification topics section",
+                  })}
+                </li>
+                <li>
+                  {intl.formatMessage({
+                    defaultMessage: "Cloud computing",
+                    id: "e6PlO0",
+                    description:
+                      "Third item in list of certification topics section",
+                  })}
+                </li>
+                <li>
+                  {intl.formatMessage({
+                    defaultMessage: "Cyber security",
+                    id: "hSoZzH",
+                    description:
+                      "Fourth item in list of certification topics section",
+                  })}
+                </li>
+                <li>
+                  {intl.formatMessage({
+                    defaultMessage: "Enterprise architecture",
+                    id: "GxrfIv",
+                    description:
+                      "Fifth item in list of certification topics section",
+                  })}
+                </li>
+                <li>
+                  {intl.formatMessage({
+                    defaultMessage: "DevOps",
+                    id: "zeLVU6",
+                    description:
+                      "Sixth item in list of certification topics section",
+                  })}
+                </li>
+                <li>
+                  {intl.formatMessage({
+                    defaultMessage: "Networking",
+                    id: "okQrE7",
+                    description:
+                      "Seventh item in list of certification topics section",
+                  })}
+                </li>
+              </ul>
+            </p>
+            <p data-h2-margin-bottom="base(x.5)">
+              {intl.formatMessage({
+                defaultMessage:
+                  "Let us know which certification exam you'd like to take, and we'll assess your application.",
+                id: "yu4wqa",
+                description: "Second paragraph of certification topics section",
+              })}
+            </p>
+          </div>
+          <div data-h2-margin-bottom="base(x3)">
+            <Heading
+              size="h3"
+              Icon={ClipboardIcon}
+              color="tertiary"
+              data-h2-margin-bottom="base(x1)"
+            >
+              {intl.formatMessage({
+                defaultMessage: "Eligibility requirements",
+                id: "mcibCA",
+                description: "Title for eligibility requirements section",
+              })}
+            </Heading>
+            <p data-h2-margin-bottom="base(x.5)">
+              <ul>
+                <li>
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "You're currently an IT-classified Government of Canada employee represented by PIPSC",
+                    id: "eQkmhS",
+                    description:
+                      "First item in list of eligibility requirements section",
+                  })}
+                </li>
+                <li>
+                  {intl.formatMessage({
+                    defaultMessage: "You have a GC Digital Talent profile",
+                    id: "2B+d2V",
+                    description:
+                      "Second item in list of eligibility requirements section",
+                  })}
+                </li>
+                <li>
+                  {intl.formatMessage({
+                    defaultMessage: "You have an active Navigar account",
+                    id: "4ddL8K",
+                    description:
+                      "Third item in list of eligibility requirements section",
+                  })}
+                </li>
+                <li>
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "You've completed any preparatory work such as prerequisite training modules and are ready to take the certification exam",
+                    id: "oc4iCB",
+                    description:
+                      "Fourth item in list of eligibility requirements section",
+                  })}
+                </li>
+              </ul>
+            </p>
+          </div>
+          <div data-h2-margin-bottom="base(x3)">
+            <Heading
+              size="h3"
+              Icon={UserCircleIcon}
+              color="quaternary"
+              data-h2-margin-bottom="base(x1)"
+            >
+              {intl.formatMessage({
+                defaultMessage: "Apply and complete your profile",
+                id: "fxhdQd",
+                description:
+                  "Title for apply and complete your profile section",
+              })}
+            </Heading>
+            <p data-h2-margin-bottom="base(x.5)">
+              {intl.formatMessage({
+                defaultMessage:
+                  "To obtain a voucher, complete the application form. Your GC Digital Talent profile helps us confirm your eligibility. Before you apply, take a moment to review and update your information or create a profile if you haven't done so yet.",
+                id: "1uoeR6",
+                description:
+                  "First paragraph of apply and complete your profile section",
+              })}
+            </p>
+          </div>
+          <div data-h2-margin-bottom="base(x3)">
+            <Heading
+              size="h3"
+              Icon={QuestionMarkCircleIcon}
+              color="quinary"
+              data-h2-margin-bottom="base(x1)"
+            >
+              {intl.formatMessage({
+                defaultMessage: "What to expect",
+                id: "8umYON",
+                description: "Title for what to expect section",
+              })}
+            </Heading>
+            <p data-h2-margin-bottom="base(x.5)">
+              {intl.formatMessage({
+                defaultMessage:
+                  "We'll respond to your application within 7 business days. If your request is approved, we’ll send you a voucher code that you can use when booking your exam on the provider's platform.",
+                id: "z5HIBF",
+                description: "First paragraph of what to expect section",
+              })}
+            </p>
+            <p data-h2-margin-bottom="base(x.5)">
+              {intl.formatMessage(
+                {
+                  defaultMessage:
+                    "For questions regarding the vouchers, please contact <mailLink>icommunity-icollectivite@tbs-sct.gc.ca</mailLink>.",
+                  id: "I2kLuc",
+                  description: "Second paragraph of what to expect section",
+                },
+                { mailLink },
+              )}
+            </p>
+          </div>
+          <div data-h2-text-align="base(center)">
+            <Link
+              icon={ChatBubbleLeftEllipsisIcon}
+              color="quaternary"
+              mode="cta"
+              href={requestAVoucherUrl[locale]}
+              state={{ referrer: window.location.href }}
+            >
+              {intl.formatMessage({
+                defaultMessage: "Request a voucher",
+                id: "yGtIgV",
+                description: "Link text to request a voucher",
+              })}
+            </Link>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+Component.displayName = "CertificationExamVouchersPage";
+
+export default Component;

--- a/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
+++ b/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
@@ -111,8 +111,8 @@ export const Component = () => {
               {intl.formatMessage(
                 {
                   defaultMessage:
-                    "<link>The IT Community Training and Development Fund</link> helps you become certified by paying for your certification exams.",
-                  id: "CHIy5L",
+                    "The <link>IT Community Training and Development Fund</link> helps you become certified by paying for your certification exams.",
+                  id: "gIvlZk",
                   description:
                     "Second paragraph of certification exam vouchers section",
                 },

--- a/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
+++ b/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
@@ -5,7 +5,6 @@ import LightBulbIcon from "@heroicons/react/24/outline/LightBulbIcon";
 import ClipboardIcon from "@heroicons/react/24/outline/ClipboardIcon";
 import UserCircleIcon from "@heroicons/react/24/outline/UserCircleIcon";
 import QuestionMarkCircleIcon from "@heroicons/react/24/outline/QuestionMarkCircleIcon";
-import ChatBubbleLeftEllipsisIcon from "@heroicons/react/24/outline/ChatBubbleLeftEllipsisIcon";
 import TicketIcon from "@heroicons/react/24/outline/TicketIcon";
 
 import { Heading, Link } from "@gc-digital-talent/ui";
@@ -324,7 +323,7 @@ export const Component = () => {
           </div>
           <div data-h2-text-align="base(center)">
             <Link
-              icon={ChatBubbleLeftEllipsisIcon}
+              icon={TicketIcon}
               color="quaternary"
               mode="cta"
               href={requestAVoucherUrl[locale]}

--- a/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
+++ b/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
@@ -305,8 +305,8 @@ export const Component = () => {
             <p data-h2-margin-bottom="base(x.5)">
               {intl.formatMessage({
                 defaultMessage:
-                  "We'll respond to your application within 7 business days. If your request is approved, we’ll send you a voucher code that you can use when booking your exam on the provider's platform.",
-                id: "z5HIBF",
+                  "We'll respond to your application within 7 business days. If your request is approved, we'll send you a voucher code that you can use when booking your exam on the provider's platform.",
+                id: "9gU2in",
                 description: "First paragraph of what to expect section",
               })}
             </p>

--- a/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
+++ b/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
@@ -145,7 +145,7 @@ export const Component = () => {
             </p>
             <p data-h2-margin-bottom="base(x.5)">
               <ul>
-                <li>
+                <li data-h2-margin-top="base(x.25)">
                   {intl.formatMessage({
                     defaultMessage: "IT project management",
                     id: "ZiCXd1",
@@ -153,7 +153,7 @@ export const Component = () => {
                       "First item in list of certification topics section",
                   })}
                 </li>
-                <li>
+                <li data-h2-margin-top="base(x.25)">
                   {intl.formatMessage({
                     defaultMessage: "business analysis",
                     id: "awyksR",
@@ -161,7 +161,7 @@ export const Component = () => {
                       "Second item in list of certification topics section",
                   })}
                 </li>
-                <li>
+                <li data-h2-margin-top="base(x.25)">
                   {intl.formatMessage({
                     defaultMessage: "cloud computing",
                     id: "vYigGH",
@@ -169,7 +169,7 @@ export const Component = () => {
                       "Third item in list of certification topics section",
                   })}
                 </li>
-                <li>
+                <li data-h2-margin-top="base(x.25)">
                   {intl.formatMessage({
                     defaultMessage: "cyber security",
                     id: "9oUpdh",
@@ -177,7 +177,7 @@ export const Component = () => {
                       "Fourth item in list of certification topics section",
                   })}
                 </li>
-                <li>
+                <li data-h2-margin-top="base(x.25)">
                   {intl.formatMessage({
                     defaultMessage: "enterprise architecture",
                     id: "yOii5k",
@@ -185,7 +185,7 @@ export const Component = () => {
                       "Fifth item in list of certification topics section",
                   })}
                 </li>
-                <li>
+                <li data-h2-margin-top="base(x.25)">
                   {intl.formatMessage({
                     defaultMessage: "DevOps",
                     id: "zeLVU6",
@@ -193,7 +193,7 @@ export const Component = () => {
                       "Sixth item in list of certification topics section",
                   })}
                 </li>
-                <li>
+                <li data-h2-margin-top="base(x.25)">
                   {intl.formatMessage({
                     defaultMessage: "networking",
                     id: "+UjXSM",
@@ -227,7 +227,7 @@ export const Component = () => {
             </Heading>
             <p data-h2-margin-bottom="base(x.5)">
               <ul>
-                <li>
+                <li data-h2-margin-top="base(x.25)">
                   {intl.formatMessage({
                     defaultMessage:
                       "You're currently an IT-classified Government of Canada employee represented by PIPSC",
@@ -236,7 +236,7 @@ export const Component = () => {
                       "First item in list of eligibility requirements section",
                   })}
                 </li>
-                <li>
+                <li data-h2-margin-top="base(x.25)">
                   {intl.formatMessage({
                     defaultMessage: "You have a GC Digital Talent profile",
                     id: "2B+d2V",
@@ -244,7 +244,7 @@ export const Component = () => {
                       "Second item in list of eligibility requirements section",
                   })}
                 </li>
-                <li>
+                <li data-h2-margin-top="base(x.25)">
                   {intl.formatMessage({
                     defaultMessage: "You have an active Navigar account",
                     id: "4ddL8K",
@@ -252,7 +252,7 @@ export const Component = () => {
                       "Third item in list of eligibility requirements section",
                   })}
                 </li>
-                <li>
+                <li data-h2-margin-top="base(x.25)">
                   {intl.formatMessage({
                     defaultMessage:
                       "You've completed any preparatory work such as prerequisite training modules and are ready to take the certification exam",

--- a/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
+++ b/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
@@ -156,32 +156,32 @@ export const Component = () => {
                 </li>
                 <li>
                   {intl.formatMessage({
-                    defaultMessage: "Business analysis",
-                    id: "+BeD0v",
+                    defaultMessage: "business analysis",
+                    id: "awyksR",
                     description:
                       "Second item in list of certification topics section",
                   })}
                 </li>
                 <li>
                   {intl.formatMessage({
-                    defaultMessage: "Cloud computing",
-                    id: "e6PlO0",
+                    defaultMessage: "cloud computing",
+                    id: "vYigGH",
                     description:
                       "Third item in list of certification topics section",
                   })}
                 </li>
                 <li>
                   {intl.formatMessage({
-                    defaultMessage: "Cyber security",
-                    id: "hSoZzH",
+                    defaultMessage: "cyber security",
+                    id: "9oUpdh",
                     description:
                       "Fourth item in list of certification topics section",
                   })}
                 </li>
                 <li>
                   {intl.formatMessage({
-                    defaultMessage: "Enterprise architecture",
-                    id: "GxrfIv",
+                    defaultMessage: "enterprise architecture",
+                    id: "yOii5k",
                     description:
                       "Fifth item in list of certification topics section",
                   })}
@@ -196,8 +196,8 @@ export const Component = () => {
                 </li>
                 <li>
                   {intl.formatMessage({
-                    defaultMessage: "Networking",
-                    id: "okQrE7",
+                    defaultMessage: "networking",
+                    id: "+UjXSM",
                     description:
                       "Seventh item in list of certification topics section",
                   })}

--- a/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
+++ b/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
@@ -15,7 +15,6 @@ import SEO from "~/components/SEO/SEO";
 import Hero from "~/components/Hero";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import pageTitles from "~/messages/pageTitles";
-import hero4Landscape from "~/assets/img/hero-4-landscape.webp";
 
 const itLink = (href: string, chunks: ReactNode) => {
   return (
@@ -80,7 +79,6 @@ export const Component = () => {
             color: "quaternary",
           },
         ]}
-        imgPath={hero4Landscape}
       />
       <div data-h2-padding="base(x3, 0)">
         <div data-h2-wrapper="base(center, large, x1) p-tablet(center, large, x2)">

--- a/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
+++ b/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
@@ -30,8 +30,8 @@ const mailLink = (chunks: ReactNode) => (
 );
 
 const requestAVoucherUrl = {
-  en: "https://forms-formulaires.alpha.canada.ca/en/id/cm5b73nug00hmaxdu1dqpit6m",
-  fr: "https://forms-formulaires.alpha.canada.ca/fr/id/cm5b73nug00hmaxdu1dqpit6m",
+  en: "https://forms-formulaires.alpha.canada.ca/en/id/cm5ffyomv00jtsdyfv7pt4qu9",
+  fr: "https://forms-formulaires.alpha.canada.ca/fr/id/cm5ffyomv00jtsdyfv7pt4qu9",
 } as const;
 
 const pageSubtitle = defineMessage({

--- a/apps/web/src/pages/ItTrainingFundPage/ItTrainingFundPage.tsx
+++ b/apps/web/src/pages/ItTrainingFundPage/ItTrainingFundPage.tsx
@@ -531,10 +531,10 @@ export const Component = () => {
                     >
                       <p data-h2-font-weight="base(bold)">
                         {intl.formatMessage({
-                          defaultMessage: "Coming in winter 2024-25",
-                          id: "h7f4Om",
+                          defaultMessage: "Available now",
+                          id: "L6MPML",
                           description:
-                            "Statement that something will be available in the future",
+                            "Statement that something is available now",
                         })}
                       </p>
                       <ul

--- a/apps/web/src/pages/ItTrainingFundPage/ItTrainingFundPage.tsx
+++ b/apps/web/src/pages/ItTrainingFundPage/ItTrainingFundPage.tsx
@@ -43,6 +43,11 @@ export const Component = () => {
   const locale = getLocale(intl);
   const paths = useRoutes();
 
+  const signUpUrl = {
+    en: "https://forms-formulaires.alpha.canada.ca/en/id/cm4ww5k8l00bbaxduytwfcrjk",
+    fr: "https://forms-formulaires.alpha.canada.ca/fr/id/cm4ww5k8l00bbaxduytwfcrjk",
+  } as const;
+
   const navigarUrl = {
     en: "https://navigar.ca/",
     fr: "https://navigar.ca/fr/",
@@ -465,6 +470,8 @@ export const Component = () => {
                         <Link
                           mode="text"
                           data-h2-font-weight="base(bold)"
+                          data-h2-padding-bottom="base(x1)"
+                          data-h2-display="base(block)"
                           color="secondary"
                           external
                           href={paths.instructorLedTraining()}
@@ -472,6 +479,21 @@ export const Component = () => {
                           {intl.formatMessage({
                             defaultMessage: "Browse training opportunities",
                             id: "alKxbI",
+                            description: "A link to sign up for updates",
+                          })}
+                        </Link>
+                        <Link
+                          mode="text"
+                          data-h2-font-weight="base(bold)"
+                          data-h2-display="base(block)"
+                          color="secondary"
+                          external
+                          href={signUpUrl[locale]}
+                        >
+                          {intl.formatMessage({
+                            defaultMessage:
+                              "Sign up for updates<hidden> about instructor-led classes and bootcamps</hidden>",
+                            id: "Tj1iyN",
                             description: "A link to sign up for updates",
                           })}
                         </Link>

--- a/apps/web/src/pages/ItTrainingFundPage/ItTrainingFundPage.tsx
+++ b/apps/web/src/pages/ItTrainingFundPage/ItTrainingFundPage.tsx
@@ -43,11 +43,6 @@ export const Component = () => {
   const locale = getLocale(intl);
   const paths = useRoutes();
 
-  const signUpUrl = {
-    en: "https://forms-formulaires.alpha.canada.ca/en/id/cm2oraxj700k8d1ec6dumq39e",
-    fr: "https://forms-formulaires.alpha.canada.ca/fr/id/cm2oraxj700k8d1ec6dumq39e",
-  } as const;
-
   const navigarUrl = {
     en: "https://navigar.ca/",
     fr: "https://navigar.ca/fr/",
@@ -576,13 +571,13 @@ export const Component = () => {
                         data-h2-font-weight="base(bold)"
                         color="secondary"
                         external
-                        href={signUpUrl[locale]}
+                        href={paths.certificationExamVouchers()}
                       >
                         {intl.formatMessage({
-                          defaultMessage:
-                            "Sign up for updates<hidden> about certification exam vouchers</hidden>",
-                          id: "bjcr+t",
-                          description: "A link to sign up for updates",
+                          defaultMessage: "Request a voucher",
+                          id: "erzpFY",
+                          description:
+                            "Link text to request a voucher (infinitive)",
                         })}
                       </Link>
                     </div>


### PR DESCRIPTION
🤖 Resolves #12360.

## 👋 Introduction

This PR adds the certification exam vouchers page and updates some links and copy on the IT training fund page.

## 🧪 Testing

1. `pnpm build`
2. Navigate to http://localhost:8000/en/it-training-fund/certification-exam-vouchers
3. Verify copy and layout match designs
4. Navigate to http://localhost:8000/en/it-training-fund
5. Verify copy and links match issue

## 📸 Screenshots

<details><summary>Screenshots (4)</summary>

![localhost_8000_en_it-training-fund_certification-exam-vouchers](https://github.com/user-attachments/assets/11bf37ac-3207-45de-a19c-d9982df16094)

![localhost_8000_fr_it-training-fund_certification-exam-vouchers](https://github.com/user-attachments/assets/2425ddaa-d57f-479f-b582-59477c3e7df8)

![localhost_8000_en_it-training-fund](https://github.com/user-attachments/assets/4b26e4e9-1b67-473e-9420-cb471f0172e6)

![localhost_8000_fr_it-training-fund](https://github.com/user-attachments/assets/60d9a7da-e8be-4dce-b8e7-4db224ed6e36)
</details> 

