### PR TITLE
[Docs] Updates deployment steps instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,6 +34,6 @@ Examples of when this is required include:
 > **Notes**
 >
 > - Remove deployment section if no steps are needed
-> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the linked issue if deployment steps are needed
+> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the PR if deployment steps are needed
 
  -->


### PR DESCRIPTION
## 👋 Introduction

This PR updates the instructions for adding a [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) when deployment steps are needed.