### PR TITLE
[Fix] Equity dialogs close on success

### DIFF
--- a/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
+++ b/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
@@ -3,10 +3,6 @@
 query getProfile($userId: UUID!) {
   user(id: $userId) {
     id
-    authInfo {
-      id
-      sub
-    }
     firstName
     lastName
     email

--- a/api/app/Http/Resources/UserResource.php
+++ b/api/app/Http/Resources/UserResource.php
@@ -69,7 +69,6 @@ class UserResource extends JsonResource
         return [
             'version' => $this->version,
             'id' => $this->id,
-            'sub' => $this->sub,
             'firstName' => $this->first_name,
             'lastName' => $this->last_name,
             'email' => $this->email,

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -44,7 +44,7 @@ class SnapshotTest extends TestCase
      *
      * @return void
      */
-    public function testCreateSnapshot()
+    public function test_create_snapshot()
     {
         $snapshotQuery = file_get_contents(base_path('app/GraphQL/Mutations/PoolCandidateSnapshot.graphql'), true);
         $user = User::factory()
@@ -93,10 +93,6 @@ class SnapshotTest extends TestCase
         // Add version number
         $expectedSnapshot['version'] = ProfileSnapshot::$VERSION;
 
-        // line-up query format with how the snapshot is ordered
-        $expectedSnapshot['sub'] = $expectedSnapshot['authInfo']['sub'];
-        unset($expectedSnapshot['authInfo']);
-
         // sort experiences the same way as order does not matter for comparison
         usort($expectedSnapshot['experiences'], function ($a, $b) {
             return strcmp($a['id'], $b['id']);
@@ -108,7 +104,7 @@ class SnapshotTest extends TestCase
         assertEquals($expectedSnapshot, $decodedActual);
     }
 
-    public function testSnapshotSkillFiltering()
+    public function test_snapshot_skill_filtering()
     {
         Skill::factory(20)->create();
 
@@ -167,7 +163,7 @@ class SnapshotTest extends TestCase
         assertEquals($intersectedArrayLength, 0);
     }
 
-    public function testSetApplicationSnapshotDoesNotOverwrite()
+    public function test_set_application_snapshot_does_not_overwrite()
     {
         // non-null snapshot value set
         $user = User::factory()
@@ -189,7 +185,7 @@ class SnapshotTest extends TestCase
         assertSame(['snapshot' => 'set'], $snapshot);
     }
 
-    public function testLocalizingLegacyEnums()
+    public function test_localizing_legacy_enums()
     {
         // non-null snapshot value set
         $user = User::factory()

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -44,7 +44,7 @@ class SnapshotTest extends TestCase
      *
      * @return void
      */
-    public function test_create_snapshot()
+    public function testCreateSnapshot()
     {
         $snapshotQuery = file_get_contents(base_path('app/GraphQL/Mutations/PoolCandidateSnapshot.graphql'), true);
         $user = User::factory()
@@ -104,7 +104,7 @@ class SnapshotTest extends TestCase
         assertEquals($expectedSnapshot, $decodedActual);
     }
 
-    public function test_snapshot_skill_filtering()
+    public function testSnapshotSkillFiltering()
     {
         Skill::factory(20)->create();
 
@@ -163,7 +163,7 @@ class SnapshotTest extends TestCase
         assertEquals($intersectedArrayLength, 0);
     }
 
-    public function test_set_application_snapshot_does_not_overwrite()
+    public function testSetApplicationSnapshotDoesNotOverwrite()
     {
         // non-null snapshot value set
         $user = User::factory()
@@ -185,7 +185,7 @@ class SnapshotTest extends TestCase
         assertSame(['snapshot' => 'set'], $snapshot);
     }
 
-    public function test_localizing_legacy_enums()
+    public function testLocalizingLegacyEnums()
     {
         // non-null snapshot value set
         $user = User::factory()

--- a/apps/web/src/components/EmploymentEquity/EquityOption.tsx
+++ b/apps/web/src/components/EmploymentEquity/EquityOption.tsx
@@ -18,7 +18,7 @@ interface EquityOptionProps {
   isAdded: boolean;
   option: EquityGroup;
   // Note: Just defining the func signature
-  onSave: (value: boolean) => void;
+  onSave: (value: boolean) => Promise<void>;
   title: ReactNode;
   description?: ReactNode;
 }

--- a/apps/web/src/components/EmploymentEquity/EquityOptions.tsx
+++ b/apps/web/src/components/EmploymentEquity/EquityOptions.tsx
@@ -82,9 +82,9 @@ const EquityOptions = ({
     return !option;
   }).length;
 
-  const handleOptionSave = (key: EquityKeys, value: boolean) => {
+  const handleOptionSave = async (key: EquityKeys, value: boolean) => {
     const handler = value ? onAdd : onRemove;
-    handler(key)
+    return handler(key)
       .then((response) => {
         if (response) {
           toast.success(
@@ -107,8 +107,8 @@ const EquityOptions = ({
     toast.error(intl.formatMessage(profileMessages.updatingFailed));
   };
 
-  const handleMultipleFieldSave = (data: UpdateUserAsUserInput) => {
-    onUpdate(data)
+  const handleMultipleFieldSave = async (data: UpdateUserAsUserInput) => {
+    return onUpdate(data)
       .then((res) => {
         if (res) toast.success(intl.formatMessage(profileMessages.userUpdated));
         else {
@@ -134,7 +134,7 @@ const EquityOptions = ({
       </Heading>
       {isDisabled && (
         <div
-          data-h2-position="base(absolute)"
+          data-h2-position="base(fixed)"
           data-h2-background-color="base(background)"
           data-h2-display="base(flex)"
           data-h2-align-items="base(center)"
@@ -155,9 +155,7 @@ const EquityOptions = ({
               option="indigenous"
               indigenousCommunities={resolvedIndigenousCommunities}
               signature={indigenousDeclarationSignature ?? undefined}
-              onSave={(newValues) => {
-                handleMultipleFieldSave(newValues);
-              }}
+              onSave={(newValues) => handleMultipleFieldSave(newValues)}
               title={intl.formatMessage(
                 getEmploymentEquityStatement("indigenous"),
               )}
@@ -168,9 +166,7 @@ const EquityOptions = ({
               disabled={isDisabled}
               option="disability"
               isAdded={resolvedDisability}
-              onSave={(newValue) => {
-                handleOptionSave("hasDisability", newValue);
-              }}
+              onSave={(newValue) => handleOptionSave("hasDisability", newValue)}
               title={intl.formatMessage(
                 getEmploymentEquityStatement("disability"),
               )}
@@ -181,9 +177,9 @@ const EquityOptions = ({
               disabled={isDisabled}
               option="minority"
               isAdded={resolvedMinority}
-              onSave={(newValue) => {
-                handleOptionSave("isVisibleMinority", newValue);
-              }}
+              onSave={(newValue) =>
+                handleOptionSave("isVisibleMinority", newValue)
+              }
               title={intl.formatMessage(
                 getEmploymentEquityStatement("minority"),
               )}
@@ -194,9 +190,7 @@ const EquityOptions = ({
               disabled={isDisabled}
               option="woman"
               isAdded={resolvedWoman}
-              onSave={(newValue) => {
-                handleOptionSave("isWoman", newValue);
-              }}
+              onSave={(newValue) => handleOptionSave("isWoman", newValue)}
               title={intl.formatMessage(getEmploymentEquityStatement("woman"))}
             />
           )}
@@ -260,9 +254,7 @@ const EquityOptions = ({
                     option="indigenous"
                     indigenousCommunities={resolvedIndigenousCommunities}
                     signature={indigenousDeclarationSignature ?? undefined}
-                    onSave={(newValues) => {
-                      handleMultipleFieldSave(newValues);
-                    }}
+                    onSave={(newValues) => handleMultipleFieldSave(newValues)}
                     title={intl.formatMessage(
                       getEmploymentEquityGroup("indigenous"),
                     )}
@@ -280,9 +272,9 @@ const EquityOptions = ({
                     disabled={isDisabled}
                     option="disability"
                     isAdded={resolvedDisability}
-                    onSave={(newValue) => {
-                      handleOptionSave("hasDisability", newValue);
-                    }}
+                    onSave={(newValue) =>
+                      handleOptionSave("hasDisability", newValue)
+                    }
                     title={intl.formatMessage(
                       getEmploymentEquityGroup("disability"),
                     )}
@@ -300,9 +292,9 @@ const EquityOptions = ({
                     disabled={isDisabled}
                     option="minority"
                     isAdded={resolvedMinority}
-                    onSave={(newValue) => {
-                      handleOptionSave("isVisibleMinority", newValue);
-                    }}
+                    onSave={(newValue) =>
+                      handleOptionSave("isVisibleMinority", newValue)
+                    }
                     title={intl.formatMessage(
                       getEmploymentEquityGroup("minority"),
                     )}
@@ -320,9 +312,7 @@ const EquityOptions = ({
                     disabled={isDisabled}
                     option="woman"
                     isAdded={resolvedWoman}
-                    onSave={(newValue) => {
-                      handleOptionSave("isWoman", newValue);
-                    }}
+                    onSave={(newValue) => handleOptionSave("isWoman", newValue)}
                     title={intl.formatMessage(
                       getEmploymentEquityGroup("woman"),
                     )}

--- a/apps/web/src/components/EmploymentEquity/IndigenousEquityOption.tsx
+++ b/apps/web/src/components/EmploymentEquity/IndigenousEquityOption.tsx
@@ -21,7 +21,7 @@ interface EquityOptionProps {
   signature: string | undefined;
   option: EquityGroup;
   // Note: Just defining the func signature
-  onSave: (data: IndigenousUpdateProps) => void;
+  onSave: (data: IndigenousUpdateProps) => Promise<void>;
   title: ReactNode;
   description?: ReactNode;
   disabled?: boolean;

--- a/apps/web/src/components/EmploymentEquity/dialogs/DisabilityDialog.tsx
+++ b/apps/web/src/components/EmploymentEquity/dialogs/DisabilityDialog.tsx
@@ -1,5 +1,6 @@
 import { useIntl } from "react-intl";
 import { FormProvider, useForm, type SubmitHandler } from "react-hook-form";
+import { useState } from "react";
 
 import { Dialog } from "@gc-digital-talent/ui";
 import { Checklist } from "@gc-digital-talent/forms";
@@ -24,6 +25,7 @@ const DisabilityDialog = ({
   disabled,
 }: EquityDialogProps) => {
   const intl = useIntl();
+  const [isOpen, setOpen] = useState<boolean>(false);
   const methods = useForm<FormValues>({
     defaultValues: {
       hasDisability: isAdded,
@@ -31,12 +33,12 @@ const DisabilityDialog = ({
   });
   const { handleSubmit } = methods;
 
-  const submitHandler: SubmitHandler<FormValues> = (data: FormValues) => {
-    onSave(data.hasDisability);
+  const submitHandler: SubmitHandler<FormValues> = async (data: FormValues) => {
+    await onSave(data.hasDisability).then(() => setOpen(false));
   };
 
   return (
-    <Dialog.Root>
+    <Dialog.Root open={isOpen} onOpenChange={setOpen}>
       <Dialog.Trigger>{children}</Dialog.Trigger>
       <Dialog.Content>
         <Dialog.Header>

--- a/apps/web/src/components/EmploymentEquity/dialogs/IndigenousDialog.tsx
+++ b/apps/web/src/components/EmploymentEquity/dialogs/IndigenousDialog.tsx
@@ -55,7 +55,6 @@ const IndigenousDialog = ({
     data: FormValuesWithSignature,
   ) => {
     const newCommunities = formValuesToApiCommunities(data);
-    console.log(onSave);
     await onSave({
       indigenousCommunities: newCommunities,
       indigenousDeclarationSignature:

--- a/apps/web/src/components/EmploymentEquity/dialogs/IndigenousDialog.tsx
+++ b/apps/web/src/components/EmploymentEquity/dialogs/IndigenousDialog.tsx
@@ -1,5 +1,6 @@
 import { useIntl } from "react-intl";
 import { FormProvider, useForm, type SubmitHandler } from "react-hook-form";
+import { useState } from "react";
 
 import { Dialog } from "@gc-digital-talent/ui";
 import { Input } from "@gc-digital-talent/forms";
@@ -35,6 +36,7 @@ const IndigenousDialog = ({
   disabled,
 }: IndigenousDialogProps) => {
   const intl = useIntl();
+  const [isOpen, setOpen] = useState<boolean>(false);
   const methods = useForm<FormValuesWithSignature>({
     defaultValues: {
       ...apiCommunitiesToFormValues(
@@ -49,21 +51,22 @@ const IndigenousDialog = ({
   const communities = watch("communities");
   const hasCommunitiesSelected = communities && communities.length > 0;
 
-  const submitHandler: SubmitHandler<FormValuesWithSignature> = (
+  const submitHandler: SubmitHandler<FormValuesWithSignature> = async (
     data: FormValuesWithSignature,
   ) => {
     const newCommunities = formValuesToApiCommunities(data);
-    onSave({
+    console.log(onSave);
+    await onSave({
       indigenousCommunities: newCommunities,
       indigenousDeclarationSignature:
         newCommunities.length > 0 ? data.signature : null,
-    });
+    }).then(() => setOpen(false));
   };
 
   const labels = getSelfDeclarationLabels(intl);
 
   return (
-    <Dialog.Root>
+    <Dialog.Root open={isOpen} onOpenChange={setOpen}>
       <Dialog.Trigger>{children}</Dialog.Trigger>
       <Dialog.Content>
         <Dialog.Header>

--- a/apps/web/src/components/EmploymentEquity/dialogs/VisibleMinorityDialog.tsx
+++ b/apps/web/src/components/EmploymentEquity/dialogs/VisibleMinorityDialog.tsx
@@ -1,5 +1,6 @@
 import { useIntl } from "react-intl";
 import { FormProvider, useForm, type SubmitHandler } from "react-hook-form";
+import { useState } from "react";
 
 import { Dialog } from "@gc-digital-talent/ui";
 import { Checklist } from "@gc-digital-talent/forms";
@@ -24,6 +25,7 @@ const VisibleMinorityDialog = ({
   disabled,
 }: EquityDialogProps) => {
   const intl = useIntl();
+  const [isOpen, setOpen] = useState<boolean>(false);
   const methods = useForm<FormValues>({
     defaultValues: {
       isVisibleMinority: isAdded,
@@ -31,12 +33,12 @@ const VisibleMinorityDialog = ({
   });
   const { handleSubmit } = methods;
 
-  const submitHandler: SubmitHandler<FormValues> = (data: FormValues) => {
-    onSave(data.isVisibleMinority);
+  const submitHandler: SubmitHandler<FormValues> = async (data: FormValues) => {
+    await onSave(data.isVisibleMinority).then(() => setOpen(false));
   };
 
   return (
-    <Dialog.Root>
+    <Dialog.Root open={isOpen} onOpenChange={setOpen}>
       <Dialog.Trigger>{children}</Dialog.Trigger>
       <Dialog.Content>
         <Dialog.Header>

--- a/apps/web/src/components/EmploymentEquity/dialogs/WomanDialog.tsx
+++ b/apps/web/src/components/EmploymentEquity/dialogs/WomanDialog.tsx
@@ -1,5 +1,6 @@
 import { useIntl } from "react-intl";
 import { FormProvider, useForm, type SubmitHandler } from "react-hook-form";
+import { useState } from "react";
 
 import { Dialog } from "@gc-digital-talent/ui";
 import { Checklist } from "@gc-digital-talent/forms";
@@ -24,6 +25,7 @@ const WomanDialog = ({
   disabled,
 }: EquityDialogProps) => {
   const intl = useIntl();
+  const [isOpen, setOpen] = useState<boolean>(false);
   const methods = useForm<FormValues>({
     defaultValues: {
       isWoman: isAdded,
@@ -31,12 +33,12 @@ const WomanDialog = ({
   });
   const { handleSubmit } = methods;
 
-  const submitHandler: SubmitHandler<FormValues> = (data: FormValues) => {
-    onSave(data.isWoman);
+  const submitHandler: SubmitHandler<FormValues> = async (data: FormValues) => {
+    await onSave(data.isWoman).then(() => setOpen(false));
   };
 
   return (
-    <Dialog.Root>
+    <Dialog.Root open={isOpen} onOpenChange={setOpen}>
       <Dialog.Trigger>{children}</Dialog.Trigger>
       <Dialog.Content>
         <Dialog.Header>

--- a/apps/web/src/components/EmploymentEquity/types.ts
+++ b/apps/web/src/components/EmploymentEquity/types.ts
@@ -18,7 +18,7 @@ export type UserMutationPromise = Promise<
 
 export interface EquityDialogProps {
   isAdded: boolean;
-  onSave: (value: boolean) => void;
+  onSave: (value: boolean) => Promise<void>;
   children: ReactNode;
   disabled?: boolean;
 }
@@ -31,7 +31,7 @@ export interface IndigenousUpdateProps {
 export interface IndigenousDialogProps {
   indigenousCommunities: LocalizedIndigenousCommunity[];
   signature: string | undefined;
-  onSave: (data: IndigenousUpdateProps) => void;
+  onSave: (data: IndigenousUpdateProps) => Promise<void>;
   children: ReactNode;
   disabled?: boolean;
 }

--- a/apps/web/src/components/Profile/components/DiversityEquityInclusion/DiversityEquityInclusion.tsx
+++ b/apps/web/src/components/Profile/components/DiversityEquityInclusion/DiversityEquityInclusion.tsx
@@ -18,7 +18,6 @@ type AccordionItems = "information" | "";
 const DiversityEquityInclusion = ({
   user,
   onUpdate,
-  isUpdating,
   pool,
 }: SectionProps<Pick<Pool, "publishingGroup">>) => {
   const intl = useIntl();

--- a/apps/web/src/components/Profile/components/DiversityEquityInclusion/DiversityEquityInclusion.tsx
+++ b/apps/web/src/components/Profile/components/DiversityEquityInclusion/DiversityEquityInclusion.tsx
@@ -171,7 +171,6 @@ const DiversityEquityInclusion = ({
         </Accordion.Item>
       </Accordion.Root>
       <EquityOptions
-        isDisabled={isUpdating}
         inApplication={!!pool}
         indigenousCommunities={user.indigenousCommunities}
         indigenousDeclarationSignature={user.indigenousDeclarationSignature}

--- a/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
+++ b/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
@@ -1,5 +1,5 @@
 import { defineMessage, useIntl } from "react-intl";
-import { useMutation, useQuery } from "urql";
+import { OperationContext, useMutation, useQuery } from "urql";
 
 import { TableOfContents, ThrowNotFound, Pending } from "@gc-digital-talent/ui";
 import { navigationMessages } from "@gc-digital-talent/i18n";
@@ -27,88 +27,6 @@ const ProfileUpdateUser_Mutation = graphql(/* GraphQL */ `
   mutation UpdateUserAsUser($id: ID!, $user: UpdateUserAsUserInput!) {
     updateUserAsUser(id: $id, user: $user) {
       id
-      firstName
-      lastName
-      telephone
-      preferredLang {
-        value
-      }
-      preferredLanguageForInterview {
-        value
-      }
-      preferredLanguageForExam {
-        value
-      }
-      currentProvince {
-        value
-      }
-      currentCity
-      preferredLang {
-        value
-      }
-      lookingForEnglish
-      lookingForFrench
-      lookingForBilingual
-      firstOfficialLanguage {
-        value
-      }
-      secondLanguageExamCompleted
-      secondLanguageExamValidity
-      comprehensionLevel {
-        value
-      }
-      writtenLevel {
-        value
-      }
-      verbalLevel {
-        value
-      }
-      estimatedLanguageAbility {
-        value
-      }
-
-      isGovEmployee
-      workEmail
-      isWorkEmailVerified
-      hasPriorityEntitlement
-      priorityNumber
-      department {
-        id
-        departmentNumber
-        name {
-          en
-          fr
-        }
-      }
-      currentClassification {
-        id
-        name {
-          en
-          fr
-        }
-        group
-        level
-        minSalary
-        maxSalary
-      }
-
-      isWoman
-      hasDisability
-      isVisibleMinority
-      indigenousCommunities {
-        value
-      }
-      indigenousDeclarationSignature
-
-      hasDiploma
-      locationPreferences {
-        value
-      }
-      locationExemptions
-      acceptedOperationalRequirements {
-        value
-      }
-      positionDuration
     }
   }
 `);
@@ -123,10 +41,6 @@ const subTitle = defineMessage(pageMessages.subTitle);
 export const UserProfile_FragmentText = /* GraphQL */ `
   fragment UserProfile on User {
     id
-    authInfo {
-      id
-      sub
-    }
     firstName
     lastName
     email
@@ -605,9 +519,16 @@ const ProfileUser_Query = graphql(/* GraphQL */ `
   }
 `);
 
+const context: Partial<OperationContext> = {
+  requestPolicy: "cache-first",
+};
+
 const ProfilePage = () => {
   const intl = useIntl();
-  const [{ data, fetching, error }] = useQuery({ query: ProfileUser_Query });
+  const [{ data, fetching, error }] = useQuery({
+    query: ProfileUser_Query,
+    context,
+  });
 
   return (
     <Pending fetching={fetching} error={error}>

--- a/packages/auth/src/components/AuthorizationProvider.tsx
+++ b/packages/auth/src/components/AuthorizationProvider.tsx
@@ -2,8 +2,8 @@ import { useQuery } from "urql";
 import { ReactNode } from "react";
 
 import { Pending } from "@gc-digital-talent/ui";
-import { notEmpty } from "@gc-digital-talent/helpers";
 import { graphql } from "@gc-digital-talent/graphql";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
 
 import AuthorizationContainer from "./AuthorizationContainer";
 
@@ -42,12 +42,9 @@ const AuthorizationProvider = ({ children }: AuthorizationProviderProps) => {
   });
   const isLoaded = !fetching && !stale;
 
-  const roleAssignmentsFiltered =
-    data?.myAuth?.roleAssignments?.filter(notEmpty) ?? [];
-
   return (
     <AuthorizationContainer
-      roleAssignments={roleAssignmentsFiltered}
+      roleAssignments={unpackMaybes(data?.myAuth?.roleAssignments)}
       userAuthInfo={data?.myAuth}
       isLoaded={isLoaded}
     >


### PR DESCRIPTION
🤖 Resolves #11355 

## 👋 Introduction

Fixes an issue where the equity dialogs were not closing on the user profile page. This also makes some adjustments to the queries on that page to avoid re-mounting it after each mutation.

## 🕵️ Details

We were storing sub in the snapshot and our tests were using the profile page query to confirm it matched. The issue here is twofold.

1. We likely should not store sub in the snapshot for security reasons
2. We moved sub to `UserAuthInfo`

We were querying `authInfo { id sub }` just to satisfy the snapshot test. Since we queried this, once the `User` became stale, it was also making its sub types as stale so the `AuthorizationContext` was re-rendering. This re-render caused the `Pending` component to unmount the children (basically the entire app) so the page "refreshed" and user lost their scroll position.

To fix this, we simply removed sub from the query and snapshot.

## 🧪 Testing

1. Build app `pnpm run dev:fresh`
2. Login as any user
3. Go to your profile edit page `/applicant/personal-information`
4. Edit any form
5. Confirm the page does not refresh and you maintain your scroll position
6. Add an Indigenous identity to the equity section
7. Confirm the dialog closes on success
8. Edit that Indigenous identity but do not remove it
9. Confirm the dialog closes on success and you maintain your scroll position