### PR TITLE
[Feature] Rename `User.gov_*` columns to prefix with `computed_`

### DIFF
--- a/api/app/Generators/PoolCandidateCsvGenerator.php
+++ b/api/app/Generators/PoolCandidateCsvGenerator.php
@@ -173,9 +173,9 @@ class PoolCandidateCsvGenerator extends CsvGenerator implements FileGeneratorInt
                     $this->localizeEnum($candidate->user->written_level, EvaluatedLanguageAbility::class), // Writing level
                     $this->localizeEnum($candidate->user->verbal_level, EvaluatedLanguageAbility::class), // Oral interaction level
                     $this->localizeEnum($candidate->user->estimated_language_ability, EstimatedLanguageAbility::class),
-                    $this->yesOrNo($candidate->user->is_gov_employee), // Government employee
+                    $this->yesOrNo($candidate->user->computed_is_gov_employee), // Government employee
                     $department->name[$this->lang] ?? '', // Department
-                    $this->localizeEnum($candidate->user->gov_employee_type, GovEmployeeType::class),
+                    $this->localizeEnum($candidate->user->computed_gov_employee_type, GovEmployeeType::class),
                     $candidate->user->work_email, // Work email
                     $candidate->user->getClassification(), // Current classification
                     $this->yesOrNo($candidate->user->has_priority_entitlement), // Priority entitlement

--- a/api/app/Generators/PoolCandidateCsvGenerator.php
+++ b/api/app/Generators/PoolCandidateCsvGenerator.php
@@ -94,7 +94,7 @@ class PoolCandidateCsvGenerator extends CsvGenerator implements FileGeneratorInt
         'department',
         'employee_type',
         'work_email',
-        'current_classification',
+        'classification',
         'priority_entitlement',
         'priority_number',
         'accept_temporary',

--- a/api/app/Generators/UserCsvGenerator.php
+++ b/api/app/Generators/UserCsvGenerator.php
@@ -103,9 +103,9 @@ class UserCsvGenerator extends CsvGenerator implements FileGeneratorInterface
                     $this->localizeEnum($user->written_level, EvaluatedLanguageAbility::class), // Writing level
                     $this->localizeEnum($user->verbal_level, EvaluatedLanguageAbility::class), // Oral interaction level
                     $this->localizeEnum($user->estimated_language_ability, EstimatedLanguageAbility::class),
-                    $this->yesOrNo($user->is_gov_employee), // Government employee
+                    $this->yesOrNo($user->computed_is_gov_employee), // Government employee
                     $department->name[$this->lang] ?? '', // Department
-                    $this->localizeEnum($user->gov_employee_type, GovEmployeeType::class),
+                    $this->localizeEnum($user->computed_gov_employee_type, GovEmployeeType::class),
                     $user->work_email, // Work email
                     $user->getClassification(), // Current classification
                     $this->yesOrNo($user->has_priority_entitlement), // Priority entitlement

--- a/api/app/Generators/UserCsvGenerator.php
+++ b/api/app/Generators/UserCsvGenerator.php
@@ -46,7 +46,7 @@ class UserCsvGenerator extends CsvGenerator implements FileGeneratorInterface
         'department',
         'employee_type',
         'work_email',
-        'current_classification',
+        'classification',
         'priority_entitlement',
         'priority_number',
         'accept_temporary',

--- a/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
+++ b/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
@@ -103,6 +103,14 @@ query getProfile($userId: UUID!) {
         fr
       }
     }
+    govPositionType {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    govEndDate
     department {
       id
       departmentNumber

--- a/api/app/Http/Resources/UserResource.php
+++ b/api/app/Http/Resources/UserResource.php
@@ -12,7 +12,6 @@ use App\Enums\Language;
 use App\Enums\OperationalRequirement;
 use App\Enums\ProvinceOrTerritory;
 use App\Enums\WorkRegion;
-use App\Models\Department;
 use App\Traits\HasLocalizedEnums;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -91,13 +90,15 @@ class UserResource extends JsonResource
             'writtenLevel' => $this->localizeEnum($this->written_level, EvaluatedLanguageAbility::class),
             'verbalLevel' => $this->localizeEnum($this->verbal_level, EvaluatedLanguageAbility::class),
             'estimatedLanguageAbility' => $this->localizeEnum($this->estimated_language_ability, EstimatedLanguageAbility::class),
-            'isGovEmployee' => $this->is_gov_employee,
+            'isGovEmployee' => $this->computed_is_gov_employee,
             'workEmail' => $this->work_email,
             'isWorkEmailVerified' => $this->isWorkEmailVerified,
             'hasPriorityEntitlement' => $this->has_priority_entitlement,
-            'govEmployeeType' => $this->localizeEnum($this->gov_employee_type, GovEmployeeType::class),
-            'department' => $this->department ? (new DepartmentResource(Department::find($this->department))) : null,
+            'govEmployeeType' => $this->localizeEnum($this->computed_gov_employee_type, GovEmployeeType::class),
+            'department' => $this->department ? (new DepartmentResource($this->department)) : null,
             'currentClassification' => (new ClassificationResource($this->currentClassification)),
+            'govPositionType' => $this->computed_gov_position_type,
+            'govEndDate' => $this->computed_gov_end_date,
             'isWoman' => $this->is_woman,
             'hasDisability' => $this->has_disability,
             'isVisibleMinority' => $this->is_visible_minority,

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -364,11 +364,12 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
 
     public function getClassification()
     {
+
         if (! $this->computed_classification) {
             return '';
         }
 
-        $classification = $this->currentClassification()->first();
+        $classification = $this->currentClassification;
 
         $leadingZero = $classification->level < 10 ? '0' : '';
 
@@ -1354,6 +1355,10 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
 
         if (isset($snapshot['department'])) {
             $user->computed_department = $snapshot['department']['id'];
+        }
+
+        if (isset($snapshot['currentClassification'])) {
+            $user->computed_classification = $snapshot['currentClassification']['id'];
         }
 
         return $user;

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -377,7 +377,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
 
     public function getDepartment()
     {
-        if (! $this->department) {
+        if (! $this->computed_department) {
             return '';
         }
 
@@ -1353,7 +1353,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
         $user = self::hydrateFields($snapshot, $fields, $user);
 
         if (isset($snapshot['department'])) {
-            $user->department = $snapshot['department']['id'];
+            $user->computed_department = $snapshot['department']['id'];
         }
 
         return $user;

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -69,8 +69,8 @@ use Staudenmeir\EloquentHasManyDeep\HasRelationships;
  * @property ?\Illuminate\Support\Carbon $work_email_verified_at
  * @property ?bool $has_priority_entitlement
  * @property ?string $priority_number
- * @property ?string $department
- * @property ?string $current_classification
+ * @property ?string $computed_department
+ * @property ?string $computed_classification
  * @property ?string $citizenship
  * @property ?string $armed_forces_status
  * @property ?bool $is_woman
@@ -364,7 +364,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
 
     public function getClassification()
     {
-        if (! $this->current_classification) {
+        if (! $this->computed_classification) {
             return '';
         }
 

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -64,7 +64,7 @@ use Staudenmeir\EloquentHasManyDeep\HasRelationships;
  * @property ?string $written_level
  * @property ?string $verbal_level
  * @property ?string $estimated_language_ability
- * @property ?bool $is_gov_employee
+ * @property ?bool $computed_is_gov_employee
  * @property ?string $work_email
  * @property ?\Illuminate\Support\Carbon $work_email_verified_at
  * @property ?bool $has_priority_entitlement
@@ -81,7 +81,7 @@ use Staudenmeir\EloquentHasManyDeep\HasRelationships;
  * @property ?string $location_exemptions
  * @property ?array $position_duration
  * @property array $accepted_operational_requirements
- * @property ?string $gov_employee_type
+ * @property ?string $computed_gov_employee_type
  * @property ?int $priority_weight
  * @property \Illuminate\Support\Carbon $created_at
  * @property ?\Illuminate\Support\Carbon $updated_at
@@ -247,14 +247,14 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
     /** @return BelongsTo<Department, $this> */
     public function department(): BelongsTo
     {
-        return $this->belongsTo(Department::class, 'department')
+        return $this->belongsTo(Department::class, 'computed_department')
             ->select(['id', 'name', 'department_number']);
     }
 
     /** @return BelongsTo<Classification, $this> */
     public function currentClassification(): BelongsTo
     {
-        return $this->belongsTo(Classification::class, 'current_classification');
+        return $this->belongsTo(Classification::class, 'computed_classification');
     }
 
     /** @return HasMany<AwardExperience, $this> */
@@ -434,7 +434,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
                 is_null($this->attributes['looking_for_french']) &&
                 is_null($this->attributes['looking_for_bilingual'])
             ) or
-            is_null($this->attributes['is_gov_employee']) or
+            is_null($this->attributes['computed_is_gov_employee']) or
             is_null($this->attributes['has_priority_entitlement']) or
             ($this->attributes['has_priority_entitlement'] && is_null($this->attributes['priority_number'])) or
             is_null($this->attributes['location_preferences']) or
@@ -466,7 +466,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
                 $query->orWhereNotNull('looking_for_french');
                 $query->orWhereNotNull('looking_for_bilingual');
             });
-            $query->whereNotNull('is_gov_employee');
+            $query->whereNotNull('computed_is_gov_employee');
             $query->where(function (Builder $query) {
                 $query->where('has_priority_entitlement', false)
                     ->orWhere(function (Builder $query) {
@@ -1072,7 +1072,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
     public static function scopeIsGovEmployee(Builder $query, ?bool $isGovEmployee): Builder
     {
         if ($isGovEmployee) {
-            $query->where('is_gov_employee', true);
+            $query->where('computed_is_gov_employee', true);
         }
 
         return $query;
@@ -1332,9 +1332,11 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
             'written_level' => 'comprehensionLevel',
             'verbal_level' => 'verbalLevel',
             'estimated_language_ability' => 'estimatedLanguageAbility',
-            'is_gov_employee' => 'isGovEmployee',
+            'computed_is_gov_employee' => 'isGovEmployee',
             'work_email' => 'workEmail',
-            'gov_employee_type' => 'govEmployeeType',
+            'computed_gov_employee_type' => 'govEmployeeType',
+            'computed_gov_position_type' => 'govPositionType',
+            'computed_gov_end_date' => 'govEndDate',
             'has_priority_entitlement' => 'hasPriorityEntitlement',
             'priority_number' => 'priorityNumber',
             'location_preferences' => 'locationPreferences',

--- a/api/app/Traits/Generator/GeneratesUserDoc.php
+++ b/api/app/Traits/Generator/GeneratesUserDoc.php
@@ -164,7 +164,7 @@ trait GeneratesUserDoc
             $this->addLabelText($section, $this->localizeHeading('department'), $department->name[$this->lang] ?? '');
             $this->addLabelText($section, $this->localizeHeading('employee_type'), $this->localizeEnum($user->computed_gov_employee_type, GovEmployeeType::class));
             $this->addLabelText($section, $this->localizeHeading('work_email'), $user->work_email);
-            $this->addLabelText($section, $this->localizeHeading('current_classification'), $user->getClassification());
+            $this->addLabelText($section, $this->localizeHeading('classification'), $user->getClassification());
         }
 
         $this->addLabelText($section, $this->localizeHeading('priority_entitlement'), $this->yesOrNo($user->has_priority_entitlement));

--- a/api/app/Traits/Generator/GeneratesUserDoc.php
+++ b/api/app/Traits/Generator/GeneratesUserDoc.php
@@ -157,12 +157,12 @@ trait GeneratesUserDoc
     {
         $section->addTitle($this->localizeHeading('government_info'), $headingRank);
 
-        $this->addLabelText($section, $this->localizeHeading('government_employee'), $this->yesOrNo($user->is_gov_employee));
+        $this->addLabelText($section, $this->localizeHeading('government_employee'), $this->yesOrNo($user->computed_is_gov_employee));
 
-        if ($user->is_gov_employee) {
+        if ($user->computed_is_gov_employee) {
             $department = $user->department()->first();
             $this->addLabelText($section, $this->localizeHeading('department'), $department->name[$this->lang] ?? '');
-            $this->addLabelText($section, $this->localizeHeading('employee_type'), $this->localizeEnum($user->gov_employee_type, GovEmployeeType::class));
+            $this->addLabelText($section, $this->localizeHeading('employee_type'), $this->localizeEnum($user->computed_gov_employee_type, GovEmployeeType::class));
             $this->addLabelText($section, $this->localizeHeading('work_email'), $user->work_email);
             $this->addLabelText($section, $this->localizeHeading('current_classification'), $user->getClassification());
         }

--- a/api/database/factories/UserFactory.php
+++ b/api/database/factories/UserFactory.php
@@ -9,6 +9,7 @@ use App\Enums\EstimatedLanguageAbility;
 use App\Enums\EvaluatedLanguageAbility;
 use App\Enums\ExecCoaching;
 use App\Enums\GovEmployeeType;
+use App\Enums\GovPositionType;
 use App\Enums\IndigenousCommunity;
 use App\Enums\Language;
 use App\Enums\Mentorship;
@@ -105,10 +106,10 @@ class UserFactory extends Factory
             'verbal_level' => $examLevels ?
                 $this->faker->randomElement(EvaluatedLanguageAbility::cases())->name
                 : null,
-            'is_gov_employee' => $isGovEmployee,
+            'computed_is_gov_employee' => $isGovEmployee,
             'work_email' => $isGovEmployee ? $this->faker->firstName().'_'.$this->faker->unique()->userName().'@gc.ca' : null,
-            'department' => $isGovEmployee && $randomDepartment ? $randomDepartment->id : null,
-            'current_classification' => $isGovEmployee && $randomClassification ? $randomClassification->id : null,
+            'computed_department' => $isGovEmployee && $randomDepartment ? $randomDepartment->id : null,
+            'computed_classification' => $isGovEmployee && $randomClassification ? $randomClassification->id : null,
             'is_woman' => $this->faker->boolean(),
             'has_disability' => $this->faker->boolean(),
             'is_visible_minority' => $this->faker->boolean(),
@@ -131,7 +132,7 @@ class UserFactory extends Factory
                 array_column(PositionDuration::cases(), 'name')
                 : [PositionDuration::PERMANENT->name], // always accepting PERMANENT
             'accepted_operational_requirements' => $this->faker->optional->randomElements(array_column(OperationalRequirement::cases(), 'name'), 2),
-            'gov_employee_type' => $isGovEmployee ? $this->faker->randomElement(GovEmployeeType::cases())->name : null,
+            'computed_gov_employee_type' => $isGovEmployee ? $this->faker->randomElement(GovEmployeeType::cases())->name : null,
             'citizenship' => $this->faker->randomElement(CitizenshipStatus::cases())->name,
             'armed_forces_status' => $this->faker->boolean() ?
                 ArmedForcesStatus::NON_CAF->name
@@ -189,11 +190,13 @@ class UserFactory extends Factory
         return $this->state(function () use ($isGovEmployee, $isVerified) {
             if (! $isGovEmployee) {
                 return [
-                    'is_gov_employee' => false,
                     'work_email' => null,
-                    'current_classification' => null,
-                    'gov_employee_type' => null,
-                    'department' => null,
+                    'computed_is_gov_employee' => false,
+                    'computed_classification' => null,
+                    'computed_gov_employee_type' => null,
+                    'computed_gov_position_type' => null,
+                    'computed_gov_end_date' => null,
+                    'computed_department' => null,
 
                 ];
             }
@@ -201,13 +204,14 @@ class UserFactory extends Factory
             $randomDepartment = Department::inRandomOrder()->first();
 
             return [
-                'is_gov_employee' => true,
                 'work_email' => $this->faker->firstName().'_'.$this->faker->unique()->userName().'@gc.ca',
                 'work_email_verified_at' => $isVerified ? $this->faker->dateTimeBetween('-1 year', 'now') : null,
-                'current_classification' => $randomClassification ? $randomClassification->id : null,
-                'gov_employee_type' => $this->faker->randomElement(GovEmployeeType::cases())->name,
-                'department' => $randomDepartment ? $randomDepartment->id : null,
-
+                'computed_is_gov_employee' => true,
+                'computed_classification' => $randomClassification ? $randomClassification->id : null,
+                'computed_department' => $randomDepartment ? $randomDepartment->id : null,
+                'computed_gov_employee_type' => $this->faker->randomElement(GovEmployeeType::cases())->name,
+                'computed_gov_position_type' => $this->faker->randomElement(GovPositionType::cases())->name,
+                'computed_gov_end_date' => $this->faker->dateTimeBetween('now', '+30 years'),
             ];
         })->afterCreating(function (User $user) use ($isGovEmployee) {
             if (! $isGovEmployee) {

--- a/api/database/migrations/2025_01_30_180016_rename_user_gov_columns.php
+++ b/api/database/migrations/2025_01_30_180016_rename_user_gov_columns.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->renameColumn('is_gov_employee', 'computed_is_gov_employee');
+            $table->renameColumn('gov_employee_type', 'computed_gov_employee_type');
+            $table->renameColumn('current_classification', 'computed_classification');
+            $table->renameColumn('department', 'computed_department');
+            $table->text('computed_gov_position_type')->nullable();
+            $table->date('computed_gov_end_date')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->renameColumn('computed_is_gov_employee', 'is_gov_employee');
+            $table->renameColumn('computes_gov_employee_type', 'gov_employee_type');
+            $table->renameColumn('computed_classification', 'current_classification');
+            $table->renameColumn('computed_department', 'department');
+            $table->dropColumn('computed_gov_position_type');
+            $table->dropColumn('computed_gov_end_date');
+        });
+    }
+};

--- a/api/database/migrations/2025_01_30_180016_rename_user_gov_columns.php
+++ b/api/database/migrations/2025_01_30_180016_rename_user_gov_columns.php
@@ -28,7 +28,7 @@ return new class extends Migration
     {
         Schema::table('users', function (Blueprint $table) {
             $table->renameColumn('computed_is_gov_employee', 'is_gov_employee');
-            $table->renameColumn('computes_gov_employee_type', 'gov_employee_type');
+            $table->renameColumn('computed_gov_employee_type', 'gov_employee_type');
             $table->renameColumn('computed_classification', 'current_classification');
             $table->renameColumn('computed_department', 'department');
             $table->dropColumn('computed_gov_position_type');

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -83,11 +83,14 @@ type User {
     @rename(attribute: "estimated_language_ability")
 
   # Gov info
-  isGovEmployee: Boolean @rename(attribute: "is_gov_employee")
+  isGovEmployee: Boolean @rename(attribute: "computed_is_gov_employee")
   workEmail: Email @rename(attribute: "work_email")
   isWorkEmailVerified: Boolean
   govEmployeeType: LocalizedGovEmployeeType
-    @rename(attribute: "gov_employee_type")
+    @rename(attribute: "computed_gov_employee_type")
+  govPositionType: LocalizedGovPositionType
+    @rename(attribute: "computed_gov_position_type")
+  govEndDate: Date @rename(attribute: "computed_gov_end_date")
   currentClassification: Classification @belongsTo # Users current classification
   department: Department @belongsTo
   hasPriorityEntitlement: Boolean @rename(attribute: "has_priority_entitlement")
@@ -1277,7 +1280,7 @@ input CreateUserInput {
     @rename(attribute: "estimated_language_ability")
 
   # Gov info
-  isGovEmployee: Boolean @rename(attribute: "is_gov_employee")
+  isGovEmployee: Boolean @rename(attribute: "computed_is_gov_employee")
   workEmail: Email
     @rename(attribute: "work_email")
     @lowerCase
@@ -1290,7 +1293,8 @@ input CreateUserInput {
       ]
       messages: [{ rule: "unique", message: "CreateUserEmailInUse" }]
     )
-  govEmployeeType: GovEmployeeType @rename(attribute: "gov_employee_type")
+  govEmployeeType: GovEmployeeType
+    @rename(attribute: "computed_gov_employee_type")
   currentClassification: ClassificationBelongsTo
   department: DepartmentBelongsTo
   hasPriorityEntitlement: Boolean @rename(attribute: "has_priority_entitlement")
@@ -1360,9 +1364,10 @@ input UpdateUserAsAdminInput @validator {
     @rename(attribute: "estimated_language_ability")
 
   # Gov info
-  isGovEmployee: Boolean @rename(attribute: "is_gov_employee")
+  isGovEmployee: Boolean @rename(attribute: "computed_is_gov_employee")
   workEmail: Email @rename(attribute: "work_email") @lowerCase
-  govEmployeeType: GovEmployeeType @rename(attribute: "gov_employee_type")
+  govEmployeeType: GovEmployeeType
+    @rename(attribute: "computed_gov_employee_type")
   currentClassification: ClassificationBelongsTo
   department: DepartmentBelongsTo
   hasPriorityEntitlement: Boolean @rename(attribute: "has_priority_entitlement")
@@ -1439,9 +1444,10 @@ input UpdateUserAsUserInput @validator {
     @rename(attribute: "estimated_language_ability")
 
   # Gov info
-  isGovEmployee: Boolean @rename(attribute: "is_gov_employee")
+  isGovEmployee: Boolean @rename(attribute: "computed_is_gov_employee")
   workEmail: Email @rename(attribute: "work_email") @lowerCase
-  govEmployeeType: GovEmployeeType @rename(attribute: "gov_employee_type")
+  govEmployeeType: GovEmployeeType
+    @rename(attribute: "computed_gov_employee_type")
   currentClassification: ClassificationBelongsTo
   department: DepartmentBelongsTo
   hasPriorityEntitlement: Boolean @rename(attribute: "has_priority_entitlement")

--- a/api/lang/en/headings.php
+++ b/api/lang/en/headings.php
@@ -34,7 +34,7 @@ return [
     'department' => 'Department',
     'employee_type' => 'Employment type',
     'work_email' => 'Work email',
-    'current_classification' => 'Current classification',
+    'classification' => 'Current classification',
     'priority_entitlement' => 'Priority entitlement',
     'priority_number' => 'Priority number',
     'work_location' => 'Work location',

--- a/api/lang/fr/headings.php
+++ b/api/lang/fr/headings.php
@@ -33,7 +33,7 @@ return [
     'government_employee' => 'Employé du gouvernement',
     'department' => 'Ministère',
     'employee_type' => 'Type d\'emploi',
-    'current_classification' => 'Classification actuelle',
+    'classification' => 'Classification actuelle',
     'priority_entitlement' => 'Droit de priorité',
     'priority_number' => 'Numéro de priorité',
     'work_location' => 'Lieu de travail',

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -603,6 +603,8 @@ type User {
   workEmail: Email
   isWorkEmailVerified: Boolean
   govEmployeeType: LocalizedGovEmployeeType
+  govPositionType: LocalizedGovPositionType
+  govEndDate: Date
   currentClassification: Classification
   department: Department
   hasPriorityEntitlement: Boolean

--- a/api/tests/Feature/KeywordSearchTest.php
+++ b/api/tests/Feature/KeywordSearchTest.php
@@ -43,7 +43,7 @@ class KeywordSearchTest extends TestCase
                 'location_preferences' => [],
                 'has_diploma' => false,
                 'position_duration' => [],
-                'is_gov_employee' => false,
+                'computed_is_gov_employee' => false,
                 'telephone' => null,
                 'first_name' => null,
                 'last_name' => null,
@@ -51,7 +51,7 @@ class KeywordSearchTest extends TestCase
     }
 
     // Test newly added user can be searched by current_city, the column that is NOT returned by the search query response but available in the user table
-    public function testUserSearchByCurrentCity()
+    public function test_user_search_by_current_city()
     {
         $user1 = User::factory()->create([
             'current_city' => 'Ottawa',
@@ -91,7 +91,7 @@ class KeywordSearchTest extends TestCase
     }
 
     // Test user can not be searched once soft deleted
-    public function testUserSearchBySoftDeleted()
+    public function test_user_search_by_soft_deleted()
     {
         $user1 = User::factory()->create([
             'first_name' => 'user',
@@ -124,7 +124,7 @@ class KeywordSearchTest extends TestCase
     }
 
     // Test user can be edited and searched by the changed value
-    public function testUserSearchByEditedValue()
+    public function test_user_search_by_edited_value()
     {
         $user = User::factory()->asApplicant()->create([
             'first_name' => 'user',
@@ -187,7 +187,7 @@ class KeywordSearchTest extends TestCase
     }
 
     // Test user can be searched by their work experience details
-    public function testUserSearchByWorkExperience()
+    public function test_user_search_by_work_experience()
     {
         $user1 = User::factory()->create([
             'first_name' => 'user',
@@ -243,7 +243,7 @@ class KeywordSearchTest extends TestCase
     }
 
     // Test user can be searched by their education details, partial search and case insensitive
-    public function testUserSearchByEducation()
+    public function test_user_search_by_education()
     {
         $user1 = User::factory()->create([
             'first_name' => 'user',
@@ -298,7 +298,7 @@ class KeywordSearchTest extends TestCase
     }
 
     // Test user can be searched by their award details and community experience details
-    public function testUserSearchByAwardAndCommunityExperience()
+    public function test_user_search_by_award_and_community_experience()
     {
         $user1 = User::factory()->create([
             'first_name' => 'user',
@@ -393,7 +393,7 @@ class KeywordSearchTest extends TestCase
     }
 
     // Test user can be searched by their name and work experience organization
-    public function testUserSearchByNameAndWorkExperienceTitle()
+    public function test_user_search_by_name_and_work_experience_title()
     {
         // create 3 users with same name
         $user1 = User::factory()->create([
@@ -489,7 +489,7 @@ class KeywordSearchTest extends TestCase
     }
 
     // Test user can be partial matched by name or email by scopes added into generalSearch function
-    public function testUserSearchPartialMatchingNameEmail()
+    public function test_user_search_partial_matching_name_email()
     {
         $user1 = User::factory()->create([
             'first_name' => 'john',
@@ -561,7 +561,7 @@ class KeywordSearchTest extends TestCase
             ]);
     }
 
-    public function testUserSearchPartialNamesEmailsWithOrLogic()
+    public function test_user_search_partial_names_emails_with_or_logic()
     {
         $user1 = User::factory()->create([
             'first_name' => 'john',
@@ -667,7 +667,7 @@ class KeywordSearchTest extends TestCase
             ])->assertJsonCount(2, 'data.usersPaginated.data');
     }
 
-    public function testUserSearchPartialNamesEmailsWithQuotes()
+    public function test_user_search_partial_names_emails_with_quotes()
     {
         $user1 = User::factory()->create([
             'first_name' => 'john',
@@ -729,7 +729,7 @@ class KeywordSearchTest extends TestCase
             ])->assertJsonCount(2, 'data.usersPaginated.data');
     }
 
-    public function testUserSearchNamesEmailsWithNegativeSearch()
+    public function test_user_search_names_emails_with_negative_search()
     {
         $user1 = User::factory()->create([
             'first_name' => 'john',
@@ -816,7 +816,7 @@ class KeywordSearchTest extends TestCase
             ])->assertJsonCount(3, 'data.usersPaginated.data');
     }
 
-    public function testUserSearchPartialNamesEmailsWithPunctuation()
+    public function test_user_search_partial_names_emails_with_punctuation()
     {
         $user1 = User::factory()->create([
             'first_name' => 'bob-jones',
@@ -908,7 +908,7 @@ class KeywordSearchTest extends TestCase
             ])->assertJsonCount(2, 'data.usersPaginated.data');
     }
 
-    public function testUserSearchMultiSpacing()
+    public function test_user_search_multi_spacing()
     {
         $user1 = User::factory()->create([
             'first_name' => 'john',

--- a/api/tests/Feature/KeywordSearchTest.php
+++ b/api/tests/Feature/KeywordSearchTest.php
@@ -51,7 +51,7 @@ class KeywordSearchTest extends TestCase
     }
 
     // Test newly added user can be searched by current_city, the column that is NOT returned by the search query response but available in the user table
-    public function test_user_search_by_current_city()
+    public function testUserSearchByCurrentCity()
     {
         $user1 = User::factory()->create([
             'current_city' => 'Ottawa',
@@ -91,7 +91,7 @@ class KeywordSearchTest extends TestCase
     }
 
     // Test user can not be searched once soft deleted
-    public function test_user_search_by_soft_deleted()
+    public function testUserSearchBySoftDeleted()
     {
         $user1 = User::factory()->create([
             'first_name' => 'user',
@@ -124,7 +124,7 @@ class KeywordSearchTest extends TestCase
     }
 
     // Test user can be edited and searched by the changed value
-    public function test_user_search_by_edited_value()
+    public function testUserSearchByEditedValue()
     {
         $user = User::factory()->asApplicant()->create([
             'first_name' => 'user',
@@ -187,7 +187,7 @@ class KeywordSearchTest extends TestCase
     }
 
     // Test user can be searched by their work experience details
-    public function test_user_search_by_work_experience()
+    public function testUserSearchByWorkExperience()
     {
         $user1 = User::factory()->create([
             'first_name' => 'user',
@@ -243,7 +243,7 @@ class KeywordSearchTest extends TestCase
     }
 
     // Test user can be searched by their education details, partial search and case insensitive
-    public function test_user_search_by_education()
+    public function testUserSearchByEducation()
     {
         $user1 = User::factory()->create([
             'first_name' => 'user',
@@ -298,7 +298,7 @@ class KeywordSearchTest extends TestCase
     }
 
     // Test user can be searched by their award details and community experience details
-    public function test_user_search_by_award_and_community_experience()
+    public function testUserSearchByAwardAndCommunityExperience()
     {
         $user1 = User::factory()->create([
             'first_name' => 'user',
@@ -393,7 +393,7 @@ class KeywordSearchTest extends TestCase
     }
 
     // Test user can be searched by their name and work experience organization
-    public function test_user_search_by_name_and_work_experience_title()
+    public function testUserSearchByNameAndWorkExperienceTitle()
     {
         // create 3 users with same name
         $user1 = User::factory()->create([
@@ -489,7 +489,7 @@ class KeywordSearchTest extends TestCase
     }
 
     // Test user can be partial matched by name or email by scopes added into generalSearch function
-    public function test_user_search_partial_matching_name_email()
+    public function testUserSearchPartialMatchingNameEmail()
     {
         $user1 = User::factory()->create([
             'first_name' => 'john',
@@ -561,7 +561,7 @@ class KeywordSearchTest extends TestCase
             ]);
     }
 
-    public function test_user_search_partial_names_emails_with_or_logic()
+    public function testUserSearchPartialNamesEmailsWithOrLogic()
     {
         $user1 = User::factory()->create([
             'first_name' => 'john',
@@ -667,7 +667,7 @@ class KeywordSearchTest extends TestCase
             ])->assertJsonCount(2, 'data.usersPaginated.data');
     }
 
-    public function test_user_search_partial_names_emails_with_quotes()
+    public function testUserSearchPartialNamesEmailsWithQuotes()
     {
         $user1 = User::factory()->create([
             'first_name' => 'john',
@@ -729,7 +729,7 @@ class KeywordSearchTest extends TestCase
             ])->assertJsonCount(2, 'data.usersPaginated.data');
     }
 
-    public function test_user_search_names_emails_with_negative_search()
+    public function testUserSearchNamesEmailsWithNegativeSearch()
     {
         $user1 = User::factory()->create([
             'first_name' => 'john',
@@ -816,7 +816,7 @@ class KeywordSearchTest extends TestCase
             ])->assertJsonCount(3, 'data.usersPaginated.data');
     }
 
-    public function test_user_search_partial_names_emails_with_punctuation()
+    public function testUserSearchPartialNamesEmailsWithPunctuation()
     {
         $user1 = User::factory()->create([
             'first_name' => 'bob-jones',
@@ -908,7 +908,7 @@ class KeywordSearchTest extends TestCase
             ])->assertJsonCount(2, 'data.usersPaginated.data');
     }
 
-    public function test_user_search_multi_spacing()
+    public function testUserSearchMultiSpacing()
     {
         $user1 = User::factory()->create([
             'first_name' => 'john',

--- a/api/tests/Feature/PoolCandidateSearchTest.php
+++ b/api/tests/Feature/PoolCandidateSearchTest.php
@@ -64,7 +64,7 @@ class PoolCandidateSearchTest extends TestCase
             ]);
     }
 
-    public function test_pool_candidates_search_filter(): void
+    public function testPoolCandidatesSearchFilter(): void
     {
         // DRAFT, NOT PRESENT
         $candidateOne = PoolCandidate::factory()->create([
@@ -208,7 +208,7 @@ class PoolCandidateSearchTest extends TestCase
             ]);
     }
 
-    public function test_pool_candidates_search_expiry_filter(): void
+    public function testPoolCandidatesSearchExpiryFilter(): void
     {
         $candidateActive = PoolCandidate::factory()->create([
             'pool_id' => $this->pool->id,
@@ -307,7 +307,7 @@ class PoolCandidateSearchTest extends TestCase
         ]);
     }
 
-    public function test_pool_candidates_search_suspended_filter(): void
+    public function testPoolCandidatesSearchSuspendedFilter(): void
     {
         PoolCandidate::factory()->count(5)->create([
             'pool_id' => $this->pool->id,
@@ -424,7 +424,7 @@ class PoolCandidateSearchTest extends TestCase
         ]);
     }
 
-    public function test_pool_candidates_search_gov_employee(): void
+    public function testPoolCandidatesSearchGovEmployee(): void
     {
         PoolCandidate::factory()->count(5)->create([
             'pool_id' => $this->pool->id,
@@ -499,7 +499,7 @@ class PoolCandidateSearchTest extends TestCase
         ]);
     }
 
-    public function test_pool_candidates_search_classification(): void
+    public function testPoolCandidatesSearchClassification(): void
     {
         // Create qualified right classification candidates
         $classificationIT1 = Classification::factory()->create([
@@ -621,7 +621,7 @@ class PoolCandidateSearchTest extends TestCase
     }
 
     // test pool candidates  general search by notes
-    public function test_pool_candidates_search_by_notes()
+    public function testPoolCandidatesSearchByNotes()
     {
         $candidateId = PoolCandidate::factory()->create([
             'pool_id' => $this->pool->id,

--- a/api/tests/Feature/PoolCandidateSearchTest.php
+++ b/api/tests/Feature/PoolCandidateSearchTest.php
@@ -64,7 +64,7 @@ class PoolCandidateSearchTest extends TestCase
             ]);
     }
 
-    public function testPoolCandidatesSearchFilter(): void
+    public function test_pool_candidates_search_filter(): void
     {
         // DRAFT, NOT PRESENT
         $candidateOne = PoolCandidate::factory()->create([
@@ -208,7 +208,7 @@ class PoolCandidateSearchTest extends TestCase
             ]);
     }
 
-    public function testPoolCandidatesSearchExpiryFilter(): void
+    public function test_pool_candidates_search_expiry_filter(): void
     {
         $candidateActive = PoolCandidate::factory()->create([
             'pool_id' => $this->pool->id,
@@ -307,7 +307,7 @@ class PoolCandidateSearchTest extends TestCase
         ]);
     }
 
-    public function testPoolCandidatesSearchSuspendedFilter(): void
+    public function test_pool_candidates_search_suspended_filter(): void
     {
         PoolCandidate::factory()->count(5)->create([
             'pool_id' => $this->pool->id,
@@ -424,7 +424,7 @@ class PoolCandidateSearchTest extends TestCase
         ]);
     }
 
-    public function testPoolCandidatesSearchGovEmployee(): void
+    public function test_pool_candidates_search_gov_employee(): void
     {
         PoolCandidate::factory()->count(5)->create([
             'pool_id' => $this->pool->id,
@@ -432,7 +432,7 @@ class PoolCandidateSearchTest extends TestCase
             'pool_candidate_status' => PoolCandidateStatus::PLACED_CASUAL->name,
             'suspended_at' => null,
             'user_id' => User::factory([
-                'is_gov_employee' => true,
+                'computed_is_gov_employee' => true,
             ]),
         ]);
         PoolCandidate::factory()->count(3)->create([
@@ -441,7 +441,7 @@ class PoolCandidateSearchTest extends TestCase
             'pool_candidate_status' => PoolCandidateStatus::PLACED_CASUAL->name,
             'suspended_at' => null,
             'user_id' => User::factory([
-                'is_gov_employee' => false,
+                'computed_is_gov_employee' => false,
             ]),
         ]);
 
@@ -499,7 +499,7 @@ class PoolCandidateSearchTest extends TestCase
         ]);
     }
 
-    public function testPoolCandidatesSearchClassification(): void
+    public function test_pool_candidates_search_classification(): void
     {
         // Create qualified right classification candidates
         $classificationIT1 = Classification::factory()->create([
@@ -621,7 +621,7 @@ class PoolCandidateSearchTest extends TestCase
     }
 
     // test pool candidates  general search by notes
-    public function testPoolCandidatesSearchByNotes()
+    public function test_pool_candidates_search_by_notes()
     {
         $candidateId = PoolCandidate::factory()->create([
             'pool_id' => $this->pool->id,

--- a/api/tests/Feature/UserTest.php
+++ b/api/tests/Feature/UserTest.php
@@ -65,7 +65,7 @@ class UserTest extends TestCase
                 'location_preferences' => [],
                 'has_diploma' => false,
                 'position_duration' => [],
-                'is_gov_employee' => false,
+                'computed_is_gov_employee' => false,
                 'telephone' => null,
                 'first_name' => null,
                 'last_name' => null,
@@ -1266,7 +1266,7 @@ class UserTest extends TestCase
                 'looking_for_bilingual' => null,
                 'telephone' => '+15407608748',
                 'current_city' => 'Somewhere random',
-                'is_gov_employee' => false,
+                'computed_is_gov_employee' => false,
             ]);
 
         // Assert query no isProfileComplete filter will return all users
@@ -1568,12 +1568,12 @@ class UserTest extends TestCase
     {
         // Create initial set of 5 users not with gov.
         User::factory()->count(5)->create([
-            'is_gov_employee' => false,
+            'computed_is_gov_employee' => false,
         ]);
 
         // Create two new users with the government.
         User::factory()->count(2)->create([
-            'is_gov_employee' => true,
+            'computed_is_gov_employee' => true,
         ]);
 
         // Assert query no isGovEmployee filter will return all users


### PR DESCRIPTION
🤖 Resolves #12645 

## 👋 Introduction

Renames the fields related to being a government employee to be prefixed with `computed_` in preparation for the work experience event listener work.

## 🕵️ Details

This only renames and points existing fields to these for now. Actual computation will be done in separate tickets.

## 🧪 Testing

1. Refresh api `make refresh-api; make seed-fresh`
2. Confirm no errors
3. Confirm the following works:
     - Setting and displaying government info on profile/application
     - Downloading user government employee info