### PR TITLE
[Feature] Community interest dialog

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -165,7 +165,6 @@ type CommunityInterest {
 type DevelopmentProgramInterest {
   id: UUID!
   developmentProgram: DevelopmentProgram! @belongsTo
-  communityInterest: CommunityInterest! @belongsTo
   participationStatus: DevelopmentProgramParticipationStatus
     @rename(attribute: "participation_status")
   completionDate: Date @rename(attribute: "completion_date")
@@ -559,6 +558,7 @@ type Community implements HasRoleAssignments {
   pools: [Pool]
     @hasMany(scopes: ["authorizedToView"])
     @canResolved(ability: "view")
+  workStreams: [WorkStream!] @hasMany
   developmentPrograms: [DevelopmentProgram!] @hasMany
 }
 

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -662,7 +662,6 @@ type CommunityInterest {
 type DevelopmentProgramInterest {
   id: UUID!
   developmentProgram: DevelopmentProgram!
-  communityInterest: CommunityInterest!
   participationStatus: DevelopmentProgramParticipationStatus
   completionDate: Date
 }
@@ -972,6 +971,7 @@ type Community implements HasRoleAssignments {
   roleAssignments: [RoleAssignment!]
   teamIdForRoleAssignment: ID
   pools: [Pool]
+  workStreams: [WorkStream!]
   developmentPrograms: [DevelopmentProgram!]
 }
 

--- a/apps/web/src/components/CommunityInterestDialog/BoolCheckIcon.tsx
+++ b/apps/web/src/components/CommunityInterestDialog/BoolCheckIcon.tsx
@@ -1,0 +1,50 @@
+import XCircleIcon from "@heroicons/react/20/solid/XCircleIcon";
+import CheckCircleIcon from "@heroicons/react/20/solid/CheckCircleIcon";
+import { ReactNode } from "react";
+
+import { Maybe } from "@gc-digital-talent/graphql";
+
+type DivProps = React.ComponentPropsWithoutRef<"div">;
+
+interface BoolCheckIconProps extends DivProps {
+  value?: Maybe<boolean>;
+  trueLabel?: string;
+  falseLabel?: string;
+  children: ReactNode;
+}
+
+const BoolCheckIcon = ({
+  value,
+  trueLabel,
+  falseLabel,
+  children,
+  ...rest
+}: BoolCheckIconProps) => {
+  const Icon = value ? CheckCircleIcon : XCircleIcon;
+
+  return (
+    <div
+      data-h2-display="base(flex)"
+      data-h2-align-items="base(center)"
+      data-h2-gap="base(x.25)"
+      {...rest}
+    >
+      <Icon
+        data-h2-width="base(x.75)"
+        data-h2-height="base(x.75)"
+        {...(value
+          ? {
+              "aria-label": trueLabel,
+              "data-h2-color": "base(success) base:dark(success.lighter)",
+            }
+          : {
+              "aria-label": falseLabel,
+              "data-h2-color": "base(gray.lighter)",
+            })}
+      />
+      <span>{children}</span>
+    </div>
+  );
+};
+
+export default BoolCheckIcon;

--- a/apps/web/src/components/CommunityInterestDialog/CommunityInterestDialog.stories.tsx
+++ b/apps/web/src/components/CommunityInterestDialog/CommunityInterestDialog.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { OverlayOrDialogDecorator } from "@gc-digital-talent/storybook-helpers";
+import { makeFragmentData } from "@gc-digital-talent/graphql";
+import { fakeCommunityInterests } from "@gc-digital-talent/fake-data";
+
+import CommunityInterestDialog, {
+  CommunityInterestDialog_Fragment,
+} from "./CommunityInterestDialog";
+
+const meta = {
+  component: CommunityInterestDialog,
+  decorators: [OverlayOrDialogDecorator],
+} satisfies Meta<typeof CommunityInterestDialog>;
+
+export default meta;
+
+const mockCommunityInterests = fakeCommunityInterests(1);
+const communityInterestQuery = makeFragmentData(
+  mockCommunityInterests[0],
+  CommunityInterestDialog_Fragment,
+);
+
+export const Default: StoryObj<typeof CommunityInterestDialog> = {
+  render: () => (
+    <CommunityInterestDialog
+      communityInterestQuery={communityInterestQuery}
+      defaultOpen
+    />
+  ),
+};

--- a/apps/web/src/components/CommunityInterestDialog/CommunityInterestDialog.tsx
+++ b/apps/web/src/components/CommunityInterestDialog/CommunityInterestDialog.tsx
@@ -1,0 +1,232 @@
+import { ReactNode, useState } from "react";
+import { useIntl } from "react-intl";
+
+import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
+import { commonMessages } from "@gc-digital-talent/i18n";
+import { Button, Dialog, Link, Separator } from "@gc-digital-talent/ui";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
+
+import useRoutes from "~/hooks/useRoutes";
+
+import BoolCheckIcon from "./BoolCheckIcon";
+
+export const CommunityInterestDialog_Fragment = graphql(/* GraphQL */ `
+  fragment CommunityInterestDialog on CommunityInterest {
+    id
+    community {
+      workStreams {
+        id
+        name {
+          localized
+        }
+      }
+      name {
+        localized
+      }
+    }
+    workStreams {
+      id
+    }
+    interestInDevelopmentPrograms {
+      developmentProgram {
+        name {
+          localized
+        }
+      }
+      participationStatus
+      completionDate
+    }
+    jobInterest
+    trainingInterest
+    additionalInformation
+  }
+`);
+
+interface CommunityInterestDialogProps {
+  communityInterestQuery: FragmentType<typeof CommunityInterestDialog_Fragment>;
+  trigger?: ReactNode;
+  defaultOpen?: boolean;
+}
+
+const CommunityInterestDialog = ({
+  communityInterestQuery,
+  trigger,
+  defaultOpen = false,
+}: CommunityInterestDialogProps) => {
+  const intl = useIntl();
+  const paths = useRoutes();
+  const [isOpen, setOpen] = useState<boolean>(defaultOpen);
+  const communityInterest = getFragment(
+    CommunityInterestDialog_Fragment,
+    communityInterestQuery,
+  );
+  const notAvailable = intl.formatMessage(commonMessages.notAvailable);
+  const title = communityInterest.community?.name?.localized ?? notAvailable;
+  const communityWorkStreams = unpackMaybes(
+    communityInterest.community.workStreams,
+  );
+  const interestedWorkStreams = unpackMaybes(
+    communityInterest?.workStreams,
+  ).flatMap((workStream) => workStream.id);
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={setOpen}>
+      <Dialog.Trigger>{trigger || <Button>{title}</Button>}</Dialog.Trigger>
+      <Dialog.Content hasSubtitle>
+        <Dialog.Header
+          subtitle={intl.formatMessage({
+            defaultMessage: "View and edit settings for this community.",
+            id: "ZxGa7h",
+            description: "Subtitle for dialog viewing a community interest",
+          })}
+        >
+          {title}
+        </Dialog.Header>
+        <Dialog.Body>
+          <p data-h2-font-weight="base(700)" data-h2-margin-bottom="base(x.25)">
+            {intl.formatMessage({
+              defaultMessage: "Interest in job opportunities",
+              id: "dYsXAU",
+              description:
+                "Label for users interest in job opportunities for a community",
+            })}
+          </p>
+          <BoolCheckIcon
+            value={communityInterest.jobInterest}
+            data-h2-margin-bottom="base(x1)"
+          >
+            {communityInterest.jobInterest
+              ? intl.formatMessage({
+                  defaultMessage: "Interested in work",
+                  id: "2L5LBG",
+                  description:
+                    "Message displayed when user expresses interest in job opportunities",
+                })
+              : intl.formatMessage({
+                  defaultMessage: "Not interested in work",
+                  id: "szxveb",
+                  description:
+                    "Message displayed when a user has expressed they are not interested in job opportunities",
+                })}
+          </BoolCheckIcon>
+          <p data-h2-font-weight="base(700)" data-h2-margin-bottom="base(x.25)">
+            {intl.formatMessage({
+              defaultMessage: "Interest in training opportunities",
+              id: "9whw8l",
+              description:
+                "Label for users interest in training opportunities for a community",
+            })}
+          </p>
+          <BoolCheckIcon
+            value={communityInterest.trainingInterest}
+            data-h2-margin-bottom="base(x1)"
+          >
+            {communityInterest.trainingInterest
+              ? intl.formatMessage({
+                  defaultMessage: "Interested in training",
+                  id: "PV+iaB",
+                  description:
+                    "Message displayed when user expresses interest in training opportunities",
+                })
+              : intl.formatMessage({
+                  defaultMessage: "Not interested in training",
+                  id: "m6NZda",
+                  description:
+                    "Message displayed when a user has expressed they are not interested in training opportunities",
+                })}
+          </BoolCheckIcon>
+          <p
+            data-h2-color="base(black.light)"
+            data-h2-font-size="base(caption)"
+            data-h2-margin-bottom="base(x1)"
+          >
+            {intl.formatMessage({
+              defaultMessage:
+                "* Note that by indicating you’re interested in jobs or training opportunities, you agree to share your profile information with Government of Canada HR and recruitment staff within this community.",
+              id: "EJPdqH",
+              description:
+                "Footnote for more information on interest in job and training opportunities",
+            })}
+          </p>
+          {communityWorkStreams.length > 0 && (
+            <>
+              <p
+                data-h2-font-weight="base(700)"
+                data-h2-margin-bottom="base(x.25)"
+              >
+                {intl.formatMessage({
+                  defaultMessage:
+                    "Preferred work streams for job opportunities",
+                  id: "Nq3XrT",
+                  description:
+                    "Label for users interest in training opportunities for a community",
+                })}
+              </p>
+              <ul
+                data-h2-list-style="base(none)"
+                data-h2-padding-left="base(0)"
+              >
+                {communityWorkStreams.map((workStream) => (
+                  <li
+                    key={workStream.id}
+                    data-h2-display="base(flex)"
+                    data-h2-align-items="base(flex-start)"
+                    data-h2-gap="base(x.25)"
+                  >
+                    <BoolCheckIcon
+                      value={interestedWorkStreams.includes(workStream.id)}
+                      trueLabel={intl.formatMessage({
+                        defaultMessage: "Interested in",
+                        id: "AQiPuW",
+                        description:
+                          "Label for user expressing interest in a specific work stream",
+                      })}
+                      falseLabel={intl.formatMessage({
+                        defaultMessage: "Not interested in",
+                        id: "KyLikL",
+                        description:
+                          "Label for user expressing they are not interested in a specific work stream",
+                      })}
+                    >
+                      {workStream.name?.localized ?? notAvailable}
+                    </BoolCheckIcon>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+          <Separator orientation="horizontal" decorative space="sm" />
+          <p data-h2-font-weight="base(700)" data-h2-margin-bottom="base(x.25)">
+            {intl.formatMessage({
+              defaultMessage: "Additional information",
+              id: "NCMG9w",
+              description:
+                "Label for a community interests additional information",
+            })}
+          </p>
+          <p>{communityInterest?.additionalInformation ?? notAvailable}</p>
+          <Dialog.Footer>
+            <Link
+              mode="solid"
+              color="secondary"
+              href={paths.communityInterest(communityInterest.id)}
+            >
+              {intl.formatMessage({
+                defaultMessage: "Edit this community",
+                id: "zpr5ny",
+                description: "Link text for edit interest in a community",
+              })}
+            </Link>
+            <Dialog.Close>
+              <Button mode="inline" color="quaternary">
+                {intl.formatMessage(commonMessages.cancel)}
+              </Button>
+            </Dialog.Close>
+          </Dialog.Footer>
+        </Dialog.Body>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+};
+
+export default CommunityInterestDialog;

--- a/apps/web/src/components/CommunityInterestDialog/CommunityInterestDialog.tsx
+++ b/apps/web/src/components/CommunityInterestDialog/CommunityInterestDialog.tsx
@@ -9,12 +9,19 @@ import { unpackMaybes } from "@gc-digital-talent/helpers";
 import useRoutes from "~/hooks/useRoutes";
 
 import BoolCheckIcon from "./BoolCheckIcon";
+import DevelopmentProgramInterestItem from "./DevelopmentProgramInterestItem";
 
 export const CommunityInterestDialog_Fragment = graphql(/* GraphQL */ `
   fragment CommunityInterestDialog on CommunityInterest {
     id
     community {
       workStreams {
+        id
+        name {
+          localized
+        }
+      }
+      developmentPrograms {
         id
         name {
           localized
@@ -29,12 +36,9 @@ export const CommunityInterestDialog_Fragment = graphql(/* GraphQL */ `
     }
     interestInDevelopmentPrograms {
       developmentProgram {
-        name {
-          localized
-        }
+        id
       }
-      participationStatus
-      completionDate
+      ...CommunityInterestDialogDevelopmentProgramInterest
     }
     jobInterest
     trainingInterest
@@ -64,6 +68,9 @@ const CommunityInterestDialog = ({
   const title = communityInterest.community?.name?.localized ?? notAvailable;
   const communityWorkStreams = unpackMaybes(
     communityInterest.community.workStreams,
+  );
+  const communityDevelopmentPrograms = unpackMaybes(
+    communityInterest?.community.developmentPrograms,
   );
   const interestedWorkStreams = unpackMaybes(
     communityInterest?.workStreams,
@@ -196,6 +203,45 @@ const CommunityInterestDialog = ({
             </>
           )}
           <Separator orientation="horizontal" decorative space="sm" />
+          {communityDevelopmentPrograms.length > 0 && (
+            <>
+              <p
+                data-h2-font-weight="base(700)"
+                data-h2-margin-bottom="base(x.25)"
+              >
+                {intl.formatMessage({
+                  defaultMessage:
+                    "Leadership and professional development options",
+                  id: "UfwS5s",
+                  description:
+                    "Label for users interest in development programs for a community",
+                })}
+              </p>
+              <ul
+                data-h2-list-style="base(none)"
+                data-h2-padding-left="base(0)"
+              >
+                {communityDevelopmentPrograms.map((developmentProgram) => {
+                  const interestedProgram =
+                    communityInterest?.interestInDevelopmentPrograms?.find(
+                      (interest) =>
+                        interest?.developmentProgram?.id ===
+                        developmentProgram.id,
+                    );
+                  return (
+                    <DevelopmentProgramInterestItem
+                      key={developmentProgram.id}
+                      developmentProgramInterestQuery={interestedProgram}
+                      label={
+                        developmentProgram?.name?.localized ?? notAvailable
+                      }
+                    />
+                  );
+                })}
+              </ul>
+              <Separator orientation="horizontal" decorative space="sm" />
+            </>
+          )}
           <p data-h2-font-weight="base(700)" data-h2-margin-bottom="base(x.25)">
             {intl.formatMessage({
               defaultMessage: "Additional information",

--- a/apps/web/src/components/CommunityInterestDialog/DevelopmentProgramInterestItem.tsx
+++ b/apps/web/src/components/CommunityInterestDialog/DevelopmentProgramInterestItem.tsx
@@ -1,0 +1,160 @@
+import { useIntl } from "react-intl";
+import CheckCircleIcon from "@heroicons/react/20/solid/CheckCircleIcon";
+import ExclamationCircleIcon from "@heroicons/react/20/solid/ExclamationCircleIcon";
+import PlayCircleIcon from "@heroicons/react/20/solid/PlayCircleIcon";
+import PauseCircleIcon from "@heroicons/react/20/solid/PauseCircleIcon";
+import XCircleIcon from "@heroicons/react/20/solid/XCircleIcon";
+
+import {
+  DevelopmentProgramParticipationStatus,
+  FragmentType,
+  getFragment,
+  graphql,
+  Maybe,
+} from "@gc-digital-talent/graphql";
+import { commonMessages } from "@gc-digital-talent/i18n";
+import { IconType } from "@gc-digital-talent/ui";
+
+interface StatusInfo {
+  Icon: IconType;
+  iconStyles: Record<string, string>;
+  message: string;
+}
+
+const useStatusInfo = (
+  status?: Maybe<DevelopmentProgramParticipationStatus>,
+  completionDate?: Maybe<string>,
+): StatusInfo => {
+  const intl = useIntl();
+
+  const defaultStatusInfo = {
+    Icon: ExclamationCircleIcon,
+    iconStyles: {
+      "data-h2-color": "base(error)",
+    },
+    message: intl.formatMessage(commonMessages.missingInformation),
+  };
+  if (!status || !completionDate) {
+    return defaultStatusInfo;
+  }
+
+  const infoMap = new Map<DevelopmentProgramParticipationStatus, StatusInfo>([
+    [
+      DevelopmentProgramParticipationStatus.Interested,
+      {
+        Icon: PlayCircleIcon,
+        iconStyles: { "data-h2-color": "base(primary)" },
+        message: intl.formatMessage({
+          defaultMessage: "Interested in this program",
+          id: "djZmfA",
+          description:
+            "Message diaplayed when a user is interested in a development program",
+        }),
+      },
+    ],
+    [
+      DevelopmentProgramParticipationStatus.NotInterested,
+      {
+        Icon: XCircleIcon,
+        iconStyles: { "data-h2-color": "base(gray.lighter)" },
+        message: intl.formatMessage({
+          defaultMessage: "Interested in this program",
+          id: "djZmfA",
+          description:
+            "Message diaplayed when a user is interested in a development program",
+        }),
+      },
+    ],
+    [
+      DevelopmentProgramParticipationStatus.Enrolled,
+      {
+        Icon: PauseCircleIcon,
+        iconStyles: { "data-h2-color": "base(primary)" },
+        message: intl.formatMessage({
+          defaultMessage: "Interested in this program",
+          id: "djZmfA",
+          description:
+            "Message diaplayed when a user is interested in a development program",
+        }),
+      },
+    ],
+    [
+      DevelopmentProgramParticipationStatus.Completed,
+      {
+        Icon: CheckCircleIcon,
+        iconStyles: { "data-h2-color": "base(success)" },
+        message: intl.formatMessage({
+          defaultMessage: "Interested in this program",
+          id: "djZmfA",
+          description:
+            "Message diaplayed when a user is interested in a development program",
+        }),
+      },
+    ],
+  ]);
+
+  return infoMap.get(status) ?? defaultStatusInfo;
+};
+
+const CommunityInterestDialogDevelopmentProgram_Fragment = graphql(
+  /* GraphQL */ `
+    fragment CommunityInterestDialogDevelopmentProgramInterest on DevelopmentProgramInterest {
+      participationStatus
+      completionDate
+    }
+  `,
+);
+
+interface DevelopopmentProgramInterestItemProps {
+  label: string;
+  developmentProgramInterestQuery?: FragmentType<
+    typeof CommunityInterestDialogDevelopmentProgram_Fragment
+  >;
+}
+
+const DevelopopmentProgramInterestItem = ({
+  label,
+  developmentProgramInterestQuery,
+}: DevelopopmentProgramInterestItemProps) => {
+  const developmentProgramInterest = getFragment(
+    CommunityInterestDialogDevelopmentProgram_Fragment,
+    developmentProgramInterestQuery,
+  );
+  const { Icon, iconStyles, message } = useStatusInfo(
+    developmentProgramInterest?.participationStatus,
+    developmentProgramInterest?.completionDate,
+  );
+
+  return (
+    <li
+      data-h2-display="base(flex)"
+      data-h2-gap="base(x.25)"
+      data-h2-align-items="base(flex-start)"
+      data-h2-margin-bottom="base(x.25)"
+    >
+      <Icon
+        data-h2-width="base(x.75)"
+        data-h2-height="base(x.75)"
+        {...iconStyles}
+      />
+      <span data-h2-display="base(flex)" data-h2-flex-direction="base(column)">
+        <span data-h2-line-height="base(1)">{label}</span>
+        <span
+          data-h2-font-size="base(caption)"
+          {...(!developmentProgramInterest?.participationStatus ||
+          !developmentProgramInterest?.completionDate
+            ? {
+                "data-h2-color": "base(error)",
+              }
+            : {
+                "data-h2-color": "base(black.light))",
+              })}
+        >
+          {message}
+        </span>
+      </span>
+    </li>
+  );
+};
+
+export default DevelopopmentProgramInterestItem;

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -256,6 +256,10 @@ const getRoutes = (lang: Locales) => {
     createExperience: () =>
       [applicantUrl, "career-timeline", "create"].join("/"),
 
+    // Community interests
+    communityInterest: (communityInterestId: string) =>
+      `${applicantUrl}/community-interests/${communityInterestId}`,
+
     // Profile and Applications
     profileAndApplications: (opts?: {
       fromIapDraft?: boolean;

--- a/packages/fake-data/src/fakeCommunities.ts
+++ b/packages/fake-data/src/fakeCommunities.ts
@@ -1,19 +1,35 @@
 import { faker } from "@faker-js/faker/locale/en";
 
-import { Community } from "@gc-digital-talent/graphql";
+import {
+  Community,
+  DevelopmentProgram,
+  WorkStream,
+} from "@gc-digital-talent/graphql";
 
 import toLocalizedString from "./fakeLocalizedString";
+import fakeWorkStreams from "./fakeWorkStreams";
+import fakeDevelopmentPrograms from "./fakeDevelopmentPrograms";
 
-const generateCommunity = (): Community => {
+const generateCommunity = (
+  developmentPrograms: DevelopmentProgram[],
+  workStreams: WorkStream[],
+): Community => {
   return {
     id: faker.string.uuid(),
     key: faker.helpers.slugify(faker.lorem.word()),
     name: toLocalizedString(faker.company.name()),
     description: toLocalizedString(faker.lorem.paragraph()),
+    developmentPrograms:
+      faker.helpers.arrayElements<DevelopmentProgram>(developmentPrograms),
+    workStreams: faker.helpers.arrayElements<WorkStream>(workStreams),
   };
 };
 
 export default (numToGenerate = 10): Community[] => {
   faker.seed(0); // repeatable results
-  return Array.from({ length: numToGenerate }, () => generateCommunity());
+  const developmentPrograms = fakeDevelopmentPrograms();
+  const workStreams = fakeWorkStreams();
+  return Array.from({ length: numToGenerate }, () =>
+    generateCommunity(developmentPrograms, workStreams),
+  );
 };

--- a/packages/fake-data/src/fakeCommunityInterests.ts
+++ b/packages/fake-data/src/fakeCommunityInterests.ts
@@ -1,0 +1,51 @@
+import { faker } from "@faker-js/faker/locale/en";
+
+import {
+  Community,
+  CommunityInterest,
+  DevelopmentProgram,
+  DevelopmentProgramParticipationStatus,
+  WorkStream,
+} from "@gc-digital-talent/graphql";
+import { FAR_PAST_DATE } from "@gc-digital-talent/date-helpers";
+
+import fakeCommunities from "./fakeCommunities";
+
+const generateCommunityInterest = (
+  communities: Community[],
+): CommunityInterest => {
+  const community = faker.helpers.arrayElement<Community>(communities);
+  const workStreams = faker.helpers.arrayElements<WorkStream>(
+    community.workStreams ?? [],
+  );
+  const interestedDevelopmentPrograms =
+    faker.helpers.arrayElements<DevelopmentProgram>(
+      community?.developmentPrograms ?? [],
+    );
+  return {
+    id: faker.string.uuid(),
+    community,
+    workStreams,
+    jobInterest: faker.datatype.boolean(),
+    trainingInterest: faker.datatype.boolean(),
+    additionalInformation: faker.lorem.paragraph(),
+    interestInDevelopmentPrograms: interestedDevelopmentPrograms.map(
+      (developmentProgram) => ({
+        id: faker.string.uuid(),
+        developmentProgram,
+        completionDate: FAR_PAST_DATE,
+        participationStatus: faker.helpers.arrayElement(
+          Object.values(DevelopmentProgramParticipationStatus),
+        ),
+      }),
+    ),
+  };
+};
+
+export default (numToGenerate = 10): CommunityInterest[] => {
+  faker.seed(0); // repeatable results
+  const communities = fakeCommunities();
+  return Array.from({ length: numToGenerate }, () =>
+    generateCommunityInterest(communities),
+  );
+};

--- a/packages/fake-data/src/fakeDevelopmentPrograms.ts
+++ b/packages/fake-data/src/fakeDevelopmentPrograms.ts
@@ -1,0 +1,19 @@
+import { faker } from "@faker-js/faker/locale/en";
+
+import { DevelopmentProgram } from "@gc-digital-talent/graphql";
+
+import toLocalizedString from "./fakeLocalizedString";
+
+const generateDevelopmentProgram = (): DevelopmentProgram => {
+  return {
+    id: faker.string.uuid(),
+    name: toLocalizedString(faker.company.name()),
+  };
+};
+
+export default (numToGenerate = 10): DevelopmentProgram[] => {
+  faker.seed(0); // repeatable results
+  return Array.from({ length: numToGenerate }, () =>
+    generateDevelopmentProgram(),
+  );
+};

--- a/packages/fake-data/src/fakeLocalizedString.ts
+++ b/packages/fake-data/src/fakeLocalizedString.ts
@@ -4,6 +4,7 @@ const toLocalizedString = (base: string): LocalizedString => {
   return {
     en: `${base} EN`,
     fr: `${base} FR`,
+    localized: `${base} LOCALIZED`,
   };
 };
 

--- a/packages/fake-data/src/index.ts
+++ b/packages/fake-data/src/index.ts
@@ -2,6 +2,7 @@ import fakeAssessmentResults from "./fakeAssessmentResults";
 import fakeAssessmentSteps from "./fakeAssessmentSteps";
 import fakeClassifications from "./fakeClassifications";
 import fakeCommunities from "./fakeCommunities";
+import fakeCommunityInterests from "./fakeCommunityInterests";
 import fakeDepartments from "./fakeDepartments";
 import fakeExperiences, { experienceGenerators } from "./fakeExperiences";
 import toLocalizedEnum, { fakeLocalizedEnum } from "./fakeLocalizedEnum";
@@ -25,6 +26,7 @@ export {
   fakeAssessmentSteps,
   fakeClassifications,
   fakeCommunities,
+  fakeCommunityInterests,
   fakeDepartments,
   fakeExperiences,
   fakePools,

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -68,6 +68,11 @@ const commonMessages = defineMessages({
     id: "euigxa",
     description: "Sentence when some form of information not provided",
   },
+  missingInformation: {
+    defaultMessage: "Missing information",
+    id: "MuM7SN",
+    description: "Message for when specific item has missing information",
+  },
   nameNotLoaded: {
     defaultMessage: "Error: name not loaded",
     id: "DdOEWx",


### PR DESCRIPTION
🤖 Resolves #12285 

## 👋 Introduction

Adds a dialog component to view community interests.

## 🕵️ Details

This does not include the alert for missing information, that has been pushed until we need it.

## 🧪 Testing

1. Start storybook `pnpm run storybook`
2. Navigate to the `CommunityInterestDialog`
3. Confirm it matches the mock up

## 📸 Screenshot

![2025-01-16_15-54](https://github.com/user-attachments/assets/e9885e20-d982-4068-9768-1b1b32b9052b)
