### PR TITLE
[Debt] Replaces `m` with `m.create`

### DIFF
--- a/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
+++ b/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
@@ -24,7 +24,7 @@ import notificationMessages from "~/messages/notificationMessages";
 import UnreadAlertBellIcon from "./UnreadAlertBellIcon";
 import NotificationList from "../NotificationList/NotificationList";
 
-const Overlay = m(DialogPrimitive.Overlay);
+const Overlay = m.create(DialogPrimitive.Overlay);
 
 // For the sake of the bell icon, we only care if the user has at least 1 unread notification
 // This is to query to minimal amount of data to display the badge


### PR DESCRIPTION
🤖 Resolves #12729.

## 👋 Introduction

This PR replaces the deprecated use of `m` with `m.create` where `m` is an alias for motion, the animation library.

## 🧪 Testing

1. `pnpm watch`
2. Navigate to http://localhost:3000/en/applicant
3. Login as any user
4. Open the notifications dialog via the bell icon
5. Verify no warning messages in console related to `m` or `motion`
