### PR TITLE
[Bug] Work experiences expected end date not working

### DIFF
--- a/apps/web/src/components/ExperienceFormFields/WorkFields/GovFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields/GovFields.tsx
@@ -223,6 +223,16 @@ const GovFields = ({ labels }: SubExperienceFormProps) => {
         defaultValue: undefined,
       });
     }
+
+    // govPositionType field only applies to INDETERMINATE
+    if (
+      watchGovEmploymentType !== WorkExperienceGovEmployeeType.Indeterminate
+    ) {
+      resetField("govPositionType", {
+        keepDirty: false,
+        defaultValue: null,
+      });
+    }
   }, [resetField, watchGovEmploymentType, watchGovContractorType]);
 
   return (

--- a/apps/web/src/utils/experienceUtils.tsx
+++ b/apps/web/src/utils/experienceUtils.tsx
@@ -348,7 +348,11 @@ export const formValuesToSubmitData = (
     cafRank,
   } = data;
 
-  const newEndDate = !currentRole && endDate ? endDate : null;
+  // for government employee experiences only, expected end date is present in end date field
+  // SUBSTANTIVE the exception, accessible solely through INDETERMINATE
+  const allowExpectedEndDate =
+    employmentCategory === EmploymentCategory.GovernmentOfCanada &&
+    govPositionType !== GovPositionType.Substantive;
 
   const dataMap: Record<ExperienceType, ExperienceDetailsSubmissionData> = {
     award: {
@@ -363,7 +367,7 @@ export const formValuesToSubmitData = (
       organization,
       project,
       startDate,
-      endDate: newEndDate,
+      endDate: !currentRole && endDate ? endDate : null,
     },
     education: {
       type: educationType,
@@ -372,20 +376,21 @@ export const formValuesToSubmitData = (
       institution,
       thesisTitle,
       startDate,
-      endDate: newEndDate,
+      endDate: !currentRole && endDate ? endDate : null,
     },
     personal: {
       title: experienceTitle,
       description: experienceDescription,
       startDate,
-      endDate: newEndDate,
+      endDate: !currentRole && endDate ? endDate : null,
     },
     work: {
       role,
       organization,
       division: team,
       startDate,
-      endDate: newEndDate,
+      endDate:
+        allowExpectedEndDate || (!currentRole && endDate) ? endDate : null,
       employmentCategory,
       extSizeOfOrganization,
       extRoleSeniority,


### PR DESCRIPTION
🤖 Resolves #12657

## 👋 Introduction

This was applicable to all work experiences, not just ones with secondment selections. 

Effectively, existing logic for `formValuesToSubmitData` did not entirely apply now that experiences could have expected end date values. The end date needed to be handled differently for work experiences

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Head to career timeline
2. Experiment with create/edit of work experiences 

