### PR TITLE
[Feature] Autocomplete experience orgs

### DIFF
--- a/apps/playwright/fixtures/ApplicationPage.ts
+++ b/apps/playwright/fixtures/ApplicationPage.ts
@@ -47,8 +47,9 @@ class ApplicationPage extends AppPage {
       .getByRole("textbox", { name: /area of study/i })
       .fill("QA Testing");
 
+    // conditional datalist attribute means this field could be a textbox or combobox
     await this.page
-      .getByRole("combobox", { name: /institution/i })
+      .getByLabel("Institution *", { exact: true })
       .fill("Playwright University");
 
     const startDate = this.page.getByRole("group", {

--- a/apps/playwright/fixtures/ApplicationPage.ts
+++ b/apps/playwright/fixtures/ApplicationPage.ts
@@ -48,7 +48,7 @@ class ApplicationPage extends AppPage {
       .fill("QA Testing");
 
     await this.page
-      .getByRole("textbox", { name: /institution/i })
+      .getByRole("combobox", { name: /institution/i })
       .fill("Playwright University");
 
     const startDate = this.page.getByRole("group", {

--- a/apps/playwright/fixtures/ExperiencePage.ts
+++ b/apps/playwright/fixtures/ExperiencePage.ts
@@ -62,7 +62,7 @@ class ExperiencePage extends AppPage {
       .click();
 
     await this.page
-      .getByRole("combobox", { name: /organization/i })
+      .getByLabel("Organization *", { exact: true })
       .fill(input.organization ?? "test org");
 
     await this.page
@@ -539,7 +539,7 @@ class ExperiencePage extends AppPage {
       .fill(input.title ?? "test role");
 
     await this.page
-      .getByRole("combobox", { name: /organization/i })
+      .getByLabel("Group / Organization / Community *", { exact: true })
       .fill(input?.organization ?? "test org");
 
     await this.page
@@ -577,7 +577,7 @@ class ExperiencePage extends AppPage {
       .selectOption({ label: "Me" });
 
     await this.page
-      .getByRole("combobox", { name: /organization/i })
+      .getByLabel("Issuing organization *", { exact: true })
       .fill(input?.issuedBy ?? "test org");
 
     await this.page
@@ -607,7 +607,7 @@ class ExperiencePage extends AppPage {
       .fill(input?.areaOfStudy ?? "test area of study");
 
     await this.page
-      .getByRole("combobox", { name: /institution/i })
+      .getByLabel("Institution *", { exact: true })
       .fill(input?.areaOfStudy ?? "test institution");
 
     await this.page

--- a/apps/playwright/fixtures/ExperiencePage.ts
+++ b/apps/playwright/fixtures/ExperiencePage.ts
@@ -62,7 +62,7 @@ class ExperiencePage extends AppPage {
       .click();
 
     await this.page
-      .getByRole("textbox", { name: /organization/i })
+      .getByRole("combobox", { name: /organization/i })
       .fill(input.organization ?? "test org");
 
     await this.page
@@ -539,7 +539,7 @@ class ExperiencePage extends AppPage {
       .fill(input.title ?? "test role");
 
     await this.page
-      .getByRole("textbox", { name: /organization/i })
+      .getByRole("combobox", { name: /organization/i })
       .fill(input?.organization ?? "test org");
 
     await this.page
@@ -577,7 +577,7 @@ class ExperiencePage extends AppPage {
       .selectOption({ label: "Me" });
 
     await this.page
-      .getByRole("textbox", { name: /organization/i })
+      .getByRole("combobox", { name: /organization/i })
       .fill(input?.issuedBy ?? "test org");
 
     await this.page
@@ -607,7 +607,7 @@ class ExperiencePage extends AppPage {
       .fill(input?.areaOfStudy ?? "test area of study");
 
     await this.page
-      .getByRole("textbox", { name: /institution/i })
+      .getByRole("combobox", { name: /institution/i })
       .fill(input?.areaOfStudy ?? "test institution");
 
     await this.page

--- a/apps/web/src/components/ExperienceFormFields/AwardFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/AwardFields.tsx
@@ -38,7 +38,10 @@ const AwardOptions_Query = graphql(/* GraphQL */ `
   }
 `);
 
-const AwardFields = ({ labels }: SubExperienceFormProps) => {
+const AwardFields = ({
+  labels,
+  organizationSuggestions,
+}: SubExperienceFormProps & { organizationSuggestions: string[] }) => {
   const intl = useIntl();
   const todayDate = new Date();
   const [{ data }] = useQuery({ query: AwardOptions_Query });
@@ -80,7 +83,13 @@ const AwardFields = ({ labels }: SubExperienceFormProps) => {
             name="issuedBy"
             type="text"
             rules={{ required: intl.formatMessage(errorMessages.required) }}
+            list="organizationSuggestions"
           />
+          <datalist id="organizationSuggestions">
+            {organizationSuggestions.map((suggestion) => {
+              return <option key={suggestion} value={suggestion}></option>;
+            })}
+          </datalist>
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
           <Select

--- a/apps/web/src/components/ExperienceFormFields/AwardFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/AwardFields.tsx
@@ -83,9 +83,13 @@ const AwardFields = ({
             name="issuedBy"
             type="text"
             rules={{ required: intl.formatMessage(errorMessages.required) }}
-            list="organizationSuggestions"
+            list={
+              organizationSuggestions.length
+                ? "organizationSuggestions"
+                : undefined
+            }
           />
-          {!!organizationSuggestions && (
+          {organizationSuggestions.length > 0 && (
             <datalist id="organizationSuggestions">
               {organizationSuggestions.map((suggestion) => {
                 return <option key={suggestion} value={suggestion}></option>;

--- a/apps/web/src/components/ExperienceFormFields/AwardFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/AwardFields.tsx
@@ -85,11 +85,13 @@ const AwardFields = ({
             rules={{ required: intl.formatMessage(errorMessages.required) }}
             list="organizationSuggestions"
           />
-          <datalist id="organizationSuggestions">
-            {organizationSuggestions.map((suggestion) => {
-              return <option key={suggestion} value={suggestion}></option>;
-            })}
-          </datalist>
+          {!!organizationSuggestions && (
+            <datalist id="organizationSuggestions">
+              {organizationSuggestions.map((suggestion) => {
+                return <option key={suggestion} value={suggestion}></option>;
+              })}
+            </datalist>
+          )}
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
           <Select

--- a/apps/web/src/components/ExperienceFormFields/CommunityFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/CommunityFields.tsx
@@ -60,11 +60,13 @@ const CommunityFields = ({
             rules={{ required: intl.formatMessage(errorMessages.required) }}
             list="organizationSuggestions"
           />
-          <datalist id="organizationSuggestions">
-            {organizationSuggestions.map((suggestion) => {
-              return <option key={suggestion} value={suggestion}></option>;
-            })}
-          </datalist>
+          {!!organizationSuggestions && (
+            <datalist id="organizationSuggestions">
+              {organizationSuggestions.map((suggestion) => {
+                return <option key={suggestion} value={suggestion}></option>;
+              })}
+            </datalist>
+          )}
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
           <Input

--- a/apps/web/src/components/ExperienceFormFields/CommunityFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/CommunityFields.tsx
@@ -15,7 +15,10 @@ import {
   CommunityFormValues,
 } from "~/types/experience";
 
-const CommunityFields = ({ labels }: SubExperienceFormProps) => {
+const CommunityFields = ({
+  labels,
+  organizationSuggestions,
+}: SubExperienceFormProps & { organizationSuggestions: string[] }) => {
   const intl = useIntl();
   const todayDate = new Date();
   // to toggle whether endDate is required, the state of the current-role checkbox must be monitored and have to adjust the form accordingly
@@ -55,7 +58,13 @@ const CommunityFields = ({ labels }: SubExperienceFormProps) => {
             name="organization"
             type="text"
             rules={{ required: intl.formatMessage(errorMessages.required) }}
+            list="organizationSuggestions"
           />
+          <datalist id="organizationSuggestions">
+            {organizationSuggestions.map((suggestion) => {
+              return <option key={suggestion} value={suggestion}></option>;
+            })}
+          </datalist>
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
           <Input

--- a/apps/web/src/components/ExperienceFormFields/CommunityFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/CommunityFields.tsx
@@ -58,9 +58,13 @@ const CommunityFields = ({
             name="organization"
             type="text"
             rules={{ required: intl.formatMessage(errorMessages.required) }}
-            list="organizationSuggestions"
+            list={
+              organizationSuggestions.length
+                ? "organizationSuggestions"
+                : undefined
+            }
           />
-          {!!organizationSuggestions && (
+          {organizationSuggestions.length > 0 && (
             <datalist id="organizationSuggestions">
               {organizationSuggestions.map((suggestion) => {
                 return <option key={suggestion} value={suggestion}></option>;

--- a/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
@@ -103,9 +103,13 @@ const EducationFields = ({
             name="institution"
             type="text"
             rules={{ required: intl.formatMessage(errorMessages.required) }}
-            list="organizationSuggestions"
+            list={
+              organizationSuggestions.length
+                ? "organizationSuggestions"
+                : undefined
+            }
           />
-          {!!organizationSuggestions && (
+          {organizationSuggestions.length > 0 && (
             <datalist id="organizationSuggestions">
               {organizationSuggestions.map((suggestion) => {
                 return <option key={suggestion} value={suggestion}></option>;

--- a/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
@@ -43,7 +43,10 @@ const EducationOptions_Query = graphql(/* GraphQL */ `
   }
 `);
 
-const EducationFields = ({ labels }: SubExperienceFormProps) => {
+const EducationFields = ({
+  labels,
+  organizationSuggestions,
+}: SubExperienceFormProps & { organizationSuggestions: string[] }) => {
   const intl = useIntl();
   const todayDate = new Date();
   const [{ data }] = useQuery({ query: EducationOptions_Query });
@@ -100,7 +103,13 @@ const EducationFields = ({ labels }: SubExperienceFormProps) => {
             name="institution"
             type="text"
             rules={{ required: intl.formatMessage(errorMessages.required) }}
+            list="organizationSuggestions"
           />
+          <datalist id="organizationSuggestions">
+            {organizationSuggestions.map((suggestion) => {
+              return <option key={suggestion} value={suggestion}></option>;
+            })}
+          </datalist>
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
           <Select

--- a/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
@@ -105,11 +105,13 @@ const EducationFields = ({
             rules={{ required: intl.formatMessage(errorMessages.required) }}
             list="organizationSuggestions"
           />
-          <datalist id="organizationSuggestions">
-            {organizationSuggestions.map((suggestion) => {
-              return <option key={suggestion} value={suggestion}></option>;
-            })}
-          </datalist>
+          {!!organizationSuggestions && (
+            <datalist id="organizationSuggestions">
+              {organizationSuggestions.map((suggestion) => {
+                return <option key={suggestion} value={suggestion}></option>;
+              })}
+            </datalist>
+          )}
         </div>
         <div data-h2-flex-item="base(1of1) p-tablet(1of2)">
           <Select

--- a/apps/web/src/components/ExperienceFormFields/ExperienceDetails.tsx
+++ b/apps/web/src/components/ExperienceFormFields/ExperienceDetails.tsx
@@ -15,9 +15,13 @@ import NullExperienceType from "./NullExperienceType";
 
 interface ExperienceDetailsProps {
   experienceType?: ExperienceType;
+  organizationSuggestions: string[];
 }
 
-const ExperienceDetails = ({ experienceType }: ExperienceDetailsProps) => {
+const ExperienceDetails = ({
+  experienceType,
+  organizationSuggestions,
+}: ExperienceDetailsProps) => {
   const intl = useIntl();
   const type = useWatch<AllExperienceFormValues>({
     name: "experienceType",
@@ -50,11 +54,31 @@ const ExperienceDetails = ({ experienceType }: ExperienceDetailsProps) => {
                 description: "Help text for the experience details section",
               })}
             </p>
-            {derivedType === "award" && <AwardFields labels={labels} />}
-            {derivedType === "community" && <CommunityFields labels={labels} />}
-            {derivedType === "education" && <EducationFields labels={labels} />}
+            {derivedType === "award" && (
+              <AwardFields
+                labels={labels}
+                organizationSuggestions={organizationSuggestions}
+              />
+            )}
+            {derivedType === "community" && (
+              <CommunityFields
+                labels={labels}
+                organizationSuggestions={organizationSuggestions}
+              />
+            )}
+            {derivedType === "education" && (
+              <EducationFields
+                labels={labels}
+                organizationSuggestions={organizationSuggestions}
+              />
+            )}
             {derivedType === "personal" && <PersonalFields labels={labels} />}
-            {derivedType === "work" && <WorkFields labels={labels} />}
+            {derivedType === "work" && (
+              <WorkFields
+                labels={labels}
+                organizationSuggestions={organizationSuggestions}
+              />
+            )}
           </>
         ) : (
           <NullExperienceType />

--- a/apps/web/src/components/ExperienceFormFields/WorkFields/ExternalFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields/ExternalFields.tsx
@@ -74,11 +74,13 @@ const ExternalFields = ({
               rules={{ required: intl.formatMessage(errorMessages.required) }}
               list="organizationSuggestions"
             />
-            <datalist id="organizationSuggestions">
-              {organizationSuggestions.map((suggestion) => {
-                return <option key={suggestion} value={suggestion}></option>;
-              })}
-            </datalist>
+            {!!organizationSuggestions && (
+              <datalist id="organizationSuggestions">
+                {organizationSuggestions.map((suggestion) => {
+                  return <option key={suggestion} value={suggestion}></option>;
+                })}
+              </datalist>
+            )}
           </div>
           <div data-h2-flex-item="base(1of1)">
             <Input

--- a/apps/web/src/components/ExperienceFormFields/WorkFields/ExternalFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields/ExternalFields.tsx
@@ -72,9 +72,13 @@ const ExternalFields = ({
               name="organization"
               type="text"
               rules={{ required: intl.formatMessage(errorMessages.required) }}
-              list="organizationSuggestions"
+              list={
+                organizationSuggestions.length
+                  ? "organizationSuggestions"
+                  : undefined
+              }
             />
-            {!!organizationSuggestions && (
+            {organizationSuggestions.length > 0 && (
               <datalist id="organizationSuggestions">
                 {organizationSuggestions.map((suggestion) => {
                   return <option key={suggestion} value={suggestion}></option>;

--- a/apps/web/src/components/ExperienceFormFields/WorkFields/ExternalFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields/ExternalFields.tsx
@@ -43,7 +43,10 @@ const ExternalWorkFieldOptions_Query = graphql(/* GraphQL */ `
   }
 `);
 
-const ExternalFields = ({ labels }: SubExperienceFormProps) => {
+const ExternalFields = ({
+  labels,
+  organizationSuggestions,
+}: SubExperienceFormProps & { organizationSuggestions: string[] }) => {
   const intl = useIntl();
   const [{ data, fetching }] = useQuery<ExternalWorkFieldOptionsQuery>({
     query: ExternalWorkFieldOptions_Query,
@@ -69,7 +72,13 @@ const ExternalFields = ({ labels }: SubExperienceFormProps) => {
               name="organization"
               type="text"
               rules={{ required: intl.formatMessage(errorMessages.required) }}
+              list="organizationSuggestions"
             />
+            <datalist id="organizationSuggestions">
+              {organizationSuggestions.map((suggestion) => {
+                return <option key={suggestion} value={suggestion}></option>;
+              })}
+            </datalist>
           </div>
           <div data-h2-flex-item="base(1of1)">
             <Input

--- a/apps/web/src/components/ExperienceFormFields/WorkFields/WorkFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields/WorkFields.tsx
@@ -41,15 +41,22 @@ const WorkFieldOptions_Query = graphql(/* GraphQL */ `
 const EmploymentCategoryFields = ({
   employmentCategory,
   labels,
+  organizationSuggestions,
 }: {
   employmentCategory: EmploymentCategory;
   labels: FieldLabels;
+  organizationSuggestions: string[];
 }) => {
   switch (employmentCategory) {
     case EmploymentCategory.CanadianArmedForces:
       return <CafFields labels={labels} />;
     case EmploymentCategory.ExternalOrganization:
-      return <ExternalFields labels={labels} />;
+      return (
+        <ExternalFields
+          labels={labels}
+          organizationSuggestions={organizationSuggestions}
+        />
+      );
     case EmploymentCategory.GovernmentOfCanada:
       return <GovFields labels={labels} />;
     default:
@@ -84,7 +91,10 @@ const employmentCategoryDescriptions: Record<
   }),
 };
 
-const WorkFields = ({ labels }: SubExperienceFormProps) => {
+const WorkFields = ({
+  labels,
+  organizationSuggestions,
+}: SubExperienceFormProps & { organizationSuggestions: string[] }) => {
   const intl = useIntl();
   const [{ data, fetching }] = useQuery<WorkFieldOptionsQuery>({
     query: WorkFieldOptions_Query,
@@ -183,6 +193,7 @@ const WorkFields = ({ labels }: SubExperienceFormProps) => {
             <EmploymentCategoryFields
               employmentCategory={watchEmploymentCategory}
               labels={labels}
+              organizationSuggestions={organizationSuggestions}
             />
           </div>
         </div>

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineAddPage/ApplicationCareerTimelineAddPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineAddPage/ApplicationCareerTimelineAddPage.tsx
@@ -6,11 +6,13 @@ import UserGroupIcon from "@heroicons/react/20/solid/UserGroupIcon";
 import LightBulbIcon from "@heroicons/react/20/solid/LightBulbIcon";
 
 import { Accordion, DescriptionList, Heading } from "@gc-digital-talent/ui";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
 
 import useRoutes from "~/hooks/useRoutes";
 import { GetPageNavInfo } from "~/types/applicationStep";
 import applicationMessages from "~/messages/applicationMessages";
 import experienceMessages from "~/messages/experienceMessages";
+import { organizationSuggestionsFromExperiences } from "~/utils/experienceUtils";
 
 import ApplicationApi, { ApplicationPageProps } from "../ApplicationApi";
 import { useApplicationContext } from "../ApplicationContext";
@@ -70,6 +72,11 @@ const ApplicationCareerTimelineAdd = ({
     application,
     stepOrdinal: currentStepOrdinal,
   });
+
+  const applicationExperiences = unpackMaybes(application.user.experiences);
+  const organizationsForAutocomplete = organizationSuggestionsFromExperiences(
+    applicationExperiences,
+  );
 
   return (
     <>
@@ -169,7 +176,10 @@ const ApplicationCareerTimelineAdd = ({
           </Accordion.Content>
         </Accordion.Item>
       </Accordion.Root>
-      <AddExperienceForm applicationId={application.id} />
+      <AddExperienceForm
+        applicationId={application.id}
+        organizationSuggestions={organizationsForAutocomplete}
+      />
     </>
   );
 };

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineAddPage/components/AddExperienceForm.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineAddPage/components/AddExperienceForm.tsx
@@ -37,9 +37,13 @@ type ExperienceExperienceFormValues =
   };
 interface AddExperienceFormProps {
   applicationId: Scalars["ID"]["output"];
+  organizationSuggestions: string[];
 }
 
-const AddExperienceForm = ({ applicationId }: AddExperienceFormProps) => {
+const AddExperienceForm = ({
+  applicationId,
+  organizationSuggestions,
+}: AddExperienceFormProps) => {
   const intl = useIntl();
   const experienceFormLabels = getExperienceFormLabels(intl);
   const navigate = useNavigate();
@@ -157,7 +161,7 @@ const AddExperienceForm = ({ applicationId }: AddExperienceFormProps) => {
             },
           ]}
         />
-        <ExperienceDetails />
+        <ExperienceDetails organizationSuggestions={organizationSuggestions} />
         <TasksAndResponsibilities />
         <Separator />
         <div

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/ApplicationCareerTimelineEditPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/ApplicationCareerTimelineEditPage.tsx
@@ -10,6 +10,7 @@ import { GetPageNavInfo } from "~/types/applicationStep";
 import { AnyExperience } from "~/types/experience";
 import applicationMessages from "~/messages/applicationMessages";
 import useRequiredParams from "~/hooks/useRequiredParams";
+import { organizationSuggestionsFromExperiences } from "~/utils/experienceUtils";
 
 import { ApplicationPageProps } from "../ApplicationApi";
 import { useApplicationContext } from "../ApplicationContext";
@@ -87,6 +88,11 @@ const ApplicationCareerTimelineEdit = ({
     stepOrdinal: currentStepOrdinal,
   });
 
+  const applicationExperiences = unpackMaybes(application.user.experiences);
+  const organizationsForAutocomplete = organizationSuggestionsFromExperiences(
+    applicationExperiences,
+  );
+
   return (
     <>
       <Heading
@@ -107,6 +113,7 @@ const ApplicationCareerTimelineEdit = ({
       <EditExperienceForm
         applicationId={application.id}
         experience={experience}
+        organizationSuggestions={organizationsForAutocomplete}
       />
     </>
   );

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/components/ExperienceEditForm.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/components/ExperienceEditForm.tsx
@@ -37,11 +37,13 @@ type ExperienceExperienceFormValues =
 interface EditExperienceFormProps {
   applicationId: Scalars["ID"]["output"];
   experience: AnyExperience;
+  organizationSuggestions: string[];
 }
 
 const EditExperienceForm = ({
   applicationId,
   experience,
+  organizationSuggestions,
 }: EditExperienceFormProps) => {
   const intl = useIntl();
   const navigate = useNavigate();
@@ -141,7 +143,10 @@ const EditExperienceForm = ({
     <FormProvider {...methods}>
       <form onSubmit={methods.handleSubmit(handleSubmit)}>
         <ErrorSummary experienceType={experienceType} />
-        <ExperienceDetails experienceType={experienceType} />
+        <ExperienceDetails
+          experienceType={experienceType}
+          organizationSuggestions={organizationSuggestions}
+        />
         <TasksAndResponsibilities experienceType={experienceType} />
         <Separator />
         <div

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceForm.stories.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceForm.stories.tsx
@@ -31,6 +31,7 @@ const TemplateExperienceFormForm: StoryFn<typeof ExperienceForm> = ({
     userId={userId}
     experienceType={experienceType}
     skillsQuery={skillsQuery}
+    organizationSuggestions={[]}
   />
 );
 

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -51,10 +51,7 @@ import ExperienceHeading from "~/components/ExperienceFormFields/ExperienceHeadi
 import {
   deriveExperienceType,
   formValuesToSubmitData,
-  isAwardExperience,
-  isCommunityExperience,
-  isEducationExperience,
-  isWorkExperience,
+  organizationSuggestionsFromExperiences,
   queryResultToDefaultValues,
 } from "~/utils/experienceUtils";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
@@ -758,27 +755,8 @@ const ExperienceFormContainer = ({ edit }: ExperienceFormContainerProps) => {
     data?.me?.experiences?.find((exp) => exp?.id === experienceId) ?? undefined;
 
   const myExperiences = unpackMaybes(data?.me?.experiences);
-  const experiencesWithoutPersonal = myExperiences.filter(
-    (exp) => exp?.__typename && exp.__typename !== "PersonalExperience",
-  );
-  const organizationsForAutocomplete = experiencesWithoutPersonal.map((exp) => {
-    if (isAwardExperience(exp)) {
-      return exp.issuedBy;
-    }
-    if (isCommunityExperience(exp)) {
-      return exp.organization;
-    }
-    if (isEducationExperience(exp)) {
-      return exp.institution;
-    }
-    if (isWorkExperience(exp)) {
-      return exp.organization;
-    }
-    return undefined;
-  });
-  const organizationsForAutocompleteFiltered: string[] = unpackMaybes(
-    organizationsForAutocomplete,
-  );
+  const organizationsForAutocomplete =
+    organizationSuggestionsFromExperiences(myExperiences);
 
   const experienceType = experience
     ? deriveExperienceType(experience)
@@ -794,7 +772,7 @@ const ExperienceFormContainer = ({ edit }: ExperienceFormContainerProps) => {
           experienceType={experienceType}
           skillsQuery={skills}
           userId={userAuthInfo?.id ?? ""}
-          organizationSuggestions={organizationsForAutocompleteFiltered}
+          organizationSuggestions={organizationsForAutocomplete}
         />
       ) : (
         <ThrowNotFound

--- a/apps/web/src/utils/experienceUtils.tsx
+++ b/apps/web/src/utils/experienceUtils.tsx
@@ -22,7 +22,7 @@ import {
   WorkExperienceGovEmployeeType,
 } from "@gc-digital-talent/graphql";
 import { strToFormDate } from "@gc-digital-talent/date-helpers";
-import { unpackMaybes } from "@gc-digital-talent/helpers";
+import { uniqueItems, unpackMaybes } from "@gc-digital-talent/helpers";
 
 import {
   AllExperienceFormValues,
@@ -916,7 +916,7 @@ export const useExperienceInfo: UseExperienceInfo = (experience) => {
 };
 
 /**
- * Returns array of organization or similar names pulled from all experiences except personal
+ * Returns a unique array of organization or similar names pulled from all experiences except personal
  *
  * @param experiences SimpleAnyExperience
  * @return string[]
@@ -946,5 +946,5 @@ export const organizationSuggestionsFromExperiences = (
     organizationsForAutocomplete,
   );
 
-  return organizationsForAutocompleteFiltered;
+  return uniqueItems(organizationsForAutocompleteFiltered);
 };

--- a/apps/web/src/utils/experienceUtils.tsx
+++ b/apps/web/src/utils/experienceUtils.tsx
@@ -22,6 +22,7 @@ import {
   WorkExperienceGovEmployeeType,
 } from "@gc-digital-talent/graphql";
 import { strToFormDate } from "@gc-digital-talent/date-helpers";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
 
 import {
   AllExperienceFormValues,
@@ -912,4 +913,38 @@ export const useExperienceInfo: UseExperienceInfo = (experience) => {
     icon: icons.get(experienceType) ?? defaults.icon,
     date: getExperienceDate(experience, intl),
   };
+};
+
+/**
+ * Returns array of organization or similar names pulled from all experiences except personal
+ *
+ * @param experiences SimpleAnyExperience
+ * @return string[]
+ */
+export const organizationSuggestionsFromExperiences = (
+  experiences: SimpleAnyExperience[],
+): string[] => {
+  const experiencesWithoutPersonal = experiences.filter(
+    (exp) => exp?.__typename && exp.__typename !== "PersonalExperience",
+  );
+  const organizationsForAutocomplete = experiencesWithoutPersonal.map((exp) => {
+    if (isAwardExperience(exp)) {
+      return exp.issuedBy;
+    }
+    if (isCommunityExperience(exp)) {
+      return exp.organization;
+    }
+    if (isEducationExperience(exp)) {
+      return exp.institution;
+    }
+    if (isWorkExperience(exp)) {
+      return exp.organization;
+    }
+    return undefined;
+  });
+  const organizationsForAutocompleteFiltered: string[] = unpackMaybes(
+    organizationsForAutocomplete,
+  );
+
+  return organizationsForAutocompleteFiltered;
 };


### PR DESCRIPTION
🤖 Resolves #12323

## 👋 Introduction

Populate with suggestions, using `<datalist />`, orgs for all experiences except personal by pulling names from all experiences except personal.
There are two contexts for experiences, through timeline and within an application. A util function for reuse was added as well due to more than one context

## 🧪 Testing

1. Login and have experiences
2. Create/edit experiences and observe whether suggestions were populated for org name

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/0e0a07ec-07a6-44bf-ad35-fb4f7913ae69)

![image](https://github.com/user-attachments/assets/70c15d8e-e017-485d-86d6-16530f38e401)



<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the linked issue if deployment steps are needed

 -->
