### PR TITLE
[Feature] Computed current gov work experience

### DIFF
--- a/api/app/Events/WorkExperienceSaved.php
+++ b/api/app/Events/WorkExperienceSaved.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\WorkExperience;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class WorkExperienceSaved
+{
+    use Dispatchable, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public WorkExperience $workExperience) {}
+}

--- a/api/app/Listeners/ComputeGovEmployeeProfileData.php
+++ b/api/app/Listeners/ComputeGovEmployeeProfileData.php
@@ -68,14 +68,14 @@ class ComputeGovEmployeeProfileData
         });
 
         if ($sameStartDate->count()) {
-            $priortySortedExperiences = $sameStartDate
+            $prioritySortedExperiences = $sameStartDate
                 ->sortBy('created_at')
                 ->sortBy([
                     fn (WorkExperience $a, WorkExperience $b) => array_search($a->gov_position_type, $this->positionTypeOrder) <=> array_search($b->gov_position_type, $this->positionTypeOrder),
                     fn (WorkExperience $a, WorkExperience $b) => array_search($a->gov_employment_type, $this->employmentTypeOrder) <=> array_search($b->gov_employment_type, $this->employmentTypeOrder),
                 ]);
 
-            $latest = $priortySortedExperiences->first();
+            $latest = $prioritySortedExperiences->first();
         }
 
         Log::info([

--- a/api/app/Listeners/ComputeGovEmployeeProfileData.php
+++ b/api/app/Listeners/ComputeGovEmployeeProfileData.php
@@ -25,6 +25,7 @@ class ComputeGovEmployeeProfileData
         WorkExperienceGovEmployeeType::INDETERMINATE->name,
         WorkExperienceGovEmployeeType::TERM->name,
         WorkExperienceGovEmployeeType::CASUAL->name,
+        null,
     ];
 
     private $positionTypeOrder = [
@@ -32,6 +33,7 @@ class ComputeGovEmployeeProfileData
         GovPositionType::SECONDMENT->name,
         GovPositionType::ASSIGNMENT->name,
         GovPositionType::SUBSTANTIVE->name,
+        null,
     ];
 
     /**
@@ -71,8 +73,8 @@ class ComputeGovEmployeeProfileData
             $priortySortedExperiences = $sameStartDate
                 ->sortBy('created_at')
                 ->sortBy([
-                    fn (WorkExperience $a, WorkExperience $b) => array_search($a?->gov_employment_type, $this->employmentTypeOrder) <=> array_search($b?->gov_employment_type, $this->employmentTypeOrder),
                     fn (WorkExperience $a, WorkExperience $b) => array_search($a?->gov_position_type, $this->positionTypeOrder) <=> array_search($b?->gov_position_type, $this->positionTypeOrder),
+                    fn (WorkExperience $a, WorkExperience $b) => array_search($a?->gov_employment_type, $this->employmentTypeOrder) <=> array_search($b?->gov_employment_type, $this->employmentTypeOrder),
                 ]);
 
             $latest = $priortySortedExperiences->first();

--- a/api/app/Listeners/ComputeGovEmployeeProfileData.php
+++ b/api/app/Listeners/ComputeGovEmployeeProfileData.php
@@ -18,7 +18,6 @@ class ComputeGovEmployeeProfileData
     private $employmentTypeOrder = [
         WorkExperienceGovEmployeeType::INDETERMINATE->name,
         WorkExperienceGovEmployeeType::TERM->name,
-        WorkExperienceGovEmployeeType::CASUAL->name,
         null,
     ];
 
@@ -44,7 +43,11 @@ class ComputeGovEmployeeProfileData
 
         $currentExperiences = WorkExperience::where('user_id', $user->id)
             ->whereIn('properties->employment_category', [EmploymentCategory::GOVERNMENT_OF_CANADA->name, EmploymentCategory::CANADIAN_ARMED_FORCES->name])
-            ->whereNotIn('properties->gov_employment_type', [WorkExperienceGovEmployeeType::STUDENT->name, WorkExperienceGovEmployeeType::CONTRACTOR->name])
+            ->whereNotIn('properties->gov_employment_type', [
+                WorkExperienceGovEmployeeType::STUDENT->name,
+                WorkExperienceGovEmployeeType::CASUAL->name,
+                WorkExperienceGovEmployeeType::CONTRACTOR->name,
+            ])
             ->where(function (Builder $query) {
                 $query->whereNull('properties->end_date')
                     ->orWhere('properties->end_date', '>=', now());

--- a/api/app/Listeners/ComputeGovEmployeeProfileData.php
+++ b/api/app/Listeners/ComputeGovEmployeeProfileData.php
@@ -60,7 +60,7 @@ class ComputeGovEmployeeProfileData
         $startDate = Carbon::parse($latest->start_date);
         $sameStartDate = $currentExperiences->where(function ($experience) use ($startDate) {
             // Is same month and year
-            return $startDate->isSameMonth($experience->start_date, true);
+            return $experience?->start_date && $startDate->isSameMonth($experience->start_date, true);
         });
 
         if ($sameStartDate->count()) {

--- a/api/app/Listeners/ComputeGovEmployeeProfileData.php
+++ b/api/app/Listeners/ComputeGovEmployeeProfileData.php
@@ -71,8 +71,8 @@ class ComputeGovEmployeeProfileData
             $priortySortedExperiences = $sameStartDate
                 ->sortBy('created_at')
                 ->sortBy([
-                    fn (WorkExperience $a, WorkExperience $b) => array_search($a?->gov_position_type, $this->positionTypeOrder) <=> array_search($b?->gov_position_type, $this->positionTypeOrder),
-                    fn (WorkExperience $a, WorkExperience $b) => array_search($a?->gov_employment_type, $this->employmentTypeOrder) <=> array_search($b?->gov_employment_type, $this->employmentTypeOrder),
+                    fn (WorkExperience $a, WorkExperience $b) => array_search($a->gov_position_type, $this->positionTypeOrder) <=> array_search($b->gov_position_type, $this->positionTypeOrder),
+                    fn (WorkExperience $a, WorkExperience $b) => array_search($a->gov_employment_type, $this->employmentTypeOrder) <=> array_search($b->gov_employment_type, $this->employmentTypeOrder),
                 ]);
 
             $latest = $priortySortedExperiences->first();

--- a/api/app/Listeners/ComputeGovEmployeeProfileData.php
+++ b/api/app/Listeners/ComputeGovEmployeeProfileData.php
@@ -38,6 +38,10 @@ class ComputeGovEmployeeProfileData
         $workExperience = $event->workExperience;
         $user = $workExperience->user;
 
+        if (! $user) {
+            return;
+        }
+
         $currentExperiences = WorkExperience::where('user_id', $user->id)
             ->whereIn('properties->employment_category', [EmploymentCategory::GOVERNMENT_OF_CANADA->name, EmploymentCategory::CANADIAN_ARMED_FORCES->name])
             ->whereNotIn('properties->gov_employment_type', [WorkExperienceGovEmployeeType::STUDENT->name, WorkExperienceGovEmployeeType::CONTRACTOR->name])

--- a/api/app/Listeners/ComputeGovEmployeeProfileData.php
+++ b/api/app/Listeners/ComputeGovEmployeeProfileData.php
@@ -13,13 +13,7 @@ use Illuminate\Support\Facades\Log;
 
 class ComputeGovEmployeeProfileData
 {
-    /**
-     * Create the event listener.
-     */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
     private $employmentTypeOrder = [
         WorkExperienceGovEmployeeType::INDETERMINATE->name,

--- a/api/app/Listeners/ComputeGovEmployeeProfileData.php
+++ b/api/app/Listeners/ComputeGovEmployeeProfileData.php
@@ -81,22 +81,12 @@ class ComputeGovEmployeeProfileData
         }
 
         Log::info([
-            'latest' => $this->logTransform($latest),
-            'priority' => $priortySortedExperiences->map(fn ($exp) => $this->logTransform($exp)),
-            'current' => $currentExperiences->map(fn ($exp) => $this->logTransform($exp)),
+            'computed_is_gov_employee' => true,
+            'computed_gov_employment_type' => $latest?->gov_employment_type,
+            'computed_classification' => $latest?->classification_id,
+            'computed_department' => $latest?->department_id,
+            'computed_gov_position_type' => $latest?->gov_position_type,
+            'computed_gov_end_date' => $latest?->end_date,
         ]);
-    }
-
-    private function logTransform(WorkExperience $exp)
-    {
-        return [
-            'title' => $exp->getTitle(),
-            'start_date' => $exp->start_date?->toDateString(),
-            'end_date' => $exp?->end_date ? $exp->end_date->toDateString() : 'null',
-            'type' => $exp->gov_employment_type,
-            'position' => $exp->gov_position_type,
-            'category' => $exp->employment_category,
-            'created_at' => $exp->created_at?->toDateString(),
-        ];
     }
 }

--- a/api/app/Listeners/ComputeGovEmployeeProfileData.php
+++ b/api/app/Listeners/ComputeGovEmployeeProfileData.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Enums\EmploymentCategory;
+use App\Enums\GovPositionType;
+use App\Enums\WorkExperienceGovEmployeeType;
+use App\Events\WorkExperienceSaved;
+use App\Models\WorkExperience;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Log;
+
+class ComputeGovEmployeeProfileData
+{
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    private $employmentTypeOrder = [
+        WorkExperienceGovEmployeeType::INDETERMINATE->name,
+        WorkExperienceGovEmployeeType::TERM->name,
+        WorkExperienceGovEmployeeType::CASUAL->name,
+    ];
+
+    private $positionTypeOrder = [
+        GovPositionType::ACTING->name,
+        GovPositionType::SECONDMENT->name,
+        GovPositionType::ASSIGNMENT->name,
+        GovPositionType::SUBSTANTIVE->name,
+    ];
+
+    /**
+     * Handle the event.
+     */
+    public function handle(WorkExperienceSaved $event): void
+    {
+        $workExperience = $event->workExperience;
+        $user = $workExperience->user;
+
+        $currentExperiences = WorkExperience::where('user_id', $user->id)
+            ->whereIn('properties->employment_category', [EmploymentCategory::GOVERNMENT_OF_CANADA->name, EmploymentCategory::CANADIAN_ARMED_FORCES->name])
+            ->whereNotIn('properties->gov_employment_type', [WorkExperienceGovEmployeeType::STUDENT->name, WorkExperienceGovEmployeeType::CONTRACTOR->name])
+            ->where(function (Builder $query) {
+                $query->whereNull('properties->end_date')
+                    ->orWhere('properties->end_date', '>=', now());
+            })
+            ->orderBy('properties->start_date', 'DESC')
+            ->get();
+
+        if (! $currentExperiences->count()) {
+            Log::info([
+                'computed_is_gov_employee' => false,
+            ]);
+
+            return;
+        }
+
+        $latest = $currentExperiences->first();
+        $startDate = Carbon::parse($latest->start_date);
+        $sameStartDate = $currentExperiences->where(function ($experience) use ($startDate) {
+            // Is same month and year
+            return $startDate->isSameMonth($experience->start_date, true);
+        });
+
+        if ($sameStartDate->count()) {
+            $priortySortedExperiences = $sameStartDate
+                ->sortBy('created_at')
+                ->sortBy([
+                    fn (WorkExperience $a, WorkExperience $b) => array_search($a?->gov_employment_type, $this->employmentTypeOrder) <=> array_search($b?->gov_employment_type, $this->employmentTypeOrder),
+                    fn (WorkExperience $a, WorkExperience $b) => array_search($a?->gov_position_type, $this->positionTypeOrder) <=> array_search($b?->gov_position_type, $this->positionTypeOrder),
+                ]);
+
+            $latest = $priortySortedExperiences->first();
+        }
+
+        Log::info([
+            'latest' => $this->logTransform($latest),
+            'priority' => $priortySortedExperiences->map(fn ($exp) => $this->logTransform($exp)),
+            'current' => $currentExperiences->map(fn ($exp) => $this->logTransform($exp)),
+        ]);
+    }
+
+    private function logTransform(WorkExperience $exp)
+    {
+        return [
+            'title' => $exp->getTitle(),
+            'start_date' => $exp->start_date?->toDateString(),
+            'end_date' => $exp?->end_date ? $exp->end_date->toDateString() : 'null',
+            'type' => $exp->gov_employment_type,
+            'position' => $exp->gov_position_type,
+            'category' => $exp->employment_category,
+            'created_at' => $exp->created_at?->toDateString(),
+        ];
+    }
+}

--- a/api/app/Models/WorkExperience.php
+++ b/api/app/Models/WorkExperience.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Enums\CafForce;
 use App\Enums\EmploymentCategory;
+use App\Events\WorkExperienceSaved;
 use App\Models\Scopes\MatchExperienceType;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -60,6 +61,13 @@ class WorkExperience extends Experience
      */
     protected $attributes = [
         'experience_type' => WorkExperience::class,
+    ];
+
+    /**
+     * Listeners for model events
+     */
+    protected $dispatchesEvents = [
+        'saved' => WorkExperienceSaved::class,
     ];
 
     protected static $hydrationFields = [

--- a/api/app/Models/WorkExperience.php
+++ b/api/app/Models/WorkExperience.php
@@ -68,6 +68,7 @@ class WorkExperience extends Experience
      */
     protected $dispatchesEvents = [
         'saved' => WorkExperienceSaved::class,
+        'deleted' => WorkExperienceSaved::class,
     ];
 
     protected static $hydrationFields = [

--- a/api/app/Models/WorkExperience.php
+++ b/api/app/Models/WorkExperience.php
@@ -26,18 +26,18 @@ use Staudenmeir\EloquentJsonRelations\HasJsonRelationships;
  * @property \Illuminate\Support\Carbon $created_at
  * @property \Illuminate\Support\Carbon $updated_at
  * @property string $employment_category
- * @property string $ext_size_of_organization
- * @property string $ext_role_seniority
- * @property string $gov_employment_type
- * @property string $gov_position_type
- * @property string $gov_contractor_role_seniority
- * @property string $gov_contractor_type
- * @property string $caf_employment_type
- * @property string $caf_force
- * @property string $caf_rank
- * @property string $classification_id
- * @property string $department_id
- * @property string $contractor_firm_agency_name
+ * @property ?string $ext_size_of_organization
+ * @property ?string $ext_role_seniority
+ * @property ?string $gov_employment_type
+ * @property ?string $gov_position_type
+ * @property ?string $gov_contractor_role_seniority
+ * @property ?string $gov_contractor_type
+ * @property ?string $caf_employment_type
+ * @property ?string $caf_force
+ * @property ?string $caf_rank
+ * @property ?string $classification_id
+ * @property ?string $department_id
+ * @property ?string $contractor_firm_agency_name
  */
 class WorkExperience extends Experience
 {

--- a/api/app/Providers/EventServiceProvider.php
+++ b/api/app/Providers/EventServiceProvider.php
@@ -5,8 +5,10 @@ namespace App\Providers;
 use App\Events\AssessmentResultSaved;
 use App\Events\CandidateStatusChanged;
 use App\Events\UserFileGenerated;
+use App\Events\WorkExperienceSaved;
 use App\Listeners\ComputeCandidateAssessmentStatus;
 use App\Listeners\ComputeCandidateFinalDecision;
+use App\Listeners\ComputeGovEmployeeProfileData;
 use App\Listeners\SendFileGeneratedNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
@@ -26,6 +28,9 @@ class EventServiceProvider extends ServiceProvider
         ],
         UserFileGenerated::class => [
             SendFileGeneratedNotification::class,
+        ],
+        WorkExperienceSaved::class => [
+            ComputeGovEmployeeProfileData::class,
         ],
     ];
 


### PR DESCRIPTION
🤖 Resolves #12643 

## 👋 Introduction

Computes and logs current work experience on created and updated work experience events.

## 🕵️ Details

This is just logging the expected values, storing them will be completed in a future ticket.

## 🧪 Testing

1. Refresh api `make refresh-api`
2. Login as any user role
3. Start be creating a few non-government experiences
4. Confirm that `computed_is_gov_employee` remains false
5. Add a few gov employee work experiences with varying position type, employment types and start dates
6. Confirm that the appropriate experience values are logged based on the logic outlined in the ticket