### PR TITLE
[Feature] Never require asset behavioural skill assessment

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -992,36 +992,36 @@ class PoolCandidate extends Model
                         continue;
                     }
                 } else { // $poolSkill is an ASSET skill
+                    // Asset behavioural skills never need to be assessed
+                    if ($poolSkill->skill->category === SkillCategory::BEHAVIOURAL->name) {
+                        continue;
+                    }
 
                     // We do not need to evaluate non-essential technical skills that are not on
                     // the users snapshot, so skip the result check
-                    if ($poolSkill->skill->category === SkillCategory::TECHNICAL->name) {
-                        $isClaimed = false;
-                        $snapshot = $this->profile_snapshot;
+                    $isClaimed = false;
+                    $snapshot = $this->profile_snapshot;
 
-                        if ($snapshot) {
-                            $experiences = collect($snapshot['experiences']);
+                    if ($snapshot) {
+                        $experiences = collect($snapshot['experiences']);
 
-                            $isClaimed = $experiences->contains(function ($experience) use ($poolSkill) {
-                                foreach ($experience['skills'] as $skill) {
-                                    if ($skill['id'] === $poolSkill->skill_id) {
-                                        return true;
-                                    }
+                        $isClaimed = $experiences->contains(function ($experience) use ($poolSkill) {
+                            foreach ($experience['skills'] as $skill) {
+                                if ($skill['id'] === $poolSkill->skill_id) {
+                                    return true;
                                 }
+                            }
 
-                                return false;
-                            });
-                        }
+                            return false;
+                        });
+                    }
 
-                        if (! $isClaimed) {
-                            continue;
-                        }
+                    if (! $isClaimed) {
+                        continue;
                     }
 
                     if (! $result || is_null($result->assessment_decision)) {
                         $hasToAssess = true;
-
-                        continue;
                     }
                 }
             }

--- a/api/tests/Feature/CandidateAssessmentStatusTest.php
+++ b/api/tests/Feature/CandidateAssessmentStatusTest.php
@@ -640,39 +640,47 @@ class CandidateAssessmentStatusTest extends TestCase
                 'team_id' => $this->team->id,
             ]);
 
-        $behaviouralSkills = Skill::where('category', SkillCategory::BEHAVIOURAL->name)->limit(2)->get();
+        $technicalSkills = Skill::where('category', SkillCategory::TECHNICAL->name)->limit(2)->get();
         $poolSkillOne = PoolSkill::create([
             'pool_id' => $pool->id,
-            'skill_id' => $behaviouralSkills[0]->id,
+            'skill_id' => $technicalSkills[0]->id,
             'type' => PoolSkillType::NONESSENTIAL->name,
         ]);
 
-        // Non-essential skills must also be assessed if a user claims them
+        // Non-essential technical skills must also be assessed if a user claims them
         $poolSkillTwo = PoolSkill::create([
             'pool_id' => $pool->id,
-            'skill_id' => $behaviouralSkills[1]->id,
+            'skill_id' => $technicalSkills[1]->id,
             'type' => PoolSkillType::NONESSENTIAL->name,
+        ]);
+
+        // Skill is not considered claimed unless it has an attached experience
+        $user = User::factory()->create();
+        $userSkill = UserSkill::factory()->create([
+            'user_id' => $user->id,
+            'skill_id' => $poolSkillTwo->skill_id,
+        ]);
+        WorkExperience::factory()->afterCreating(function (WorkExperience $experience) use ($userSkill) {
+            $experience->userSkills()->sync([
+                $userSkill->id => ['details' => 'first skill'],
+            ]);
+        })->create([
+            'user_id' => $user->id,
         ]);
 
         $candidate = PoolCandidate::factory()->withSnapshot()->create([
+            'user_id' => $user->id,
             'pool_id' => $pool->id,
             'submitted_at' => config('constants.past_date'),
             'expiry_date' => config('constants.far_future_date'),
         ]);
 
-        $stepOne = $pool->assessmentSteps->first();
-
-        $stepTwo = AssessmentStep::factory()
-            ->afterCreating(function (AssessmentStep $step) use ($poolSkillOne, $poolSkillTwo) {
-                $step->poolSkills()->sync([$poolSkillOne->id, $poolSkillTwo->id]);
-            })->create([
-                'pool_id' => $pool->id,
-            ]);
+        $assessmentStep = $pool->assessmentSteps->first();
 
         AssessmentResult::factory()
             ->withResultType(AssessmentResultType::EDUCATION)
             ->create([
-                'assessment_step_id' => $stepOne->id,
+                'assessment_step_id' => $assessmentStep->id,
                 'pool_candidate_id' => $candidate->id,
                 'assessment_decision' => AssessmentDecision::SUCCESSFUL->name,
             ]);
@@ -680,7 +688,7 @@ class CandidateAssessmentStatusTest extends TestCase
         AssessmentResult::factory()
             ->withResultType(AssessmentResultType::SKILL)
             ->create([
-                'assessment_step_id' => $stepTwo->id,
+                'assessment_step_id' => $assessmentStep->id,
                 'pool_candidate_id' => $candidate->id,
                 'assessment_decision' => AssessmentDecision::SUCCESSFUL->name,
                 'pool_skill_id' => $poolSkillOne->id,
@@ -692,15 +700,11 @@ class CandidateAssessmentStatusTest extends TestCase
                 'data' => [
                     'poolCandidate' => [
                         'assessmentStatus' => [
-                            'currentStep' => 2,
+                            'currentStep' => 1,
                             'overallAssessmentStatus' => OverallAssessmentStatus::TO_ASSESS->name,
                             'assessmentStepStatuses' => [
                                 [
-                                    'step' => $stepOne->id,
-                                    'decision' => AssessmentDecision::SUCCESSFUL->name,
-                                ],
-                                [
-                                    'step' => $stepTwo->id,
+                                    'step' => $assessmentStep->id,
                                     'decision' => null,
                                 ],
                             ],
@@ -712,7 +716,7 @@ class CandidateAssessmentStatusTest extends TestCase
         $result = AssessmentResult::factory()
             ->withResultType(AssessmentResultType::SKILL)
             ->create([
-                'assessment_step_id' => $stepTwo->id,
+                'assessment_step_id' => $assessmentStep->id,
                 'pool_candidate_id' => $candidate->id,
                 'assessment_decision' => null,
                 'pool_skill_id' => $poolSkillTwo->id,
@@ -725,15 +729,11 @@ class CandidateAssessmentStatusTest extends TestCase
                 'data' => [
                     'poolCandidate' => [
                         'assessmentStatus' => [
-                            'currentStep' => 2,
+                            'currentStep' => 1,
                             'overallAssessmentStatus' => OverallAssessmentStatus::TO_ASSESS->name,
                             'assessmentStepStatuses' => [
                                 [
-                                    'step' => $stepOne->id,
-                                    'decision' => AssessmentDecision::SUCCESSFUL->name,
-                                ],
-                                [
-                                    'step' => $stepTwo->id,
+                                    'step' => $assessmentStep->id,
                                     'decision' => null,
                                 ],
                             ],
@@ -756,11 +756,7 @@ class CandidateAssessmentStatusTest extends TestCase
                             'overallAssessmentStatus' => OverallAssessmentStatus::QUALIFIED->name,
                             'assessmentStepStatuses' => [
                                 [
-                                    'step' => $stepOne->id,
-                                    'decision' => AssessmentDecision::SUCCESSFUL->name,
-                                ],
-                                [
-                                    'step' => $stepTwo->id,
+                                    'step' => $assessmentStep->id,
                                     'decision' => AssessmentDecision::SUCCESSFUL->name,
                                 ],
                             ],

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -19,6 +19,7 @@ import {
   PoolSkillType,
   Scalars,
   Skill,
+  SkillCategory,
   UpdateAssessmentResultInput,
   User,
   graphql,
@@ -484,7 +485,9 @@ export const ScreeningDecisionDialog = ({
             <>
               {intl.formatMessage(
                 poolSkill?.type?.value === PoolSkillType.Nonessential &&
-                  !experienceAttachedToSkill
+                  (!experienceAttachedToSkill ||
+                    poolSkill?.skill?.category.value ===
+                      SkillCategory.Behavioural)
                   ? poolCandidateMessages.unclaimed
                   : poolCandidateMessages.toAssess,
               )}


### PR DESCRIPTION
🤖 Resolves #12552

## 👋 Introduction

Updates the site to prevent requiring assessment for non-essential behavioural skills. Essential skills and non-essential technical skills should remain the same.

## 🧪 Testing

1. Create a pool with both an essential skill and an asset behavioural skill.
2. Create an assessment step which assesses both skills.
3. Publish the pool filling in any other fields required.
4. Create and submit an application to the pool.
5. Navigate to view the application at `admin/candidates/{candidateId}/application`.
6. Confirm the essential skill appears as "To assess" and the asset skill as "Unclaimed" in the assessment step from 2.
7. Assess the essential skill as demonstrated.
8. Confirm the step appears as successful.