### PR TITLE
[Copy] Formatting, typos, and unnecessary spaces

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -64,6 +64,8 @@ Spatie
 spinbutton
 Staudenmeir
 subcomponents
+subproject
+subprojects
 subquery
 TALENTSEARCH
 tanstack

--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -33,6 +33,7 @@ GCNOTIFY
 gctalent
 heroicons
 ilike
+inclusivity
 Inclusivity
 inuk
 Inuk

--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -68,6 +68,7 @@ subquery
 TALENTSEARCH
 tanstack
 teamable
+telework
 Telework
 TELEWORK
 testid

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Lighthouse PHP](https://github.com/GCTC-NTGC/gc-digital-talent/actions/workflows/lighthouse-php.yml/badge.svg)](https://github.com/GCTC-NTGC/gc-digital-talent/actions/workflows/lighthouse-php.yml) [![CodeQL](https://github.com/GCTC-NTGC/gc-digital-talent/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/GCTC-NTGC/gc-digital-talent/actions/workflows/codeql-analysis.yml) [![Jest](https://github.com/GCTC-NTGC/gc-digital-talent/actions/workflows/jest.yml/badge.svg)](https://github.com/GCTC-NTGC/gc-digital-talent/actions/workflows/jest.yml) [![Lint](https://github.com/GCTC-NTGC/gc-digital-talent/actions/workflows/lint.yml/badge.svg)](https://github.com/GCTC-NTGC/gc-digital-talent/actions/workflows/lint.yml) [![PHPUnit](https://github.com/GCTC-NTGC/gc-digital-talent/actions/workflows/phpunit.yml/badge.svg)](https://github.com/GCTC-NTGC/gc-digital-talent/actions/workflows/phpunit.yml) [![Playwright](https://github.com/GCTC-NTGC/gc-digital-talent/actions/workflows/playwright.yml/badge.svg)](https://github.com/GCTC-NTGC/gc-digital-talent/actions/workflows/playwright.yml) [![Translations](https://github.com/GCTC-NTGC/gc-digital-talent/actions/workflows/translations.yml/badge.svg?branch=main)](https://github.com/GCTC-NTGC/gc-digital-talent/actions/workflows/translations.yml) [![codecov](https://codecov.io/github/GCTC-NTGC/gc-digital-talent/graph/badge.svg?token=GL1BG06350)](https://codecov.io/github/GCTC-NTGC/gc-digital-talent)
 
-The GC Digital Talent app is divided into multiple services, each treated as its own sub-project:
+The GC Digital Talent app is divided into multiple services, each treated as its own subproject:
 
 - [`/api`](/api/README.md), API service
 - `/apps`, frontend applications
@@ -15,7 +15,7 @@ The GC Digital Talent app is divided into multiple services, each treated as its
 
 The api and frontend projects are both designed to run in separate containers. However, they can also be run on a single server with requests routed carefully between them. This is currently how the docker infrastructure works.
 
-Each sub-project has its own `README.md`, with advice on how to contribute to that sub-project. The README files also contain notes on how to configure the sub-projects, but if you simply want to get the project running on a new machine, you may disregard these notes and move straight to the steps below.
+Each subproject has its own `README.md`, with advice on how to contribute to that subproject. The README files also contain notes on how to configure the subprojects, but if you simply want to get the project running on a new machine, you may disregard these notes and move straight to the steps below.
 
 ## Testing
 

--- a/apps/web/src/components/Pagination/usePagination.ts
+++ b/apps/web/src/components/Pagination/usePagination.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 
-export const DOTS = "...";
+export const DOTS = "…";
 
 const range = (start: number, end: number): number[] => {
   const length = end - start + 1;

--- a/apps/web/src/components/Profile/components/WorkPreferences/utils.ts
+++ b/apps/web/src/components/Profile/components/WorkPreferences/utils.ts
@@ -36,8 +36,8 @@ export const getLabels = (intl: IntlShape) => ({
     description: "Legend for the work location preferences section",
   }),
   locationPreferences: intl.formatMessage({
-    defaultMessage: "I am willing to work in the...",
-    id: "1PVIbX",
+    defaultMessage: "I am willing to work in the…",
+    id: "OhN2Ud",
     description: "Legend for work regions check list in work preferences form",
   }),
   locationExemptions: intl.formatMessage({

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -803,10 +803,6 @@
     "defaultMessage": "Cette section porte sur les renseignements qui fournissent à la candidate ou au candidat le contexte du type de travail qu'il fera, avec qui il travaillera et l'incidence du rôle sur les Canadiens et Canadiennes.",
     "description": "Sub title for basic information"
   },
-  "22KlYO": {
-    "defaultMessage": "Embauchez un(e) apprenti(e) en TI",
-    "description": "Link text to the IT Apprenticehip program for Indigenous peoples page"
-  },
   "23/pqm": {
     "defaultMessage": "Aucune compétence n'a été liée à des expériences.",
     "description": "Null state for when no skills have been linked to any experiences"
@@ -6222,6 +6218,10 @@
   "Tj1iyN": {
     "defaultMessage": "S’inscrire aux mises à jour<hidden> sur les cours et camps d'entrainement dirigés par un instructeur ou une instructrice</hidden>",
     "description": "A link to sign up for updates"
+  },
+  "TjvnvR": {
+    "defaultMessage": "Embauchez un(e) apprenti(e) en TI",
+    "description": "Link text to the IT Apprenticeship Program for Indigenous Peoples page"
   },
   "TomxAe": {
     "defaultMessage": "{time} le {date}",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -431,10 +431,6 @@
     "defaultMessage": "Informations sur la compétence",
     "description": "Heading for the 'view a skill' form"
   },
-  "094835": {
-    "defaultMessage": "Je cherche à...",
-    "description": "Support form subject field label"
-  },
   "09ijOa": {
     "defaultMessage": "<strong>Non</strong>, je n'ai pas de droit de priorité.",
     "description": "Label displayed for does not have priority entitlement option"
@@ -678,10 +674,6 @@
   "1MtuHa": {
     "defaultMessage": "Veuillez préciser le facteur",
     "description": "Label for _other operations considerations_ fieldset in the _digital services contracting questionnaire_"
-  },
-  "1PVIbX": {
-    "defaultMessage": "Je consens à travailler dans...",
-    "description": "Legend for work regions check list in work preferences form"
   },
   "1Q/4Yb": {
     "defaultMessage": "Publier une annonce",
@@ -5207,6 +5199,10 @@
     "defaultMessage": "Vous êtes à l'aise de partager vos renseignements sur l'équité en matière d'emploi pour des possibilités de recrutement et à des fins de statistiques anonymisées.",
     "description": "Second condition for selecting an employment equity group"
   },
+  "OhN2Ud": {
+    "defaultMessage": "Je consens à travailler dans…",
+    "description": "Legend for work regions check list in work preferences form"
+  },
   "Ok+Ojl": {
     "defaultMessage": "{skill} est défini comme :",
     "description": "Heading for a specific skills definition"
@@ -7469,6 +7465,10 @@
   "aH4Suk": {
     "defaultMessage": "Un plan en lien avec talents pour l’initiative numérique a-t-il été soumis précédemment pour cette initiative?",
     "description": "Label for _digital initiative plan submitted_ fieldset in the _digital services contracting questionnaire_"
+  },
+  "aHpCQS": {
+    "defaultMessage": "Je cherche à…",
+    "description": "Support form subject field label"
   },
   "aIEKtJ": {
     "defaultMessage": "Informations sur la compétence",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -771,6 +771,10 @@
     "defaultMessage": "À vous de découvrir",
     "description": "Heading for featured items on the homepage"
   },
+  "1ru8HO": {
+    "defaultMessage": "Appuyez le cheminement de carrière des peuples des Premières Nations, des Inuit et des Métis, qui sont passionnés par les TI, et contribuez à créer une fonction publique diversifiée, équitable et inclusive. Embauchez par le biais du Programme d'apprentissage en TI pour les personnes autochtones.",
+    "description": "Description for the IT Apprenticeship Program for Indigenous Peoples"
+  },
   "1sutYh": {
     "defaultMessage": "Groupes de compétences (anglais)",
     "description": "Title for skill families in English"
@@ -3915,6 +3919,10 @@
     "defaultMessage": "<strong>Non</strong>, c’est une compétence que j’ai utilisée dans le passé.",
     "description": "Option for when a skill was only used in the past"
   },
+  "IDhld2": {
+    "defaultMessage": "Embaucher des talents autochtones",
+    "description": "Heading for the IT Apprenticeship Program for Indigenous Peoples section"
+  },
   "IEp0sR": {
     "defaultMessage": "Un grade est quand même requis. Cependant, la spécialisation en économie, en sociologie ou en statistique peut également être formée d’un agencement acceptable d’études, de formation ou d’expérience.",
     "description": "Description for the `other education with specialization` option for EC education requirements"
@@ -5259,10 +5267,6 @@
     "defaultMessage": "Par type",
     "description": "Tab title for experiences sorted by type in applicant profile."
   },
-  "P06ncG": {
-    "defaultMessage": "Embaucher des talents autochtones",
-    "description": "Heading for the IT Apprenticehip program for Indigenous peoples section"
-  },
   "P3WkJv": {
     "defaultMessage": "Ajoutez jusqu’à trois questions dans votre processus de candidature.",
     "description": "Helper message indicating max screening questions allowed"
@@ -5626,10 +5630,6 @@
   "QlCJM8": {
     "defaultMessage": "Dans cette étape, des questions de présélection et des questions générales peuvent vous être posées. Vos réponses aux <strong>questions de présélection seront évaluées</strong> dans le cadre de votre candidature. Assurez-vous de donner des réponses réfléchies et détaillées qui vous représentent vraiment ainsi que votre expérience.",
     "description": "Application step for additional questions, introduction description, paragraph one"
-  },
-  "Qm8QWW": {
-    "defaultMessage": "Appuyez le cheminement de carrière des peuples des Premières Nations, des Inuit et des Métis, qui sont passionnés par les TI, et contribuez à créer une fonction publique diversifiée, équitable et inclusive. Embauchez par le biais du Programme d'apprentissage en TI pour les personnes autochtones.",
-    "description": "Description for the IT Apprenticehip program for Indigenous peoples"
   },
   "Qn8C+Z": {
     "defaultMessage": "Domaines de certification",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -9119,7 +9119,7 @@
     "description": "button to request a new code"
   },
   "hyBNpJ": {
-    "defaultMessage": "Les comptes de médias sociaux peuvent comporter des liens ou des annonces liés à des sites Web échappant au contrôle du gouvernement du Canada. Ces liens sont fournis aux utilisateurs uniquement par souci de commodité. Le gouvernement du Canada n’assume aucune responsabilité à l’égard de l’information obtenue au moyen de ces liens ou de ces annonces, pas plus qu’il ne cautionne ces sites et leur contenu..",
+    "defaultMessage": "Les comptes de médias sociaux peuvent comporter des liens ou des annonces liés à des sites Web échappant au contrôle du gouvernement du Canada. Ces liens sont fournis aux utilisateurs uniquement par souci de commodité. Le gouvernement du Canada n’assume aucune responsabilité à l’égard de l’information obtenue au moyen de ces liens ou de ces annonces, pas plus qu’il ne cautionne ces sites et leur contenu.",
     "description": "Paragraph for link to others section"
   },
   "hyJz3G": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -156,7 +156,7 @@
     "description": "Message that appears when a required skill has no experiences linked to it"
   },
   "+lxGIT": {
-    "defaultMessage": "Suivre, « aimer » et s’abonner",
+    "defaultMessage": "Suivre, « aimer » et s’abonner",
     "description": "Heading for following section"
   },
   "+mCsoW": {
@@ -4876,7 +4876,7 @@
     "description": "intro to request a new code"
   },
   "MxmB1v": {
-    "defaultMessage": "Utilisez le bouton « Ajoutez un rôle dans la collectivité » pour commencer.",
+    "defaultMessage": "Utilisez le bouton « Ajoutez un rôle dans la collectivité » pour commencer.",
     "description": "Instructions for adding community membership to a user."
   },
   "Mxu+IY": {
@@ -10015,7 +10015,7 @@
     "description": "Label for _hr_ option in _authorities involved_ fieldset in the _digital services contracting questionnaire_"
   },
   "mSdBi1": {
-    "defaultMessage": "La décision du gouvernement du Canada de « suivre », « d'aimer » ou de « s'abonner » à un autre compte de médias sociaux ne signifie pas qu'il approuve ce compte, cette voie de communication, cette page ou ce site, et il en est de même pour le partage (retransmission, republication ou lien) de contenu provenant d'un autre utilisateur.",
+    "defaultMessage": "La décision du gouvernement du Canada de « suivre », « d'aimer » ou de « s'abonner » à un autre compte de médias sociaux ne signifie pas qu'il approuve ce compte, cette voie de communication, cette page ou ce site, et il en est de même pour le partage (retransmission, republication ou lien) de contenu provenant d'un autre utilisateur.",
     "description": "Paragraph for following section"
   },
   "mTsq+x": {
@@ -12379,7 +12379,7 @@
     "description": "Paragraph for comments and interaction section"
   },
   "zcr51k": {
-    "defaultMessage": "La reproduction des symboles officiels du gouvernement du Canada, y compris le mot-symbole « Canada », les armoiries du Canada et le symbole du drapeau, à des fins commerciales ou non commerciales, est interdite sans <trademarkLink>autorisation écrite</trademarkLink> au préalable.",
+    "defaultMessage": "La reproduction des symboles officiels du gouvernement du Canada, y compris le mot-symbole « Canada », les armoiries du Canada et le symbole du drapeau, à des fins commerciales ou non commerciales, est interdite sans <trademarkLink>autorisation écrite</trademarkLink> au préalable.",
     "description": "Paragraph describing trademark notice section"
   },
   "zdGy4D": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -268,7 +268,7 @@
     "description": "Legend for the Education Requirement filter radio group"
   },
   "/K1/1n": {
-    "defaultMessage": "Groupe de classifications actuel ",
+    "defaultMessage": "Groupe de classifications actuel",
     "description": "Label displayed on classification group input"
   },
   "/K8/eG": {
@@ -420,7 +420,7 @@
     "description": "Message for when a candidate has no claims to be verified"
   },
   "07p+1J": {
-    "defaultMessage": "Avez-vous d'autres questions? N'hésitez pas à <link>communiquer avec notre équipe</link> pour obtenir de plus amples renseignements. ",
+    "defaultMessage": "Avez-vous d'autres questions? N'hésitez pas à <link>communiquer avec notre équipe</link> pour obtenir de plus amples renseignements.",
     "description": "Third paragraph for pool closing date dialog"
   },
   "07sCDh": {
@@ -780,7 +780,7 @@
     "description": "Role with group, HTML"
   },
   "1uoeR6": {
-    "defaultMessage": "Pour obtenir un bon, vous devez remplir le formulaire de demande. Votre profil sur Talents numériques du GC nous permettra de vérifier si vous êtes admissible. Avant de présenter votre demande, prenez le temps de revoir et de mettre à jour les renseignements dans votre profil, ou de vous en créer un si vous ne l'avez pas déjà fait. ",
+    "defaultMessage": "Pour obtenir un bon, vous devez remplir le formulaire de demande. Votre profil sur Talents numériques du GC nous permettra de vérifier si vous êtes admissible. Avant de présenter votre demande, prenez le temps de revoir et de mettre à jour les renseignements dans votre profil, ou de vous en créer un si vous ne l'avez pas déjà fait.",
     "description": "First paragraph of apply and complete your profile section"
   },
   "1xI8uo": {
@@ -948,7 +948,7 @@
     "description": "Paragraph 3, importance of self-declaration"
   },
   "2m5USi": {
-    "defaultMessage": "Utilisez le bouton « Modifiez » pour commencer. ",
+    "defaultMessage": "Utilisez le bouton « Modifiez » pour commencer.",
     "description": "Null message on sections for edit pool page."
   },
   "2n0e2i": {
@@ -1724,7 +1724,7 @@
     "description": "An example in the _examples of contracts_ section of the _digital services contracting questionnaire_"
   },
   "6ceoYt": {
-    "defaultMessage": "Mises à jour des procédures obligatoires ",
+    "defaultMessage": "Mises à jour des procédures obligatoires",
     "description": "Heading for the mandatory procedures card"
   },
   "6cr+Qy": {
@@ -2168,7 +2168,7 @@
     "description": "Required skill level column header for tables"
   },
   "93zCaS": {
-    "defaultMessage": "Reflète la spécialisation nécessaire ",
+    "defaultMessage": "Reflète la spécialisation nécessaire",
     "description": "Text for education accepted information context in screening decision dialog"
   },
   "953EAy": {
@@ -2500,7 +2500,7 @@
     "description": "Describes selecting asset skills for a process."
   },
   "Af4zOR": {
-    "defaultMessage": "Vous pouvez gérer les types de notifications et la façon dont elles vous sont envoyées sur la page des paramètres de votre compte. ",
+    "defaultMessage": "Vous pouvez gérer les types de notifications et la façon dont elles vous sont envoyées sur la page des paramètres de votre compte.",
     "description": "Describing where to go to manage notification settings"
   },
   "AfSlkm": {
@@ -4128,7 +4128,7 @@
     "description": "Message for the english positions option"
   },
   "JBavNE": {
-    "defaultMessage": "Confirmation du besoin d’une note spéciale ",
+    "defaultMessage": "Confirmation du besoin d’une note spéciale",
     "description": "Label for input confirmation of need for special note on edit pool."
   },
   "JCX6jN": {
@@ -5064,7 +5064,7 @@
     "description": "No assessments for a skill"
   },
   "O5dDCM": {
-    "defaultMessage": "Aller à la page suivante ",
+    "defaultMessage": "Aller à la page suivante",
     "description": "Aria label for next page button in pagination nav"
   },
   "O8U5Sz": {
@@ -5120,7 +5120,7 @@
     "description": "Label for goc employment category on work experience card metadata"
   },
   "OM75j3": {
-    "defaultMessage": "La démonstration des compétences permet à un candidat de fournir une série conserve de listes qui mettent en évidence leurs forces, lacunes particulières, de même que leurs occasions de croissances. Ces listes peuvent vous donner un aperçu de l’ensemble plus vaste de compétences d’un candidat, et préciser où ils pourraient être intéressés à apprendre de nouvelles compétences. ",
+    "defaultMessage": "La démonstration des compétences permet à un candidat de fournir une série conserve de listes qui mettent en évidence leurs forces, lacunes particulières, de même que leurs occasions de croissances. Ces listes peuvent vous donner un aperçu de l’ensemble plus vaste de compétences d’un candidat, et préciser où ils pourraient être intéressés à apprendre de nouvelles compétences.",
     "description": "Lead in text for a users skill showcase for admins."
   },
   "ONrdDg": {
@@ -5408,7 +5408,7 @@
     "description": "Number of job poster templates being displayed in the list"
   },
   "PkE/Ir": {
-    "defaultMessage": "Sauvegardez les objectifs et le style de travail ",
+    "defaultMessage": "Sauvegardez les objectifs et le style de travail",
     "description": "Text on a button to save goals and work style form"
   },
   "PmDeul": {
@@ -6563,7 +6563,7 @@
     "description": "An item in a list of points about cert exams"
   },
   "Vfa3Ek": {
-    "defaultMessage": "Compétence mise à jour avec succès! ",
+    "defaultMessage": "Compétence mise à jour avec succès!",
     "description": "Message displayed when a user updates a skill"
   },
   "VhqbdZ": {
@@ -8631,7 +8631,7 @@
     "description": "Title for education level on summary of filters section"
   },
   "ftg8sT": {
-    "defaultMessage": "L’identification de votre demande {title} a été copiée ",
+    "defaultMessage": "L’identification de votre demande {title} a été copiée",
     "description": "Button text to indicate that a specific application’s ID has been copied"
   },
   "fvsYkj": {
@@ -10143,7 +10143,7 @@
     "description": "Heading for table of a users other applications and recruitments"
   },
   "n+tkit": {
-    "defaultMessage": "Aller à la première page ",
+    "defaultMessage": "Aller à la première page",
     "description": "Label for first page button in pagination nav"
   },
   "n2bW9s": {
@@ -10607,7 +10607,7 @@
     "description": "Subtitle for the individual pool page"
   },
   "pPOGwF": {
-    "defaultMessage": "Ils sont membres des Premières Nations (avec ou sans statut), Inuit ou Métis ",
+    "defaultMessage": "Ils sont membres des Premières Nations (avec ou sans statut), Inuit ou Métis",
     "description": "IAP Requirement list item one"
   },
   "pPOT4g": {
@@ -10867,7 +10867,7 @@
     "description": "An OCIO role in the _supporting the community_ section of the _digital services contracting questionnaire_"
   },
   "qtCt+G": {
-    "defaultMessage": "Aller à la dernière page ",
+    "defaultMessage": "Aller à la dernière page",
     "description": "Label for last page button in pagination nav"
   },
   "quxa4Q": {
@@ -10935,7 +10935,7 @@
     "description": "Support form toast message error"
   },
   "rQ3Gbb": {
-    "defaultMessage": "Erreur : échec de la création de la compétence ",
+    "defaultMessage": "Erreur : échec de la création de la compétence",
     "description": "Message displayed to user after skill family fails to get created."
   },
   "rQ61eh": {
@@ -11795,7 +11795,7 @@
     "description": "Link text to direct users to the profile page when anonymous"
   },
   "wSlABO": {
-    "defaultMessage": "Modifier un groupe de compétences ",
+    "defaultMessage": "Modifier un groupe de compétences",
     "description": "Page title for the skill family edit page"
   },
   "wTAdQe": {
@@ -12103,7 +12103,7 @@
     "description": "Paragraph describing using files section"
   },
   "yGy+to": {
-    "defaultMessage": "Aller à la page précédente ",
+    "defaultMessage": "Aller à la page précédente",
     "description": "Aria label for previous page button in pagination nav"
   },
   "yGyjXK": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -900,7 +900,7 @@
     "description": "Message displayed for user not found."
   },
   "2cZySB": {
-    "defaultMessage": " Télécharger CSV sans évaluations",
+    "defaultMessage": "Télécharger CSV sans évaluations",
     "description": "Button label for download candidate csv without ROD data."
   },
   "2dkgQe": {
@@ -8015,7 +8015,7 @@
     "description": "Aria label for system notification icons in notification settings."
   },
   "d8CQJr": {
-    "defaultMessage": " Création réussie du groupe de compétences!",
+    "defaultMessage": "Création réussie du groupe de compétences!",
     "description": "Message displayed to user after skill family is created successfully."
   },
   "d8j/Sr": {
@@ -10291,7 +10291,7 @@
     "description": "Message displayed to users to sign out of the application"
   },
   "nmx1ym": {
-    "defaultMessage": " Sélectionnez cette option si l'emploi était dans un ministère ou un organisme fédéral ou une société d'État, ou si vous étiez un entrepreneur ou une entrepreneuse travaillant pour l'une de ces organisations.",
+    "defaultMessage": "Sélectionnez cette option si l'emploi était dans un ministère ou un organisme fédéral ou une société d'État, ou si vous étiez un entrepreneur ou une entrepreneuse travaillant pour l'une de ces organisations.",
     "description": "Description for the goc employment category option in work experience"
   },
   "nn9B4R": {
@@ -10407,7 +10407,7 @@
     "description": "Competitive contract solicitation procedure"
   },
   "oURESC": {
-    "defaultMessage": " J’accepte de faire part de ces renseignements avec les gestionnaires d’embauche et les conseillers en RH vérifiés du gouvernement du Canada qui ont accès à cette plateforme.",
+    "defaultMessage": "J’accepte de faire part de ces renseignements avec les gestionnaires d’embauche et les conseillers en RH vérifiés du gouvernement du Canada qui ont accès à cette plateforme.",
     "description": "Label displayed on Personal Experience form for disclaimer checkbox"
   },
   "oWPn6I": {
@@ -10935,7 +10935,7 @@
     "description": "Support form toast message error"
   },
   "rQ3Gbb": {
-    "defaultMessage": " Erreur : échec de la création de la compétence ",
+    "defaultMessage": "Erreur : échec de la création de la compétence ",
     "description": "Message displayed to user after skill family fails to get created."
   },
   "rQ61eh": {
@@ -11635,7 +11635,7 @@
     "description": "Title at organization"
   },
   "vW/JGo": {
-    "defaultMessage": " Cette page offre un aperçu complet de l’historique de vos notifications. À partir de cette page, vous pouvez consulter, épingler et supprimer des notifications de votre compte. Si vous souhaitez gérer les notifications que vous recevez et leur format, vous pouvez le faire à partir de la page des paramètres de votre compte.",
+    "defaultMessage": "Cette page offre un aperçu complet de l’historique de vos notifications. À partir de cette page, vous pouvez consulter, épingler et supprimer des notifications de votre compte. Si vous souhaitez gérer les notifications que vous recevez et leur format, vous pouvez le faire à partir de la page des paramètres de votre compte.",
     "description": "Description of the list of a users notifications"
   },
   "vXcg28": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1635,6 +1635,10 @@
     "defaultMessage": "Compétences techniques constituant un atout - Exemples",
     "description": "Long title of the 'asset technical skills' section of the job poster template page"
   },
+  "6+MKIv": {
+    "defaultMessage": "Gérer et visualiser l’information relative à votre processus.",
+    "description": "Subtitle for the individual pool page"
+  },
   "6+TjHb": {
     "defaultMessage": "Trois compétences comportementales que vous aimeriez améliorer",
     "description": "Page title for the improve behavioural skills page"
@@ -10601,10 +10605,6 @@
   "pLef1V": {
     "defaultMessage": "Dissimuler les détails de {experienceName}",
     "description": "Button text to hide a specific experience's details"
-  },
-  "pM43Xu": {
-    "defaultMessage": "Gérer et visualiser l’information relative à votre processus.",
-    "description": "Subtitle for the individual pool page"
   },
   "pPOGwF": {
     "defaultMessage": "Ils sont membres des Premières Nations (avec ou sans statut), Inuit ou Métis",

--- a/apps/web/src/lang/mic.json
+++ b/apps/web/src/lang/mic.json
@@ -356,7 +356,7 @@
     "description": "Second paragraph about who the program is for"
   },
   "Z9W+O2": {
-    "defaultMessage": " Suwa’te’n nike’ wjit poqjilukwatn ki’l IT career wutawti.",
+    "defaultMessage": "Suwa’te’n nike’ wjit poqjilukwatn ki’l IT career wutawti.",
     "description": "Meta tag description for IT Apprenticeship Program for Indigenous Peoples site"
   },
   "oMpO+C": {

--- a/apps/web/src/pages/Home/ManagerHomePage/ManagerHomePage.tsx
+++ b/apps/web/src/pages/Home/ManagerHomePage/ManagerHomePage.tsx
@@ -183,9 +183,9 @@ const ManagerHomePage = () => {
             color="tertiary"
             title={intl.formatMessage({
               defaultMessage: "Hire Indigenous talent",
-              id: "P06ncG",
+              id: "IDhld2",
               description:
-                "Heading for the IT Apprenticehip program for Indigenous peoples section",
+                "Heading for the IT Apprenticeship Program for Indigenous Peoples section",
             })}
             links={[
               {
@@ -204,9 +204,9 @@ const ManagerHomePage = () => {
               {intl.formatMessage({
                 defaultMessage:
                   "Support career pathways for First Nations, Inuit and Métis apprentices with a passion for IT and help create a more diverse, equitable and inclusive public service. Hire through the IT Apprenticeship Program for Indigenous Peoples.",
-                id: "Qm8QWW",
+                id: "1ru8HO",
                 description:
-                  "Description for the IT Apprenticehip program for Indigenous peoples",
+                  "Description for the IT Apprenticeship Program for Indigenous Peoples",
               })}
             </p>
           </CardFlat>

--- a/apps/web/src/pages/Home/ManagerHomePage/ManagerHomePage.tsx
+++ b/apps/web/src/pages/Home/ManagerHomePage/ManagerHomePage.tsx
@@ -193,9 +193,9 @@ const ManagerHomePage = () => {
                 mode: "solid",
                 label: intl.formatMessage({
                   defaultMessage: "Hire an IT apprentice",
-                  id: "22KlYO",
+                  id: "TjvnvR",
                   description:
-                    "Link text to the IT Apprenticehip program for Indigenous peoples page",
+                    "Link text to the IT Apprenticeship Program for Indigenous Peoples page",
                 }),
               },
             ]}

--- a/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
@@ -191,8 +191,8 @@ export const ViewPool = ({
   });
 
   const pageSubtitle = intl.formatMessage({
-    defaultMessage: "Manage and view information about your process. ",
-    id: "pM43Xu",
+    defaultMessage: "Manage and view information about your process.",
+    id: "6+MKIv",
     description: "Subtitle for the individual pool page",
   });
 

--- a/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
+++ b/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
@@ -211,8 +211,8 @@ const SupportForm = ({
                 required: intl.formatMessage(errorMessages.required),
               }}
               label={intl.formatMessage({
-                defaultMessage: "I'm looking to...",
-                id: "094835",
+                defaultMessage: "I'm looking to…",
+                id: "aHpCQS",
                 description: "Support form subject field label",
               })}
               options={[

--- a/documentation/translation.md
+++ b/documentation/translation.md
@@ -14,7 +14,7 @@ For contextual descriptions of images, there are additional resources available 
 
 ## Tools
 
-The i18n subproject contains a script (`dist/cli.js`) to help manage the react-intl translations files. It has been written to run without any dependencies or compilation. It is expected to be used along with the [formatjs cli](https://formatjs.io/docs/tooling/cli).
+The i18n sub-project contains a script (`dist/cli.js`) to help manage the react-intl translations files. It has been written to run without any dependencies or compilation. It is expected to be used along with the [formatjs cli](https://formatjs.io/docs/tooling/cli).
 
 ### Bulk Translation
 

--- a/documentation/translation.md
+++ b/documentation/translation.md
@@ -14,14 +14,14 @@ For contextual descriptions of images, there are additional resources available 
 
 ## Tools
 
-The i18n sub-project contains a script (`dist/cli.js`) to help manage the react-intl translations files. It has been written to run without any dependencies or compilation. It is expected to be used along with the [formatjs cli](https://formatjs.io/docs/tooling/cli).
+The i18n subproject contains a script (`dist/cli.js`) to help manage the react-intl translations files. It has been written to run without any dependencies or compilation. It is expected to be used along with the [formatjs cli](https://formatjs.io/docs/tooling/cli).
 
 ### Bulk Translation
 
 The checkIntl script can be run with different flags and options. For more details on how individual options work, see the checkIntl file itself. In practice, it is easiest to save the commands, with options included, as **package.json** scripts.
 
 > [!NOTE]  
-> Each sub-project using react-intl (e.g. packages/i18n, apps/web, etc.) requires its own set of commands, and must be managed separately.
+> Each subproject using react-intl (e.g. packages/i18n, apps/web, etc.) requires its own set of commands, and must be managed separately.
 
 For example, to ensure translations in the apps/web project are up to date:
 

--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -21,7 +21,7 @@ To set up a local development environment, run these commands from anywhere in r
 
 ## Environment Maintenance
 
-To refresh each sub-project after they have been setup run one of the refresh scripts:
+To refresh each subproject after they have been setup run one of the refresh scripts:
 
 - `docker compose run --rm maintenance bash refresh_api.sh`
 - `docker compose run --rm maintenance bash refresh_frontend.sh`

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -300,7 +300,7 @@
     "description": "Message displayed to user after attempting to update a candidate with an unexpected status."
   },
   "AvBSV+": {
-    "defaultMessage": "Oh non... ",
+    "defaultMessage": "Oh non...",
     "description": "Title displayed for a table error loading state."
   },
   "BXxvCZ": {

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -75,13 +75,13 @@
     "defaultMessage": "<hidden>Étape, actuelle, </hidden>{label}",
     "description": "Prefix when a step is the currently active one."
   },
+  "0ieoVD": {
+    "defaultMessage": "Chargement des résultats…",
+    "description": "Message to display when a search is currently loading results."
+  },
   "0p1W7Q": {
     "defaultMessage": "Fils d’Ariane",
     "description": "Label for the links to page ancestors"
-  },
-  "14Cv7d": {
-    "defaultMessage": "Retrait en cours...",
-    "description": "Submitting text for delete button."
   },
   "16AY+M": {
     "defaultMessage": "Incapable de postuler pour ce bassin",
@@ -171,10 +171,6 @@
     "defaultMessage": "Agrandir tout",
     "description": "Generic link text to expand all accordions in a section"
   },
-  "4l+gBD": {
-    "defaultMessage": "Recherche...",
-    "description": "Message to display when a search is being done."
-  },
   "4lV1Od": {
     "defaultMessage": "Éliminé à la présélection",
     "description": "Screened out"
@@ -218,6 +214,10 @@
   "6iZHGg": {
     "defaultMessage": "Alerte d’avertissement :",
     "description": "Descriptor for a warning alert"
+  },
+  "6sIidC": {
+    "defaultMessage": "Chargement…",
+    "description": "Text for a component which can't be rendered yet because a data load is in progress."
   },
   "6tekaa": {
     "defaultMessage": "Septembre",
@@ -299,10 +299,6 @@
     "defaultMessage": "Le statut du candidat est irrégulier.",
     "description": "Message displayed to user after attempting to update a candidate with an unexpected status."
   },
-  "AvBSV+": {
-    "defaultMessage": "Oh non...",
-    "description": "Title displayed for a table error loading state."
-  },
   "BXxvCZ": {
     "defaultMessage": "Aucun nom n'a été fourni",
     "description": "Message for when no name value"
@@ -363,10 +359,6 @@
     "defaultMessage": "Non disponible",
     "description": "Message displayed when specific information is not available"
   },
-  "ErrpJC": {
-    "defaultMessage": "Chargement...",
-    "description": "Text for a component which can't be rendered yet because a data load is in progress."
-  },
   "F6j96P": {
     "defaultMessage": "Refaire",
     "description": "Label for redoing an action in the rich text editor"
@@ -402,6 +394,10 @@
   "GqmxO8": {
     "defaultMessage": "Termine demain, à {time}",
     "description": "Text displayed when relative date is tomorrow."
+  },
+  "GtVkbt": {
+    "defaultMessage": "Oh non…",
+    "description": "Title displayed for a table error loading state."
   },
   "Gv3lBS": {
     "defaultMessage": "Votre demande n'a pas été complétée. Veuillez réessayer ou contactez notre équipe pour obtenir de l'aide.",
@@ -443,6 +439,10 @@
     "defaultMessage": "Aucun résultat n’a été trouvé.",
     "description": "Message displayed when combobox has no options available"
   },
+  "Ib6fY4": {
+    "defaultMessage": "Sauvegarde en cours…",
+    "description": "Submitting text for save button."
+  },
   "IlPyP8": {
     "defaultMessage": "Vous devez remédier aux erreurs suivantes avant de soumettre le formulaire :",
     "description": "Message indicating which errors the form has"
@@ -482,6 +482,10 @@
   "JqjYZq": {
     "defaultMessage": "Ce champ est obligatoire. Veuillez inscrire une valeur.",
     "description": "Error message that this field must filled for the form to be valid."
+  },
+  "JxjglQ": {
+    "defaultMessage": "Recherche…",
+    "description": "Message to display when a search is being done."
   },
   "K9SPL+": {
     "defaultMessage": "À un stade initial de développement",
@@ -619,10 +623,6 @@
     "defaultMessage": "J'accepte de faire des heures supplémentaires régulièrement.",
     "description": "The operational requirement described as regular overtime."
   },
-  "QRXLf/": {
-    "defaultMessage": "Chargement des résultats...",
-    "description": "Message to display when a search is currently loading results."
-  },
   "QZpZQh": {
     "defaultMessage": "Personne handicapée",
     "description": "Group for when someone indicates they have a disability"
@@ -714,10 +714,6 @@
   "TiIkSF": {
     "defaultMessage": "Deux années post-secondaire",
     "description": "Option for education requirement, 2-year post-secondary"
-  },
-  "Tw90Pi": {
-    "defaultMessage": "Sauvegarde en cours...",
-    "description": "Submitting text for save button."
   },
   "U/4a27": {
     "defaultMessage": "Effacer votre sélection",
@@ -919,6 +915,10 @@
     "defaultMessage": "Région de la capitale nationale (Ottawa, en Ontario et Gatineau, au Québec.)",
     "description": "The work region of Canada described as National Capital."
   },
+  "dyGR7U": {
+    "defaultMessage": "Recherche…",
+    "description": "Message to display when a search is in progress."
+  },
   "e6YQ8t": {
     "defaultMessage": "Ouvrir le menu",
     "description": "Text label for button that opens side menu."
@@ -1035,6 +1035,10 @@
     "defaultMessage": "J'accepte d'avoir un emploi qui <strong>nécessite des déplacements</strong>.",
     "description": "The operational requirement described as travel as required."
   },
+  "j4ZYQw": {
+    "defaultMessage": "Retrait en cours…",
+    "description": "Submitting text for delete button."
+  },
   "j6WJBY": {
     "defaultMessage": "{wordsLeft, plural, one {mot restant} other {mots restants}}.",
     "description": "Message for when user goes over word limit."
@@ -1050,6 +1054,10 @@
   "jqyjFm": {
     "defaultMessage": "Je suis un ancien combattant des Forces armées canadiennes.",
     "description": "declare self to be a CAF veteran without bolding"
+  },
+  "jubxvJ": {
+    "defaultMessage": "Chargement…",
+    "description": "Message shown in options dropdown when Select field is loading options."
   },
   "juklNA": {
     "defaultMessage": "Un champ obligatoire est vide : Anglais – Votre incidence",
@@ -1395,10 +1403,6 @@
     "defaultMessage": "Un champ obligatoire est vide : Titres des volets/emplois",
     "description": "Error message that the pool advertisement must have a stream."
   },
-  "w6vHXf": {
-    "defaultMessage": "Recherche...",
-    "description": "Message to display when a search is in progress."
-  },
   "wUJqDi": {
     "defaultMessage": "La compétence que vous avez sélectionnée est déjà reliée à votre profil.",
     "description": "Error message that the skill selected is already linked to the user profile."
@@ -1438,10 +1442,6 @@
   "yHeFkO": {
     "defaultMessage": "Janvier",
     "description": "Name of the first month"
-  },
-  "ylHC90": {
-    "defaultMessage": "Chargement...",
-    "description": "Message shown in options dropdown when Select field is loading options."
   },
   "yuWHKJ": {
     "defaultMessage": "Par ordre de date (la plus récente étant en premier)",

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -17,29 +17,29 @@ const commonMessages = defineMessages({
     description: "Title displayed for a table initial loading state.",
   },
   loading: {
-    defaultMessage: "Loading...",
-    id: "ErrpJC",
+    defaultMessage: "Loading…",
+    id: "6sIidC",
     description:
       "Text for a component which can't be rendered yet because a data load is in progress.",
   },
   saving: {
-    defaultMessage: "Saving...",
-    id: "Tw90Pi",
+    defaultMessage: "Saving…",
+    id: "Ib6fY4",
     description: "Submitting text for save button.",
   },
   removing: {
-    defaultMessage: "Removing...",
-    id: "14Cv7d",
+    defaultMessage: "Removing…",
+    id: "j4ZYQw",
     description: "Submitting text for delete button.",
   },
   searching: {
-    defaultMessage: "Searching...",
-    id: "w6vHXf",
+    defaultMessage: "Searching…",
+    id: "dyGR7U",
     description: "Message to display when a search is in progress.",
   },
   loadingError: {
-    defaultMessage: "Oh no...",
-    id: "AvBSV+",
+    defaultMessage: "Oh no…",
+    id: "GtVkbt",
     description: "Title displayed for a table error loading state.",
   },
   notFound: {

--- a/packages/i18n/src/messages/formMessages.ts
+++ b/packages/i18n/src/messages/formMessages.ts
@@ -168,8 +168,8 @@ const formMessages = defineMessages({
       "Default placeholder shown when Select field has nothing actively selected.",
   },
   loading: {
-    defaultMessage: "Loading...",
-    id: "ylHC90",
+    defaultMessage: "Loading…",
+    id: "jubxvJ",
     description:
       "Message shown in options dropdown when Select field is loading options.",
   },

--- a/packages/i18n/src/messages/uiMessages.ts
+++ b/packages/i18n/src/messages/uiMessages.ts
@@ -40,13 +40,13 @@ const uiMessages = defineMessages({
     description: "Button text for a dismissible chip",
   },
   searching: {
-    defaultMessage: "Searching...",
-    id: "4l+gBD",
+    defaultMessage: "Searching…",
+    id: "JxjglQ",
     description: "Message to display when a search is being done.",
   },
   loadingResults: {
-    defaultMessage: "Loading results...",
-    id: "QRXLf/",
+    defaultMessage: "Loading results…",
+    id: "0ieoVD",
     description:
       "Message to display when a search is currently loading results.",
   },


### PR DESCRIPTION
🤖 Resolves #12535.

## 👋 Introduction

This PR removes unnecessary leading spaces, removes unnecessary trailing spaces, removes unnecessary trailing periods, replaces non-unicode spaces with unicode spaces, fixes typos in descriptions, replaces `...` (three periods) with `…` (one ellipsis), and adds a few terms to the project dictionary for spell checking.

## 🧪 Testing

1. Verify no unnecessary leading spaces in `intl` messages exist in codebase
2. Verify no unnecessary trailing spaces in `intl` messages exist in codebase
3. Verify no unnecessary trailing periods in `intl` messages exist in codebase
4. Verify no non-unicode spaces in `intl` messages exist in codebase
5. Verify no typos in descriptions in `intl` messages (or at least less than before)
6. Verify no  `...` (three periods) used where `…` (one ellipsis) is meant