### PR TITLE
[Fix] Removes invalid auto value for `text-align`

### DIFF
--- a/apps/web/src/components/NavMenu/MainNavMenu.tsx
+++ b/apps/web/src/components/NavMenu/MainNavMenu.tsx
@@ -107,8 +107,8 @@ const MainNavMenu = () => {
             data-h2-color="base:hover(secondary.darker) base:focus-visible(black)"
             href={languageTogglePath}
             lang={changeToLang === "en" ? "en" : "fr"}
-            data-h2-flex="base(1)"
-            data-h2-text-align="base(right) l-tablet(auto)"
+            data-h2-flex="base(1) l-tablet(auto)"
+            data-h2-text-align="base(right)"
           >
             {intl.formatMessage({
               defaultMessage: "<hidden>Changer la langue en </hidden>Français",


### PR DESCRIPTION
🤖 Resolves #12610.

## 👋 Introduction

This PR removes an invalid `text-align` css value from the `MainNavMenu` component which was never being applied due  to it being applied via a media query.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/ with Firefox browser
3. Verify no change to mobile menu on screen width of less than 1080px
4. Verify no css warning Error in parsing value for ‘text-align’. Declaration dropped.

## 📸 Screenshot

<img width="1215" alt="Screen Shot 2025-01-30 at 17 00 57" src="https://github.com/user-attachments/assets/a0da4865-aa0f-494c-bda6-27b8e653e476" />

