### PR TITLE
[Fix] Resetting end date for current work experiences

### DIFF
--- a/apps/web/src/types/experience.ts
+++ b/apps/web/src/types/experience.ts
@@ -114,7 +114,7 @@ export type WorkFormValues = FormValueDateRange & {
   cafEmploymentType?: CafEmploymentType | null;
   cafForce?: CafForce | null;
   cafRank?: CafRank | null;
-  currentRole?: boolean | null;
+  currentRole: boolean;
 };
 
 export type AllExperienceFormValues = AwardFormValues &

--- a/apps/web/src/utils/experienceUtils.tsx
+++ b/apps/web/src/utils/experienceUtils.tsx
@@ -385,7 +385,7 @@ export const formValuesToSubmitData = (
       organization,
       division: team,
       startDate,
-      endDate: endDate,
+      endDate: newEndDate,
       employmentCategory,
       extSizeOfOrganization,
       extRoleSeniority,


### PR DESCRIPTION
🤖 Resolves #12557 

## 👋 Introduction

Fixes an issue where checking current role on an existing work experience was not resetting the end date.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as any user
3. Create a work experience with an end date
4. Edit experience from step 3, checking the "current role" checkbox
5. Confirm the end date is set to null and renders as "Present"