### PR TITLE
[Fix] Rule for pool skill not added as both essential and asset

### DIFF
--- a/api/app/GraphQL/Validators/CreatePoolSkillInputValidator.php
+++ b/api/app/GraphQL/Validators/CreatePoolSkillInputValidator.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Validators;
+
+use Database\Helpers\ApiErrorEnums;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Validation\Rule;
+use Nuwave\Lighthouse\Validation\Validator;
+
+final class CreatePoolSkillInputValidator extends Validator
+{
+    /**
+     * Return the validation rules.
+     *
+     * @return array<string, array<mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'skillId' => [Rule::unique('pool_skill', 'skill_id')->where(fn (Builder $query) => $query->where('pool_id', $this->arg('poolId')))],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'skillId.unique' => ApiErrorEnums::POOL_SKILL_NOT_ESSENTIAL_AND_ASSET_TYPES,
+        ];
+    }
+}

--- a/api/database/helpers/ApiErrorEnums.php
+++ b/api/database/helpers/ApiErrorEnums.php
@@ -27,6 +27,8 @@ class ApiErrorEnums
 
     const CHANGE_JUSTIFICATION_REQUIRED = 'ChangeJustificationRequired';
 
+    const POOL_SKILL_NOT_ESSENTIAL_AND_ASSET_TYPES = 'PoolSkillNotEssentialAndAssetTypes';
+
     // pool candidate field validation
     const EXPIRY_DATE_REQUIRED = 'ExpiryDateRequired';
 

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -2016,7 +2016,9 @@ input UpdatePublishedPoolInput @validator {
   aboutUs: LocalizedStringInput @rename(attribute: "about_us")
 }
 
-input CreatePoolSkillInput {
+input CreatePoolSkillInput @validator {
+  poolId: ID! @rename(attribute: "pool_id")
+  skillId: ID! @rename(attribute: "skill_id")
   type: PoolSkillType!
   requiredLevel: SkillLevel @rename(attribute: "required_skill_level")
 }
@@ -2547,11 +2549,7 @@ type Mutation {
     @guard
     @canFind(ability: "view", find: "pool_id", model: "Pool", injectArgs: true)
 
-  createPoolSkill(
-    poolId: ID! @rename(attribute: "pool_id")
-    skillId: ID! @rename(attribute: "skill_id")
-    poolSkill: CreatePoolSkillInput! @spread
-  ): PoolSkill
+  createPoolSkill(poolSkill: CreatePoolSkillInput! @spread): PoolSkill
     @create
     @guard
     @canFind(

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -478,7 +478,7 @@ type Mutation {
   updatePool(id: ID!, pool: UpdatePoolInput!): Pool
   updatePublishedPool(id: ID!, pool: UpdatePublishedPoolInput!): Pool
   togglePoolUserBookmark(poolId: UUID!): Pool
-  createPoolSkill(poolId: ID!, skillId: ID!, poolSkill: CreatePoolSkillInput!): PoolSkill
+  createPoolSkill(poolSkill: CreatePoolSkillInput!): PoolSkill
   updatePoolSkill(id: ID!, poolSkill: UpdatePoolSkillInput!): PoolSkill
   deletePoolSkill(id: ID!): PoolSkill
   publishPool(id: ID!): Pool
@@ -2034,6 +2034,8 @@ input UpdatePublishedPoolInput {
 }
 
 input CreatePoolSkillInput {
+  poolId: ID!
+  skillId: ID!
   type: PoolSkillType!
   requiredLevel: SkillLevel
 }

--- a/apps/playwright/utils/pools.ts
+++ b/apps/playwright/utils/pools.ts
@@ -148,28 +148,22 @@ export const updatePool: GraphQLRequestFunc<Pool, UpdatePoolArgs> = async (
 };
 
 const Test_CreatePoolSkillMutationDocument = /* GraphQL */ `
-  mutation Test_CreatePoolSkill(
-    $poolId: ID!
-    $skillId: ID!
-    $poolSkill: CreatePoolSkillInput!
-  ) {
-    createPoolSkill(poolId: $poolId, skillId: $skillId, poolSkill: $poolSkill) {
+  mutation Test_CreatePoolSkill($poolSkill: CreatePoolSkillInput!) {
+    createPoolSkill(poolSkill: $poolSkill) {
       id
     }
   }
 `;
 
 interface CreatePoolSkillArgs {
-  poolId: string;
-  skillId?: string;
   poolSkill: CreatePoolSkillInput;
 }
 
 export const createPoolSkill: GraphQLRequestFunc<
   PoolSkill,
   CreatePoolSkillArgs
-> = async (ctx, { poolId, poolSkill, ...opts }) => {
-  let skillId = opts?.skillId;
+> = async (ctx, { poolSkill }) => {
+  let skillId: string | undefined = poolSkill.skillId;
   if (!skillId) {
     const technicalSkill = await getSkills(ctx, {}).then((skills) => {
       return skills.find(
@@ -183,8 +177,6 @@ export const createPoolSkill: GraphQLRequestFunc<
     .post(Test_CreatePoolSkillMutationDocument, {
       isPrivileged: true,
       variables: {
-        poolId,
-        skillId,
         poolSkill,
       },
     })

--- a/apps/playwright/utils/pools.ts
+++ b/apps/playwright/utils/pools.ts
@@ -275,14 +275,22 @@ export const createAndPublishPool: GraphQLRequestFunc<
         }),
       );
     } else {
-      await createPoolSkill(ctx, {
-        poolSkill: {
-          poolId: pool.id,
-          skillId: "",
-          type: PoolSkillType.Essential,
-          requiredLevel: SkillLevel.Beginner,
-        },
+      const technicalSkill = await getSkills(ctx, {}).then((skills) => {
+        return skills.find(
+          (skill) => skill.category.value === SkillCategory.Technical,
+        );
       });
+      const skillId = technicalSkill?.id;
+      if (skillId) {
+        await createPoolSkill(ctx, {
+          poolSkill: {
+            poolId: pool.id,
+            skillId,
+            type: PoolSkillType.Essential,
+            requiredLevel: SkillLevel.Beginner,
+          },
+        });
+      }
     }
 
     return await publishPool(ctx, pool.id);

--- a/apps/playwright/utils/pools.ts
+++ b/apps/playwright/utils/pools.ts
@@ -265,9 +265,9 @@ export const createAndPublishPool: GraphQLRequestFunc<
       await Promise.all(
         skillIds.map(async (skillId) => {
           await createPoolSkill(ctx, {
-            poolId: pool.id,
-            skillId,
             poolSkill: {
+              poolId: pool.id,
+              skillId,
               type: PoolSkillType.Essential,
               requiredLevel: SkillLevel.Beginner,
             },
@@ -276,8 +276,9 @@ export const createAndPublishPool: GraphQLRequestFunc<
       );
     } else {
       await createPoolSkill(ctx, {
-        poolId: pool.id,
         poolSkill: {
+          poolId: pool.id,
+          skillId: "",
           type: PoolSkillType.Essential,
           requiredLevel: SkillLevel.Beginner,
         },

--- a/apps/web/src/hooks/usePoolMutations.ts
+++ b/apps/web/src/hooks/usePoolMutations.ts
@@ -92,12 +92,8 @@ const UnarchivePool_Mutation = graphql(/* GraphQL */ `
 `);
 
 const CreatePoolSkill_Mutation = graphql(/* GraphQL */ `
-  mutation CreatePoolSkill(
-    $poolId: ID!
-    $skillId: ID!
-    $poolSkill: CreatePoolSkillInput!
-  ) {
-    createPoolSkill(poolId: $poolId, skillId: $skillId, poolSkill: $poolSkill) {
+  mutation CreatePoolSkill($poolSkill: CreatePoolSkillInput!) {
+    createPoolSkill(poolSkill: $poolSkill) {
       id
     }
   }
@@ -420,12 +416,8 @@ const usePoolMutations = (returnPath?: string) => {
     executeCreatePoolSkillMutation,
   ] = useMutation(CreatePoolSkill_Mutation);
 
-  const createPoolSkill = async (
-    poolId: string,
-    skillId: string,
-    poolSkill: CreatePoolSkillInput,
-  ) => {
-    return executeCreatePoolSkillMutation({ poolId, skillId, poolSkill })
+  const createPoolSkill = async (poolSkill: CreatePoolSkillInput) => {
+    return executeCreatePoolSkillMutation({ poolSkill })
       .then((result) => {
         if (result.data?.createPoolSkill) {
           toast.success(

--- a/apps/web/src/pages/Pools/EditPoolPage/components/AssetSkillsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/AssetSkillsSection.tsx
@@ -75,7 +75,9 @@ const AssetSkillsSection = ({
     skillSelected: string,
     skillLevel: SkillLevel,
   ) => {
-    await poolSkillMutations.create(pool.id, skillSelected, {
+    await poolSkillMutations.create({
+      poolId: pool.id,
+      skillId: skillSelected,
       type: PoolSkillType.Nonessential,
       requiredLevel: skillLevel,
     });

--- a/apps/web/src/pages/Pools/EditPoolPage/components/EssentialSkillsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/EssentialSkillsSection.tsx
@@ -75,7 +75,9 @@ const EssentialSkillsSection = ({
     skillSelected: string,
     skillLevel: SkillLevel,
   ) => {
-    await poolSkillMutations.create(pool.id, skillSelected, {
+    await poolSkillMutations.create({
+      poolId: pool.id,
+      skillId: skillSelected,
       type: PoolSkillType.Essential,
       requiredLevel: skillLevel,
     });

--- a/apps/web/src/pages/Pools/EditPoolPage/types.ts
+++ b/apps/web/src/pages/Pools/EditPoolPage/types.ts
@@ -69,11 +69,7 @@ export type SectionKey =
   | "generalQuestions";
 
 export interface PoolSkillMutationsType {
-  create: (
-    poolId: string,
-    skillId: string,
-    poolSkill: CreatePoolSkillInput,
-  ) => Promise<void>;
+  create: (poolSkill: CreatePoolSkillInput) => Promise<void>;
   update: (id: string, poolSkill: UpdatePoolSkillInput) => Promise<void>;
   delete: (id: string) => Promise<void>;
 }

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1047,6 +1047,10 @@
     "defaultMessage": "Chaque compétence doit être incluse dans une évaluation",
     "description": "Error message that the pool advertisement skills are lacking an assessment"
   },
+  "kHtt2N": {
+    "defaultMessage": "Vous ne pouvez pas inclure une compétence à la fois comme essentielle et comme atout dans le même processus. Veuillez en choisir une et la retirer de l'autre section.",
+    "description": "Error message that the pool advertisement skills cannot be both essential and asset"
+  },
   "kQTtt9": {
     "defaultMessage": "Enum introuvable",
     "description": "Error message when human readable message not found"

--- a/packages/i18n/src/messages/apiMessages.ts
+++ b/packages/i18n/src/messages/apiMessages.ts
@@ -333,6 +333,13 @@ export const apiMessages: Record<string, MessageDescriptor> = defineMessages({
       "Error message that the pool advertisement skills are lacking an assessment",
     id: "kDw+xr",
   },
+  PoolSkillNotEssentialAndAssetTypes: {
+    defaultMessage:
+      "You can't include a skill as both essential and an asset in the same process. Please choose one and remove it from the other section.",
+    description:
+      "Error message that the pool advertisement skills cannot be both essential and asset",
+    id: "kHtt2N",
+  },
 
   APPLICATION_EXISTS: {
     defaultMessage: "You have already applied to this pool",


### PR DESCRIPTION
🤖 Resolves #11432.

## 👋 Introduction

This PR creates a rule that does not allow a skill to added as both essential and asset in a pool (process).

## 🧪 Testing

1. `make refresh-api; pnpm build:fresh`
2. Create a process
3. Add a skill to the pool as essential
4. Verify skill is added successfully
5. Add the same skill that was added as an essential skill previously to the pool as asset
6. Verify error toast is rendered with message "You can't include a skill as both essential and an asset in the same process. Please choose one and remove it from the other section."

## 📸 Screenshots

<img width="1198" alt="Screen Shot 2025-01-28 at 11 06 21" src="https://github.com/user-attachments/assets/0ba614c5-0e27-4a8c-82cf-aa3d2f0b994f" />
<img width="1310" alt="Screen Shot 2025-01-28 at 11 06 35" src="https://github.com/user-attachments/assets/03634f6b-09cd-4fa6-83ac-a3c4a52d695a" />
<img width="1124" alt="Screen Shot 2025-01-28 at 11 08 33" src="https://github.com/user-attachments/assets/3a51af64-3f79-4070-815d-a83dbcf55a65" />