### PR TITLE
[Bug] work experience form reset fields bug

### DIFF
--- a/api/app/Generators/ApplicationDocGenerator.php
+++ b/api/app/Generators/ApplicationDocGenerator.php
@@ -89,7 +89,22 @@ class ApplicationDocGenerator extends DocGenerator implements FileGeneratorInter
         }
 
         if (isset($snapshot['experiences'])) {
-            $experiences = Experience::hydrateSnapshot($snapshot['experiences']);
+            $snapshotExperiences = $snapshot['experiences'];
+
+            // the snapshot stores the department and classification models connected by relation
+            // to render with GeneratesUserDoc, map the model to a string with the appropriate property name
+            foreach ($snapshotExperiences as &$experience) {
+                if ($experience['__typename'] === 'WorkExperience') {
+                    if (isset($experience['department'])) {
+                        $experience['departmentId'] = $experience['department']['id'];
+                    }
+                    if (isset($experience['classification'])) {
+                        $experience['classificationId'] = $experience['classification']['id'];
+                    }
+                }
+            }
+
+            $experiences = Experience::hydrateSnapshot($snapshotExperiences);
             $this->experiences($section, collect($experiences), false, 2);
         }
 

--- a/api/app/Models/WorkExperience.php
+++ b/api/app/Models/WorkExperience.php
@@ -101,6 +101,7 @@ class WorkExperience extends Experience
 
             return sprintf('%s %s %s', $this->role, Lang::get('common.with', [], $lang), $caf_force);
         }
+
         return sprintf('%s %s %s', $this->role, Lang::get('common.with', [], $lang), $this->organization);
     }
 

--- a/api/app/Models/WorkExperience.php
+++ b/api/app/Models/WorkExperience.php
@@ -92,14 +92,15 @@ class WorkExperience extends Experience
         if ($this->employment_category === EmploymentCategory::GOVERNMENT_OF_CANADA->name) {
             /** @var Department | null $department */
             $department = $this->department_id ? Department::find($this->department_id) : null;
+
             return sprintf('%s %s %s', $this->role, Lang::get('common.with', [], $lang), $department ? $department->name[$lang] : Lang::get('common.not_found', [], $lang));
         }
 
         if ($this->employment_category === EmploymentCategory::CANADIAN_ARMED_FORCES->name) {
             $caf_force = $this->caf_force ? CafForce::localizedString($this->caf_force)[$lang] : Lang::get('common.not_found', [], $lang);
+
             return sprintf('%s %s %s', $this->role, Lang::get('common.with', [], $lang), $caf_force);
         }
-
         return sprintf('%s %s %s', $this->role, Lang::get('common.with', [], $lang), $this->organization);
     }
 

--- a/api/app/Models/WorkExperience.php
+++ b/api/app/Models/WorkExperience.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Enums\CafForce;
+use App\Enums\EmploymentCategory;
 use App\Models\Scopes\MatchExperienceType;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -83,7 +85,22 @@ class WorkExperience extends Experience
 
     public function getTitle(?string $lang = 'en'): string
     {
-        return sprintf('%s %s %s', $this->role, Lang::get('common.at', [], $lang), $this->organization);
+        if ($this->employment_category === EmploymentCategory::EXTERNAL_ORGANIZATION->name) {
+            return sprintf('%s %s %s', $this->role, Lang::get('common.with', [], $lang), $this->organization);
+        }
+
+        if ($this->employment_category === EmploymentCategory::GOVERNMENT_OF_CANADA->name) {
+            /** @var Department | null $department */
+            $department = $this->department_id ? Department::find($this->department_id) : null;
+            return sprintf('%s %s %s', $this->role, Lang::get('common.with', [], $lang), $department ? $department->name[$lang] : Lang::get('common.not_found', [], $lang));
+        }
+
+        if ($this->employment_category === EmploymentCategory::CANADIAN_ARMED_FORCES->name) {
+            $caf_force = $this->caf_force ? CafForce::localizedString($this->caf_force)[$lang] : Lang::get('common.not_found', [], $lang);
+            return sprintf('%s %s %s', $this->role, Lang::get('common.with', [], $lang), $caf_force);
+        }
+
+        return sprintf('%s %s %s', $this->role, Lang::get('common.with', [], $lang), $this->organization);
     }
 
     // extends dateRange, check if the end date is in the future and append a message if needed

--- a/api/app/Traits/Generator/GeneratesUserDoc.php
+++ b/api/app/Traits/Generator/GeneratesUserDoc.php
@@ -37,7 +37,6 @@ use App\Models\UserSkill;
 use App\Models\WorkExperience;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Lang;
-use Illuminate\Support\Facades\Log;
 use PhpOffice\PhpWord\Element\Section;
 
 trait GeneratesUserDoc

--- a/api/app/Traits/Generator/GeneratesUserDoc.php
+++ b/api/app/Traits/Generator/GeneratesUserDoc.php
@@ -37,6 +37,7 @@ use App\Models\UserSkill;
 use App\Models\WorkExperience;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Lang;
+use Illuminate\Support\Facades\Log;
 use PhpOffice\PhpWord\Element\Section;
 
 trait GeneratesUserDoc
@@ -342,7 +343,7 @@ trait GeneratesUserDoc
                     sprintf(
                         '%s %s %s',
                         $experience->role,
-                        Lang::get('common.at', [], $this->lang),
+                        Lang::get('common.with', [], $this->lang),
                         $this->localizeEnum($experience->caf_force,
                             CafForce::class),
                     ),
@@ -362,12 +363,12 @@ trait GeneratesUserDoc
                 );
             } elseif ($experience->employment_category === EmploymentCategory::GOVERNMENT_OF_CANADA->name) {
                 /** @var Department | null $department */
-                $department = Department::find($experience->department_id);
+                $department = $experience->department_id ? Department::find($experience->department_id) : null;
                 $section->addTitle(
                     sprintf(
                         '%s %s %s',
                         $experience->role,
-                        Lang::get('common.at', [], $this->lang),
+                        Lang::get('common.with', [], $this->lang),
                         $department ? $department->name[$this->lang] : Lang::get('common.not_found', [], $this->lang),
                     ),
                     $headingRank

--- a/api/lang/en/common.php
+++ b/api/lang/en/common.php
@@ -17,6 +17,7 @@ return [
     'status' => 'Status',
     'present' => 'Present',
     'at' => 'at',
+    'with' => 'with',
     'not_provided' => 'Not provided',
     'not_sure' => 'Not sure',
     'expected_end_date' => '(Expected end date)',

--- a/api/lang/fr/common.php
+++ b/api/lang/fr/common.php
@@ -17,6 +17,7 @@ return [
     'status' => 'Statut',
     'present' => 'Aujourd’hui',
     'at' => 'à',
+    'with' => 'à',
     'not_provided' => 'Renseignements manquants',
     'not_sure' => 'Pas certain',
     'expected_end_date' => '(Date de fin prévue)',

--- a/apps/web/src/components/ExperienceFormFields/WorkFields/GovFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields/GovFields.tsx
@@ -337,7 +337,7 @@ const GovFields = ({ labels }: SubExperienceFormProps) => {
                   label={labels.classificationGroup}
                   name="classificationGroup"
                   nullSelection={intl.formatMessage(
-                    uiMessages.nullSelectionOptionLevel,
+                    uiMessages.nullSelectionOptionGroup,
                   )}
                   rules={{
                     required: intl.formatMessage(errorMessages.required),

--- a/apps/web/src/components/ExperienceFormFields/WorkFields/WorkFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields/WorkFields.tsx
@@ -1,7 +1,7 @@
 import { useIntl, defineMessage, MessageDescriptor } from "react-intl";
 import { useQuery } from "urql";
 import { useFormContext, useWatch } from "react-hook-form";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import {
   FieldLabels,
@@ -92,6 +92,9 @@ const WorkFields = ({ labels }: SubExperienceFormProps) => {
 
   const { resetField, formState } = useFormContext<WorkFormValues>();
 
+  const prevEmploymentCategory = useRef<EmploymentCategory | null | undefined>(
+    formState.defaultValues?.employmentCategory,
+  );
   const watchEmploymentCategory = useWatch<{
     employmentCategory: EmploymentCategory;
   }>({
@@ -118,7 +121,7 @@ const WorkFields = ({ labels }: SubExperienceFormProps) => {
       resetField(name, { keepDirty: false, defaultValue: null });
     };
 
-    if (formState.dirtyFields.employmentCategory) {
+    if (prevEmploymentCategory.current !== watchEmploymentCategory) {
       resetDirtyField("team"); // both external and goc
 
       // external fields
@@ -146,7 +149,9 @@ const WorkFields = ({ labels }: SubExperienceFormProps) => {
       resetDirtyField("currentRole");
       resetDirtyField("endDate");
     }
-  }, [formState.dirtyFields, watchEmploymentCategory, resetField]);
+
+    prevEmploymentCategory.current = watchEmploymentCategory;
+  }, [watchEmploymentCategory, resetField]);
 
   return (
     <div>

--- a/apps/web/src/components/Profile/components/GovernmentInformation/FormFields.tsx
+++ b/apps/web/src/components/Profile/components/GovernmentInformation/FormFields.tsx
@@ -251,11 +251,9 @@ const FormFields = ({
                 id="currentClassificationGroup"
                 label={labels.currentClassificationGroup}
                 name="currentClassificationGroup"
-                nullSelection={intl.formatMessage({
-                  defaultMessage: "Select a group",
-                  id: "9Upe1V",
-                  description: "Null selection for form.",
-                })}
+                nullSelection={intl.formatMessage(
+                  uiMessages.nullSelectionOptionGroup,
+                )}
                 rules={{
                   required: intl.formatMessage(errorMessages.required),
                 }}

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2263,10 +2263,6 @@
     "defaultMessage": "Organisation",
     "description": "Label displayed on Work Experience form for organization input"
   },
-  "9Upe1V": {
-    "defaultMessage": "Sélectionnez un groupe",
-    "description": "Null selection for form."
-  },
   "9VPBwR": {
     "defaultMessage": "Homme danseur en régalia traditionnelle.",
     "description": "Indigenous Apprenticeship lower back image text alternative"

--- a/apps/web/src/utils/experienceUtils.tsx
+++ b/apps/web/src/utils/experienceUtils.tsx
@@ -639,14 +639,38 @@ const getWorkExperienceDefaultValues = (
     cafForce,
     cafRank,
   } = experience;
+
+  const isIndeterminate =
+    govEmploymentType?.value === WorkExperienceGovEmployeeType.Indeterminate;
+  const indeterminateActing =
+    isIndeterminate && govPositionType?.value === GovPositionType.Acting;
+  const indeterminateAssignment =
+    isIndeterminate && govPositionType?.value === GovPositionType.Assignment;
+  const indeterminateSecondment =
+    isIndeterminate && govPositionType?.value === GovPositionType.Secondment;
+
+  const expectedEndDate =
+    govEmploymentType?.value === WorkExperienceGovEmployeeType.Student ||
+    govEmploymentType?.value === WorkExperienceGovEmployeeType.Casual ||
+    govEmploymentType?.value === WorkExperienceGovEmployeeType.Term ||
+    indeterminateActing ||
+    indeterminateAssignment ||
+    indeterminateSecondment;
+
+  let currentRole = false;
+
+  if (endDate) {
+    currentRole = false;
+    if (expectedEndDate) {
+      currentRole = endDate >= strToFormDate(new Date().toISOString());
+    }
+  }
   return {
     role,
     organization,
     team: division,
     startDate,
-    currentRole: endDate
-      ? endDate >= strToFormDate(new Date().toISOString()) // today's date
-      : true,
+    currentRole,
     endDate,
     employmentCategory: employmentCategory?.value,
     extSizeOfOrganization: extSizeOfOrganization?.value,

--- a/apps/web/src/utils/experienceUtils.tsx
+++ b/apps/web/src/utils/experienceUtils.tsx
@@ -664,7 +664,10 @@ const getWorkExperienceDefaultValues = (
     if (expectedEndDate) {
       currentRole = endDate >= strToFormDate(new Date().toISOString());
     }
+  } else {
+    currentRole = true;
   }
+
   return {
     role,
     organization,

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1139,6 +1139,10 @@
     "defaultMessage": "Technologie de l’information",
     "description": "Full name of abbreviation for IT"
   },
+  "nICORU": {
+    "defaultMessage": "Sélectionnez un groupe",
+    "description": "Null selection og group for select input."
+  },
   "nMX0n8": {
     "defaultMessage": "Vous n’avez ajouté aucune expérience de ce type.",
     "description": "Message to user when no experiences of that type exist."

--- a/packages/i18n/src/messages/uiMessages.ts
+++ b/packages/i18n/src/messages/uiMessages.ts
@@ -131,6 +131,11 @@ const uiMessages = defineMessages({
     id: "xEkbvy",
     description: "Null selection of level for select input",
   },
+  nullSelectionOptionGroup: {
+    defaultMessage: "Select a group",
+    id: "nICORU",
+    description: "Null selection og group for select input.",
+  },
 });
 
 export default uiMessages;


### PR DESCRIPTION
🤖 Resolves #12434 

## 👋 Introduction

- Fixes work experience fields resetting when a skill is added
- Fixes null message on classification select

## 🧪 Testing

1. Build app `pnpm run dev`
2. Login as `applicant@test.com` (or whoever)
3. Go to career timeline and create an experience
4. Select work experience type and fill in some sub fields
5. Scroll down and add a skill
6. Scroll back up and confirm no sub fields have been reset
