### PR TITLE
[Debt] Removes export for `WorkStreamTableRow_Fragment`

### DIFF
--- a/apps/web/src/pages/WorkStreams/WorkStreamTable.tsx
+++ b/apps/web/src/pages/WorkStreams/WorkStreamTable.tsx
@@ -18,7 +18,7 @@ import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import adminMessages from "~/messages/adminMessages";
 import { normalizedText } from "~/components/Table/sortingFns";
 
-export const WorkStreamTableRow_Fragment = graphql(/* GraphQL */ `
+const WorkStreamTableRow_Fragment = graphql(/* GraphQL */ `
   fragment WorkStreamTableRow on WorkStream {
     id
     name {


### PR DESCRIPTION
🤖 Resolves #12617.

## 👋 Introduction

This PR removes export for `WorkStreamTableRow_Fragment`.

## 🧪 Testing

Verify `WorkStreamTableRow_Fragment` is not referenced anywhere except in `apps/web/src/pages/WorkStreams/WorkStreamTable.tsx`.