### PR TITLE
[Fix] `AS` classification group education requirements

### DIFF
--- a/apps/web/src/components/EducationRequirements/EducationRequirements.tsx
+++ b/apps/web/src/components/EducationRequirements/EducationRequirements.tsx
@@ -3,6 +3,7 @@ import { HTMLProps, ReactNode } from "react";
 
 import { Link, Heading, HeadingLevel, CardBasic } from "@gc-digital-talent/ui";
 import { getLocale } from "@gc-digital-talent/i18n";
+import { assertUnreachable } from "@gc-digital-talent/helpers";
 
 import applicationMessages from "~/messages/applicationMessages";
 import {
@@ -12,6 +13,7 @@ import {
   foreignDegreeLink,
   postSecondaryLink,
 } from "~/utils/educationUtils";
+import { ClassificationGroup } from "~/types/classificationGroup";
 
 type TextProps = HTMLProps<HTMLParagraphElement>;
 
@@ -65,7 +67,7 @@ const Or = (props: HTMLProps<HTMLDivElement>) => {
 
 interface EducationRequirementsProps {
   isIAP: boolean;
-  classificationGroup?: string;
+  classificationGroup: ClassificationGroup;
   headingAs?: HeadingLevel;
 }
 
@@ -280,7 +282,7 @@ const EducationRequirements = ({
           </CardBasic>
         </Wrapper>
       );
-    default:
+    case "IT":
       return (
         <Wrapper>
           <CardBasic>
@@ -352,6 +354,8 @@ const EducationRequirements = ({
           </CardBasic>
         </Wrapper>
       );
+    default:
+      return assertUnreachable(classificationGroup); // exhaustive switch
   }
 };
 

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -42,11 +42,16 @@ import {
   getSkillLevelName,
 } from "@gc-digital-talent/i18n";
 import { toast } from "@gc-digital-talent/toast";
+import { useLogger } from "@gc-digital-talent/logger";
 
 import { getExperienceSkills } from "~/utils/skillUtils";
 import { getEducationRequirementOptions } from "~/utils/educationUtils";
 import { isIAPPool } from "~/utils/poolUtils";
 import poolCandidateMessages from "~/messages/poolCandidateMessages";
+import {
+  ClassificationGroup,
+  isClassificationGroup,
+} from "~/types/classificationGroup";
 
 import useLabels from "./useLabels";
 import ExperienceCard from "../ExperienceCard/ExperienceCard";
@@ -345,6 +350,7 @@ export const ScreeningDecisionDialog = ({
 }: ScreeningDecisionDialogProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
+  const logger = useLogger();
   const dialogType = useDialogType(
     educationRequirement ? undefined : { type: assessmentStep?.type },
   );
@@ -386,7 +392,16 @@ export const ScreeningDecisionDialog = ({
     getExperienceSkills(unpackMaybes(parsedSnapshot?.experiences), skill)
       .length > 0;
 
-  const classificationGroup = poolCandidate.pool.classification?.group;
+  let classificationGroup: ClassificationGroup;
+
+  if (isClassificationGroup(poolCandidate.pool.classification?.group)) {
+    classificationGroup = poolCandidate.pool.classification?.group;
+  } else {
+    logger.error(
+      `Unexpected classification: ${poolCandidate.pool.classification?.group}`,
+    );
+    classificationGroup = "IT";
+  }
 
   const educationRequirementOption = getEducationRequirementOptions(
     intl,

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
@@ -17,6 +17,7 @@ import {
   EducationRequirementOption,
   Experience,
 } from "@gc-digital-talent/graphql";
+import { useLogger } from "@gc-digital-talent/logger";
 
 import applicationMessages from "~/messages/applicationMessages";
 import { isEducationExperience } from "~/utils/experienceUtils";
@@ -24,6 +25,10 @@ import useRoutes from "~/hooks/useRoutes";
 import { GetPageNavInfo } from "~/types/applicationStep";
 import { ExperienceForDate } from "~/types/experience";
 import { getEducationRequirementOptions } from "~/utils/educationUtils";
+import {
+  ClassificationGroup,
+  isClassificationGroup,
+} from "~/types/classificationGroup";
 
 import useUpdateApplicationMutation from "../useUpdateApplicationMutation";
 import { ApplicationPageProps } from "../ApplicationApi";
@@ -88,6 +93,7 @@ const ApplicationEducation = ({
   const intl = useIntl();
   const locale = getLocale(intl);
   const paths = useRoutes();
+  const logger = useLogger();
   const navigate = useNavigate();
   const { followingPageUrl, currentStepOrdinal, isIAP, classificationGroup } =
     useApplicationContext();
@@ -210,6 +216,15 @@ const ApplicationEducation = ({
     }
   };
 
+  let classificationGroupTyped: ClassificationGroup;
+
+  if (isClassificationGroup(classificationGroup)) {
+    classificationGroupTyped = classificationGroup;
+  } else {
+    logger.error(`Unexpected classification: ${classificationGroup}`);
+    classificationGroupTyped = "IT";
+  }
+
   return (
     <>
       <Heading
@@ -265,7 +280,7 @@ const ApplicationEducation = ({
             items={getEducationRequirementOptions(
               intl,
               locale,
-              classificationGroup,
+              classificationGroupTyped,
               isIAP,
             )}
             rules={{

--- a/apps/web/src/pages/Pools/EditPoolPage/components/EducationRequirementsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/EducationRequirementsSection.tsx
@@ -10,11 +10,16 @@ import {
   getFragment,
   graphql,
 } from "@gc-digital-talent/graphql";
+import { useLogger } from "@gc-digital-talent/logger";
 
 import EducationRequirements from "~/components/EducationRequirements/EducationRequirements";
 import { isInNullState } from "~/validators/process/classification";
 import useToggleSectionInfo from "~/hooks/useToggleSectionInfo";
 import { wrapAbbr } from "~/utils/nameUtils";
+import {
+  ClassificationGroup,
+  isClassificationGroup,
+} from "~/types/classificationGroup";
 
 import { SectionProps } from "../types";
 
@@ -85,7 +90,16 @@ const EducationRequirementsSection = ({
     emptyRequired: isNull, // Not a required field
     fallbackIcon: TagIcon,
   });
-  const classificationGroup = pool.classification?.group;
+  const logger = useLogger();
+
+  let classificationGroup: ClassificationGroup;
+
+  if (isClassificationGroup(pool.classification?.group)) {
+    classificationGroup = pool.classification.group;
+  } else {
+    logger.error(`Unexpected classification: ${pool.classification?.group}`);
+    classificationGroup = "IT";
+  }
   const classificationAbbr = pool.classification
     ? wrapAbbr(
         `${classificationGroup}-${pool.classification.level < 10 ? "0" : ""}${pool.classification.level}`,

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -45,6 +45,7 @@ import {
   FragmentType,
   getFragment,
 } from "@gc-digital-talent/graphql";
+import { useLogger } from "@gc-digital-talent/logger";
 
 import {
   formatClassificationString,
@@ -63,6 +64,10 @@ import ApplicationLink, {
   ApplicationLinkProps,
 } from "~/components/ApplicationLink/ApplicationLink";
 import SkillAccordion from "~/components/PoolSkillAccordion/PoolSkillAccordion";
+import {
+  ClassificationGroup,
+  isClassificationGroup,
+} from "~/types/classificationGroup";
 
 import Text from "./components/Text";
 import DataRow from "./components/DataRow";
@@ -309,6 +314,7 @@ export const PoolPoster = ({
   const intl = useIntl();
   const locale = getLocale(intl);
   const paths = useRoutes();
+  const logger = useLogger();
   const notAvailable = intl.formatMessage(commonMessages.notAvailable);
   const [moreInfoValue, setMoreInfoValue] = useState<string[]>([]);
   const [skillsValue, setSkillsValue] = useState<string[]>([]);
@@ -492,7 +498,14 @@ export const PoolPoster = ({
     },
   };
 
-  const classificationGroup = pool.classification?.group;
+  let classificationGroup: ClassificationGroup;
+
+  if (isClassificationGroup(pool.classification?.group)) {
+    classificationGroup = pool.classification.group;
+  } else {
+    logger.error(`Unexpected classification: ${pool.classification?.group}`);
+    classificationGroup = "IT";
+  }
 
   return (
     <>

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -25,9 +25,11 @@ import {
   WorkStream,
 } from "@gc-digital-talent/graphql";
 import { commonMessages } from "@gc-digital-talent/i18n";
+import { useLogger } from "@gc-digital-talent/logger";
 
 import { FormValues } from "~/types/searchRequest";
 import useRoutes from "~/hooks/useRoutes";
+import { isClassificationGroup } from "~/types/classificationGroup";
 
 import { formValuesToData } from "../utils";
 import { useCandidateCount, useInitialFilters } from "../hooks";
@@ -61,7 +63,14 @@ export const SearchForm = ({
   const intl = useIntl();
   const navigate = useNavigate();
   const paths = useRoutes();
+  const logger = useLogger();
   const { defaultValues, initialFilters } = useInitialFilters();
+
+  classifications.forEach(({ group }) => {
+    if (!isClassificationGroup(group)) {
+      logger.error(`Unexpected classification: ${group}`);
+    }
+  });
 
   const [applicantFilter, setApplicantFilter] =
     useState<ApplicantFilterInput>(initialFilters);

--- a/apps/web/src/types/classificationGroup.ts
+++ b/apps/web/src/types/classificationGroup.ts
@@ -1,1 +1,17 @@
-export type ClassificationGroup = "AS" | "CR" | "EC" | "EX" | "IT" | "PM";
+export const CLASSIFICATION_GROUP = [
+  "AS",
+  "CR",
+  "EC",
+  "EX",
+  "IT",
+  "PM",
+] as const; // List of classification groups that we expect need to be handled.
+
+export type ClassificationGroup = (typeof CLASSIFICATION_GROUP)[number];
+
+export const isClassificationGroup = (x: unknown): x is ClassificationGroup => {
+  return (
+    typeof x === "string" &&
+    CLASSIFICATION_GROUP.includes(x as ClassificationGroup)
+  );
+};

--- a/apps/web/src/types/classificationGroup.ts
+++ b/apps/web/src/types/classificationGroup.ts
@@ -1,0 +1,1 @@
+export type ClassificationGroup = "AS" | "CR" | "EC" | "EX" | "IT" | "PM";

--- a/apps/web/src/utils/educationUtils.tsx
+++ b/apps/web/src/utils/educationUtils.tsx
@@ -198,6 +198,7 @@ export const getEducationRequirementOptions = (
           ),
         },
       ];
+    case "AS":
     case "PM":
       return [
         {

--- a/apps/web/src/utils/educationUtils.tsx
+++ b/apps/web/src/utils/educationUtils.tsx
@@ -6,8 +6,10 @@ import { Locales } from "@gc-digital-talent/i18n";
 import { Link } from "@gc-digital-talent/ui";
 import { Radio } from "@gc-digital-talent/forms";
 import { EducationRequirementOption } from "@gc-digital-talent/graphql";
+import { assertUnreachable } from "@gc-digital-talent/helpers";
 
 import applicationMessages from "~/messages/applicationMessages";
+import { ClassificationGroup } from "~/types/classificationGroup";
 
 export const foreignDegreeLink = (chunks: ReactNode, locale: Locales) => {
   const href =
@@ -93,7 +95,7 @@ const appliedWorkListMessages = (isIAP = false) => [
 export const getEducationRequirementOptions = (
   intl: IntlShape,
   locale: Locales,
-  classificationGroup?: string,
+  classificationGroup: ClassificationGroup,
   isIAP = false,
 ): Radio[] => {
   switch (classificationGroup) {
@@ -278,7 +280,7 @@ export const getEducationRequirementOptions = (
           ),
         },
       ];
-    default:
+    case "IT":
       return [
         {
           value: EducationRequirementOption.AppliedWork,
@@ -350,5 +352,7 @@ export const getEducationRequirementOptions = (
           ),
         },
       ];
+    default:
+      return assertUnreachable(classificationGroup); // exhaustive switch
   }
 };


### PR DESCRIPTION
🤖 Resolves #12495.

## 👋 Introduction

This PR fixes `AS` classification group so that it inherits values from the `PM` classification group. It also adds some type safety with the `ClassificationGroup` type (thanks @petertgiles).

## 🧪 Testing

1. `pnpm build`
2. Create a process with classification set to `AS-03`
3. Navigate to the published process and apply
4. Verify Minimum experience or equivalent education options are the same as on the edit process page (Advertisement information)

## 📸 Screenshots
<img width="1169" alt="Screen Shot 2025-01-15 at 11 55 41" src="https://github.com/user-attachments/assets/9285b33a-88cc-4e7d-8f06-9175c283691e" />
<img width="1168" alt="Screen Shot 2025-01-15 at 11 56 20" src="https://github.com/user-attachments/assets/1a6841f0-16ef-4326-af26-2adf9ba2e205" />
