### PR TITLE
[Bug] Fix mistake in how status is computed for final assessment step

### DIFF
--- a/api/app/Console/Commands/SyncAssessmentStatus.php
+++ b/api/app/Console/Commands/SyncAssessmentStatus.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Events\CandidateStatusChanged;
 use App\Models\PoolCandidate;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Collection;
@@ -34,6 +35,9 @@ class SyncAssessmentStatus extends Command
                 $candidate->computed_assessment_status = $assessmentStatus;
 
                 $candidate->save();
+
+                // If assessment status changes, "final decision" may as well.
+                CandidateStatusChanged::dispatch($candidate);
             }
         });
     }

--- a/api/database/seeders/AssessmentResultTestSeeder.php
+++ b/api/database/seeders/AssessmentResultTestSeeder.php
@@ -6,6 +6,7 @@ use App\Enums\AssessmentDecision;
 use App\Enums\AssessmentDecisionLevel;
 use App\Enums\AssessmentResultJustification;
 use App\Enums\AssessmentResultType;
+use App\Enums\AssessmentStepType;
 use App\Enums\PoolSkillType;
 use App\Models\AssessmentResult;
 use App\Models\AssessmentStep;
@@ -74,107 +75,116 @@ class AssessmentResultTestSeeder extends Seeder
         ]);
 
         $publishedPool = Pool::select('id')->where('name->en', 'Published – Complex')->sole();
-        $user1 = User::select('id')->where('email', 'perfect@test.com')->sole();
-        $poolCandidate1 = PoolCandidate::select('id')->where('user_id', $user1->id)->where('pool_id', $publishedPool->id)->sole();
-        $assessmentStep = AssessmentStep::factory()->create([
-            'pool_id' => $publishedPool->id,
-        ]);
-        $this->assessSkillsWithLevelAndJustification(
-            $poolCandidate1,
-            $publishedPool->poolSkills()->pluck('id')->toArray(),
-            $assessmentStep,
-            AssessmentDecisionLevel::ABOVE_REQUIRED->name,
-            [AssessmentResultJustification::EDUCATION_ACCEPTED_INFORMATION->name],
-            AssessmentDecision::SUCCESSFUL->name,
-            AssessmentResultType::EDUCATION);
+        $publishedPool->load('assessmentSteps.poolSkills');
+        foreach ($publishedPool->assessmentSteps as $assessmentStep) {
+            $user1 = User::select('id')->where('email', 'perfect@test.com')->sole();
+            $poolCandidate1 = PoolCandidate::select('id')->where('user_id', $user1->id)->where('pool_id', $publishedPool->id)->sole();
+            $this->assessSkillsWithLevelAndJustification(
+                $poolCandidate1,
+                $assessmentStep->poolSkills,
+                $assessmentStep,
+                AssessmentDecisionLevel::ABOVE_REQUIRED->name,
+                [AssessmentResultJustification::EDUCATION_ACCEPTED_INFORMATION->name],
+                AssessmentDecision::SUCCESSFUL->name,
+                AssessmentResultType::EDUCATION);
+            $this->assessSkillsWithLevelAndJustification(
+                $poolCandidate1,
+                $assessmentStep->poolSkills,
+                $assessmentStep,
+                AssessmentDecisionLevel::ABOVE_REQUIRED->name,
+                null,
+                AssessmentDecision::SUCCESSFUL->name,
+                AssessmentResultType::SKILL);
 
-        $user2 = User::select('id')->where('email', 'veteran@test.com')->sole();
-        $poolCandidate2 = PoolCandidate::select('id')->where('user_id', $user2->id)->where('pool_id', $publishedPool->id)->sole();
-        $this->assessSkillsWithLevelAndJustification(
-            $poolCandidate2,
-            $publishedPool->poolSkills()->where('type', PoolSkillType::ESSENTIAL->name)->pluck('id')->toArray(),
-            $assessmentStep,
-            AssessmentDecisionLevel::AT_REQUIRED->name,
-            [AssessmentResultJustification::EDUCATION_ACCEPTED_WORK_EXPERIENCE_EQUIVALENCY->name],
-            AssessmentDecision::SUCCESSFUL->name,
-            AssessmentResultType::SKILL);
+            $user2 = User::select('id')->where('email', 'veteran@test.com')->sole();
+            $poolCandidate2 = PoolCandidate::select('id')->where('user_id', $user2->id)->where('pool_id', $publishedPool->id)->sole();
+            $this->assessSkillsWithLevelAndJustification(
+                $poolCandidate2,
+                $assessmentStep->poolSkills()->where('type', PoolSkillType::ESSENTIAL->name)->get(),
+                $assessmentStep,
+                AssessmentDecisionLevel::AT_REQUIRED->name,
+                null,
+                AssessmentDecision::SUCCESSFUL->name,
+                AssessmentResultType::SKILL);
 
-        $user3 = User::select('id')->where('email', 'assertive@test.com')->sole();
-        $poolCandidate3 = PoolCandidate::select('id')->where('user_id', $user3->id)->where('pool_id', $publishedPool->id)->sole();
-        $this->assessSkillsWithLevelAndJustification(
-            $poolCandidate3,
-            $publishedPool->poolSkills()->pluck('id')->toArray(),
-            $assessmentStep,
-            AssessmentDecisionLevel::ABOVE_REQUIRED->name,
-            [AssessmentResultJustification::EDUCATION_ACCEPTED_WORK_EXPERIENCE_EQUIVALENCY->name],
-            AssessmentDecision::SUCCESSFUL->name,
-            AssessmentResultType::SKILL);
+            $user3 = User::select('id')->where('email', 'assertive@test.com')->sole();
+            $poolCandidate3 = PoolCandidate::select('id')->where('user_id', $user3->id)->where('pool_id', $publishedPool->id)->sole();
+            $this->assessSkillsWithLevelAndJustification(
+                $poolCandidate3,
+                $assessmentStep->poolSkills,
+                $assessmentStep,
+                AssessmentDecisionLevel::ABOVE_REQUIRED->name,
+                null,
+                AssessmentDecision::SUCCESSFUL->name,
+                AssessmentResultType::SKILL);
 
-        $user4 = User::select('id')->where('email', 'absent@test.com')->sole();
-        $poolCandidate4 = PoolCandidate::select('id')->where('user_id', $user4->id)->where('pool_id', $publishedPool->id)->sole();
-        $this->assessSkillsWithLevelAndJustification(
-            $poolCandidate4,
-            $publishedPool->poolSkills()->where('type', PoolSkillType::ESSENTIAL->name)->pluck('id')->toArray(),
-            $assessmentStep, AssessmentDecisionLevel::AT_REQUIRED->name,
-            [AssessmentResultJustification::EDUCATION_ACCEPTED_WORK_EXPERIENCE_EQUIVALENCY->name],
-            AssessmentDecision::HOLD->name,
-            AssessmentResultType::SKILL);
+            $user4 = User::select('id')->where('email', 'absent@test.com')->sole();
+            $poolCandidate4 = PoolCandidate::select('id')->where('user_id', $user4->id)->where('pool_id', $publishedPool->id)->sole();
+            $this->assessSkillsWithLevelAndJustification(
+                $poolCandidate4,
+                $assessmentStep->poolSkills()->where('type', PoolSkillType::ESSENTIAL->name)->get(),
+                $assessmentStep, AssessmentDecisionLevel::AT_REQUIRED->name,
+                null,
+                AssessmentDecision::HOLD->name,
+                AssessmentResultType::SKILL);
 
-        $user5 = User::select('id')->where('email', 'screened-out@test.com')->sole();
-        $poolCandidate5 = PoolCandidate::select('id')->where('user_id', $user5->id)->where('pool_id', $publishedPool->id)->sole();
-        $this->assessSkillsWithLevelAndJustification(
-            $poolCandidate5,
-            $publishedPool->poolSkills()->where('type', PoolSkillType::ESSENTIAL->name)->pluck('id')->toArray(),
-            $assessmentStep,
-            AssessmentDecisionLevel::AT_REQUIRED->name,
-            [AssessmentResultJustification::EDUCATION_FAILED_NOT_RELEVANT->name,
-                AssessmentResultJustification::EDUCATION_FAILED_REQUIREMENT_NOT_MET->name],
-            AssessmentDecision::UNSUCCESSFUL->name,
-            AssessmentResultType::EDUCATION);
+            $user5 = User::select('id')->where('email', 'screened-out@test.com')->sole();
+            $poolCandidate5 = PoolCandidate::select('id')->where('user_id', $user5->id)->where('pool_id', $publishedPool->id)->sole();
+            $this->assessSkillsWithLevelAndJustification(
+                $poolCandidate5,
+                $assessmentStep->poolSkills()->where('type', PoolSkillType::ESSENTIAL->name)->get(),
+                $assessmentStep,
+                AssessmentDecisionLevel::AT_REQUIRED->name,
+                [AssessmentResultJustification::EDUCATION_FAILED_NOT_RELEVANT->name,
+                    AssessmentResultJustification::EDUCATION_FAILED_REQUIREMENT_NOT_MET->name],
+                AssessmentDecision::UNSUCCESSFUL->name,
+                AssessmentResultType::EDUCATION);
 
-        $user6 = User::select('id')->where('email', 'failed@test.com')->sole();
-        $poolCandidate6 = PoolCandidate::select('id')->where('user_id', $user6->id)->where('pool_id', $publishedPool->id)->sole();
-        $this->assessSkillsWithLevelAndJustification(
-            $poolCandidate6,
-            $publishedPool->poolSkills()->pluck('id')->toArray(), $assessmentStep,
-            null,
-            [AssessmentResultJustification::EDUCATION_FAILED_REQUIREMENT_NOT_MET->name],
-            AssessmentDecision::UNSUCCESSFUL->name,
-            AssessmentResultType::EDUCATION);
+            $user6 = User::select('id')->where('email', 'failed@test.com')->sole();
+            $poolCandidate6 = PoolCandidate::select('id')->where('user_id', $user6->id)->where('pool_id', $publishedPool->id)->sole();
+            $this->assessSkillsWithLevelAndJustification(
+                $poolCandidate6,
+                $assessmentStep->poolSkills,
+                $assessmentStep,
+                null,
+                [AssessmentResultJustification::EDUCATION_FAILED_REQUIREMENT_NOT_MET->name],
+                AssessmentDecision::UNSUCCESSFUL->name,
+                AssessmentResultType::EDUCATION);
 
-        $user7 = User::select('id')->where('email', 'entry-level-holder@test.com')->sole();
-        $poolCandidate7 = PoolCandidate::select('id')->where('user_id', $user7->id)->where('pool_id', $publishedPool->id)->sole();
-        $this->assessSkillsWithLevelAndJustification(
-            $poolCandidate7,
-            null,
-            $assessmentStep,
-            null,
-            [AssessmentResultJustification::EDUCATION_ACCEPTED_WORK_EXPERIENCE_EQUIVALENCY->name],
-            AssessmentDecision::HOLD->name,
-            assessmentResultType::EDUCATION);
-        $this->assessSkillsWithLevelAndJustification(
-            $poolCandidate7,
-            $publishedPool->poolSkills()->pluck('id')->toArray(),
-            $assessmentStep,
-            null,
-            [AssessmentResultJustification::SKILL_FAILED_INSUFFICIENTLY_DEMONSTRATED->name],
-            AssessmentDecision::HOLD->name,
-            assessmentResultType::SKILL);
+            $user7 = User::select('id')->where('email', 'entry-level-holder@test.com')->sole();
+            $poolCandidate7 = PoolCandidate::select('id')->where('user_id', $user7->id)->where('pool_id', $publishedPool->id)->sole();
+            $this->assessSkillsWithLevelAndJustification(
+                $poolCandidate7,
+                null,
+                $assessmentStep,
+                null,
+                [AssessmentResultJustification::EDUCATION_ACCEPTED_WORK_EXPERIENCE_EQUIVALENCY->name],
+                AssessmentDecision::HOLD->name,
+                assessmentResultType::EDUCATION);
+            $this->assessSkillsWithLevelAndJustification(
+                $poolCandidate7,
+                $assessmentStep->poolSkills,
+                $assessmentStep,
+                null,
+                null,
+                AssessmentDecision::HOLD->name,
+                assessmentResultType::SKILL);
 
-        $user8 = User::select('id')->where('email', 'unsuccessful@test.com')->sole();
-        $poolCandidate8 = PoolCandidate::select('id')->where('user_id', $user8->id)->where('pool_id', $publishedPool->id)->sole();
-        // select first essential skill from pool skills
-        $firstEssentialSkill = $publishedPool->poolSkills()->where('type', PoolSkillType::ESSENTIAL->name)->first();
-        $this->assessSkillsWithLevelAndJustification(
-            $poolCandidate8,
-            [$firstEssentialSkill->id],
-            $assessmentStep,
-            null,
-            [AssessmentResultJustification::SKILL_FAILED_INSUFFICIENTLY_DEMONSTRATED->name,
-                AssessmentResultJustification::FAILED_NOT_ENOUGH_INFORMATION->name,
-                AssessmentResultJustification::FAILED_OTHER->name],
-            AssessmentDecision::UNSUCCESSFUL->name,
-            AssessmentResultType::SKILL);
+            $user8 = User::select('id')->where('email', 'unsuccessful@test.com')->sole();
+            $poolCandidate8 = PoolCandidate::select('id')->where('user_id', $user8->id)->where('pool_id', $publishedPool->id)->sole();
+            // select first essential skill from pool skills
+            $firstEssentialSkill = $assessmentStep->poolSkills()->where('type', PoolSkillType::ESSENTIAL->name)->get()->first();
+            $this->assessSkillsWithLevelAndJustification(
+                $poolCandidate8,
+                [$firstEssentialSkill],
+                $assessmentStep,
+                null,
+                [AssessmentResultJustification::SKILL_FAILED_INSUFFICIENTLY_DEMONSTRATED->name,
+                    AssessmentResultJustification::FAILED_NOT_ENOUGH_INFORMATION->name,
+                    AssessmentResultJustification::FAILED_OTHER->name],
+                AssessmentDecision::UNSUCCESSFUL->name,
+                AssessmentResultType::SKILL);
+        }
     }
 
     private function assessSkillsWithLevelAndJustification($poolCandidate,
@@ -185,6 +195,11 @@ class AssessmentResultTestSeeder extends Seeder
         $assessmentDecision,
         $assessmentResultType)
     {
+        // Only save education assessment for the first assessment step
+        if ($assessmentResultType == AssessmentResultType::EDUCATION && $assessmentStep->type != AssessmentStepType::APPLICATION_SCREENING->name) {
+            return;
+        }
+
         $nullJustifications = $assessmentDecision === AssessmentDecision::HOLD->name || is_null($assessmentDecision);
 
         if ($assessmentResultType == null) {
@@ -201,7 +216,7 @@ class AssessmentResultTestSeeder extends Seeder
                 AssessmentResult::factory()->withResultType($assessmentResultType)->create([
                     'assessment_step_id' => $assessmentStep->id,
                     'pool_candidate_id' => $poolCandidate->id,
-                    'pool_skill_id' => $poolSkill,
+                    'pool_skill_id' => $poolSkill->id,
                     'assessment_decision_level' => $level,
                     'justifications' => $nullJustifications ? null : $justifications,
                     'assessment_decision' => $assessmentDecision,

--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -37,7 +37,7 @@ class DatabaseSeeder extends Seeder
             TeamRandomSeeder::class,
             PoolRandomSeeder::class,
             UserRandomSeeder::class,
-            AssessmentResultRandomSeeder::class,
+            // AssessmentResultRandomSeeder::class,
             SearchRequestRandomSeeder::class,
             DigitalContractingQuestionnaireRandomSeeder::class,
             DepartmentSpecificRecruitmentProcessFormRandomSeeder::class,

--- a/api/tests/Feature/CandidateAssessmentStatusTest.php
+++ b/api/tests/Feature/CandidateAssessmentStatusTest.php
@@ -930,26 +930,20 @@ class CandidateAssessmentStatusTest extends TestCase
      */
     public function testUnsuccessfulEssentialInFinalStepMeansDisqualified(): void
     {
-        $stepOne = $this->pool->assessmentSteps->first();
-        $stepTwo = AssessmentStep::factory()
-            ->afterCreating(function (AssessmentStep $step) {
-                $step->poolSkills()->sync([$this->poolSkill->id]);
-            })->create([
-                'pool_id' => $this->pool->id,
-            ]);
+        $steps = $this->pool->assessmentSteps;
 
         AssessmentResult::factory()
             ->withResultType(AssessmentResultType::EDUCATION)
             ->create([
-                'assessment_step_id' => $stepOne->id,
+                'assessment_step_id' => $steps[0]->id,
                 'pool_candidate_id' => $this->candidate->id,
                 'assessment_decision' => AssessmentDecision::SUCCESSFUL->name,
+                'pool_skill_id' => $this->poolSkill->id,
             ]);
-
         AssessmentResult::factory()
             ->withResultType(AssessmentResultType::SKILL)
             ->create([
-                'assessment_step_id' => $stepOne->id,
+                'assessment_step_id' => $steps[0]->id,
                 'pool_candidate_id' => $this->candidate->id,
                 'assessment_decision' => AssessmentDecision::SUCCESSFUL->name,
                 'pool_skill_id' => $this->poolSkill->id,
@@ -958,7 +952,7 @@ class CandidateAssessmentStatusTest extends TestCase
         AssessmentResult::factory()
             ->withResultType(AssessmentResultType::SKILL)
             ->create([
-                'assessment_step_id' => $stepTwo->id,
+                'assessment_step_id' => $steps[1]->id,
                 'pool_candidate_id' => $this->candidate->id,
                 'assessment_decision' => AssessmentDecision::UNSUCCESSFUL->name,
                 'pool_skill_id' => $this->poolSkill->id,
@@ -972,11 +966,11 @@ class CandidateAssessmentStatusTest extends TestCase
                         'assessmentStatus' => [
                             'assessmentStepStatuses' => [
                                 [
-                                    'step' => $stepOne->id,
+                                    'step' => $steps[0]->id,
                                     'decision' => AssessmentDecision::SUCCESSFUL->name,
                                 ],
                                 [
-                                    'step' => $stepTwo->id,
+                                    'step' => $steps[1]->id,
                                     'decision' => AssessmentDecision::UNSUCCESSFUL->name,
                                 ],
                             ],


### PR DESCRIPTION
🤖 Resolves #12525

## 👋 Introduction

Fixes bug where an unsuccessful assessment in final assessment step didn't lead to an overall status of "Disqualified: Pending decision"

## 🕵️ Details

I also made some changes to assessment step seeding to make this easier to test manually. Its still not perfect, but a lot easier I think.

## 🧪 Testing

Make sure the unit test does what its supposed to.
1. Revert commit 2c3b7c488d2ff95403fb4552682903f2b708a4f6 locally
2. Run phpunit tests (I use `make artisan CMD=test`). The new test should fail.
3. Undo your revert. All tests should pass.

Testing manually
1. Run data seeders
2. Log in as admin@test.com
3. Go to the process called "Published – Complex"
4. Go to the user named Perfect Priority
5. unplace the user, and undo final decision
6. Assess an essential skill in the final assessment step as Unsuccessful
7. The overall status should become "Disqualified: Pending decision" (but not if you reverted the fix

## 🚚 Deployment

We should run `app:sync-assessment-status`. This will be long, and can be done outside of deployment hours.
