### PR TITLE
[Debt] Removes `isScreenedOutStatus` function; removes unnecessary exports; removes unused `SCREENED_OUT_STATUSES`

### DIFF
--- a/apps/web/src/constants/poolCandidate.ts
+++ b/apps/web/src/constants/poolCandidate.ts
@@ -67,9 +67,3 @@ export const INACTIVE_STATUSES = [
   PoolCandidateStatus.QualifiedUnavailable,
   PoolCandidateStatus.QualifiedWithdrew,
 ];
-
-export const SCREENED_OUT_STATUSES = [
-  PoolCandidateStatus.ScreenedOutNotInterested,
-  PoolCandidateStatus.ScreenedOutNotResponsive,
-  PoolCandidateStatus.Removed,
-];

--- a/apps/web/src/utils/poolCandidate.ts
+++ b/apps/web/src/utils/poolCandidate.ts
@@ -70,10 +70,6 @@ export const isNotPlacedStatus = (
   status: Maybe<PoolCandidateStatus> | undefined,
 ): boolean => (status ? NOT_PLACED_STATUSES.includes(status) : false);
 
-export const isScreenedOutStatus = (
-  status: Maybe<PoolCandidateStatus> | undefined,
-): boolean => (status ? SCREENED_OUT_STATUSES.includes(status) : false);
-
 export const isInactiveStatus = (
   status: Maybe<PoolCandidateStatus> | undefined,
 ): boolean => (status ? INACTIVE_STATUSES.includes(status) : false);

--- a/apps/web/src/utils/poolCandidate.ts
+++ b/apps/web/src/utils/poolCandidate.ts
@@ -99,7 +99,7 @@ export const isExpired = (
   return expirationDate ? isPast(parseDateTimeUtc(expirationDate)) : false;
 };
 
-export const isDisqualifiedFinalDecision = (
+const isDisqualifiedFinalDecision = (
   status: Maybe<FinalDecision> | undefined,
 ): boolean => {
   return status

--- a/apps/web/src/utils/poolCandidate.ts
+++ b/apps/web/src/utils/poolCandidate.ts
@@ -109,7 +109,7 @@ const isDisqualifiedFinalDecision = (
     : false;
 };
 
-export const isQualifiedFinalDecision = (
+const isQualifiedFinalDecision = (
   status: Maybe<FinalDecision> | undefined,
 ): boolean => {
   return status

--- a/apps/web/src/utils/poolCandidate.ts
+++ b/apps/web/src/utils/poolCandidate.ts
@@ -37,7 +37,6 @@ import {
   NOT_PLACED_STATUSES,
   DRAFT_STATUSES,
   INACTIVE_STATUSES,
-  SCREENED_OUT_STATUSES,
 } from "~/constants/poolCandidate";
 
 import { NullableDecision } from "./assessmentResults";


### PR DESCRIPTION
🤖 Resolves #12642.

## 👋 Introduction

This PR removes the `isScreenedOutStatus` function. It also removes the unnecessary export of `isDisqualifiedFinalDecision` and `isQualifiedFinalDecision`. Finally, it removes the unused `SCREENED_OUT_STATUSES`

## 🧪 Testing

1. Verify `isScreenedOutStatus` function is not referenced anywhere in codebase
2. Verify `isDisqualifiedFinalDecision` function is only referenced in own file `apps/web/src/utils/poolCandidate.ts`
3. Verify `isQualifiedFinalDecision` function is only referenced in own file `apps/web/src/utils/poolCandidate.ts`
4. Verify `SCREENED_OUT_STATUSES` is not referenced anywhere in codebase
