### PR TITLE
[Fix] Avoids CSP violations for robots.txt

### DIFF
--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -1,4 +1,9 @@
 
+map $request_uri $csp_header {
+    default "default-src 'self'; font-src fonts.gstatic.com 'self'; style-src-elem fonts.googleapis.com 'self' 'unsafe-inline'; script-src-elem 'self' 'nonce-$cspNonce'; img-src 'self' data:; report-uri /api/csp-report/; report-to csp;";
+    ~^/robots.txt "default-src 'self'; style-src-attr 'unsafe-inline';";
+}
+
 server {
     #proxy_cache cache;
     #proxy_cache_valid 200 1s;
@@ -23,7 +28,7 @@ server {
     sub_filter_once off;
 
     add_header Reporting-Endpoints csp="/api/csp-report";
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; font-src fonts.gstatic.com 'self'; style-src-elem fonts.googleapis.com 'self' 'unsafe-inline'; script-src-elem 'self' 'nonce-$cspNonce'; img-src 'self' data:; report-uri /api/csp-report/; report-to csp;" always;
+    add_header Content-Security-Policy-Report-Only $csp_header always;
 
     # Permanent redirects to avoid dead links
     location = /en/communities/digital-talent {

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -10,6 +10,11 @@ map $upstream_http_cache_control $hdr_cache_control {
     '' "no-store";
 }
 
+map $request_uri $csp_header {
+    default "default-src 'self'; font-src fonts.gstatic.com 'self'; style-src-elem fonts.googleapis.com 'self' 'unsafe-inline'; script-src-elem 'self' 'nonce-$cspNonce'; img-src 'self' data:; report-uri /api/csp-report/; report-to csp;";
+    ~^/robots.txt "default-src 'self'; style-src-attr 'unsafe-inline';";
+}
+
 server {
     #proxy_cache cache;
     #proxy_cache_valid 200 1s;
@@ -36,7 +41,7 @@ server {
     sub_filter_once off;
 
     add_header Reporting-Endpoints csp="/api/csp-report";
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; font-src fonts.gstatic.com 'self'; style-src-elem fonts.googleapis.com 'self' 'unsafe-inline'; script-src-elem 'self' 'nonce-$cspNonce'; img-src 'self' data:; report-uri /api/csp-report/; report-to csp;" always;
+    add_header Content-Security-Policy-Report-Only $csp_header always;
 
     # Permanent redirects to avoid dead links
     location = /en/communities/digital-talent {


### PR DESCRIPTION
🤖 Resolves #12436.

## 👋 Introduction

This PR sets an exception for /robots.txt to avoid CSP violations from requests for /robots.txt.

## 🧪 Testing

1. `make down; make up;` 
2. Navigate to http://localhost:8000/robots.txt
3. Verify nothing in console related to CSP

## 📸 Screenshot

<img width="1226" alt="Screen Shot 2025-01-10 at 16 54 09" src="https://github.com/user-attachments/assets/86014452-b89a-4fee-882d-1f36094513e5" />