### PR TITLE
[Feat] Log role assignment activity

### DIFF
--- a/api/app/Models/RoleAssignment.php
+++ b/api/app/Models/RoleAssignment.php
@@ -23,7 +23,7 @@ class RoleAssignment extends Model
 
     protected $keyType = 'string';
 
-    public $timestamps = false;
+    public $timestamps = true;
 
     protected $fillable = [
         'role_id',

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -497,7 +497,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
      * @param  string  $eventName  The action taken `roleAdded` | `roleRemoved`
      * @param  User  $user  User being affected (subject)
      * @param  ?string  $roleId  Id of the role being added or removed
-     * @param  ?string|array  $team  IF team based role, the ID or array of then team ID
+     * @param  mixed  $team  IF team based role, the ID or array of then team ID
      */
     private static function logRoleChange(string $eventName, User $user, ?string $roleId, mixed $team)
     {

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -524,6 +524,40 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
                 $user->update(['email' => $newWorkEmail]);
             }
         });
+
+        static::roleAdded(function (User $user, string $role, $team) {
+            if (! $role) {
+                return;
+            }
+
+            $properties = ['role' => $role];
+            if ($team) {
+                $properties['team'] = $team;
+            }
+
+            activity()
+                ->causedBy(Auth::user())
+                ->performedOn($user)
+                ->withProperties($properties)
+                ->log('roleAdded');
+        });
+
+        static::roleRemoved(function (User $user, string $role, $team) {
+            if (! $role) {
+                return;
+            }
+
+            $properties = ['role' => $role];
+            if ($team) {
+                $properties['team'] = $team;
+            }
+
+            activity()
+                ->causedBy(Auth::user())
+                ->performedOn($user)
+                ->withProperties($properties)
+                ->log('roleRemoved');
+        });
     }
 
     /**

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -539,6 +539,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
                 ->causedBy(Auth::user())
                 ->performedOn($user)
                 ->withProperties($properties)
+                ->event('roleAdded')
                 ->log('roleAdded');
         });
 
@@ -556,6 +557,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
                 ->causedBy(Auth::user())
                 ->performedOn($user)
                 ->withProperties($properties)
+                ->event('roleAdded')
                 ->log('roleRemoved');
         });
     }

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -501,7 +501,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
         activity()
             ->causedBy(Auth::user())
             ->performedOn($user)
-            ->withProperties(['attributes' => ['roleAssignments' => [$properties]]])
+            ->withProperties(['attributes' => $properties])
             ->event($eventName)
             ->log($eventName);
     }
@@ -548,11 +548,11 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
         });
 
         static::roleAdded(function (User $user, string $role, $team) {
-            self::logRoleChange('created', $user, $role, $team);
+            self::logRoleChange('roleAdded', $user, $role, $team);
         });
 
         static::roleRemoved(function (User $user, string $role, $team) {
-            self::logRoleChange('deleted', $user, $role, $team);
+            self::logRoleChange('roleRemoved', $user, $role, $team);
         });
     }
 

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -25,6 +25,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Support\Arr;
@@ -106,7 +107,9 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
     use HasFactory;
     use HasLocalizedEnums;
     use HasRelationships;
-    use HasRolesAndPermissions;
+    use HasRolesAndPermissions {
+        roles as baseRoles;
+    }
     use HydratesSnapshot;
     use LogsActivity;
     use Searchable;
@@ -204,6 +207,15 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
             ->logOnly(['*'])
             ->logOnlyDirty()
             ->dontSubmitEmptyLogs();
+    }
+
+    /**
+     * Extends Laratrust roles relationship to
+     * support timestamp updating.
+     */
+    public function roles(): MorphToMany
+    {
+        return $this->baseRoles()->withTimestamps();
     }
 
     /**

--- a/api/database/migrations/2025_01_20_164045_add_timestamps_role_user_table.php
+++ b/api/database/migrations/2025_01_20_164045_add_timestamps_role_user_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('role_user', function (Blueprint $table) {
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('role_user', function (Blueprint $table) {
+            $table->dropTimestamps();
+        });
+    }
+};


### PR DESCRIPTION
🤖 Resolves #12491 

## 👋 Introduction

Adds timestamps and activity log to role assignments.

## 🕵️ Details

This is a little more involved because of traits coming from Laratrust.

- Had to extend the `roles` relationship that comes from the trait
- Added custom logs on the `roleAdded` and `roleRemoved` model events since the default made it difficult to determine what actually happened.

The logged properties are the ID of role and team (if present) removed or added. Hopefully this makes sense, if it does not, this is not too difficult to change.

## 🧪 Testing

1. Refresh API `make refresh-api`
2. Login as admin `admin@test.com`
3. Navigate to edit a user `/admin/users/{userId}/edit`
4. Add both a normal and team based role
5. Confirm the new records in the database for `role_user` table have the appropriate timestamps
6. Remove both roles added in step 4
7. Confirm the activity log contains `roleAdded` and `roleRemoved` activities with the expected properties