### PR TITLE
[Bug] Add `unsuspend-placed-candidates` command

### DIFF
--- a/api/app/Console/Commands/UnsuspendPlacedCandidates.php
+++ b/api/app/Console/Commands/UnsuspendPlacedCandidates.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\PoolCandidateStatus;
+use App\Models\PoolCandidate;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection;
+
+class UnsuspendPlacedCandidates extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:unsuspend-placed-candidates';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Set suspended at date to null for placed term and indeterminate candidates';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $applicableStatuses = [PoolCandidateStatus::PLACED_TERM->name, PoolCandidateStatus::PLACED_INDETERMINATE->name];
+
+        PoolCandidate::whereIn('pool_candidate_status', $applicableStatuses)
+            ->whereNotNull('suspended_at')
+            ->with('user')
+            ->chunkById(100, function (Collection $candidates) {
+                foreach ($candidates as $candidate) {
+                    /** @var \App\Models\PoolCandidate $candidate */
+                    $candidate->suspended_at = null;
+                    $candidate->save();
+                }
+            }
+            );
+
+        return Command::SUCCESS;
+    }
+}

--- a/api/app/Console/Commands/UnsuspendPlacedCandidates.php
+++ b/api/app/Console/Commands/UnsuspendPlacedCandidates.php
@@ -31,18 +31,22 @@ class UnsuspendPlacedCandidates extends Command
     public function handle()
     {
         $applicableStatuses = [PoolCandidateStatus::PLACED_TERM->name, PoolCandidateStatus::PLACED_INDETERMINATE->name];
+        $candidatesUpdated = 0;
 
         PoolCandidate::whereIn('pool_candidate_status', $applicableStatuses)
             ->whereNotNull('suspended_at')
             ->with('user')
-            ->chunkById(100, function (Collection $candidates) {
+            ->chunkById(100, function (Collection $candidates) use (&$candidatesUpdated) {
                 foreach ($candidates as $candidate) {
                     /** @var \App\Models\PoolCandidate $candidate */
                     $candidate->suspended_at = null;
                     $candidate->save();
+                    $candidatesUpdated++;
                 }
             }
             );
+
+        $this->info("Updated $candidatesUpdated candidates");
 
         return Command::SUCCESS;
     }


### PR DESCRIPTION
🤖 Resolves #12479

## 👋 Introduction

Adds a command for the purpose of reversing what was done database-wise in https://github.com/GCTC-NTGC/gc-digital-talent/issues/12212
Effectively the same command just reversed

## 🧪 Testing

1. Set candidates with the relevant status as suspended
2. Run command below
3. Check it worked


## 🚚 Deployment

Can be run before or after deployment, so at anytime

Run

`php artisan app:unsuspend-placed-candidates`

