### PR TITLE
[Debt] Removes `TextArea` custom arg `maxWidth` from story

### DIFF
--- a/packages/forms/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/forms/src/components/TextArea/TextArea.stories.tsx
@@ -18,13 +18,10 @@ export default {
   },
 };
 
-const TemplateTextArea: StoryFn<TextAreaProps & { maxWidth: string }> = (
-  args,
-) => {
-  const { ...rest } = args;
+const TemplateTextArea: StoryFn<TextAreaProps> = (args) => {
   return (
     <Form onSubmit={action("Submit Form")}>
-      <TextArea {...rest} />
+      <TextArea {...args} />
       <p data-h2-margin-top="base(x1)">
         <Submit />
       </p>


### PR DESCRIPTION
🤖 Resolves #12474.

## 👋 Introduction

This PR removes `TextArea` custom arg `maxWidth` from story.


## 🧪 Testing

1. `pnpm storybook`
2. Verify `TextArea` stories work as before