### PR TITLE
[Debt] Removes export for `WorkStreamTable`

### DIFF
--- a/apps/web/src/pages/WorkStreams/WorkStreamTable.tsx
+++ b/apps/web/src/pages/WorkStreams/WorkStreamTable.tsx
@@ -50,10 +50,7 @@ interface WorkStreamTableProps {
   title: string;
 }
 
-export const WorkStreamTable = ({
-  workStreamsQuery,
-  title,
-}: WorkStreamTableProps) => {
+const WorkStreamTable = ({ workStreamsQuery, title }: WorkStreamTableProps) => {
   const intl = useIntl();
   const paths = useRoutes();
   const workStreams = getFragment(


### PR DESCRIPTION
🤖 Resolves #12618.

## 👋 Introduction

This PR removes export for `WorkStreamTable`.

## 🧪 Testing

Verify `WorkStreamTable` is not referenced anywhere except in `apps/web/src/pages/WorkStreams/WorkStreamTable.tsx`.