### PR TITLE
[Tests] Adds `.skip` to Should have frontend and backend queries matching test

### DIFF
--- a/apps/web/src/pages/Profile/ProfilePage/ProfileSnapshot.test.ts
+++ b/apps/web/src/pages/Profile/ProfilePage/ProfileSnapshot.test.ts
@@ -15,7 +15,8 @@ function normalizeQuery(q: string[]): string[] {
 }
 
 describe("Profile snapshot tests", () => {
-  test("Should have frontend and backend queries matching", async () => {
+  // remove .skip in #12648.
+  test.skip("Should have frontend and backend queries matching", async () => {
     const frontendQueryLines = normalizeQuery(frontendQuery.split("\n"));
     // expect that the outer layer will be different so remove it from test
     if (


### PR DESCRIPTION
🤖 Resolves #12683.

## 👋 Introduction

This PR adds `.skip` to Should have frontend and backend queries matching test.

## 🧪 Testing

1. `cd apps/web`
2. `pnpm test -- src/pages/Profile/ProfilePage/ProfileSnapshot.test.ts`
3. Verify Should have frontend and backend queries matching test is skipped

## 📸 Screenshot

<img width="784" alt="Screen Shot 2025-02-04 at 10 07 17" src="https://github.com/user-attachments/assets/4e5be55a-e109-4c78-80a8-4cf5b4441adf" />