### PR TITLE
[Fix] Dashboard lists have equal vertical spacing

### DIFF
--- a/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
+++ b/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
@@ -260,14 +260,9 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
                 })}
               </Heading>
               <CardBasic data-h2-min-width="base(x14.5)">
-                <ul>
-                  {recruitmentCollectionSorted.map((item, i, { length }) => (
-                    <li
-                      key={item.label}
-                      data-h2-margin-bottom={
-                        i === length - 1 ? "base(initial)" : "base(x.5)"
-                      }
-                    >
+                <ul data-h2-margin-bottom="base:children[li:not(:last-child)](x.5)">
+                  {recruitmentCollectionSorted.map((item) => (
+                    <li key={item.label}>
                       <Link color="primary" mode="inline" href={item.href}>
                         {item.label}
                       </Link>
@@ -291,14 +286,9 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
               })}
             </Heading>
             <CardBasic data-h2-min-width="base(x14.5)">
-              <ul>
-                {resourcesCollectionSorted.map((item, i, { length }) => (
-                  <li
-                    key={item.label}
-                    data-h2-margin-bottom={
-                      i === length - 1 ? "base(initial)" : "base(x.5)"
-                    }
-                  >
+              <ul data-h2-margin-bottom="base:children[li:not(:last-child)](x.5)">
+                {resourcesCollectionSorted.map((item) => (
+                  <li key={item.label}>
                     <Link color="secondary" mode="inline" href={item.href}>
                       {item.label}
                     </Link>
@@ -322,14 +312,9 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
                 })}
               </Heading>
               <CardBasic data-h2-min-width="base(x14.5)">
-                <ul>
-                  {administrationCollectionSorted.map((item, i, { length }) => (
-                    <li
-                      key={item.label}
-                      data-h2-margin-bottom={
-                        i === length - 1 ? "base(initial)" : "base(x.5)"
-                      }
-                    >
+                <ul data-h2-margin-bottom="base:children[li:not(:last-child)](x.5)">
+                  {administrationCollectionSorted.map((item) => (
+                    <li key={item.label}>
                       <Link color="error" mode="inline" href={item.href}>
                         {item.label}
                       </Link>

--- a/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
+++ b/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
@@ -261,8 +261,13 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
               </Heading>
               <CardBasic data-h2-min-width="base(x14.5)">
                 <ul>
-                  {recruitmentCollectionSorted.map((item) => (
-                    <li key={item.label} data-h2-margin-bottom="base(x.5)">
+                  {recruitmentCollectionSorted.map((item, i, { length }) => (
+                    <li
+                      key={item.label}
+                      data-h2-margin-bottom={
+                        i === length - 1 ? "base(initial)" : "base(x.5)"
+                      }
+                    >
                       <Link color="primary" mode="inline" href={item.href}>
                         {item.label}
                       </Link>
@@ -287,8 +292,13 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
             </Heading>
             <CardBasic data-h2-min-width="base(x14.5)">
               <ul>
-                {resourcesCollectionSorted.map((item) => (
-                  <li key={item.label} data-h2-margin-bottom="base(x.5)">
+                {resourcesCollectionSorted.map((item, i, { length }) => (
+                  <li
+                    key={item.label}
+                    data-h2-margin-bottom={
+                      i === length - 1 ? "base(initial)" : "base(x.5)"
+                    }
+                  >
                     <Link color="secondary" mode="inline" href={item.href}>
                       {item.label}
                     </Link>
@@ -313,8 +323,13 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
               </Heading>
               <CardBasic data-h2-min-width="base(x14.5)">
                 <ul>
-                  {administrationCollectionSorted.map((item) => (
-                    <li key={item.label} data-h2-margin-bottom="base(x.5)">
+                  {administrationCollectionSorted.map((item, i, { length }) => (
+                    <li
+                      key={item.label}
+                      data-h2-margin-bottom={
+                        i === length - 1 ? "base(initial)" : "base(x.5)"
+                      }
+                    >
                       <Link color="error" mode="inline" href={item.href}>
                         {item.label}
                       </Link>

--- a/apps/web/src/pages/CommunityDashboardPage/CommunityDashboardPage.tsx
+++ b/apps/web/src/pages/CommunityDashboardPage/CommunityDashboardPage.tsx
@@ -260,14 +260,9 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
                 })}
               </Heading>
               <CardBasic data-h2-min-width="base(x14.5)">
-                <ul>
-                  {recruitmentCollectionSorted.map((item, i, { length }) => (
-                    <li
-                      key={item.label}
-                      data-h2-margin-bottom={
-                        i === length - 1 ? "base(initial)" : "base(x.5)"
-                      }
-                    >
+                <ul data-h2-margin-bottom="base:children[li:not(:last-child)](x.5)">
+                  {recruitmentCollectionSorted.map((item) => (
+                    <li key={item.label}>
                       <Link color="primary" mode="inline" href={item.href}>
                         {item.label}
                       </Link>
@@ -291,14 +286,9 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
               })}
             </Heading>
             <CardBasic data-h2-min-width="base(x14.5)">
-              <ul>
-                {resourcesCollectionSorted.map((item, i, { length }) => (
-                  <li
-                    key={item.label}
-                    data-h2-margin-bottom={
-                      i === length - 1 ? "base(initial)" : "base(x.5)"
-                    }
-                  >
+              <ul data-h2-margin-bottom="base:children[li:not(:last-child)](x.5)">
+                {resourcesCollectionSorted.map((item) => (
+                  <li key={item.label}>
                     <Link color="secondary" mode="inline" href={item.href}>
                       {item.label}
                     </Link>
@@ -322,14 +312,9 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
                 })}
               </Heading>
               <CardBasic data-h2-min-width="base(x14.5)">
-                <ul>
-                  {administrationCollectionSorted.map((item, i, { length }) => (
-                    <li
-                      key={item.label}
-                      data-h2-margin-bottom={
-                        i === length - 1 ? "base(initial)" : "base(x.5)"
-                      }
-                    >
+                <ul data-h2-margin-bottom="base:children[li:not(:last-child)](x.5)">
+                  {administrationCollectionSorted.map((item) => (
+                    <li key={item.label}>
                       <Link color="error" mode="inline" href={item.href}>
                         {item.label}
                       </Link>

--- a/apps/web/src/pages/CommunityDashboardPage/CommunityDashboardPage.tsx
+++ b/apps/web/src/pages/CommunityDashboardPage/CommunityDashboardPage.tsx
@@ -261,8 +261,13 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
               </Heading>
               <CardBasic data-h2-min-width="base(x14.5)">
                 <ul>
-                  {recruitmentCollectionSorted.map((item) => (
-                    <li key={item.label} data-h2-margin-bottom="base(x.5)">
+                  {recruitmentCollectionSorted.map((item, i, { length }) => (
+                    <li
+                      key={item.label}
+                      data-h2-margin-bottom={
+                        i === length - 1 ? "base(initial)" : "base(x.5)"
+                      }
+                    >
                       <Link color="primary" mode="inline" href={item.href}>
                         {item.label}
                       </Link>
@@ -287,8 +292,13 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
             </Heading>
             <CardBasic data-h2-min-width="base(x14.5)">
               <ul>
-                {resourcesCollectionSorted.map((item) => (
-                  <li key={item.label} data-h2-margin-bottom="base(x.5)">
+                {resourcesCollectionSorted.map((item, i, { length }) => (
+                  <li
+                    key={item.label}
+                    data-h2-margin-bottom={
+                      i === length - 1 ? "base(initial)" : "base(x.5)"
+                    }
+                  >
                     <Link color="secondary" mode="inline" href={item.href}>
                       {item.label}
                     </Link>
@@ -313,8 +323,13 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
               </Heading>
               <CardBasic data-h2-min-width="base(x14.5)">
                 <ul>
-                  {administrationCollectionSorted.map((item) => (
-                    <li key={item.label} data-h2-margin-bottom="base(x.5)">
+                  {administrationCollectionSorted.map((item, i, { length }) => (
+                    <li
+                      key={item.label}
+                      data-h2-margin-bottom={
+                        i === length - 1 ? "base(initial)" : "base(x.5)"
+                      }
+                    >
                       <Link color="error" mode="inline" href={item.href}>
                         {item.label}
                       </Link>


### PR DESCRIPTION
🤖 Resolves #12110.

## 👋 Introduction

This PR updates `margin-bottom` on last item in array for dashboard lists so that they have equal vertical spacing.

## 🧪 Testing

1. `pnpm build`
2. Navigate to http://localhost:3000/en/admin
3. Verify dashboard lists have equal vertical spacing
4. Navigate to http://localhost:3000/en/community
5. Verify dashboard lists have equal vertical spacing

## 📸 Screenshot

<img width="1300" alt="Screen Shot 2025-01-10 at 09 01 18" src="https://github.com/user-attachments/assets/d2f629a5-0b28-418d-ad56-bc7144435a42" />
