### PR TITLE
[Fix] Turn off autocomplete for resource name fields

### DIFF
--- a/apps/web/src/pages/Classifications/CreateClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/CreateClassificationPage.tsx
@@ -130,6 +130,7 @@ export const CreateClassification = () => {
                   <Input
                     id="name_en"
                     name="name.en"
+                    autoComplete="off"
                     label={intl.formatMessage(adminMessages.nameEn)}
                     type="text"
                     rules={{
@@ -139,6 +140,7 @@ export const CreateClassification = () => {
                   <Input
                     id="name_fr"
                     name="name.fr"
+                    autoComplete="off"
                     label={intl.formatMessage(adminMessages.nameFr)}
                     type="text"
                     rules={{

--- a/apps/web/src/pages/Classifications/UpdateClassificationPage.tsx
+++ b/apps/web/src/pages/Classifications/UpdateClassificationPage.tsx
@@ -193,6 +193,7 @@ export const UpdateClassificationForm = ({
                 <Input
                   id="name_en"
                   name="name.en"
+                  autoComplete="off"
                   label={intl.formatMessage(adminMessages.nameEn)}
                   type="text"
                   rules={{
@@ -202,6 +203,7 @@ export const UpdateClassificationForm = ({
                 <Input
                   id="name_fr"
                   name="name.fr"
+                  autoComplete="off"
                   label={intl.formatMessage(adminMessages.nameFr)}
                   type="text"
                   rules={{

--- a/apps/web/src/pages/Communities/CreateCommunityPage/components/CreateCommunityForm.tsx
+++ b/apps/web/src/pages/Communities/CreateCommunityPage/components/CreateCommunityForm.tsx
@@ -116,6 +116,7 @@ const CreateCommunityForm = ({ onSubmit }: CreateCommunityFormProps) => {
             id="name.en"
             label={intl.formatMessage(adminMessages.nameEn)}
             name="name.en"
+            autoComplete="off"
             type="text"
             rules={{
               required: intl.formatMessage(errorMessages.required),
@@ -125,6 +126,7 @@ const CreateCommunityForm = ({ onSubmit }: CreateCommunityFormProps) => {
             id="name.fr"
             label={intl.formatMessage(adminMessages.nameFr)}
             name="name.fr"
+            autoComplete="off"
             type="text"
             rules={{
               required: intl.formatMessage(errorMessages.required),

--- a/apps/web/src/pages/Communities/UpdateCommunityPage/UpdateCommunityPage.tsx
+++ b/apps/web/src/pages/Communities/UpdateCommunityPage/UpdateCommunityPage.tsx
@@ -170,6 +170,7 @@ const CommunityForm = ({
             <Input
               id="nameEn"
               name="nameEn"
+              autoComplete="off"
               label={intl.formatMessage(adminMessages.nameEn)}
               type="text"
               rules={{
@@ -179,6 +180,7 @@ const CommunityForm = ({
             <Input
               id="nameFr"
               name="nameFr"
+              autoComplete="off"
               label={intl.formatMessage(adminMessages.nameFr)}
               type="text"
               rules={{

--- a/apps/web/src/pages/Departments/CreateDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/CreateDepartmentPage.tsx
@@ -98,6 +98,7 @@ export const CreateDepartmentForm = ({
             <Input
               id="name_en"
               name="name.en"
+              autoComplete="off"
               label={intl.formatMessage(adminMessages.nameEn)}
               type="text"
               rules={{
@@ -107,6 +108,7 @@ export const CreateDepartmentForm = ({
             <Input
               id="name_fr"
               name="name.fr"
+              autoComplete="off"
               label={intl.formatMessage(adminMessages.nameFr)}
               type="text"
               rules={{

--- a/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
@@ -134,6 +134,7 @@ export const UpdateDepartmentForm = ({
             <Input
               id="name_en"
               name="name.en"
+              autoComplete="off"
               label={intl.formatMessage(adminMessages.nameEn)}
               type="text"
               rules={{
@@ -143,6 +144,7 @@ export const UpdateDepartmentForm = ({
             <Input
               id="name_fr"
               name="name.fr"
+              autoComplete="off"
               label={intl.formatMessage(adminMessages.nameFr)}
               type="text"
               rules={{

--- a/apps/web/src/pages/SkillFamilies/CreateSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/CreateSkillFamilyPage.tsx
@@ -184,6 +184,7 @@ export const CreateSkillFamily = ({ skills }: CreateSkillFamilyProps) => {
                   <Input
                     id="name_en"
                     name="name.en"
+                    autoComplete="off"
                     label={intl.formatMessage(adminMessages.nameEn)}
                     type="text"
                     rules={{
@@ -193,6 +194,7 @@ export const CreateSkillFamily = ({ skills }: CreateSkillFamilyProps) => {
                   <Input
                     id="name_fr"
                     name="name.fr"
+                    autoComplete="off"
                     label={intl.formatMessage(adminMessages.nameFr)}
                     type="text"
                     rules={{

--- a/apps/web/src/pages/SkillFamilies/UpdateSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/UpdateSkillFamilyPage.tsx
@@ -269,6 +269,7 @@ export const UpdateSkillFamily = ({
                 <Input
                   id="name_en"
                   name="name.en"
+                  autoComplete="off"
                   label={intl.formatMessage(adminMessages.nameEn)}
                   type="text"
                   rules={{
@@ -278,6 +279,7 @@ export const UpdateSkillFamily = ({
                 <Input
                   id="name_fr"
                   name="name.fr"
+                  autoComplete="off"
                   label={intl.formatMessage(adminMessages.nameFr)}
                   type="text"
                   rules={{

--- a/apps/web/src/pages/Skills/CreateSkillPage.tsx
+++ b/apps/web/src/pages/Skills/CreateSkillPage.tsx
@@ -169,6 +169,7 @@ export const CreateSkillForm = ({
             <Input
               id="name_en"
               name="name.en"
+              autoComplete="off"
               label={intl.formatMessage(adminMessages.nameEn)}
               type="text"
               rules={{
@@ -178,6 +179,7 @@ export const CreateSkillForm = ({
             <Input
               id="name_fr"
               name="name.fr"
+              autoComplete="off"
               label={intl.formatMessage(adminMessages.nameFr)}
               type="text"
               rules={{

--- a/apps/web/src/pages/Skills/UpdateSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateSkillPage.tsx
@@ -245,6 +245,7 @@ export const UpdateSkillForm = ({
             <Input
               id="name_en"
               name="name.en"
+              autoComplete="off"
               label={intl.formatMessage(adminMessages.nameEn)}
               type="text"
               rules={{
@@ -254,6 +255,7 @@ export const UpdateSkillForm = ({
             <Input
               id="name_fr"
               name="name.fr"
+              autoComplete="off"
               label={intl.formatMessage(adminMessages.nameFr)}
               type="text"
               rules={{


### PR DESCRIPTION
🤖 Resolves #12159 

## 👋 Introduction

This adds the `autocomplete="off"` attribute to name fields for our resources so that they no longer suggest personal names.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as admin `admin@test.com`
3. Navigate to the create/update page for each resource (system setting)
4. Confirm personal name suggestions do not appear and it has autocomplete turn off on the name fields