### PR TITLE
[Feature] Increases classification level options

### DIFF
--- a/api/app/Models/Classification.php
+++ b/api/app/Models/Classification.php
@@ -52,7 +52,7 @@ class Classification extends Model
     {
         /** @disregard P1003 Not using values */
         return Attribute::make(
-            get: fn (mixed $value, array $attributes) => $attributes['group'].'-'.($attributes['level'] < 10 ? "0" : "").$attributes['level'],
+            get: fn (mixed $value, array $attributes) => $attributes['group'].'-'.($attributes['level'] < 10 ? '0' : '').$attributes['level'],
         );
     }
 

--- a/api/app/Models/Classification.php
+++ b/api/app/Models/Classification.php
@@ -52,8 +52,7 @@ class Classification extends Model
     {
         /** @disregard P1003 Not using values */
         return Attribute::make(
-            get: fn (mixed $value, array $attributes) => $attributes['group'].'-'.sprintf('%02d', $attributes['level']),
-
+            get: fn (mixed $value, array $attributes) => $attributes['group'].'-'.($attributes['level'] < 10 ? "0" : "").$attributes['level'],
         );
     }
 

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -352,7 +352,9 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
 
         $classification = $this->currentClassification()->first();
 
-        return $classification->group.'-0'.$classification->level;
+        $leadingZero = $classification->level < 10 ? "0" : "";
+
+        return $classification->group.'-'.$leadingZero.$classification->level;
     }
 
     public function getDepartment()

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -352,7 +352,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
 
         $classification = $this->currentClassification()->first();
 
-        $leadingZero = $classification->level < 10 ? "0" : "";
+        $leadingZero = $classification->level < 10 ? '0' : '';
 
         return $classification->group.'-'.$leadingZero.$classification->level;
     }

--- a/apps/playwright/tests/search-workflows.spec.ts
+++ b/apps/playwright/tests/search-workflows.spec.ts
@@ -134,7 +134,7 @@ test.describe("Talent search", () => {
     await expectNoCandidate(appPage.page);
 
     await classificationFilter.selectOption({
-      value: `${classification.group}-0${classification.level}`,
+      value: `${classification.group}-${classification.level < 10 ? "0" : ""}${classification.level}`,
     });
 
     const streamFilter = appPage.page.getByRole("combobox", {
@@ -221,7 +221,7 @@ test.describe("Talent search", () => {
     await expect(
       appPage.page.getByText(
         new RegExp(
-          `${classification.group}-0${classification.level}: search pool`,
+          `${classification.group}-${classification.level < 10 ? "0" : ""}${classification.level}: search pool`,
           "i",
         ),
       ),

--- a/apps/web/src/components/ExperienceCard/WorkContent/GovContent.tsx
+++ b/apps/web/src/components/ExperienceCard/WorkContent/GovContent.tsx
@@ -78,7 +78,7 @@ const GovContent = ({
             headingLevel={headingLevel}
           >
             {classification
-              ? `${classification.group}-0${classification.level}`
+              ? `${classification.group}-${classification.level < 10 ? "0" : ""}${classification.level}`
               : intl.formatMessage(commonMessages.notAvailable)}
           </ContentSection>
         </div>
@@ -122,7 +122,7 @@ const GovContent = ({
             headingLevel={headingLevel}
           >
             {classification
-              ? `${classification.group}-0${classification.level}`
+              ? `${classification.group}-${classification.level < 10 ? "0" : ""}${classification.level}`
               : intl.formatMessage(commonMessages.notAvailable)}
           </ContentSection>
         </div>

--- a/apps/web/src/components/ExperienceFormFields/WorkFields/GovFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields/GovFields.tsx
@@ -164,9 +164,10 @@ const GovFields = ({ labels }: SubExperienceFormProps) => {
     .map((iterator) => {
       return {
         value: iterator.id.toString(), // change the value to id for the query
-        label: iterator.level.toString(),
+        label: iterator.level,
       };
-    });
+    })
+    .sort((a, b) => a.label - b.label);
 
   /**
    * Reset classification level when group changes
@@ -356,6 +357,7 @@ const GovFields = ({ labels }: SubExperienceFormProps) => {
                     uiMessages.nullSelectionOptionLevel,
                   )}
                   options={levelOptions}
+                  doNotSort
                 />
               </div>
             </>

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
@@ -206,7 +206,7 @@ const PoolCandidateFilterDialog = ({
           label={intl.formatMessage(adminMessages.classifications)}
           options={classifications.map(({ group, level }) => ({
             value: `${group}-${level}`,
-            label: `${group}-0${level}`,
+            label: `${group}-${level < 10 ? "0" : ""}${level}`,
           }))}
         />
         <Combobox

--- a/apps/web/src/components/PoolCard/PoolCard.tsx
+++ b/apps/web/src/components/PoolCard/PoolCard.tsx
@@ -188,7 +188,7 @@ const PoolCard = ({ poolQuery, headingLevel = "h3" }: PoolCardProps) => {
 
   const classificationAbbr = pool.classification
     ? wrapAbbr(
-        `${pool.classification.group}-0${pool.classification.level}`,
+        `${pool.classification.group}-${pool.classification.level < 10 ? "0" : ""}${pool.classification.level}`,
         intl,
       )
     : "";

--- a/apps/web/src/components/Profile/components/GovernmentInformation/Display.tsx
+++ b/apps/web/src/components/Profile/components/GovernmentInformation/Display.tsx
@@ -133,7 +133,7 @@ const Display = ({
           >
             {!!currentClassification?.group && !!currentClassification?.level
               ? wrapAbbr(
-                  `${currentClassification?.group}-${currentClassification?.level}`,
+                  `${currentClassification?.group}-${currentClassification?.level < 10 ? "0" : ""}${currentClassification?.level}`,
                   intl,
                 )
               : notProvided}

--- a/apps/web/src/components/Profile/components/GovernmentInformation/FormFields.tsx
+++ b/apps/web/src/components/Profile/components/GovernmentInformation/FormFields.tsx
@@ -114,7 +114,10 @@ const FormFields = ({
     ]);
 
   const groupOptions = getGroupOptions([...classifications], intl);
-  const levelOptions = getLevelOptions([...classifications], groupSelection);
+  const levelOptions = getLevelOptions(
+    [...classifications],
+    groupSelection,
+  ).sort((a, b) => a.value - b.value);
   const hasPriorityEntitlement = priorityEntitlement === "yes";
   const isGovEmployee = govEmployee === "yes";
   const isPlaced =
@@ -272,6 +275,7 @@ const FormFields = ({
                     uiMessages.nullSelectionOptionLevel,
                   )}
                   options={levelOptions}
+                  doNotSort
                 />
               </div>
             )}

--- a/apps/web/src/components/Profile/components/GovernmentInformation/utils.ts
+++ b/apps/web/src/components/Profile/components/GovernmentInformation/utils.ts
@@ -239,7 +239,7 @@ export const getLevelOptions = (
     .filter((x) => x.group === groupSelection)
     .map((iterator) => {
       return {
-        value: iterator.level.toString(),
+        value: iterator.level,
         label: iterator.level.toString(),
       };
     });

--- a/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -44,14 +44,20 @@ const ApplicantFilters = ({
   // else set values if filters prop is of ApplicantFilterInput type
   const classificationsFromBrowserHistory = selectedClassifications?.map(
     (classification) =>
-      wrapAbbr(`${classification?.group}-0${classification?.level}`, intl),
+      wrapAbbr(
+        `${classification?.group}-${classification?.level < 10 ? "0" : ""}${classification?.level}`,
+        intl,
+      ),
   );
 
   const classifications = applicantFilter?.qualifiedClassifications ?? [];
   const classificationsFromApplicantFilter = classifications
     .filter(notEmpty)
     .map((classification) =>
-      wrapAbbr(`${classification?.group}-0${classification?.level}`, intl),
+      wrapAbbr(
+        `${classification?.group}-${classification?.level < 10 ? "0" : ""}${classification?.level}`,
+        intl,
+      ),
     );
 
   const skills: string[] | undefined = applicantFilter?.skills?.map((skill) => {
@@ -270,7 +276,7 @@ const SearchRequestFilters = ({
   const classifications: string[] | undefined =
     poolCandidateFilter?.classifications?.map(
       (classification) =>
-        `${classification?.group.toLocaleUpperCase()}-0${classification?.level}`,
+        `${classification?.group.toLocaleUpperCase()}-${classification?.level < 10 ? "0" : ""}${classification?.level}`,
     );
 
   const pools: Pool[] | undefined = poolCandidateFilter

--- a/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -45,7 +45,7 @@ const ApplicantFilters = ({
   const classificationsFromBrowserHistory = selectedClassifications?.map(
     (classification) =>
       wrapAbbr(
-        `${classification?.group}-${classification?.level < 10 ? "0" : ""}${classification?.level}`,
+        `${classification?.group}-${classification && classification?.level < 10 ? "0" : ""}${classification?.level}`,
         intl,
       ),
   );

--- a/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -276,7 +276,7 @@ const SearchRequestFilters = ({
   const classifications: string[] | undefined =
     poolCandidateFilter?.classifications?.map(
       (classification) =>
-        `${classification?.group.toLocaleUpperCase()}-${classification?.level < 10 ? "0" : ""}${classification?.level}`,
+        `${classification?.group.toLocaleUpperCase()}-${classification && classification?.level < 10 ? "0" : ""}${classification?.level}`,
     );
 
   const pools: Pool[] | undefined = poolCandidateFilter

--- a/apps/web/src/components/SearchRequestTable/components/SearchRequestFilterDialog.tsx
+++ b/apps/web/src/components/SearchRequestTable/components/SearchRequestFilterDialog.tsx
@@ -129,7 +129,7 @@ const SearchRequestFilterDialog = ({
           label={intl.formatMessage(adminMessages.classifications)}
           options={classifications.map((classification) => ({
             value: classification.id,
-            label: `${classification.group}-0${classification.level}`,
+            label: `${classification.group}-${classification.level < 10 ? "0" : ""}${classification.level}`,
           }))}
         />
         <Combobox

--- a/apps/web/src/components/SearchRequestTable/components/helpers.tsx
+++ b/apps/web/src/components/SearchRequestTable/components/helpers.tsx
@@ -18,7 +18,7 @@ export function classificationAccessor(
 ) {
   return classifications
     ?.filter(notEmpty)
-    ?.map((c) => `${c.group}-0${c.level}`)
+    ?.map((c) => `${c.group}-${level < 10 ? "0" : ""}${c.level}`)
     ?.join(", ");
 }
 
@@ -34,10 +34,10 @@ export function classificationsCell(
   const chipsArray = filteredClassifications.map((classification) => {
     return (
       <Chip
-        key={`${classification.group}-0${classification.level}`}
+        key={`${classification.group}-${classification.level < 10 ? "0" : ""}${classification.level}`}
         color="primary"
       >
-        {`${classification.group}-0${classification.level}`}
+        {`${classification.group}-${classification.level < 10 ? "0" : ""}${classification.level}`}
       </Chip>
     );
   });

--- a/apps/web/src/components/SearchRequestTable/components/helpers.tsx
+++ b/apps/web/src/components/SearchRequestTable/components/helpers.tsx
@@ -18,7 +18,7 @@ export function classificationAccessor(
 ) {
   return classifications
     ?.filter(notEmpty)
-    ?.map((c) => `${c.group}-${level < 10 ? "0" : ""}${c.level}`)
+    ?.map((c) => `${c.group}-${c.level < 10 ? "0" : ""}${c.level}`)
     ?.join(", ");
 }
 

--- a/apps/web/src/components/UserProfile/ProfileSections/GovernmentInformationSection.tsx
+++ b/apps/web/src/components/UserProfile/ProfileSections/GovernmentInformationSection.tsx
@@ -110,7 +110,7 @@ const GovernmentInformationSection = ({
                 </span>
                 <span data-h2-font-weight="base(700)">
                   {wrapAbbr(
-                    `${currentClassification?.group}-${currentClassification?.level}`,
+                    `${currentClassification?.group}-${currentClassification?.level < 10 ? "0" : ""}${currentClassification?.level}`,
                     intl,
                   )}
                 </span>

--- a/apps/web/src/pages/Auth/RegistrationPages/EmployeeInformationPage/EmployeeInformationPage.tsx
+++ b/apps/web/src/pages/Auth/RegistrationPages/EmployeeInformationPage/EmployeeInformationPage.tsx
@@ -136,7 +136,7 @@ export const EmployeeInformationFormFields = ({
     .filter((x) => x.group === groupSelection)
     .map((iterator) => {
       return {
-        value: iterator.level.toString(),
+        value: iterator.level,
         label: iterator.level.toString(),
       };
     });

--- a/apps/web/src/pages/Auth/RegistrationPages/EmployeeInformationPage/EmployeeInformationPage.tsx
+++ b/apps/web/src/pages/Auth/RegistrationPages/EmployeeInformationPage/EmployeeInformationPage.tsx
@@ -139,7 +139,8 @@ export const EmployeeInformationFormFields = ({
         value: iterator.level,
         label: iterator.level.toString(),
       };
-    });
+    })
+    .sort((a, b) => a.value - b.value);
 
   const isGovEmployee = govEmployee === "yes";
 
@@ -345,6 +346,7 @@ export const EmployeeInformationFormFields = ({
                   uiMessages.nullSelectionOptionLevel,
                 )}
                 options={levelOptions}
+                doNotSort
               />
             </div>
           </>

--- a/apps/web/src/pages/Classifications/CreateClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/CreateClassificationPage.tsx
@@ -21,6 +21,7 @@ import pageTitles from "~/messages/pageTitles";
 import Hero from "~/components/Hero";
 
 import messages from "./messages";
+import { getClassificationLevels } from "./helpers";
 
 type FormValues = CreateClassificationInput;
 
@@ -168,17 +169,8 @@ export const CreateClassification = () => {
                     rules={{
                       required: intl.formatMessage(errorMessages.required),
                     }}
-                    options={[
-                      { value: 1, label: "1" },
-                      { value: 2, label: "2" },
-                      { value: 3, label: "3" },
-                      { value: 4, label: "4" },
-                      { value: 5, label: "5" },
-                      { value: 6, label: "6" },
-                      { value: 7, label: "7" },
-                      { value: 8, label: "8" },
-                      { value: 9, label: "9" },
-                    ]}
+                    options={getClassificationLevels()}
+                    doNotSort
                   />
                   <Input
                     id="minSalary"

--- a/apps/web/src/pages/Classifications/UpdateClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/UpdateClassificationPage.tsx
@@ -41,6 +41,7 @@ import { getClassificationName } from "~/utils/poolUtils";
 import Hero from "~/components/Hero";
 
 import messages from "./messages";
+import { getClassificationLevels } from "./helpers";
 
 export const ClassificationForm_Fragment = graphql(/* GraphQL */ `
   fragment ClassificationForm on Classification {
@@ -231,17 +232,8 @@ export const UpdateClassificationForm = ({
                   rules={{
                     required: intl.formatMessage(errorMessages.required),
                   }}
-                  options={[
-                    { value: 1, label: "1" },
-                    { value: 2, label: "2" },
-                    { value: 3, label: "3" },
-                    { value: 4, label: "4" },
-                    { value: 5, label: "5" },
-                    { value: 6, label: "6" },
-                    { value: 7, label: "7" },
-                    { value: 8, label: "8" },
-                    { value: 9, label: "9" },
-                  ]}
+                  options={getClassificationLevels()}
+                  doNotSort
                   disabled
                 />
                 <Input

--- a/apps/web/src/pages/Classifications/helpers.tsx
+++ b/apps/web/src/pages/Classifications/helpers.tsx
@@ -1,0 +1,13 @@
+export function getClassificationLevels(): {
+  value: number;
+  label: number;
+}[] {
+  const levels: {
+    value: number;
+    label: number;
+  }[] = [];
+  for (let i = 1; i <= 19; i++) {
+    levels.push({ value: i, label: i });
+  }
+  return levels;
+}

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -132,7 +132,7 @@ function previewMetaData(
     metaData.push({
       key: classification.id,
       type: "chip",
-      children: `${classification.group}-0${classification.level}`,
+      children: `${classification.group}-${classification.level < 10 ? "0" : ""}${classification.level}`,
     } satisfies PreviewMetaData);
   }
 
@@ -356,7 +356,7 @@ const JobPosterTemplatesPage = () => {
                         .sort((a, b) => a.level - b.level)
                         .map((classification) => ({
                           value: classification.id,
-                          label: `${classification.group}-0${classification.level}`,
+                          label: `${classification.group}-${classification.level < 10 ? "0" : ""}${classification.level}`,
                         }))}
                     />
                     <Checklist

--- a/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
+++ b/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
@@ -156,10 +156,12 @@ export const CreatePoolForm = ({
 
   // recycled from EditPool
   const classificationOptions: Option[] = classifications.map(
-    ({ id, group, level, name }) => ({
-      value: id,
-      label: `${group}-0${level} (${getLocalizedName(name, intl)})`,
-    }),
+    ({ id, group, level, name }) => {
+      return {
+        value: id,
+        label: `${group}-${level < 10 ? "0" : ""}${level} (${getLocalizedName(name, intl)})`,
+      };
+    },
   );
 
   const departmentOptions: Option[] = departments.map(({ id, name }) => ({

--- a/apps/web/src/pages/Pools/EditPoolPage/components/EducationRequirementsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/EducationRequirementsSection.tsx
@@ -87,7 +87,10 @@ const EducationRequirementsSection = ({
   });
   const classificationGroup = pool.classification?.group;
   const classificationAbbr = pool.classification
-    ? wrapAbbr(`${classificationGroup}-0${pool.classification.level}`, intl)
+    ? wrapAbbr(
+        `${classificationGroup}-${pool.classification.level < 10 ? "0" : ""}${pool.classification.level}`,
+        intl,
+      )
     : "";
 
   return (

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/utils.ts
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/utils.ts
@@ -91,7 +91,7 @@ export const getClassificationOptions = (
 ): Option[] => {
   return classifications.filter(notEmpty).map(({ id, group, level, name }) => ({
     value: id,
-    label: `${group}-0${level} (${getLocalizedName(name, intl)})`,
+    label: `${group}-${level < 10 ? "0" : ""}${level} (${getLocalizedName(name, intl)})`,
   }));
 };
 

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolFilterDialog.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolFilterDialog.tsx
@@ -108,7 +108,7 @@ const PoolFilterDialog = ({
           options={unpackMaybes(data?.classifications).map(
             ({ group, level }) => ({
               value: `${group}-${level}`,
-              label: `${group}-0${level}`,
+              label: `${group}-${level < 10 ? "0" : ""}${level}`,
             }),
           )}
         />

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
@@ -99,7 +99,7 @@ export function classificationCell(
 
   return (
     <Chip color="primary">
-      {`${classification.group}-0${classification.level}`}
+      {`${classification.group}-${classification.level < 10 ? "0" : ""}${classification.level}`}
     </Chip>
   );
 }

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
@@ -88,7 +88,7 @@ export function classificationAccessor(
   classification: Maybe<Pick<Classification, "group" | "level">> | undefined,
 ) {
   return classification
-    ? `${classification.group}-0${classification.level}`
+    ? `${classification.group}-${classification.level < 10 ? "0" : ""}${classification.level}`
     : "";
 }
 

--- a/apps/web/src/pages/SearchRequests/SearchPage/utils.ts
+++ b/apps/web/src/pages/SearchRequests/SearchPage/utils.ts
@@ -25,7 +25,7 @@ export const getClassificationLabel = (
   labels: Record<string, MessageDescriptor>,
   intl: IntlShape,
 ) => {
-  const key = `${group}-0${level}`;
+  const key = `${group}-${level < 10 ? "0" : ""}${level}`;
   return !hasKey(labels, key) ? key : intl.formatMessage(labels[key]);
 };
 

--- a/apps/web/src/utils/nameUtils.tsx
+++ b/apps/web/src/utils/nameUtils.tsx
@@ -149,7 +149,7 @@ export const wrapAbbr = (text: ReactNode, intl: IntlShape, title?: string) => {
   }
   switch (stringifyText) {
     // Regex that matches all IT classifications with levels
-    case /[IT]-0\d/.exec(stringifyText)?.input:
+    case /[IT]-[0-9]\d/.exec(stringifyText)?.input:
       return (
         <abbr title={intl.formatMessage(getAbbreviations("IT"))}>
           <span aria-label={splitAndJoin(stringifyText.replace("-0", ""))}>
@@ -165,7 +165,7 @@ export const wrapAbbr = (text: ReactNode, intl: IntlShape, title?: string) => {
         </abbr>
       );
     // Regex that matches all AS classifications with levels
-    case /[AS]-0\d/.exec(stringifyText)?.input:
+    case /[AS]-[0-9]\d/.exec(stringifyText)?.input:
       return (
         <abbr title={intl.formatMessage(getAbbreviations("AS"))}>
           <span aria-label={splitAndJoin(stringifyText.replace("-0", ""))}>

--- a/apps/web/src/utils/nameUtils.tsx
+++ b/apps/web/src/utils/nameUtils.tsx
@@ -148,11 +148,20 @@ export const wrapAbbr = (text: ReactNode, intl: IntlShape, title?: string) => {
     );
   }
   switch (stringifyText) {
-    // Regex that matches all IT classifications with levels
-    case /[IT]-[0-9]\d/.exec(stringifyText)?.input:
+    // Regex that matches IT classifications with levels from 01-09
+    case /[IT]-0\d/.exec(stringifyText)?.input:
       return (
         <abbr title={intl.formatMessage(getAbbreviations("IT"))}>
           <span aria-label={splitAndJoin(stringifyText.replace("-0", ""))}>
+            {text}
+          </span>
+        </abbr>
+      );
+    // Regex that matches IT classifications with levels from 10 and up
+    case /[IT]-\d/.exec(stringifyText)?.input:
+      return (
+        <abbr title={intl.formatMessage(getAbbreviations("IT"))}>
+          <span aria-label={splitAndJoin(stringifyText.replace("-", ""))}>
             {text}
           </span>
         </abbr>
@@ -164,11 +173,20 @@ export const wrapAbbr = (text: ReactNode, intl: IntlShape, title?: string) => {
           <span aria-label={splitAndJoin(stringifyText)}>{text}</span>
         </abbr>
       );
-    // Regex that matches all AS classifications with levels
-    case /[AS]-[0-9]\d/.exec(stringifyText)?.input:
+    // Regex that matches AS classifications with levels from 01-09
+    case /[AS]-0\d/.exec(stringifyText)?.input:
       return (
         <abbr title={intl.formatMessage(getAbbreviations("AS"))}>
           <span aria-label={splitAndJoin(stringifyText.replace("-0", ""))}>
+            {text}
+          </span>
+        </abbr>
+      );
+    // Regex that matches AS classifications with levels from 10 and up
+    case /[AS]-\d/.exec(stringifyText)?.input:
+      return (
+        <abbr title={intl.formatMessage(getAbbreviations("AS"))}>
+          <span aria-label={splitAndJoin(stringifyText.replace("-", ""))}>
             {text}
           </span>
         </abbr>

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -85,7 +85,7 @@ export const formatClassificationString = ({
   group,
   level,
 }: formatClassificationStringProps): string => {
-  return `${group}-0${level}`;
+  return `${group}-${level < 10 ? "0" : ""}${level}`;
 };
 interface formattedPoolPosterTitleProps {
   title: Maybe<string> | undefined;
@@ -457,7 +457,7 @@ export function getClassificationName(
   { group, level, name }: Pick<Classification, "group" | "level" | "name">,
   intl: IntlShape,
 ) {
-  const groupLevelStr = `${group}-0${level}`;
+  const groupLevelStr = `${group}-${level < 10 ? "0" : ""}${level}`;
 
   if (!name) {
     return groupLevelStr;


### PR DESCRIPTION
🤖 Resolves #12248.

## 👋 Introduction

This PR increases classification level options and accounts for the absence or presence of a leading zero in the levels.

## 🧪 Testing

1. `make refresh-api; make seed-fresh; pnpm i; pnpm build:fresh`
2. Navigate to http://localhost:8000/en/admin/settings/classifications/create
3. Create a classification item with a level of **19**
4. Navigate throughout the site wherever classification levels are rendered or used in aria-labels to verify absence or presence of a leading zero in the levels depending on if the level is single digit or two digits.