### PR TITLE
[Feature] `CommunityInterest` paginated query

### DIFF
--- a/api/app/Models/CommunityInterest.php
+++ b/api/app/Models/CommunityInterest.php
@@ -12,12 +12,25 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * Class CommunityInterest
  *
  * @property string $id
+ * @property string $user_id
+ * @property string $community_id
+ * @property bool $job_interest
+ * @property bool $training_interest
+ * @property string $additional_information
+ * @property \Illuminate\Support\Carbon $created_at
+ * @property ?\Illuminate\Support\Carbon $updated_at
  */
 class CommunityInterest extends Model
 {
     use HasFactory;
 
     protected $keyType = 'string';
+
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
 
     /** @return BelongsTo<Community, $this> */
     public function community(): BelongsTo

--- a/api/app/Models/CommunityInterest.php
+++ b/api/app/Models/CommunityInterest.php
@@ -71,6 +71,7 @@ class CommunityInterest extends Model
     }
 
     // scope the query to CommunityInterests the current user can view
+    // belongs to your community and one or more of jobInterest or trainingInterest is TRUE
     public function scopeAuthorizedToView(Builder $query)
     {
         /** @var \App\Models\User | null */
@@ -85,6 +86,13 @@ class CommunityInterest extends Model
                     ->toArray();
 
                 return $query->whereIn('community_id', $communityIds);
+            });
+
+            $query->where(function (Builder $query) {
+                $query->orWhere('job_interest', true);
+                $query->orWhere('training_interest', true);
+
+                return $query;
             });
 
             return $query;

--- a/api/app/Policies/CommunityInterestPolicy.php
+++ b/api/app/Policies/CommunityInterestPolicy.php
@@ -44,4 +44,12 @@ class CommunityInterestPolicy
     {
         return $user->isAbleTo('update-own-employeeProfile') && $user->id === $communityInterest->user_id;
     }
+
+    /**
+     * Determine whether the user can access user profiles associated with models.
+     */
+    public function viewUser(User $user): bool
+    {
+        return $user->isAbleTo('view-team-communityInterest');
+    }
 }

--- a/api/config/rolepermission.php
+++ b/api/config/rolepermission.php
@@ -86,6 +86,7 @@ return [
         'communityTeamMembers' => 'communityTeamMembers',
         'trainingOpportunity' => 'trainingOpportunity',
         'workStream' => 'workStream',
+        'communityInterest' => 'communityInterest',
 
         'platformAdminMembership' => 'platformAdminMembership',
         'communityAdminMembership' => 'communityAdminMembership',
@@ -632,6 +633,11 @@ return [
             'en' => 'Create or update a training opportunity',
             'fr' => 'Créer ou mettre à jour une opportunité de formation',
         ],
+
+        'view-team-communityInterest' => [
+            'en' => 'View community interest records associated with a community',
+            'fr' => 'Consulter les fiches d\'intérêt communautaire associées à une communauté',
+        ],
     ],
 
     /*
@@ -1065,6 +1071,9 @@ return [
             'processOperatorMembership' => [
                 'team' => ['update'],
             ],
+            'communityInterest' => [
+                'team' => ['view'],
+            ],
         ],
 
         'community_admin' => [
@@ -1115,6 +1124,9 @@ return [
             ],
             'processOperatorMembership' => [
                 'team' => ['update'],
+            ],
+            'communityInterest' => [
+                'team' => ['view'],
             ],
         ],
 

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1048,6 +1048,10 @@ input ClaimVerificationSort {
   useBookmark: Boolean
 }
 
+input CommunityInterestFilterInput {
+  userName: String @scope
+}
+
 type Query {
   myAuth: UserAuthInfo @auth
   me: User @auth
@@ -1214,6 +1218,12 @@ type Query {
     enumName: String!
       @rules(apply: ["required", "App\\Rules\\LocalizedEnumExists"])
   ): [LocalizedEnumString!]
+  communityInterestsPaginated(
+    where: CommunityInterestFilterInput
+    orderBy: [OrderByClause!] @orderBy
+  ): [CommunityInterest]!
+    @guard
+    @paginate(defaultCount: 10, maxCount: 500, scopes: ["authorizedToView"])
 }
 
 input ClassificationBelongsTo {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -155,6 +155,7 @@ type User {
 type CommunityInterest {
   id: UUID!
   community: Community! @belongsTo
+  user: User! @belongsTo @canRoot(ability: "viewUser")
   workStreams: [WorkStream!] @belongsToMany
   jobInterest: Boolean @rename(attribute: "job_interest")
   trainingInterest: Boolean @rename(attribute: "training_interest")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -640,6 +640,7 @@ type User {
 type CommunityInterest {
   id: UUID!
   community: Community!
+  user: User!
   workStreams: [WorkStream!]
   jobInterest: Boolean
   trainingInterest: Boolean

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -410,6 +410,16 @@ type Query {
     "The offset from which items are returned."
     page: Int
   ): TrainingOpportunityPaginator!
+  communityInterestsPaginated(
+    where: CommunityInterestFilterInput
+    orderBy: [OrderByClause!]
+
+    "Limits number of fetched items. Maximum allowed value: 500."
+    first: Int! = 10
+
+    "The offset from which items are returned."
+    page: Int
+  ): CommunityInterestPaginator!
 }
 
 type Mutation {
@@ -1395,6 +1405,10 @@ input ClaimVerificationSort {
   useBookmark: Boolean
 }
 
+input CommunityInterestFilterInput {
+  userName: String
+}
+
 input ClassificationBelongsTo {
   connect: ID
   disconnect: Boolean
@@ -2328,6 +2342,15 @@ type TrainingOpportunityPaginator {
 
   "A list of TrainingOpportunity items."
   data: [TrainingOpportunity!]!
+}
+
+"A paginated list of CommunityInterest items."
+type CommunityInterestPaginator {
+  "Pagination information about the list of items."
+  paginatorInfo: PaginatorInfo!
+
+  "A list of CommunityInterest items."
+  data: [CommunityInterest!]!
 }
 
 "Allowed column names for Query.poolsPaginated.orderBy."

--- a/api/tests/Feature/CommunityInterestTest.php
+++ b/api/tests/Feature/CommunityInterestTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature;
 
 use App\Models\Community;
+use App\Models\CommunityInterest;
+use App\Models\Pool;
 use App\Models\User;
 use App\Models\WorkStream;
 use Database\Helpers\ApiErrorEnums;
@@ -14,6 +16,8 @@ use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
 use Tests\UsesProtectedGraphqlEndpoint;
 
+use function PHPUnit\Framework\assertEquals;
+
 class CommunityInterestTest extends TestCase
 {
     use MakesGraphQLRequests;
@@ -22,6 +26,16 @@ class CommunityInterestTest extends TestCase
     use UsesProtectedGraphqlEndpoint;
 
     protected $applicant;
+
+    protected $baseUser;
+
+    protected $platformAdmin;
+
+    protected $processOperator;
+
+    protected $communityRecruiter;
+
+    protected $communityAdmin;
 
     protected $communityId;
 
@@ -40,6 +54,23 @@ class CommunityInterestTest extends TestCase
             }
         }
     GRAPHQL;
+
+    protected $paginatedCommunityInterestsQuery =
+        /** @lang GraphQL */
+        '
+        query communityInterestsPaginated($where: CommunityInterestFilterInput){
+            communityInterestsPaginated(where: $where) {
+                data
+                {
+                    id
+                }
+                paginatorInfo
+                {
+                    total
+                }
+            }
+        }
+    ';
 
     protected function setUp(): void
     {
@@ -60,6 +91,25 @@ class CommunityInterestTest extends TestCase
         $this->communityId = $community->id;
         $this->workStreamIds = $community->workStreams()->pluck('id')->toArray();
 
+        $communityPool = Pool::factory()->create(['community_id' => $this->communityId]);
+
+        $this->baseUser = User::factory()->create();
+
+        $this->platformAdmin = User::factory()
+            ->asAdmin()
+            ->create();
+
+        $this->processOperator = User::factory()
+            ->asProcessOperator($communityPool->id)
+            ->create();
+
+        $this->communityRecruiter = User::factory()
+            ->asCommunityRecruiter($this->communityId)
+            ->create();
+
+        $this->communityAdmin = User::factory()
+            ->asCommunityAdmin($this->communityId)
+            ->create();
     }
 
     /**
@@ -227,5 +277,103 @@ class CommunityInterestTest extends TestCase
                 ],
             ])
             ->assertGraphQLValidationError('communityInterest.workStreams.sync.0', ApiErrorEnums::WORK_STREAM_NOT_IN_COMMUNITY);
+    }
+
+    // test querying CommunityInterests with various roles
+    public function testCommunityInterestsPaginatedRoles(): void
+    {
+        CommunityInterest::truncate();
+        $communityInterestModel = CommunityInterest::factory()->create(['community_id' => $this->communityId]);
+
+        // these roles cannot see the created model
+        $this->actingAs($this->applicant, 'api')->graphQL(
+            $this->paginatedCommunityInterestsQuery,
+            [],
+        )->assertJsonFragment(['total' => 0]);
+        $this->actingAs($this->baseUser, 'api')->graphQL(
+            $this->paginatedCommunityInterestsQuery,
+            [],
+        )->assertJsonFragment(['total' => 0]);
+        $this->actingAs($this->platformAdmin, 'api')->graphQL(
+            $this->paginatedCommunityInterestsQuery,
+            [],
+        )->assertJsonFragment(['total' => 0]);
+        $this->actingAs($this->processOperator, 'api')->graphQL(
+            $this->paginatedCommunityInterestsQuery,
+            [],
+        )->assertJsonFragment(['total' => 0]);
+
+        // only community recruiter and community admin can see the model
+        $this->actingAs($this->communityRecruiter, 'api')->graphQL(
+            $this->paginatedCommunityInterestsQuery,
+            [],
+        )->assertJsonFragment(['total' => 1])
+            ->assertJsonFragment(['id' => $communityInterestModel->id]);
+        $this->actingAs($this->communityAdmin, 'api')->graphQL(
+            $this->paginatedCommunityInterestsQuery,
+            [],
+        )->assertJsonFragment(['total' => 1])
+            ->assertJsonFragment(['id' => $communityInterestModel->id]);
+    }
+
+    // test scopeAuthorizedToView for community admin and community recruiter
+    // scope acts on community and job/training interest
+    public function testCommunityInterestsPaginatedAuthorizedToView(): void
+    {
+        CommunityInterest::truncate();
+        $communityInterestWithBothInterests = CommunityInterest::factory()->create([
+            'user_id' => User::factory(),
+            'community_id' => $this->communityId,
+            'job_interest' => true,
+            'training_interest' => true,
+        ]);
+        $communityInterestWithJobInterest = CommunityInterest::factory()->create([
+            'user_id' => User::factory(),
+            'community_id' => $this->communityId,
+            'job_interest' => true,
+            'training_interest' => false,
+        ]);
+        $communityInterestWithTrainingInterest = CommunityInterest::factory()->create([
+            'user_id' => User::factory(),
+            'community_id' => $this->communityId,
+            'job_interest' => false,
+            'training_interest' => true,
+        ]);
+        $communityInterestWithNoInterests = CommunityInterest::factory()->create([
+            'user_id' => User::factory(),
+            'community_id' => $this->communityId,
+            'job_interest' => false,
+            'training_interest' => false,
+        ]);
+        $otherCommunityInterest = CommunityInterest::factory()->create([
+            'user_id' => User::factory(),
+            'community_id' => Community::factory(),
+            'job_interest' => false,
+            'training_interest' => false,
+        ]);
+
+        // five records in total
+        assertEquals(5, count(CommunityInterest::all()));
+
+        // three results should be returned in total for both roles
+        // communityInterestWithBothInterests
+        // communityInterestWithJobInterest
+        // communityInterestWithTrainingInterest
+
+        $this->actingAs($this->communityRecruiter, 'api')->graphQL(
+            $this->paginatedCommunityInterestsQuery,
+            [],
+        )->assertJsonFragment(['total' => 3])
+            ->assertJsonFragment(['id' => $communityInterestWithBothInterests->id])
+            ->assertJsonFragment(['id' => $communityInterestWithJobInterest->id])
+            ->assertJsonFragment(['id' => $communityInterestWithTrainingInterest->id]);
+
+        $this->actingAs($this->communityAdmin, 'api')->graphQL(
+            $this->paginatedCommunityInterestsQuery,
+            [],
+        )->assertJsonFragment(['total' => 3])
+            ->assertJsonFragment(['id' => $communityInterestWithBothInterests->id])
+            ->assertJsonFragment(['id' => $communityInterestWithJobInterest->id])
+            ->assertJsonFragment(['id' => $communityInterestWithTrainingInterest->id]);
     }
 }

--- a/api/tests/Feature/RolePermissionTest.php
+++ b/api/tests/Feature/RolePermissionTest.php
@@ -288,6 +288,7 @@ class RolePermissionTest extends TestCase
             'view-team-communityTeamMembers',
             'view-team-poolTeamMembers',
             'update-team-processOperatorMembership',
+            'view-team-communityInterest',
         ];
         $allPermissions = Permission::all()->pluck('name')->toArray();
         $notPossessedPermissions = array_diff($allPermissions, $permissionsToCheck);
@@ -347,6 +348,7 @@ class RolePermissionTest extends TestCase
             'update-team-publishedPool',
             'update-team-community',
             'update-team-communityRecruiterMembership',
+            'view-team-communityInterest',
         ];
         $allPermissions = Permission::all()->pluck('name')->toArray();
         $notPossessedPermissions = array_diff($allPermissions, $permissionsToCheck);


### PR DESCRIPTION
🤖 Resolves #12603 

## 👋 Introduction

Add a paginated query to fetch records, it scopes by what community the authenticated user is. As well, it is restricted to community admin and community recruiter roles. 

New permission added `view-team-communityInterest`
Also added to Google Sheets file

## 🧪 Testing

1. It will probably be necessary to open Adminer/whatever to adjust the community_interest records to be in a community a user has admin/recruiter privileges in first
2. Query as a community admin/recruiter for records

Query

```
query b {
  communityInterestsPaginated(where: {
    userName: null
  }) {
    paginatorInfo {
      total
    }
    data {
      community {
        name {
          en
        }
      }
      user {
        firstName
      }
      trainingInterest
      jobInterest
    }
  }
}
```

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/3d7b1cd3-db8a-407a-99a0-a9edd217a5c2)


## 🚚 Deployment

Run role-permission seeder
`./artisan db:seed --class=RolePermissionSeeder`
