### PR TITLE
[Test] Submit work experience after linking skill

### DIFF
--- a/apps/playwright/fixtures/ExperiencePage.ts
+++ b/apps/playwright/fixtures/ExperiencePage.ts
@@ -639,9 +639,6 @@ class ExperiencePage extends AppPage {
     experienceType: string;
     skill: string;
   }) {
-    await this.create();
-    await this.typeLocator.selectOption(input.experienceType);
-
     await this.page.getByRole("button", { name: "Add a skill" }).click();
 
     await this.page.getByRole("combobox", { name: "Skill *" }).click();

--- a/apps/playwright/fixtures/ExperiencePage.ts
+++ b/apps/playwright/fixtures/ExperiencePage.ts
@@ -214,7 +214,10 @@ class ExperiencePage extends AppPage {
     await this.waitForGraphqlResponse("CreateWorkExperience");
   }
 
-  async addGovTermOrIndeterminateWorkExperience(input: WorkExperienceInput) {
+  async addGovTermOrIndeterminateWorkExperience(
+    input: WorkExperienceInput,
+    save = true,
+  ) {
     await this.create();
     await this.typeLocator.selectOption("work");
 
@@ -286,8 +289,10 @@ class ExperiencePage extends AppPage {
       .getByRole("textbox", { name: /additional details/i })
       .fill(input.details ?? "test details");
 
-    await this.save();
-    await this.waitForGraphqlResponse("CreateWorkExperience");
+    if (save) {
+      await this.save();
+      await this.waitForGraphqlResponse("CreateWorkExperience");
+    }
   }
 
   async addGovContractorWorkExperience(input: WorkExperienceInput) {

--- a/apps/playwright/tests/applicant/experience/link-skill.spec.ts
+++ b/apps/playwright/tests/applicant/experience/link-skill.spec.ts
@@ -10,6 +10,8 @@ test("Can link skill to experience", async ({ appPage }) => {
   await loginBySub(experiencePage.page, "applicant@test.com");
 
   // Ensure the other fields are filled out first
+  // Must be a work experience as regression
+  // for fields resetting on skill link
   await experiencePage.addGovTermOrIndeterminateWorkExperience(
     {
       role,

--- a/apps/playwright/tests/applicant/experience/link-skill.spec.ts
+++ b/apps/playwright/tests/applicant/experience/link-skill.spec.ts
@@ -32,6 +32,12 @@ test("Can link skill to experience", async ({ appPage }) => {
     skill + " selected.",
   );
 
+  await expect(experiencePage.page.getByText(skill + " selected")).toBeHidden();
+
+  await experiencePage.page
+    .getByRole("textbox", { name: new RegExp(`how ${skill} featured`, "i") })
+    .fill("Test description");
+
   await experiencePage.save();
   await experiencePage.waitForGraphqlResponse("CreateWorkExperience");
 

--- a/apps/playwright/tests/applicant/experience/link-skill.spec.ts
+++ b/apps/playwright/tests/applicant/experience/link-skill.spec.ts
@@ -2,9 +2,22 @@ import { test, expect } from "~/fixtures";
 import ExperiencePage from "~/fixtures/ExperiencePage";
 import { loginBySub } from "~/utils/auth";
 
+const uniqueTestId = Date.now().valueOf();
+
 test("Can link skill to experience", async ({ appPage }) => {
+  const role = `Test add goc term or indeterminate work experience (${uniqueTestId})`;
   const experiencePage = new ExperiencePage(appPage.page);
   await loginBySub(experiencePage.page, "applicant@test.com");
+
+  // Ensure the other fields are filled out first
+  await experiencePage.addGovTermOrIndeterminateWorkExperience(
+    {
+      role,
+      startDate: "2001-01",
+      endDate: "2023-01",
+    },
+    false,
+  );
 
   const skill = "Courage";
 
@@ -15,5 +28,12 @@ test("Can link skill to experience", async ({ appPage }) => {
 
   await expect(experiencePage.page.getByRole("alert")).toContainText(
     skill + " selected.",
+  );
+
+  await experiencePage.save();
+  await experiencePage.waitForGraphqlResponse("CreateWorkExperience");
+
+  await expect(experiencePage.page.getByRole("alert")).toContainText(
+    /successfully added experience/i,
   );
 });


### PR DESCRIPTION
🤖 Resolves #12493

## 👋 Introduction

Updates the skill link test to also submit a work experience to cover a case where fields were resetting after linking a skill.

## 🧪 Testing

1. Confirm test changes cover the case specified in the ticket
2. Confirm it passes