### PR TITLE
[Feature] Adds AS-03, AS-05 to `scopeAvailableInSearch`

### DIFF
--- a/api/app/Models/Classification.php
+++ b/api/app/Models/Classification.php
@@ -58,7 +58,7 @@ class Classification extends Model
 
     /**
      * Used to limit the results for the search page input
-     * to IT up to level 5; PM up to level 6; CR level 4; EX level 3, EX level 4.
+     * to IT up to level 5; PM up to level 6; CR level 4; EX level 3, EX level 4; AS level 3, AS level 5.
      *
      * TODO: Update in #9483 to derive from new column
      */
@@ -78,6 +78,10 @@ class Classification extends Model
             $query->where('group', 'EX')->where('level', '=', 3);
         })->orWhere(function ($query) {
             $query->where('group', 'EX')->where('level', '=', 4);
-        });
+        })->orWhere(function ($query) {
+            $query->where('group', 'AS')->where('level', '=', 3);
+        })->orWhere(function ($query) {
+            $query->where('group', 'AS')->where('level', '=', 5);
+    });
     }
 }

--- a/api/app/Models/Classification.php
+++ b/api/app/Models/Classification.php
@@ -82,6 +82,6 @@ class Classification extends Model
             $query->where('group', 'AS')->where('level', '=', 3);
         })->orWhere(function ($query) {
             $query->where('group', 'AS')->where('level', '=', 5);
-    });
+        });
     }
 }

--- a/api/database/seeders/ClassificationSeeder.php
+++ b/api/database/seeders/ClassificationSeeder.php
@@ -90,40 +90,40 @@ class ClassificationSeeder extends Seeder
                 $asGroup,
                 [
                     'level' => 1,
-                    'min_salary' => 43514,
-                    'max_salary' => 49351,
+                    'min_salary' => 61786,
+                    'max_salary' => 69106,
                 ]
             ),
             array_merge(
                 $asGroup,
                 [
                     'level' => 2,
-                    'min_salary' => 48323,
-                    'max_salary' => 53416,
+                    'min_salary' => 68849,
+                    'max_salary' => 74180,
                 ]
             ),
             array_merge(
                 $asGroup,
                 [
                     'level' => 3,
-                    'min_salary' => 53139,
-                    'max_salary' => 56390,
+                    'min_salary' => 73798,
+                    'max_salary' => 79511,
                 ]
             ),
             array_merge(
                 $asGroup,
                 [
                     'level' => 4,
-                    'min_salary' => 56951,
-                    'max_salary' => 61594,
+                    'min_salary' => 79511,
+                    'max_salary' => 87108,
                 ]
             ),
             array_merge(
                 $asGroup,
                 [
                     'level' => 5,
-                    'min_salary' => 67981,
-                    'max_salary' => 73495,
+                    'min_salary' => 96235,
+                    'max_salary' => 104044,
                 ]
             ),
             // https://www.tbs-sct.canada.ca/agreements-conventions/view-visualiser-eng.aspx?id=15#toc44294244301

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1151,6 +1151,10 @@
     "defaultMessage": "Ce programme a été pour moi une occasion de changer ma vie et je vois <b>un meilleur avenir</b>.",
     "description": "testimonial number one"
   },
+  "40Z3LU": {
+    "defaultMessage": "AS-03 : Conseiller(ère) ou analyste",
+    "description": "AS-03 classification label including titles"
+  },
   "436DA5": {
     "defaultMessage": "Croissance",
     "description": "Talent portal strategy item 2 heading"
@@ -6890,6 +6894,10 @@
     "defaultMessage": "Les renseignements personnels recueillis par le truchement de Talents numériques du GC sont décrits dans le fichier de <personalInfoLink>renseignements personnels du Nuage de talents (SCT PPU 095)</personalInfoLink>.",
     "description": "Paragraph for privacy policy page"
   },
+  "XZ8zbg": {
+    "defaultMessage": "Conseiller(ère) ou analyste A S 3",
+    "description": "AS-03 classification aria label including titles"
+  },
   "XcS2q2": {
     "defaultMessage": "Rôle retiré avec succès",
     "description": "Message displayed to user when a role has been removed from a user"
@@ -8638,6 +8646,10 @@
     "defaultMessage": "Rapports obligatoires",
     "description": "Heading for section for the downloadable forms section"
   },
+  "g7zCg/": {
+    "defaultMessage": "AS-05 : Conseiller(ère) principal(e) ou analyste",
+    "description": "AS-05 classification label including titles"
+  },
   "g8Ur9z": {
     "defaultMessage": "Renseignements personnels",
     "description": "applicant dashboard card title for profile card"
@@ -10077,6 +10089,10 @@
   "n92mcX": {
     "defaultMessage": "Responsables de l’approvisionnement",
     "description": "Title for procurement officer resource card"
+  },
+  "n9Q5yf": {
+    "defaultMessage": "Conseiller(ère) principal(e) ou analyste A S 5",
+    "description": "AS-05 classification aria label including titles"
   },
   "n9YPWe": {
     "defaultMessage": "Statut du bassin",

--- a/apps/web/src/pages/SearchRequests/SearchPage/labels.ts
+++ b/apps/web/src/pages/SearchRequests/SearchPage/labels.ts
@@ -72,6 +72,16 @@ export const classificationLabels: Record<string, MessageDescriptor> =
       id: "GwhSUZ",
       description: "EX-04 classification label including titles",
     },
+    "AS-03": {
+      defaultMessage: "AS-03: Advisor or Analyst",
+      id: "40Z3LU",
+      description: "AS-03 classification label including titles",
+    },
+    "AS-05": {
+      defaultMessage: "AS-05: Senior Advisor or Analyst",
+      id: "g7zCg/",
+      description: "AS-05 classification label including titles",
+    },
   });
 
 export const classificationAriaLabels: Record<string, MessageDescriptor> =
@@ -145,5 +155,15 @@ export const classificationAriaLabels: Record<string, MessageDescriptor> =
       defaultMessage: "Digital Leader E X 4",
       id: "EbG039",
       description: "EX-04 classification aria label including titles",
+    },
+    "AS-03": {
+      defaultMessage: "Advisor or Analyst A S 3",
+      id: "XZ8zbg",
+      description: "AS-03 classification aria label including titles",
+    },
+    "AS-05": {
+      defaultMessage: "Senior Advisor or Analyst A S 5",
+      id: "n9Q5yf",
+      description: "AS-05 classification aria label including titles",
     },
   });


### PR DESCRIPTION
🤖 Resolves #12498.

## 👋 Introduction

This PR adds AS-03 and AS-05 to `scopeAvailableInSearch` so that they are available as options in the classification filter of the search for talent form.

> [!NOTE]
> AS-01 to AS-05 min and max salaries were update to current levels in `ClassificationSeeder`.

## 🧪 Testing

1. Navigate to http://localhost:8000/en/search
2. Verify AS-03 and AS-05 are options with English job titles in classification filter select
3. Switch to French
4. Verify AS-03 and AS-05 are options with French job titles in classification filter select

## 📸 Screenshots


<img width="1265" alt="Screen Shot 2025-01-16 at 12 21 44" src="https://github.com/user-attachments/assets/21f94402-be07-4bb9-a0c4-3f526bc08827" />
<img width="1258" alt="Screen Shot 2025-01-16 at 12 22 10" src="https://github.com/user-attachments/assets/bb9a73e5-76fc-4b0b-857f-6054ff386a65" />
