### PR TITLE
[Debt] Removes unreferenced interface `TeamAssignment`

### DIFF
--- a/apps/web/src/pages/Users/UpdateUserPage/types.ts
+++ b/apps/web/src/pages/Users/UpdateUserPage/types.ts
@@ -35,7 +35,3 @@ export interface CommunityAssignment {
   community: CommunityTeamable;
   roles: Role[];
 }
-export interface TeamAssignment {
-  team: TeamTeamable;
-  roles: Role[];
-}


### PR DESCRIPTION
🤖 Resolves #12616.

## 👋 Introduction

This PR removes the unreferenced interface `TeamAssignment`.

## 🧪 Testing

Verify `TeamAssignment` interface is not referenced anywhere and is not present in the codebase.