### PR TITLE
[Fix] Notify user of unknown support form errors

### DIFF
--- a/apps/web/src/pages/SupportPage/components/SupportForm/utils.ts
+++ b/apps/web/src/pages/SupportPage/components/SupportForm/utils.ts
@@ -1,0 +1,69 @@
+import { Logger } from "@gc-digital-talent/logger";
+
+import { API_SUPPORT_ENDPOINT } from "~/constants/talentSearchConstants";
+
+export const SUPPORT_TICKET_ERROR = {
+  UNKNOWN: "UknownError",
+  INVALID_EMAIL: "InvalidEmailError",
+} as const;
+
+class UnknownError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = SUPPORT_TICKET_ERROR.UNKNOWN;
+  }
+}
+
+class InvalidEmailError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = SUPPORT_TICKET_ERROR.INVALID_EMAIL;
+  }
+}
+
+export interface FormValues {
+  user_id: string;
+  name: string;
+  email: string;
+  description: string;
+  subject: string;
+  previous_url: string;
+  user_agent: string;
+}
+
+interface JSONResponse {
+  serviceResponse?: string;
+  errorDetail?: string;
+}
+
+export async function submitTicket(
+  values: FormValues,
+  logger: Logger,
+): Promise<boolean> {
+  const response = await fetch(API_SUPPORT_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(values),
+  });
+
+  const body: JSONResponse = (await response.json()) as JSONResponse;
+  if (response.ok) {
+    logger.info("Ticket successfully submitted");
+    return true;
+  } else {
+    logger.error(`Failed to submit ticket: ${JSON.stringify(body)}`);
+
+    const errorCode = `${response.status} - ${response.statusText}`;
+    let error = new UnknownError(errorCode);
+    if (
+      body?.serviceResponse === "error" &&
+      body?.errorDetail === "invalid_email"
+    ) {
+      error = new InvalidEmailError(errorCode);
+    }
+
+    return Promise.reject(error);
+  }
+}


### PR DESCRIPTION
🤖 Resolves #12473 

## 👋 Introduction

Refactors the support form in order to handle unknown errors.

## 🕵️ Details

The form was handling all errors from the response except edge cases where we had no response to work with (500). This refactors it to handle that edge case and return the default error.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Navigate to support form `/support`
3. Turn off the web container
4. Submit the form
5. Confirm an error toast appears