### PR TITLE
[Debt] Removes export for `CLASSIFICATION_GROUP`

### DIFF
--- a/apps/web/src/types/classificationGroup.ts
+++ b/apps/web/src/types/classificationGroup.ts
@@ -1,11 +1,4 @@
-export const CLASSIFICATION_GROUP = [
-  "AS",
-  "CR",
-  "EC",
-  "EX",
-  "IT",
-  "PM",
-] as const; // List of classification groups that we expect need to be handled.
+const CLASSIFICATION_GROUP = ["AS", "CR", "EC", "EX", "IT", "PM"] as const; // List of classification groups that we expect need to be handled.
 
 export type ClassificationGroup = (typeof CLASSIFICATION_GROUP)[number];
 


### PR DESCRIPTION
🤖 Resolves #12637.

## 👋 Introduction

This PR removes export for `CLASSIFICATION_GROUP`.

## 🧪 Testing

Verify `CLASSIFICATION_GROUP` is not referenced anywhere except in `apps/web/src/types/classificationGroup.ts`.