### PR TITLE
[Debt-ture] `updatePoolCandidateStatus` policy enhancment 

### DIFF
--- a/api/app/Policies/PoolCandidatePolicy.php
+++ b/api/app/Policies/PoolCandidatePolicy.php
@@ -189,7 +189,7 @@ class PoolCandidatePolicy
      *
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function updateStatus(User $user, PoolCandidate $poolCandidate)
+    public function updateStatusLegacy(User $user, PoolCandidate $poolCandidate)
     {
         if ($user->isAbleTo('update-any-applicationStatus')) {
             return true;
@@ -327,7 +327,7 @@ class PoolCandidatePolicy
      * @param  array{id: ?string, expiry_date: ?string, pool_candidate_status: ?string }  $args
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function updatePoolCandidateStatusParent(User $user, PoolCandidate $poolCandidate, $args)
+    public function updateStatus(User $user, PoolCandidate $poolCandidate, $args)
     {
         $inputStatus = $args['pool_candidate_status'] ?? null;
 
@@ -345,7 +345,7 @@ class PoolCandidatePolicy
             }
 
             if (in_array($inputStatus, $draftOrExpired)) {
-                return $this->updateStatus($user, $poolCandidate);
+                return $this->updateStatusLegacy($user, $poolCandidate);
             }
 
             return $this->updateDecision($user, $poolCandidate);
@@ -353,10 +353,10 @@ class PoolCandidatePolicy
 
         $inputExpiryDate = $args['expiry_date'] ?? null;
 
-        // attempting to update just the expiry date, which falls to updateStatus()
+        // attempting to update just the expiry date, which falls to updateStatusLegacy()
         if ($inputExpiryDate) {
 
-            return $this->updateStatus($user, $poolCandidate);
+            return $this->updateStatusLegacy($user, $poolCandidate);
 
         }
 

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -2326,11 +2326,7 @@ type Mutation {
     poolCandidate: UpdatePoolCandidateStatusInput! @spread
   ): PoolCandidate
     @guard
-    @canFind(
-      ability: "updatePoolCandidateStatusParent"
-      find: "id"
-      injectArgs: true
-    )
+    @canFind(ability: "updateStatus", find: "id", injectArgs: true)
   # Return a boolean to prevent automatically updating the client's cache
   togglePoolCandidateBookmark(id: ID!): Boolean
     @guard

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -2326,7 +2326,11 @@ type Mutation {
     poolCandidate: UpdatePoolCandidateStatusInput! @spread
   ): PoolCandidate
     @guard
-    @canFind(ability: "updateStatus", find: "id", injectArgs: true)
+    @canFind(
+      ability: "updatePoolCandidateStatusParent"
+      find: "id"
+      injectArgs: true
+    )
   # Return a boolean to prevent automatically updating the client's cache
   togglePoolCandidateBookmark(id: ID!): Boolean
     @guard

--- a/api/tests/Feature/PoolCandidateUpdateTest.php
+++ b/api/tests/Feature/PoolCandidateUpdateTest.php
@@ -10,6 +10,7 @@ use App\Enums\EducationRequirementOption;
 use App\Enums\PlacementType;
 use App\Enums\PoolCandidateStatus;
 use App\Facades\Notify;
+use App\Models\Community;
 use App\Models\CommunityExperience;
 use App\Models\Department;
 use App\Models\EducationExperience;
@@ -51,11 +52,19 @@ class PoolCandidateUpdateTest extends TestCase
 
     protected $adminUser;
 
+    protected $community;
+
     protected $team;
 
     protected $teamPool;
 
     protected $poolCandidate;
+
+    protected $processOperatorUser;
+
+    protected $communityRecruiterUser;
+
+    protected $communityAdminUser;
 
     protected $unauthorizedMessage;
 
@@ -98,6 +107,8 @@ class PoolCandidateUpdateTest extends TestCase
             ]);
 
         $this->team = Team::factory()->create(['name' => 'test-team']);
+        $this->community = Community::factory()->create(['name' => ['en' => 'test-team EN', 'fr' => 'test-team FR']]);
+
         $this->poolOperatorUser = User::factory()
             ->asPoolOperator($this->team->name)
             ->create([
@@ -129,7 +140,26 @@ class PoolCandidateUpdateTest extends TestCase
         $this->teamPool = Pool::factory()->create([
             'user_id' => $this->poolOperatorUser->id,
             'team_id' => $this->team->id,
+            'community_id' => $this->community->id,
         ]);
+
+        $this->processOperatorUser = User::factory()
+            ->asProcessOperator($this->teamPool->id)
+            ->create([
+                'email' => 'process-operator-user@test.com',
+            ]);
+
+        $this->communityRecruiterUser = User::factory()
+            ->asCommunityRecruiter($this->community->id)
+            ->create([
+                'email' => 'community-recruiter-user@test.com',
+            ]);
+
+        $this->communityAdminUser = User::factory()
+            ->asCommunityAdmin($this->community->id)
+            ->create([
+                'email' => 'community-admin-user@test.com',
+            ]);
 
         $this->poolCandidate = PoolCandidate::factory()->create([
             'user_id' => $this->candidateUser->id,
@@ -1142,5 +1172,145 @@ class PoolCandidateUpdateTest extends TestCase
                 'placed_at',
             ],
         ];
+    }
+
+    // test policy correctly allows sample manual status updates to work, when expected and fail otherwise
+    public function testManualStatusUpdatePolicy(): void
+    {
+        $past = config('constants.past_datetime');
+        $this->poolCandidate->pool_candidate_status = PoolCandidateStatus::NEW_APPLICATION->name;
+        $this->poolCandidate->submitted_at = $past;
+        $this->poolCandidate->save();
+
+        // process operator
+        // can set to SCREENED IN, QUALIFIED, REMOVED only
+        // cannot set PLACED TERM, or DRAFT
+        $this->actingAs($this->processOperatorUser, 'api')
+            ->graphQL($this->manualStatusUpdateMutation, [
+                'id' => $this->poolCandidate->id,
+                'candidate' => ['status' => PoolCandidateStatus::DRAFT->name],
+            ])->assertGraphQLErrorMessage($this->unauthorizedMessage);
+        $this->actingAs($this->processOperatorUser, 'api')
+            ->graphQL($this->manualStatusUpdateMutation, [
+                'id' => $this->poolCandidate->id,
+                'candidate' => ['status' => PoolCandidateStatus::SCREENED_IN->name],
+            ])->assertJsonFragment([
+                'status' => [
+                    'value' => PoolCandidateStatus::SCREENED_IN->name,
+                ],
+            ]);
+        $this->actingAs($this->processOperatorUser, 'api')
+            ->graphQL($this->manualStatusUpdateMutation, [
+                'id' => $this->poolCandidate->id,
+                'candidate' => ['status' => PoolCandidateStatus::QUALIFIED_AVAILABLE->name],
+            ])->assertJsonFragment([
+                'status' => [
+                    'value' => PoolCandidateStatus::QUALIFIED_AVAILABLE->name,
+                ],
+            ]);
+        $this->actingAs($this->processOperatorUser, 'api')
+            ->graphQL($this->manualStatusUpdateMutation, [
+                'id' => $this->poolCandidate->id,
+                'candidate' => ['status' => PoolCandidateStatus::REMOVED->name],
+            ])->assertJsonFragment([
+                'status' => [
+                    'value' => PoolCandidateStatus::REMOVED->name,
+                ],
+            ]);
+        $this->actingAs($this->processOperatorUser, 'api')
+            ->graphQL($this->manualStatusUpdateMutation, [
+                'id' => $this->poolCandidate->id,
+                'candidate' => ['status' => PoolCandidateStatus::PLACED_TERM->name],
+            ])->assertGraphQLErrorMessage($this->unauthorizedMessage);
+
+        // community recruiter
+        // can set to SCREENED IN, QUALIFIED, REMOVED, PLACED TERM only
+        // cannot set DRAFT
+        $this->actingAs($this->communityRecruiterUser, 'api')
+            ->graphQL($this->manualStatusUpdateMutation, [
+                'id' => $this->poolCandidate->id,
+                'candidate' => ['status' => PoolCandidateStatus::DRAFT->name],
+            ])->assertGraphQLErrorMessage($this->unauthorizedMessage);
+        $this->actingAs($this->communityRecruiterUser, 'api')
+            ->graphQL($this->manualStatusUpdateMutation, [
+                'id' => $this->poolCandidate->id,
+                'candidate' => ['status' => PoolCandidateStatus::SCREENED_IN->name],
+            ])->assertJsonFragment([
+                'status' => [
+                    'value' => PoolCandidateStatus::SCREENED_IN->name,
+                ],
+            ]);
+        $this->actingAs($this->communityRecruiterUser, 'api')
+            ->graphQL($this->manualStatusUpdateMutation, [
+                'id' => $this->poolCandidate->id,
+                'candidate' => ['status' => PoolCandidateStatus::QUALIFIED_AVAILABLE->name],
+            ])->assertJsonFragment([
+                'status' => [
+                    'value' => PoolCandidateStatus::QUALIFIED_AVAILABLE->name,
+                ],
+            ]);
+        $this->actingAs($this->communityRecruiterUser, 'api')
+            ->graphQL($this->manualStatusUpdateMutation, [
+                'id' => $this->poolCandidate->id,
+                'candidate' => ['status' => PoolCandidateStatus::REMOVED->name],
+            ])->assertJsonFragment([
+                'status' => [
+                    'value' => PoolCandidateStatus::REMOVED->name,
+                ],
+            ]);
+        $this->actingAs($this->communityRecruiterUser, 'api')
+            ->graphQL($this->manualStatusUpdateMutation, [
+                'id' => $this->poolCandidate->id,
+                'candidate' => ['status' => PoolCandidateStatus::PLACED_TERM->name],
+            ])->assertJsonFragment([
+                'status' => [
+                    'value' => PoolCandidateStatus::PLACED_TERM->name,
+                ],
+            ]);
+
+        // community admin
+        // can set to SCREENED IN, QUALIFIED, REMOVED, PLACED TERM only
+        // cannot set DRAFT
+        $this->actingAs($this->communityAdminUser, 'api')
+            ->graphQL($this->manualStatusUpdateMutation, [
+                'id' => $this->poolCandidate->id,
+                'candidate' => ['status' => PoolCandidateStatus::DRAFT->name],
+            ])->assertGraphQLErrorMessage($this->unauthorizedMessage);
+        $this->actingAs($this->communityAdminUser, 'api')
+            ->graphQL($this->manualStatusUpdateMutation, [
+                'id' => $this->poolCandidate->id,
+                'candidate' => ['status' => PoolCandidateStatus::SCREENED_IN->name],
+            ])->assertJsonFragment([
+                'status' => [
+                    'value' => PoolCandidateStatus::SCREENED_IN->name,
+                ],
+            ]);
+        $this->actingAs($this->communityAdminUser, 'api')
+            ->graphQL($this->manualStatusUpdateMutation, [
+                'id' => $this->poolCandidate->id,
+                'candidate' => ['status' => PoolCandidateStatus::QUALIFIED_AVAILABLE->name],
+            ])->assertJsonFragment([
+                'status' => [
+                    'value' => PoolCandidateStatus::QUALIFIED_AVAILABLE->name,
+                ],
+            ]);
+        $this->actingAs($this->communityAdminUser, 'api')
+            ->graphQL($this->manualStatusUpdateMutation, [
+                'id' => $this->poolCandidate->id,
+                'candidate' => ['status' => PoolCandidateStatus::REMOVED->name],
+            ])->assertJsonFragment([
+                'status' => [
+                    'value' => PoolCandidateStatus::REMOVED->name,
+                ],
+            ]);
+        $this->actingAs($this->communityAdminUser, 'api')
+            ->graphQL($this->manualStatusUpdateMutation, [
+                'id' => $this->poolCandidate->id,
+                'candidate' => ['status' => PoolCandidateStatus::PLACED_TERM->name],
+            ])->assertJsonFragment([
+                'status' => [
+                    'value' => PoolCandidateStatus::PLACED_TERM->name,
+                ],
+            ]);
     }
 }

--- a/api/tests/Unit/PoolCandidatePolicyTest.php
+++ b/api/tests/Unit/PoolCandidatePolicyTest.php
@@ -276,23 +276,23 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testUpdateStatus()
+    public function testUpdateStatusLegacy()
     {
         // Ensure candidate is not draft
         $this->poolCandidate->submitted_at = config('constants.past_date');
         $this->poolCandidate->save();
 
-        $this->assertTrue($this->poolOperatorUser->can('updateStatus', $this->poolCandidate));
-        $this->assertTrue($this->requestResponderUser->can('updateStatus', $this->poolCandidate));
+        $this->assertTrue($this->poolOperatorUser->can('updateStatusLegacy', $this->poolCandidate));
+        $this->assertTrue($this->requestResponderUser->can('updateStatusLegacy', $this->poolCandidate));
 
-        $this->assertFalse($this->guestUser->can('updateStatus', $this->poolCandidate));
-        $this->assertFalse($this->candidateUser->can('updateStatus', $this->poolCandidate));
-        $this->assertFalse($this->applicantUser->can('updateStatus', $this->poolCandidate));
-        $this->assertFalse($this->communityManagerUser->can('updateStatus', $this->poolCandidate));
-        $this->assertFalse($this->adminUser->can('updateStatus', $this->poolCandidate));
-        $this->assertFalse($this->processOperatorUser->can('updateStatus', $this->poolCandidate));
-        $this->assertFalse($this->communityRecruiterUser->can('updateStatus', $this->poolCandidate));
-        $this->assertFalse($this->communityAdminUser->can('updateStatus', $this->poolCandidate));
+        $this->assertFalse($this->guestUser->can('updateStatusLegacy', $this->poolCandidate));
+        $this->assertFalse($this->candidateUser->can('updateStatusLegacy', $this->poolCandidate));
+        $this->assertFalse($this->applicantUser->can('updateStatusLegacy', $this->poolCandidate));
+        $this->assertFalse($this->communityManagerUser->can('updateStatusLegacy', $this->poolCandidate));
+        $this->assertFalse($this->adminUser->can('updateStatusLegacy', $this->poolCandidate));
+        $this->assertFalse($this->processOperatorUser->can('updateStatusLegacy', $this->poolCandidate));
+        $this->assertFalse($this->communityRecruiterUser->can('updateStatusLegacy', $this->poolCandidate));
+        $this->assertFalse($this->communityAdminUser->can('updateStatusLegacy', $this->poolCandidate));
     }
 
     /**
@@ -698,7 +698,7 @@ class PoolCandidatePolicyTest extends TestCase
      *
      * @return void
      */
-    public function testUpdatePoolCandidateStatusParent()
+    public function testUpdateStatus()
     {
         // test all the statuses
         // grouped similar statuses to condense this blob
@@ -710,16 +710,16 @@ class PoolCandidatePolicyTest extends TestCase
         ];
         foreach ($draftOrExpiredStatuses as $draftOrExpiredStatus) {
             $this->assertTrue($this->poolOperatorUser->can(
-                'updatePoolCandidateStatusParent',
+                'updateStatus',
                 [$this->poolCandidate, ['pool_candidate_status' => $draftOrExpiredStatus]]));
             $this->assertFalse($this->processOperatorUser->can(
-                'updatePoolCandidateStatusParent',
+                'updateStatus',
                 [$this->poolCandidate, ['pool_candidate_status' => $draftOrExpiredStatus]]));
             $this->assertFalse($this->communityRecruiterUser->can(
-                'updatePoolCandidateStatusParent',
+                'updateStatus',
                 [$this->poolCandidate, ['pool_candidate_status' => $draftOrExpiredStatus]]));
             $this->assertFalse($this->communityAdminUser->can(
-                'updatePoolCandidateStatusParent',
+                'updateStatus',
                 [$this->poolCandidate, ['pool_candidate_status' => $draftOrExpiredStatus]]));
         }
 
@@ -731,16 +731,16 @@ class PoolCandidatePolicyTest extends TestCase
         ];
         foreach ($placedStatuses as $placedStatus) {
             $this->assertTrue($this->poolOperatorUser->can(
-                'updatePoolCandidateStatusParent',
+                'updateStatus',
                 [$this->poolCandidate, ['pool_candidate_status' => $placedStatus]]));
             $this->assertFalse($this->processOperatorUser->can(
-                'updatePoolCandidateStatusParent',
+                'updateStatus',
                 [$this->poolCandidate, ['pool_candidate_status' => $placedStatus]]));
             $this->assertTrue($this->communityRecruiterUser->can(
-                'updatePoolCandidateStatusParent',
+                'updateStatus',
                 [$this->poolCandidate, ['pool_candidate_status' => $placedStatus]]));
             $this->assertTrue($this->communityAdminUser->can(
-                'updatePoolCandidateStatusParent',
+                'updateStatus',
                 [$this->poolCandidate, ['pool_candidate_status' => $placedStatus]]));
         }
 
@@ -751,16 +751,16 @@ class PoolCandidatePolicyTest extends TestCase
         ];
         foreach ($initialStatuses as $initialStatus) {
             $this->assertTrue($this->poolOperatorUser->can(
-                'updatePoolCandidateStatusParent',
+                'updateStatus',
                 [$this->poolCandidate, ['pool_candidate_status' => $initialStatus]]));
             $this->assertTrue($this->processOperatorUser->can(
-                'updatePoolCandidateStatusParent',
+                'updateStatus',
                 [$this->poolCandidate, ['pool_candidate_status' => $initialStatus]]));
             $this->assertTrue($this->communityRecruiterUser->can(
-                'updatePoolCandidateStatusParent',
+                'updateStatus',
                 [$this->poolCandidate, ['pool_candidate_status' => $initialStatus]]));
             $this->assertTrue($this->communityAdminUser->can(
-                'updatePoolCandidateStatusParent',
+                'updateStatus',
                 [$this->poolCandidate, ['pool_candidate_status' => $initialStatus]]));
         }
 
@@ -773,16 +773,16 @@ class PoolCandidatePolicyTest extends TestCase
         ];
         foreach ($screeningStatuses as $screeningStatus) {
             $this->assertTrue($this->poolOperatorUser->can(
-                'updatePoolCandidateStatusParent',
+                'updateStatus',
                 [$this->poolCandidate, ['pool_candidate_status' => $screeningStatus]]));
             $this->assertTrue($this->processOperatorUser->can(
-                'updatePoolCandidateStatusParent',
+                'updateStatus',
                 [$this->poolCandidate, ['pool_candidate_status' => $screeningStatus]]));
             $this->assertTrue($this->communityRecruiterUser->can(
-                'updatePoolCandidateStatusParent',
+                'updateStatus',
                 [$this->poolCandidate, ['pool_candidate_status' => $screeningStatus]]));
             $this->assertTrue($this->communityAdminUser->can(
-                'updatePoolCandidateStatusParent',
+                'updateStatus',
                 [$this->poolCandidate, ['pool_candidate_status' => $screeningStatus]]));
         }
 
@@ -793,31 +793,31 @@ class PoolCandidatePolicyTest extends TestCase
         ];
         foreach ($qualifiedStatuses as $qualifiedStatus) {
             $this->assertTrue($this->poolOperatorUser->can(
-                'updatePoolCandidateStatusParent',
+                'updateStatus',
                 [$this->poolCandidate, ['pool_candidate_status' => $qualifiedStatus]]));
             $this->assertTrue($this->processOperatorUser->can(
-                'updatePoolCandidateStatusParent',
+                'updateStatus',
                 [$this->poolCandidate, ['pool_candidate_status' => $qualifiedStatus]]));
             $this->assertTrue($this->communityRecruiterUser->can(
-                'updatePoolCandidateStatusParent',
+                'updateStatus',
                 [$this->poolCandidate, ['pool_candidate_status' => $qualifiedStatus]]));
             $this->assertTrue($this->communityAdminUser->can(
-                'updatePoolCandidateStatusParent',
+                'updateStatus',
                 [$this->poolCandidate, ['pool_candidate_status' => $qualifiedStatus]]));
         }
 
         // test REMOVED
         $this->assertTrue($this->poolOperatorUser->can(
-            'updatePoolCandidateStatusParent',
+            'updateStatus',
             [$this->poolCandidate, ['pool_candidate_status' => PoolCandidateStatus::REMOVED->name]]));
         $this->assertTrue($this->processOperatorUser->can(
-            'updatePoolCandidateStatusParent',
+            'updateStatus',
             [$this->poolCandidate, ['pool_candidate_status' => PoolCandidateStatus::REMOVED->name]]));
         $this->assertTrue($this->communityRecruiterUser->can(
-            'updatePoolCandidateStatusParent',
+            'updateStatus',
             [$this->poolCandidate, ['pool_candidate_status' => PoolCandidateStatus::REMOVED->name]]));
         $this->assertTrue($this->communityAdminUser->can(
-            'updatePoolCandidateStatusParent',
+            'updateStatus',
             [$this->poolCandidate, ['pool_candidate_status' => PoolCandidateStatus::REMOVED->name]]));
     }
 
@@ -831,16 +831,16 @@ class PoolCandidatePolicyTest extends TestCase
     {
         // test policy again with just an expiry date
         $this->assertTrue($this->poolOperatorUser->can(
-            'updatePoolCandidateStatusParent',
+            'updateStatus',
             [$this->poolCandidate, ['expiry_date' => '2000-01-01']]));
         $this->assertFalse($this->processOperatorUser->can(
-            'updatePoolCandidateStatusParent',
+            'updateStatus',
             [$this->poolCandidate, ['expiry_date' => '2000-01-01']]));
         $this->assertFalse($this->communityRecruiterUser->can(
-            'updatePoolCandidateStatusParent',
+            'updateStatus',
             [$this->poolCandidate, ['expiry_date' => '2000-01-01']]));
         $this->assertFalse($this->communityAdminUser->can(
-            'updatePoolCandidateStatusParent',
+            'updateStatus',
             [$this->poolCandidate, ['expiry_date' => '2000-01-01']]));
     }
 }

--- a/api/tests/Unit/PoolCandidatePolicyTest.php
+++ b/api/tests/Unit/PoolCandidatePolicyTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use App\Enums\PoolCandidateStatus;
 use App\Facades\Notify;
 use App\Models\Community;
 use App\Models\Pool;
@@ -689,5 +690,157 @@ class PoolCandidatePolicyTest extends TestCase
         $this->assertFalse($this->processOperatorUser->can('updatePlacement', $this->unOwnedPoolCandidate));
         $this->assertFalse($this->communityRecruiterUser->can('updatePlacement', $this->unOwnedPoolCandidate));
         $this->assertFalse($this->communityAdminUser->can('updatePlacement', $this->unOwnedPoolCandidate));
+    }
+
+    /**
+     * Assert that the policy method references the correct subsequent method for a given input status
+     * testing pool operator, process operator, community recruiter, community admin
+     *
+     * @return void
+     */
+    public function testUpdatePoolCandidateStatusParent()
+    {
+        // test all the statuses
+        // grouped similar statuses to condense this blob
+
+        $draftOrExpiredStatuses = [
+            PoolCandidateStatus::DRAFT->name,
+            PoolCandidateStatus::DRAFT_EXPIRED->name,
+            PoolCandidateStatus::EXPIRED->name,
+        ];
+        foreach ($draftOrExpiredStatuses as $draftOrExpiredStatus) {
+            $this->assertTrue($this->poolOperatorUser->can(
+                'updatePoolCandidateStatusParent',
+                [$this->poolCandidate, ['pool_candidate_status' => $draftOrExpiredStatus]]));
+            $this->assertFalse($this->processOperatorUser->can(
+                'updatePoolCandidateStatusParent',
+                [$this->poolCandidate, ['pool_candidate_status' => $draftOrExpiredStatus]]));
+            $this->assertFalse($this->communityRecruiterUser->can(
+                'updatePoolCandidateStatusParent',
+                [$this->poolCandidate, ['pool_candidate_status' => $draftOrExpiredStatus]]));
+            $this->assertFalse($this->communityAdminUser->can(
+                'updatePoolCandidateStatusParent',
+                [$this->poolCandidate, ['pool_candidate_status' => $draftOrExpiredStatus]]));
+        }
+
+        $placedStatuses = [
+            PoolCandidateStatus::PLACED_TENTATIVE->name,
+            PoolCandidateStatus::PLACED_CASUAL->name,
+            PoolCandidateStatus::PLACED_TERM->name,
+            PoolCandidateStatus::PLACED_INDETERMINATE->name,
+        ];
+        foreach ($placedStatuses as $placedStatus) {
+            $this->assertTrue($this->poolOperatorUser->can(
+                'updatePoolCandidateStatusParent',
+                [$this->poolCandidate, ['pool_candidate_status' => $placedStatus]]));
+            $this->assertFalse($this->processOperatorUser->can(
+                'updatePoolCandidateStatusParent',
+                [$this->poolCandidate, ['pool_candidate_status' => $placedStatus]]));
+            $this->assertTrue($this->communityRecruiterUser->can(
+                'updatePoolCandidateStatusParent',
+                [$this->poolCandidate, ['pool_candidate_status' => $placedStatus]]));
+            $this->assertTrue($this->communityAdminUser->can(
+                'updatePoolCandidateStatusParent',
+                [$this->poolCandidate, ['pool_candidate_status' => $placedStatus]]));
+        }
+
+        $initialStatuses = [
+            PoolCandidateStatus::NEW_APPLICATION->name,
+            PoolCandidateStatus::APPLICATION_REVIEW->name,
+            PoolCandidateStatus::UNDER_ASSESSMENT->name,
+        ];
+        foreach ($initialStatuses as $initialStatus) {
+            $this->assertTrue($this->poolOperatorUser->can(
+                'updatePoolCandidateStatusParent',
+                [$this->poolCandidate, ['pool_candidate_status' => $initialStatus]]));
+            $this->assertTrue($this->processOperatorUser->can(
+                'updatePoolCandidateStatusParent',
+                [$this->poolCandidate, ['pool_candidate_status' => $initialStatus]]));
+            $this->assertTrue($this->communityRecruiterUser->can(
+                'updatePoolCandidateStatusParent',
+                [$this->poolCandidate, ['pool_candidate_status' => $initialStatus]]));
+            $this->assertTrue($this->communityAdminUser->can(
+                'updatePoolCandidateStatusParent',
+                [$this->poolCandidate, ['pool_candidate_status' => $initialStatus]]));
+        }
+
+        $screeningStatuses = [
+            PoolCandidateStatus::SCREENED_IN->name,
+            PoolCandidateStatus::SCREENED_OUT_APPLICATION->name,
+            PoolCandidateStatus::SCREENED_OUT_ASSESSMENT->name,
+            PoolCandidateStatus::SCREENED_OUT_NOT_INTERESTED->name,
+            PoolCandidateStatus::SCREENED_OUT_NOT_RESPONSIVE->name,
+        ];
+        foreach ($screeningStatuses as $screeningStatus) {
+            $this->assertTrue($this->poolOperatorUser->can(
+                'updatePoolCandidateStatusParent',
+                [$this->poolCandidate, ['pool_candidate_status' => $screeningStatus]]));
+            $this->assertTrue($this->processOperatorUser->can(
+                'updatePoolCandidateStatusParent',
+                [$this->poolCandidate, ['pool_candidate_status' => $screeningStatus]]));
+            $this->assertTrue($this->communityRecruiterUser->can(
+                'updatePoolCandidateStatusParent',
+                [$this->poolCandidate, ['pool_candidate_status' => $screeningStatus]]));
+            $this->assertTrue($this->communityAdminUser->can(
+                'updatePoolCandidateStatusParent',
+                [$this->poolCandidate, ['pool_candidate_status' => $screeningStatus]]));
+        }
+
+        $qualifiedStatuses = [
+            PoolCandidateStatus::QUALIFIED_AVAILABLE->name,
+            PoolCandidateStatus::QUALIFIED_UNAVAILABLE->name,
+            PoolCandidateStatus::QUALIFIED_WITHDREW->name,
+        ];
+        foreach ($qualifiedStatuses as $qualifiedStatus) {
+            $this->assertTrue($this->poolOperatorUser->can(
+                'updatePoolCandidateStatusParent',
+                [$this->poolCandidate, ['pool_candidate_status' => $qualifiedStatus]]));
+            $this->assertTrue($this->processOperatorUser->can(
+                'updatePoolCandidateStatusParent',
+                [$this->poolCandidate, ['pool_candidate_status' => $qualifiedStatus]]));
+            $this->assertTrue($this->communityRecruiterUser->can(
+                'updatePoolCandidateStatusParent',
+                [$this->poolCandidate, ['pool_candidate_status' => $qualifiedStatus]]));
+            $this->assertTrue($this->communityAdminUser->can(
+                'updatePoolCandidateStatusParent',
+                [$this->poolCandidate, ['pool_candidate_status' => $qualifiedStatus]]));
+        }
+
+        // test REMOVED
+        $this->assertTrue($this->poolOperatorUser->can(
+            'updatePoolCandidateStatusParent',
+            [$this->poolCandidate, ['pool_candidate_status' => PoolCandidateStatus::REMOVED->name]]));
+        $this->assertTrue($this->processOperatorUser->can(
+            'updatePoolCandidateStatusParent',
+            [$this->poolCandidate, ['pool_candidate_status' => PoolCandidateStatus::REMOVED->name]]));
+        $this->assertTrue($this->communityRecruiterUser->can(
+            'updatePoolCandidateStatusParent',
+            [$this->poolCandidate, ['pool_candidate_status' => PoolCandidateStatus::REMOVED->name]]));
+        $this->assertTrue($this->communityAdminUser->can(
+            'updatePoolCandidateStatusParent',
+            [$this->poolCandidate, ['pool_candidate_status' => PoolCandidateStatus::REMOVED->name]]));
+    }
+
+    /**
+     * Assert that the policy method handles expiry date input
+     * testing pool operator, process operator, community recruiter, community admin
+     *
+     * @return void
+     */
+    public function testUpdatePoolCandidateStatusParentOnlyExpiry()
+    {
+        // test policy again with just an expiry date
+        $this->assertTrue($this->poolOperatorUser->can(
+            'updatePoolCandidateStatusParent',
+            [$this->poolCandidate, ['expiry_date' => '2000-01-01']]));
+        $this->assertFalse($this->processOperatorUser->can(
+            'updatePoolCandidateStatusParent',
+            [$this->poolCandidate, ['expiry_date' => '2000-01-01']]));
+        $this->assertFalse($this->communityRecruiterUser->can(
+            'updatePoolCandidateStatusParent',
+            [$this->poolCandidate, ['expiry_date' => '2000-01-01']]));
+        $this->assertFalse($this->communityAdminUser->can(
+            'updatePoolCandidateStatusParent',
+            [$this->poolCandidate, ['expiry_date' => '2000-01-01']]));
     }
 }


### PR DESCRIPTION
🤖 Resolves #12480

## 👋 Introduction

Adds a policy method that calls other policy methods in order to allow the mutation to adapt to different input statuses. Being permissive depending on the status passed in, allowing roles like process operator to do more. 

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Test the mutation

Mutation 

```
mutation a {
  updatePoolCandidateStatus(
    id: "id123"
    poolCandidate: {expiryDate: null, status: NEW_APPLICATION}
  ) {
    id
    status {
      value
    }
  }
}
```

