### PR TITLE
[Feature] Store computed government information values

### DIFF
--- a/api/app/Listeners/ComputeGovEmployeeProfileData.php
+++ b/api/app/Listeners/ComputeGovEmployeeProfileData.php
@@ -9,7 +9,6 @@ use App\Events\WorkExperienceSaved;
 use App\Models\WorkExperience;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Facades\Log;
 
 class ComputeGovEmployeeProfileData
 {
@@ -56,8 +55,13 @@ class ComputeGovEmployeeProfileData
             ->get();
 
         if (! $currentExperiences->count()) {
-            Log::info([
+            $user->update([
                 'computed_is_gov_employee' => false,
+                'computed_gov_employee_type' => null,
+                'computed_classification' => null,
+                'computed_department' => null,
+                'computed_gov_position_type' => null,
+                'computed_gov_end_date' => null,
             ]);
 
             return;
@@ -81,9 +85,9 @@ class ComputeGovEmployeeProfileData
             $latest = $prioritySortedExperiences->first();
         }
 
-        Log::info([
+        $user->update([
             'computed_is_gov_employee' => true,
-            'computed_gov_employment_type' => $latest?->gov_employment_type,
+            'computed_gov_employee_type' => $latest?->gov_employment_type,
             'computed_classification' => $latest?->classification_id,
             'computed_department' => $latest?->department_id,
             'computed_gov_position_type' => $latest?->gov_position_type,

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -129,6 +129,12 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
     protected $fillable = [
         'email',
         'sub',
+        'computed_is_gov_employee',
+        'computed_gov_employee_type',
+        'computed_classification',
+        'computed_department',
+        'computed_gov_position_type',
+        'computed_gov_end_date',
     ];
 
     protected $hidden = [];

--- a/api/database/factories/UserFactory.php
+++ b/api/database/factories/UserFactory.php
@@ -19,6 +19,7 @@ use App\Enums\OperationalRequirement;
 use App\Enums\OrganizationTypeInterest;
 use App\Enums\PositionDuration;
 use App\Enums\ProvinceOrTerritory;
+use App\Enums\WorkExperienceGovEmployeeType;
 use App\Models\AwardExperience;
 use App\Models\Classification;
 use App\Models\Community;
@@ -220,6 +221,10 @@ class UserFactory extends Factory
                 'user_id' => $user->id,
                 'end_date' => null,
                 'employment_category' => EmploymentCategory::GOVERNMENT_OF_CANADA->name,
+                'gov_employment_type' => $this->faker->randomElement([
+                    WorkExperienceGovEmployeeType::INDETERMINATE->name,
+                    WorkExperienceGovEmployeeType::TERM->name,
+                ]),
             ]);
             $this->createExperienceAndSyncSkills($user, $userSkills, $factory);
         });
@@ -399,6 +404,9 @@ class UserFactory extends Factory
             $allSkills = Skill::select('id')->whereDoesntHave('userSkills', function ($query) use ($user) {
                 $query->where('user_id', $user->id);
             })->inRandomOrder()->take($count)->get();
+            if (! $allSkills->count()) {
+                $allSkills = Skill::factory($count)->create();
+            }
         }
         $skillSequence = $allSkills->shuffle()->map(fn ($skill) => ['skill_id' => $skill['id']])->toArray();
 

--- a/api/database/factories/UserFactory.php
+++ b/api/database/factories/UserFactory.php
@@ -51,8 +51,6 @@ class UserFactory extends Factory
      */
     public function definition()
     {
-        $randomDepartment = Department::inRandomOrder()->first();
-        $randomClassification = Classification::inRandomOrder()->first();
         $isGovEmployee = $this->faker->boolean();
         $hasPriorityEntitlement = $this->faker->boolean(10);
         $isDeclared = $this->faker->boolean();
@@ -106,10 +104,7 @@ class UserFactory extends Factory
             'verbal_level' => $examLevels ?
                 $this->faker->randomElement(EvaluatedLanguageAbility::cases())->name
                 : null,
-            'computed_is_gov_employee' => $isGovEmployee,
             'work_email' => $isGovEmployee ? $this->faker->firstName().'_'.$this->faker->unique()->userName().'@gc.ca' : null,
-            'computed_department' => $isGovEmployee && $randomDepartment ? $randomDepartment->id : null,
-            'computed_classification' => $isGovEmployee && $randomClassification ? $randomClassification->id : null,
             'is_woman' => $this->faker->boolean(),
             'has_disability' => $this->faker->boolean(),
             'is_visible_minority' => $this->faker->boolean(),
@@ -132,7 +127,6 @@ class UserFactory extends Factory
                 array_column(PositionDuration::cases(), 'name')
                 : [PositionDuration::PERMANENT->name], // always accepting PERMANENT
             'accepted_operational_requirements' => $this->faker->optional->randomElements(array_column(OperationalRequirement::cases(), 'name'), 2),
-            'computed_gov_employee_type' => $isGovEmployee ? $this->faker->randomElement(GovEmployeeType::cases())->name : null,
             'citizenship' => $this->faker->randomElement(CitizenshipStatus::cases())->name,
             'armed_forces_status' => $this->faker->boolean() ?
                 ArmedForcesStatus::NON_CAF->name

--- a/api/database/factories/UserFactory.php
+++ b/api/database/factories/UserFactory.php
@@ -105,6 +105,7 @@ class UserFactory extends Factory
             'verbal_level' => $examLevels ?
                 $this->faker->randomElement(EvaluatedLanguageAbility::cases())->name
                 : null,
+            'computed_is_gov_employee' => $isGovEmployee,
             'work_email' => $isGovEmployee ? $this->faker->firstName().'_'.$this->faker->unique()->userName().'@gc.ca' : null,
             'is_woman' => $this->faker->boolean(),
             'has_disability' => $this->faker->boolean(),

--- a/api/tests/Feature/ComputeGovInfoTest.php
+++ b/api/tests/Feature/ComputeGovInfoTest.php
@@ -45,14 +45,14 @@ class ComputeGovInfoTest extends TestCase
             ]);
     }
 
-    public function test_non_work_experience()
+    public function testNonWorkExperience()
     {
         PersonalExperience::factory()->create(['user_id' => $this->user->id]);
 
         $this->assertEquals(false, $this->user->is_gov_employee);
     }
 
-    public function test_acting_term_prioritized_over_substantive_indeterminate()
+    public function testActingTermPrioritizedOverSubstantiveIndeterminate()
     {
 
         $sharedState = [
@@ -99,10 +99,11 @@ class ComputeGovInfoTest extends TestCase
     /**
      * @dataProvider workExperienceProvider
      */
-    public function test_work_experience_computes_proper_data(array $experienceState, array $expected)
+    public function testWorkExperienceComputesProperData(array $experienceState, array $expected)
     {
         WorkExperience::factory()->create([
             'user_id' => $this->user->id,
+            'end_date' => null,
             ...$experienceState,
         ]);
 

--- a/api/tests/Feature/PoolCandidateSearchTest.php
+++ b/api/tests/Feature/PoolCandidateSearchTest.php
@@ -431,10 +431,9 @@ class PoolCandidateSearchTest extends TestCase
             'expiry_date' => config('constants.far_future_date'),
             'pool_candidate_status' => PoolCandidateStatus::PLACED_CASUAL->name,
             'suspended_at' => null,
-            'user_id' => User::factory([
-                'computed_is_gov_employee' => true,
-            ]),
+            'user_id' => User::factory()->asGovEmployee(),
         ]);
+
         PoolCandidate::factory()->count(3)->create([
             'pool_id' => $this->pool->id,
             'expiry_date' => config('constants.far_future_date'),


### PR DESCRIPTION
🤖 Resolves #12648 

## 👋 Introduction

Updates the event listener for work experiences to store the values it computes.

## 🕵️ Details

...

## 🧪 Testing

1. Login as any user
2. Add a work experience with the following state:
    - Is a government experience
    - Has either no end date or one in the future
3. Confirm your profile updates saying you are a government employee with details specific to the experience created in step 2
4. Delete said experience
5. Confirm your profile updates to indicate you are not a government employee
6. Refer to the priority laid out in https://github.com/GCTC-NTGC/gc-digital-talent/issues/12643 and confirm it functions as expected