### PR TITLE
[Bug] Fix default value handling of DateInput

### DIFF
--- a/packages/forms/src/components/DateInput/ControlledInput.tsx
+++ b/packages/forms/src/components/DateInput/ControlledInput.tsx
@@ -6,6 +6,7 @@ import {
 } from "react-hook-form";
 import { useIntl } from "react-intl";
 import { ChangeEvent } from "react";
+import get from "lodash/get";
 
 import { dateMessages } from "@gc-digital-talent/i18n";
 
@@ -36,7 +37,13 @@ const ControlledInput = ({
   const intl = useIntl();
   const inputStyles = useInputStyles();
   const selectStyles = useInputStyles("select");
-  const defaultValue = defaultValues ? String(defaultValues[name]) : undefined;
+  const rawDefaultValue: unknown = get(defaultValues, name);
+  const defaultValue =
+    rawDefaultValue !== null && rawDefaultValue !== undefined
+      ? // It's a input field so it should be stringable
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
+        String(rawDefaultValue)
+      : undefined;
   const { year, month, day } = splitSegments(defaultValue);
   const ID = {
     YEAR: `${name}Year`,

--- a/packages/forms/src/components/DateInput/DateInput.stories.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.stories.tsx
@@ -249,3 +249,44 @@ AsyncDefaultValue.args = {
 AsyncDefaultValue.parameters = {
   chromatic: { delay: 1500 },
 };
+
+const FieldArrayTemplate: StoryFn = () => {
+  const formValues = {
+    dates: [
+      {
+        legend: "Date 1",
+        value: "2025-01-01",
+      },
+      {
+        legend: "Date 2",
+        value: "2026-02-02",
+      },
+    ],
+  };
+
+  return (
+    <Form
+      options={{
+        mode: "onSubmit",
+        defaultValues: formValues,
+      }}
+      onSubmit={(data) => action("Submit Form")(data)}
+    >
+      {formValues.dates.map((val, i) => (
+        <div key={val.legend}>
+          <DateInput
+            id={`dateInput-${i}`}
+            name={`dates.${i}.value`}
+            legend={val.legend}
+          />
+        </div>
+      ))}
+
+      <p data-h2-margin-top="base(x1)">
+        <Submit />
+      </p>
+    </Form>
+  );
+};
+
+export const InAFieldArray = FieldArrayTemplate.bind({});


### PR DESCRIPTION
🤖 Resolves #12655 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Fixes the display of a default value in DateInput when in a field array.  Includes a storybook story for demo.


h/t @mnigh and @esizer for pointing me through this.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->
I've switch the default value access from a simple property dereference to the Lodash Get method which handles indexed array access well.

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. DateInput Storybook stories all work
2. Exist DateInputs still work in the app

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

## 🚚 Deployment

<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the PR if deployment steps are needed

 -->
