### PR TITLE
[Bug] Resolve toast spam in create application path when an application already exists

### DIFF
--- a/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
+++ b/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
@@ -85,10 +85,10 @@ const CreateApplication = () => {
     path: string,
     toastFunction: () => void,
   ): Promise<void> => {
-    if (navigateWithToastCounter.current > 0) return; // we've already started navigation
+    navigateWithToastCounter.current += 1;
+    if (navigateWithToastCounter.current > 1) return; // we've already started navigation
     await navigate(path, { replace: true });
     toastFunction();
-    navigateWithToastCounter.current += 1;
   };
 
   // If a "me" object came back then we've checked.


### PR DESCRIPTION
🤖 Resolves #12314

## 👋 Introduction

As the title states, fix that annoyance. 
Followed the suggestion to handle the toast spam rather than try and diagnose why duplicate application creation was happening

## 🧪 Testing

1. Navigate to some process `/browse/pools/:id`
2. Apply
3. Apply again by visiting directly `/browse/pools/:id/create-application`
4. Observe toasts

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/400978f2-45e5-46f7-b25b-3741723bfa36)

