### PR TITLE
[Style] Show full description in skill table

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7498,10 +7498,6 @@
     "defaultMessage": "Votre numéro de suivi pour cette demande est : <strong>{requestId}</strong>",
     "description": "Message to the user about the ID of their request for referencing the request"
   },
-  "aq2pSe": {
-    "defaultMessage": "description pour {name}",
-    "description": "Link text suffix to read more of the description for a skill"
-  },
   "aqkSW2": {
     "defaultMessage": "Inscrivez-vous plutôt",
     "description": "Link text to register instead of signing in"

--- a/apps/web/src/pages/Skills/components/SkillTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillTable.tsx
@@ -30,7 +30,6 @@ import messages from "~/lang/frCompiled.json";
 
 import {
   categoryAccessor,
-  descriptionCell,
   familiesAccessor,
   skillFamiliesCell,
 } from "./tableHelpers";
@@ -210,12 +209,6 @@ const SkillTable = ({
       {
         id: "description",
         sortingFn: normalizedText,
-        cell: ({ row: { original: skill } }) =>
-          descriptionCell(
-            intl,
-            getLocalizedName(skill.name, intl),
-            getLocalizedName(skill.description, intl),
-          ),
         header: intl.formatMessage(commonMessages.description),
       },
     ),

--- a/apps/web/src/pages/Skills/components/tableHelpers.tsx
+++ b/apps/web/src/pages/Skills/components/tableHelpers.tsx
@@ -2,7 +2,6 @@ import { IntlShape } from "react-intl";
 
 import { getLocalizedName } from "@gc-digital-talent/i18n";
 import { notEmpty } from "@gc-digital-talent/helpers";
-import { Spoiler } from "@gc-digital-talent/ui";
 import {
   LocalizedSkillCategory,
   Maybe,
@@ -48,27 +47,4 @@ export function familiesAccessor(skill: Skill, intl: IntlShape) {
     .filter(notEmpty)
     .sort()
     .join(", ");
-}
-
-export function descriptionCell(
-  intl: IntlShape,
-  name: string,
-  description?: Maybe<string>,
-) {
-  return description ? (
-    <Spoiler
-      text={description}
-      linkSuffix={intl.formatMessage(
-        {
-          defaultMessage: "description for {name}",
-          id: "aq2pSe",
-          description:
-            "Link text suffix to read more of the description for a skill",
-        },
-        {
-          name,
-        },
-      )}
-    />
-  ) : null;
 }


### PR DESCRIPTION
🤖 Resolves #12155 

## 👋 Introduction

Updates skill table, removing spoiler, to show full description.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Navigate to skills page `/skills`
3. Confirm you see the full description with no "read more" links
 

## 📸 Screenshot

![2025-01-10_13-56](https://github.com/user-attachments/assets/8a466500-9be7-4232-8af8-7b77b9eb7e55)
