### PR TITLE
[Debt] Removes `@deprecated` directive for `hasDiploma` fields

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -103,9 +103,7 @@ type User {
     @rename(attribute: "indigenous_declaration_signature")
 
   # Applicant info
-  hasDiploma: Boolean
-    @rename(attribute: "has_diploma")
-    @deprecated(reason: "hasDiploma to be replaced")
+  hasDiploma: Boolean @rename(attribute: "has_diploma")
   locationPreferences: [LocalizedWorkRegion]
     @rename(attribute: "location_preferences")
   locationExemptions: String @rename(attribute: "location_exemptions")
@@ -626,9 +624,7 @@ input EquitySelectionsInput {
 type PoolCandidateFilter {
   id: ID!
   classifications: [Classification] @belongsToMany
-  hasDiploma: Boolean
-    @rename(attribute: "has_diploma")
-    @deprecated(reason: "hasDiploma to be replaced")
+  hasDiploma: Boolean @rename(attribute: "has_diploma")
   equity: EquitySelections
   languageAbility: LocalizedLanguageAbility
     @rename(attribute: "language_ability")
@@ -641,9 +637,7 @@ type PoolCandidateFilter {
 # ApplicantFilter only includes the fields which Talent Seekers can use to search for candidates.
 type ApplicantFilter {
   id: ID!
-  hasDiploma: Boolean
-    @rename(attribute: "has_diploma")
-    @deprecated(reason: "hasDiploma to be replaced")
+  hasDiploma: Boolean @rename(attribute: "has_diploma")
   equity: EquitySelections
   languageAbility: LocalizedLanguageAbility
     @rename(attribute: "language_ability")
@@ -951,7 +945,7 @@ input OrderByColumnInput {
 # Changes to this input will require some manual updates to api/app/GraphQL/Queries/CountPoolCandidatesByPool.php since it doesn't use the directives for automatic resolution
 input ApplicantFilterInput {
   equity: EquitySelectionsInput @scope
-  hasDiploma: Boolean @scope @deprecated(reason: "hasDiploma to be replaced")
+  hasDiploma: Boolean @scope
   languageAbility: LanguageAbility @scope
   locationPreferences: [WorkRegion] @scope
   operationalRequirements: [OperationalRequirement] @scope
@@ -1306,9 +1300,7 @@ input CreateUserInput {
     @rename(attribute: "indigenous_declaration_signature")
 
   # Applicant info
-  hasDiploma: Boolean
-    @rename(attribute: "has_diploma")
-    @deprecated(reason: "hasDiploma to be replaced")
+  hasDiploma: Boolean @rename(attribute: "has_diploma")
   locationPreferences: [WorkRegion] @rename(attribute: "location_preferences")
   locationExemptions: String @rename(attribute: "location_exemptions")
   acceptedOperationalRequirements: [OperationalRequirement]
@@ -1378,9 +1370,7 @@ input UpdateUserAsAdminInput @validator {
     @rename(attribute: "indigenous_declaration_signature")
 
   # Applicant info
-  hasDiploma: Boolean
-    @rename(attribute: "has_diploma")
-    @deprecated(reason: "hasDiploma to be replaced")
+  hasDiploma: Boolean @rename(attribute: "has_diploma")
   locationPreferences: [WorkRegion] @rename(attribute: "location_preferences")
   locationExemptions: String @rename(attribute: "location_exemptions")
   acceptedOperationalRequirements: [OperationalRequirement]
@@ -1457,9 +1447,7 @@ input UpdateUserAsUserInput @validator {
     @rename(attribute: "indigenous_declaration_signature")
 
   # Applicant info
-  hasDiploma: Boolean
-    @rename(attribute: "has_diploma")
-    @deprecated(reason: "hasDiploma to be replaced")
+  hasDiploma: Boolean @rename(attribute: "has_diploma")
   locationPreferences: [WorkRegion] @rename(attribute: "location_preferences")
   locationExemptions: String @rename(attribute: "location_exemptions")
   acceptedOperationalRequirements: [OperationalRequirement]
@@ -1710,9 +1698,7 @@ input UpdateCommunityInput {
 }
 
 input CreateApplicantFilterInput {
-  hasDiploma: Boolean
-    @rename(attribute: "has_diploma")
-    @deprecated(reason: "hasDiploma to be replaced")
+  hasDiploma: Boolean @rename(attribute: "has_diploma")
   equity: EquitySelectionsInput @spread
   languageAbility: LanguageAbility @rename(attribute: "language_ability")
   operationalRequirements: [OperationalRequirement]

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -612,7 +612,7 @@ type User {
   isVisibleMinority: Boolean
   indigenousCommunities: [LocalizedIndigenousCommunity]
   indigenousDeclarationSignature: String
-  hasDiploma: Boolean @deprecated(reason: "hasDiploma to be replaced")
+  hasDiploma: Boolean
   locationPreferences: [LocalizedWorkRegion]
   locationExemptions: String
   acceptedOperationalRequirements: [LocalizedOperationalRequirement]
@@ -1022,7 +1022,7 @@ input EquitySelectionsInput {
 type PoolCandidateFilter {
   id: ID!
   classifications: [Classification]
-  hasDiploma: Boolean @deprecated(reason: "hasDiploma to be replaced")
+  hasDiploma: Boolean
   equity: EquitySelections
   languageAbility: LocalizedLanguageAbility
   operationalRequirements: [LocalizedOperationalRequirement]
@@ -1032,7 +1032,7 @@ type PoolCandidateFilter {
 
 type ApplicantFilter {
   id: ID!
-  hasDiploma: Boolean @deprecated(reason: "hasDiploma to be replaced")
+  hasDiploma: Boolean
   equity: EquitySelections
   languageAbility: LocalizedLanguageAbility
   operationalRequirements: [LocalizedOperationalRequirement]
@@ -1304,7 +1304,7 @@ input OrderByColumnInput {
 
 input ApplicantFilterInput {
   equity: EquitySelectionsInput
-  hasDiploma: Boolean @deprecated(reason: "hasDiploma to be replaced")
+  hasDiploma: Boolean
   languageAbility: LanguageAbility
   locationPreferences: [WorkRegion]
   operationalRequirements: [OperationalRequirement]
@@ -1442,7 +1442,7 @@ input CreateUserInput {
   isVisibleMinority: Boolean
   indigenousCommunities: [IndigenousCommunity]
   indigenousDeclarationSignature: String
-  hasDiploma: Boolean @deprecated(reason: "hasDiploma to be replaced")
+  hasDiploma: Boolean
   locationPreferences: [WorkRegion]
   locationExemptions: String
   acceptedOperationalRequirements: [OperationalRequirement]
@@ -1490,7 +1490,7 @@ input UpdateUserAsAdminInput {
   isVisibleMinority: Boolean
   indigenousCommunities: [IndigenousCommunity]
   indigenousDeclarationSignature: String
-  hasDiploma: Boolean @deprecated(reason: "hasDiploma to be replaced")
+  hasDiploma: Boolean
   locationPreferences: [WorkRegion]
   locationExemptions: String
   acceptedOperationalRequirements: [OperationalRequirement]
@@ -1547,7 +1547,7 @@ input UpdateUserAsUserInput {
   isVisibleMinority: Boolean
   indigenousCommunities: [IndigenousCommunity]
   indigenousDeclarationSignature: String
-  hasDiploma: Boolean @deprecated(reason: "hasDiploma to be replaced")
+  hasDiploma: Boolean
   locationPreferences: [WorkRegion]
   locationExemptions: String
   acceptedOperationalRequirements: [OperationalRequirement]
@@ -1762,7 +1762,7 @@ input UpdateCommunityInput {
 }
 
 input CreateApplicantFilterInput {
-  hasDiploma: Boolean @deprecated(reason: "hasDiploma to be replaced")
+  hasDiploma: Boolean
   equity: EquitySelectionsInput
   languageAbility: LanguageAbility
   operationalRequirements: [OperationalRequirement]


### PR DESCRIPTION
🤖 Resolves #12649.

## 👋 Introduction

This PR removes the `@deprecated` directive for `hasDiploma` fields.

## 🧪 Testing

Verify `@deprecated(reason: "hasDiploma to be replaced")` has been removed from all instances of the `hasDiploma` field in `api/graphql/schema.graphql`.