### PR TITLE
[Debt] Upgrades `react-to-print` to version 3

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -63,7 +63,7 @@
     "react-hook-form": "^7.54.2",
     "react-intl": "^7.1.0",
     "react-router": "^7.1.1",
-    "react-to-print": "^2.15.1",
+    "react-to-print": "^3.0.4",
     "urql": "^4.2.1"
   },
   "devDependencies": {

--- a/apps/web/src/pages/SearchRequests/RequestConfirmationPage/RequestConfirmationPage.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestConfirmationPage/RequestConfirmationPage.tsx
@@ -73,7 +73,7 @@ export const Component = () => {
 
   const componentRef = useRef(null);
   const handlePrint = useReactToPrint({
-    content: () => componentRef.current,
+    contentRef: componentRef,
     pageStyle: printStyles,
     documentTitle: intl.formatMessage({
       defaultMessage: "Request submitted",
@@ -153,7 +153,11 @@ export const Component = () => {
             data-h2-gap="base(x1)"
             data-h2-flex-direction="base(row)"
           >
-            <Button mode="solid" color="secondary" onClick={handlePrint}>
+            <Button
+              mode="solid"
+              color="secondary"
+              onClick={() => handlePrint()}
+            >
               {intl.formatMessage({
                 defaultMessage: "Print this information",
                 id: "idu0MU",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,8 +151,8 @@ importers:
         specifier: ^7.1.1
         version: 7.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-to-print:
-        specifier: ^2.15.1
-        version: 2.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^3.0.4
+        version: 3.0.4(react@18.3.1)
       urql:
         specifier: ^4.2.1
         version: 4.2.1(@urql/core@5.1.0(graphql@16.10.0))(react@18.3.1)
@@ -6907,11 +6907,10 @@ packages:
       '@types/react':
         optional: true
 
-  react-to-print@2.15.1:
-    resolution: {integrity: sha512-1foogIFbCpzAVxydkhBiDfMiFYhIMphiagDOfcG4X/EcQ+fBPqJ0rby9Wv/emzY1YLkIQy/rEgOrWQT+rBKhjw==}
+  react-to-print@3.0.4:
+    resolution: {integrity: sha512-33opQsuskUs0UyK1OLAAN2Ziy1GPneeTLvypRYjT6E9bl2NDxZtEr0KYMOxszcBY0bs+XlWOkGNlyla55GQjuA==}
     peerDependencies:
-      react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ~19
 
   react-toastify@11.0.2:
     resolution: {integrity: sha512-GjHuGaiXMvbls3ywqv8XdWONwrcO4DXCJIY1zVLkHU73gEElKvTTXNI5Vom3s/k/M8hnkrfsqgBSX3OwmlonbA==}
@@ -14599,10 +14598,9 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.13
 
-  react-to-print@2.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-to-print@3.0.4(react@18.3.1):
     dependencies:
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
 
   react-toastify@11.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:


### PR DESCRIPTION
🤖 Resolves #12387.

## 👋 Introduction

This PR upgrades `react-to-print` to version 3.

## 🧪 Testing

1. `pnpm i; pnpm build:fresh`
2. Navigate to http://localhost:8000/en/search
3. Submit a talent request
4. Click Print this information button
5. Print dialog with content from page should appear in browser

## 🎥 Screen recording

https://github.com/user-attachments/assets/98fa9f7e-a5f0-4f74-af1b-b0c074424e98

