### PR TITLE
[Feature] Placed casual displays as open to offers

### DIFF
--- a/apps/web/src/components/QualifiedRecruitmentCard/utils.ts
+++ b/apps/web/src/components/QualifiedRecruitmentCard/utils.ts
@@ -93,6 +93,7 @@ export const getQualifiedRecruitmentInfo = (
     statusChip: getQualifiedRecruitmentStatusChip(
       candidate.suspendedAt,
       candidate.placedAt,
+      candidate.status?.value ?? null,
       intl,
     ),
     availability: getAvailabilityInfo(candidate, intl),

--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewRecruitmentProcessDialog.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewRecruitmentProcessDialog.tsx
@@ -50,6 +50,9 @@ const ReviewRecruitmentProcessDialog_Fragment = graphql(/* GraphQL */ `
     finalDecisionAt
     suspendedAt
     placedAt
+    status {
+      value
+    }
     pool {
       id
       name {
@@ -182,6 +185,7 @@ const ReviewRecruitmentProcessDialog = ({
   const status = getQualifiedRecruitmentStatusChip(
     recruitmentProcess.suspendedAt,
     recruitmentProcess.placedAt,
+    recruitmentProcess.status?.value ?? null,
     intl,
   );
 

--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewRecruitmentProcessPreviewList.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewRecruitmentProcessPreviewList.tsx
@@ -20,6 +20,9 @@ const ReviewRecruitmentProcessPreviewList_Fragment = graphql(/* GraphQL */ `
     finalDecisionAt
     suspendedAt
     placedAt
+    status {
+      value
+    }
     finalDecision {
       value
     }
@@ -72,6 +75,7 @@ const ReviewRecruitmentProcessPreviewList = ({
             const status = getQualifiedRecruitmentStatusChip(
               recruitmentProcess.suspendedAt,
               recruitmentProcess.placedAt,
+              recruitmentProcess.status?.value ?? null,
               intl,
             );
 

--- a/apps/web/src/utils/poolCandidate.ts
+++ b/apps/web/src/utils/poolCandidate.ts
@@ -574,9 +574,11 @@ const qualifiedRecruitmentStatusDescriptions = defineMessages({
 export const getQualifiedRecruitmentStatusChip = (
   suspendedAt: PoolCandidate["suspendedAt"],
   placedAt: PoolCandidate["placedAt"],
+  status: PoolCandidateStatus | null,
   intl: IntlShape,
 ): StatusChipWithDescription => {
-  if (placedAt) {
+  // placed casual is an exception
+  if (placedAt && status !== PoolCandidateStatus.PlacedCasual) {
     return {
       color: "secondary",
       label: intl.formatMessage(qualifiedRecruitmentStatusLabels.HIRED),


### PR DESCRIPTION
🤖 Resolves #12738 

## 👋 Introduction

Have `PLACED_CASUAL` as an exception for the applicant's processes view, they see it as "open to offers" still

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Submit an application
2. Head to application view for it and hop through actions
3. Set it to various states like qualified available, placed casual, and other placed fields
4. Observe status chip at `/en/applicant/career-timeline#qualified-recruitment-processes`

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

![image](https://github.com/user-attachments/assets/08324e97-7db5-4601-91e3-1973e208f6f2)

![image](https://github.com/user-attachments/assets/2536f395-612c-4753-8a8f-23d28fecd223)

