### PR TITLE
[a11y] Announce table row count to ATs

### DIFF
--- a/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
@@ -334,7 +334,7 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
           description:
             "Message announced to assistive technology when number of items in a table changes",
         },
-        { count },
+        { total: count },
       ),
     );
   }, 300);

--- a/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
@@ -329,8 +329,8 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
       intl.formatMessage(
         {
           defaultMessage:
-            "{total, plural, =0 {0 results found} =1 {1 result found} other {# result found}}",
-          id: "uZYkk1",
+            "{total, plural, =0 {0 results found} =1 {1 result found} other {# results found}}",
+          id: "SLYAoc",
           description:
             "Message announced to assistive technology when number of items in a table changes",
         },

--- a/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
@@ -328,8 +328,9 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
     announce(
       intl.formatMessage(
         {
-          defaultMessage: "{count} items found.",
-          id: "5ySBS0",
+          defaultMessage:
+            "{total, plural, =0 {0 results found} =1 {1 result found} other {# result found}}",
+          id: "uZYkk1",
           description:
             "Message announced to assistive technology when number of items in a table changes",
         },

--- a/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
@@ -117,10 +117,10 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
 
   const manualPageSize = !pagination?.internal
     ? Math.ceil(
-      (pagination?.total ?? 0) /
-      (state.pagination?.pageSize ??
-        INITIAL_STATE.paginationState.pageSize),
-    )
+        (pagination?.total ?? 0) /
+          (state.pagination?.pageSize ??
+            INITIAL_STATE.paginationState.pageSize),
+      )
     : undefined;
 
   const table = useReactTable({

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -11514,6 +11514,10 @@
     "defaultMessage": "Exigences essentielles",
     "description": "Sub title for the pool core requirements"
   },
+  "uZYkk1": {
+    "defaultMessage": "{total, plural, =0 {0 résultats trouvés} =1 {1 résultat trouvé} other { # résultats trouvés}}",
+    "description": "Message announced to assistive technology when number of items in a table changes"
+  },
   "uZuEHk": {
     "defaultMessage": "Sélectionnez cette option si l'emploi était dans l'Armée canadienne, dans l'Aviation royale canadienne ou dans la Marine royale canadienne, dans la Force régulière ou dans la Force de réserve.",
     "description": "Description for the caf employment category option in work experience"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5959,6 +5959,10 @@
     "defaultMessage": "femme.",
     "description": "Statement for when someone indicates they are a woman"
   },
+  "SLYAoc": {
+    "defaultMessage": "{total, plural, =0 {0 résultats trouvés} =1 {1 résultat trouvé} other { # résultats trouvés}}",
+    "description": "Message announced to assistive technology when number of items in a table changes"
+  },
   "SLedtO": {
     "defaultMessage": "Profil de l’utilisateur",
     "description": "Title for the user profile page"
@@ -11513,10 +11517,6 @@
   "uWfG0e": {
     "defaultMessage": "Exigences essentielles",
     "description": "Sub title for the pool core requirements"
-  },
-  "uZYkk1": {
-    "defaultMessage": "{total, plural, =0 {0 résultats trouvés} =1 {1 résultat trouvé} other { # résultats trouvés}}",
-    "description": "Message announced to assistive technology when number of items in a table changes"
   },
   "uZuEHk": {
     "defaultMessage": "Sélectionnez cette option si l'emploi était dans l'Armée canadienne, dans l'Aviation royale canadienne ou dans la Marine royale canadienne, dans la Force régulière ou dans la Force de réserve.",


### PR DESCRIPTION
🤖 Resolves #12100 

## 👋 Introduction

Adds an announcement for ATs that the total number of items in the table has changed.

## 🧪 Testing

1. Build app `pnpm run dev:fresh`
2. Open your favourte screen reader
3. Navigate to a client side table e.g `/skills`
4. Change some filters
5. Observe the announcement of row count
6. Login as admin `admin@test.com`
7. Navigate to a server side table `/admin/users`
8. Repeat steps 4 + 5