### PR TITLE
[Bug] Skills section of application download, experience names fixed

### DIFF
--- a/api/app/Models/Experience.php
+++ b/api/app/Models/Experience.php
@@ -285,6 +285,10 @@ class Experience extends Model
         );
     }
 
+    /**
+     * @param  mixed  $snapshot  the snapshot
+     * @return array array of experiences
+     */
     public static function hydrateSnapshot(mixed $snapshot): Model|array
     {
         $experiences = [];


### PR DESCRIPTION
🤖 Resolves #12459

## 👋 Introduction

Render names correctly, in this case department name was missing

## 🕵️ Details

Reused the logic of massaging the relational fields, condensed into one place to avoid redundancy 

## 🧪 Testing

1. Test application download for various experiences

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/6c0e73f2-e7f3-4c61-b104-44201679bdcb)



