### PR TITLE
[Fix] `ToggleSection.Header` component Heading and Toggle style

### DIFF
--- a/packages/ui/src/components/ToggleSection/ToggleSection.stories.tsx
+++ b/packages/ui/src/components/ToggleSection/ToggleSection.stories.tsx
@@ -10,85 +10,103 @@ const Toggle = () => {
 
   return (
     <ToggleSection.Trigger>
-      <Button mode="inline">{context?.open ? "Close" : "Open"} Section</Button>
+      <Button mode="inline">{context?.open ? "Close" : "Open"} section</Button>
     </ToggleSection.Trigger>
   );
 };
 
+type ToggleSectionRootAndHeader = {
+  headerText?: string;
+} & React.ComponentPropsWithoutRef<typeof ToggleSection.Root>;
+
 export default {
   component: ToggleSection.Root,
-} as Meta<typeof ToggleSection.Root>;
+  args: {
+    headerText: "Toggle section header",
+  },
+  argTypes: {
+    headerText: {
+      control: { type: "text" },
+    },
+  },
+} as Meta;
 
-const Template: StoryFn<typeof ToggleSection.Root> = (args) => (
-  <ToggleSection.Root
-    {...args}
-    onOpenChange={(open) => action("onOpenToggle")(open)}
-  >
-    <ToggleSection.Header Icon={AcademicCapIcon} toggle={<Toggle />}>
-      Toggle Section
-    </ToggleSection.Header>
+const Template: StoryFn<ToggleSectionRootAndHeader> = (args) => {
+  const { headerText } = args;
+  return (
+    <ToggleSection.Root
+      {...args}
+      onOpenChange={(open) => action("onOpenToggle")(open)}
+    >
+      <ToggleSection.Header Icon={AcademicCapIcon} toggle={<Toggle />}>
+        {headerText}
+      </ToggleSection.Header>
 
-    <ToggleSection.Content data-h2-text-align="base(center)">
-      <ToggleSection.InitialContent>
-        <p>Initial Content Here</p>
-        <ToggleSection.Open>
-          <Button mode="inline">Open</Button>
-        </ToggleSection.Open>
-      </ToggleSection.InitialContent>
+      <ToggleSection.Content data-h2-text-align="base(center)">
+        <ToggleSection.InitialContent>
+          <p>The initial content.</p>
+          <ToggleSection.Open>
+            <Button mode="inline">Open</Button>
+          </ToggleSection.Open>
+        </ToggleSection.InitialContent>
 
-      <ToggleSection.OpenContent>
-        <p>Open Content Here</p>
-        <ToggleSection.Close>
-          <Button mode="inline">Close</Button>
-        </ToggleSection.Close>
-      </ToggleSection.OpenContent>
-    </ToggleSection.Content>
-  </ToggleSection.Root>
-);
+        <ToggleSection.OpenContent>
+          <p>The open content.</p>
+          <ToggleSection.Close>
+            <Button mode="inline">Close</Button>
+          </ToggleSection.Close>
+        </ToggleSection.OpenContent>
+      </ToggleSection.Content>
+    </ToggleSection.Root>
+  );
+};
 
 export const Default = Template.bind({});
 
-const NestedTemplate: StoryFn<typeof ToggleSection.Root> = (args) => (
-  <ToggleSection.Root
-    {...args}
-    onOpenChange={(open) => action("onOpenToggle")(open)}
-  >
-    <ToggleSection.Header Icon={AcademicCapIcon} toggle={<Toggle />}>
-      Toggle Section
-    </ToggleSection.Header>
+const NestedTemplate: StoryFn<ToggleSectionRootAndHeader> = (args) => {
+  const { headerText } = args;
+  return (
+    <ToggleSection.Root
+      {...args}
+      onOpenChange={(open) => action("onOpenToggle")(open)}
+    >
+      <ToggleSection.Header Icon={AcademicCapIcon} toggle={<Toggle />}>
+        {headerText}
+      </ToggleSection.Header>
 
-    <ToggleSection.Content data-h2-text-align="base(center)">
-      <ToggleSection.InitialContent>
-        <p>Initial Content Here</p>
-        <ToggleSection.Open>
-          <Button mode="inline">Open Main Content</Button>
-        </ToggleSection.Open>
+      <ToggleSection.Content data-h2-text-align="base(center)">
+        <ToggleSection.InitialContent>
+          <p>The initial content.</p>
+          <ToggleSection.Open>
+            <Button mode="inline">Open main content</Button>
+          </ToggleSection.Open>
 
-        <ToggleSection.Root>
-          <ToggleSection.Trigger>
-            <Button mode="inline">Toggle Nested Content</Button>
-          </ToggleSection.Trigger>
+          <ToggleSection.Root>
+            <ToggleSection.Trigger>
+              <Button mode="inline">Toggle nested content</Button>
+            </ToggleSection.Trigger>
 
-          <ToggleSection.Content data-h2-text-align="base(center)">
-            <ToggleSection.InitialContent>
-              <p>Nested Initial Content Here</p>
-            </ToggleSection.InitialContent>
+            <ToggleSection.Content data-h2-text-align="base(center)">
+              <ToggleSection.InitialContent>
+                <p>The nested initial content.</p>
+              </ToggleSection.InitialContent>
 
-            <ToggleSection.OpenContent>
-              <p>Nested Open Content Here</p>
-            </ToggleSection.OpenContent>
-          </ToggleSection.Content>
-        </ToggleSection.Root>
-      </ToggleSection.InitialContent>
+              <ToggleSection.OpenContent>
+                <p>The nested open content.</p>
+              </ToggleSection.OpenContent>
+            </ToggleSection.Content>
+          </ToggleSection.Root>
+        </ToggleSection.InitialContent>
 
-      <ToggleSection.OpenContent>
-        <p>Open Content Here</p>
-        <ToggleSection.Close>
-          <Button mode="inline">Close</Button>
-        </ToggleSection.Close>
-      </ToggleSection.OpenContent>
-    </ToggleSection.Content>
-  </ToggleSection.Root>
-);
+        <ToggleSection.OpenContent>
+          <p>The open content.</p>
+          <ToggleSection.Close>
+            <Button mode="inline">Close</Button>
+          </ToggleSection.Close>
+        </ToggleSection.OpenContent>
+      </ToggleSection.Content>
+    </ToggleSection.Root>
+  );
+};
 
 export const Nested = NestedTemplate.bind({});

--- a/packages/ui/src/components/ToggleSection/ToggleSection.tsx
+++ b/packages/ui/src/components/ToggleSection/ToggleSection.tsx
@@ -265,13 +265,13 @@ interface HeaderProps extends HeadingProps {
 const Header = forwardRef<HTMLHeadingElement, HeaderProps>(
   ({ toggle, ...headingProps }, forwardedRef) => {
     return (
-      <div data-h2-flex-grid="base(center, x2)">
+      <div data-h2-flex-grid="base(flex-start, x2, x1) p-tablet(center, x2)">
         <Heading
           ref={forwardedRef}
-          data-h2-flex-item="base(fill)"
+          data-h2-flex-item="base(1of1) p-tablet(fill)"
           {...headingProps}
         />
-        <div data-h2-flex-item="base(content)">{toggle}</div>
+        <div data-h2-flex-item="base(1of1) p-tablet(content)">{toggle}</div>
       </div>
     );
   },


### PR DESCRIPTION
🤖 Resolves #11935.

## 👋 Introduction

This PR fixes the `ToggleSection.Header` component Heading and Toggle text so it does not overlap and is on a new row for smaller screens.

## 📸 Screenshot

<img width="750" alt="Screen Shot 2025-01-13 at 11 10 53" src="https://github.com/user-attachments/assets/764baccf-7c07-4119-90d4-dfb63000009a" />

## 🧪 Testing

1. `pnpm build`
2. Navigate to http://localhost:8000/en/admin/settings/announcements
3. Edit the form
4. Verify text Sitewide announcement does not overlap with Cancel editing and Cancel editing is on a new row