### PR TITLE
[Debt] Removes unnecessary export of `TeamTeamable`

### DIFF
--- a/apps/web/src/pages/Users/UpdateUserPage/types.ts
+++ b/apps/web/src/pages/Users/UpdateUserPage/types.ts
@@ -24,7 +24,7 @@ export type CommunityTeamable = Pick<
   Community,
   "id" | "__typename" | "name" | "teamIdForRoleAssignment"
 >;
-export type TeamTeamable = Pick<Team, "id" | "__typename" | "displayName">;
+type TeamTeamable = Pick<Team, "id" | "__typename" | "displayName">;
 export type Teamable = PoolTeamable | CommunityTeamable | TeamTeamable;
 
 export interface PoolAssignment {


### PR DESCRIPTION
🤖 Resolves #12646.

## 👋 Introduction

This PR removes the unnecessary export of `TeamTeamable` type.

## 🧪 Testing

Verify `TeamTeamable` type is only referenced in own file `apps/web/src/pages/Users/UpdateUserPage/types.ts`