### PR TITLE
[Feature] Adds `INELIGIBLE` element to `CandidateRemovalReason` enum

### DIFF
--- a/api/app/Enums/CandidateRemovalReason.php
+++ b/api/app/Enums/CandidateRemovalReason.php
@@ -10,6 +10,7 @@ enum CandidateRemovalReason
 
     case REQUESTED_TO_BE_WITHDRAWN;
     case NOT_RESPONSIVE;
+    case INELIGIBLE;
     case OTHER;
 
     public static function getLangFilename(): string

--- a/api/lang/en/candidate_removal_reason.php
+++ b/api/lang/en/candidate_removal_reason.php
@@ -3,5 +3,6 @@
 return [
     'requested_to_be_withdrawn' => 'Candidate has requested to be withdrawn',
     'not_responsive' => 'Candidate is not responsive',
+    'ineligible' => 'Candidate is ineligible',
     'other' => 'Other reason',
 ];

--- a/api/lang/fr/candidate_removal_reason.php
+++ b/api/lang/fr/candidate_removal_reason.php
@@ -3,5 +3,6 @@
 return [
     'requested_to_be_withdrawn' => 'Le candidat a demandé à être retiré',
     'not_responsive' => 'Le candidat ne répond pas',
+    'ineligible' => 'Le candidat est inéligible',
     'other' => 'Autre motif',
 ];

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -2950,6 +2950,7 @@ enum CandidateExpiryFilter {
 enum CandidateRemovalReason {
   REQUESTED_TO_BE_WITHDRAWN
   NOT_RESPONSIVE
+  INELIGIBLE
   OTHER
 }
 

--- a/packages/i18n/src/utils/enum.ts
+++ b/packages/i18n/src/utils/enum.ts
@@ -166,6 +166,7 @@ export function sortCandidateRemovalReason(
     [
       CandidateRemovalReason.RequestedToBeWithdrawn,
       CandidateRemovalReason.NotResponsive,
+      CandidateRemovalReason.Ineligible,
       CandidateRemovalReason.Other,
     ],
     removalReasons,


### PR DESCRIPTION
🤖 Resolves #12500.

## 👋 Introduction

This PR adds `INELIGIBLE` element to the `CandidateRemovalReason` enum.

## 🧪 Testing

1. `make refresh-api; pnpm build:fresh`
2. Login as a user with `platform_admin` role
3. Navigate to a pool candidate `/admin/candidates/:pool-candidate-id/application` without a status of `REMOVED`
4. In the More actions section, click on status link to open dialog
5. Verify **Candidate is ineligible** is the third radio option for **Reason**
6. Submit form
7. Verify no errors

## 📸 Screenshots

<img width="1116" alt="Screen Shot 2025-01-16 at 11 42 38" src="https://github.com/user-attachments/assets/4d6dd9ca-66a2-4496-a175-744cf2a7634a" />

<img width="1066" alt="Screen Shot 2025-01-16 at 11 42 19" src="https://github.com/user-attachments/assets/0c07c691-6f12-4961-8b1e-ccdaabd3afcc" />