### PR TITLE
[Bug] Fix typos in select for `EmployeeProfile::userPublicProfile()`

### DIFF
--- a/api/app/Models/EmployeeProfile.php
+++ b/api/app/Models/EmployeeProfile.php
@@ -69,7 +69,7 @@ class EmployeeProfile extends Model
     /** @return HasOne<User, $this> */
     public function userPublicProfile(): HasOne
     {
-        return $this->hasOne(User::class, 'id')->select(['email', 'firstName', 'lastName']);
+        return $this->hasOne(User::class, 'id')->select(['id', 'email', 'first_name', 'last_name']);
     }
 
     /** @return HasMany<CommunityInterest, $this> */


### PR DESCRIPTION
🤖 Resolves #12537

## 👋 Introduction

Fix the typos
Added `id` to match return type

![image](https://github.com/user-attachments/assets/50625663-7a27-4ea6-8bdb-a5c8bd4f6022)


## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Run query without issue

```
query me {
  me {
    id
    employeeProfile {
      userPublicProfile {
        id
      }
    }
  }
}
```

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/f81b79cc-f063-4396-b0e6-5c707bac9a37)



