### PR TITLE
[Feature] Improve candidate assessmentStatus data

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -940,6 +940,7 @@ class PoolCandidate extends Model
      *               else mark nothing and continue, since the result doesn't actually matter
      *       and if step is Application Assessment then repeat the Essential switch statement education assessment result
      *       stepStatus is first of UNSUCCESSFUL, TO ASSESS, HOLD, and else QUALIFIED
+     *       no decision for steps that are TO ASSESS but have no results so we can tell when they've been started
      */
     public function computeAssessmentStatus()
     {
@@ -1063,6 +1064,8 @@ class PoolCandidate extends Model
             }
 
             if ($hasToAssess) {
+                // Don't add the step if it has no results yet to allow differentiating between
+                // not started and in progress steps
                 if (! $stepResults->isEmpty()) {
                     $decisions[] = [
                         'step' => $stepId,

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -963,6 +963,10 @@ class PoolCandidate extends Model
             $isApplicationScreening = $step->type === AssessmentStepType::APPLICATION_SCREENING->name;
             $stepResults = $this->assessmentResults->where('assessment_step_id', $stepId);
 
+            if ($stepResults->isEmpty()) {
+                continue;
+            }
+
             foreach ($step->poolSkills as $poolSkill) {
                 $result = $stepResults->firstWhere('pool_skill_id', $poolSkill->id);
                 $decision = $result?->assessment_decision;

--- a/api/tests/Feature/CandidateAssessmentStatusTest.php
+++ b/api/tests/Feature/CandidateAssessmentStatusTest.php
@@ -493,10 +493,6 @@ class CandidateAssessmentStatusTest extends TestCase
                             'overallAssessmentStatus' => OverallAssessmentStatus::TO_ASSESS->name,
                             'assessmentStepStatuses' => [
                                 [
-                                    'step' => $steps[0]->id,
-                                    'decision' => null,
-                                ],
-                                [
                                     'step' => $steps[1]->id,
                                     'decision' => AssessmentDecision::SUCCESSFUL->name,
                                 ],
@@ -599,10 +595,6 @@ class CandidateAssessmentStatusTest extends TestCase
                                     'step' => $stepOne->id,
                                     'decision' => null,
                                 ],
-                                [
-                                    'step' => $stepTwo->id,
-                                    'decision' => null,
-                                ],
                             ],
                         ],
                     ],
@@ -631,10 +623,6 @@ class CandidateAssessmentStatusTest extends TestCase
                                 [
                                     'step' => $stepOne->id,
                                     'decision' => AssessmentDecision::SUCCESSFUL->name,
-                                ],
-                                [
-                                    'step' => $stepTwo->id,
-                                    'decision' => null,
                                 ],
                             ],
                         ],
@@ -900,10 +888,6 @@ class CandidateAssessmentStatusTest extends TestCase
                                     'step' => $stepOne->id,
                                     'decision' => null,
                                 ],
-                                [
-                                    'step' => $stepTwo->id,
-                                    'decision' => null,
-                                ],
                             ],
                         ],
                     ],
@@ -931,10 +915,6 @@ class CandidateAssessmentStatusTest extends TestCase
                                 [
                                     'step' => $stepOne->id,
                                     'decision' => AssessmentDecision::SUCCESSFUL->name,
-                                ],
-                                [
-                                    'step' => $stepTwo->id,
-                                    'decision' => null,
                                 ],
                             ],
                         ],


### PR DESCRIPTION
🤖 Resolves #12421

## 👋 Introduction

Updates the way the assessmentStatus field for PoolCandidates is calculated to allow a slightly more detailed status to be shown to candidates.

## 🕵️ Details

Prevents assessmentSteps showing up in the assessmentStatus.assessmentStepStatuses field on PoolCandidates until they have at least one assessmentResult to make it possible for candidates to tell if the step has started to be assessed or not.

## 🧪 Testing

1. Confirm tests still pass
2. Create and submit an application and update it's assessment progress confirming it's possible to tell if a step has begun assessment by whether it shows in the assessmentStepStatuses field.

Useful query:
```
query PoolCandidate {
  poolCandidate(id: userId) {
      assessmentStatus {
        assessmentStepStatuses {
          step
          decision
        }
        overallAssessmentStatus
        currentStep
      }
    }
}
```

## 🚚 Deployment
After deployment run the artisan command to recalculate assessment statuses:

```sh
php artisan app:sync-assessment-status
```