### PR TITLE
[Feat] Add employee profile link

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3375,6 +3375,10 @@
     "defaultMessage": "Fournir quelques détails",
     "description": "Heading for the experience type section fo the experience form"
   },
+  "GBfPU+": {
+    "defaultMessage": "Préférences en matière de développement de carrière et objectifs de carrière.",
+    "description": "Helper instructions for an 'employee profile' card"
+  },
   "GCjnow": {
     "defaultMessage": "J'envisagerais des possibilités dans d'autres sociétés d'État.",
     "description": "List item, interest in opportunities at other crown corporations"
@@ -5370,6 +5374,10 @@
   "Qxl9Ec": {
     "defaultMessage": "Afin d’écourter le processus de demande, l’information n’est recueillie que sur certaines compétences particulières à l’étape de la demande. Celles-ci sont identifiées individuellement sous le nom de la compétence en se servant de la mention « Évaluées à l’étape initiale de la demande ». D’autres évaluations suivront plus tard au cours de votre processus de demande si elle s’avère réussie. Ces évaluations supplémentaires peuvent être menées sur toutes les compétences obligatoires ou facultatives.",
     "description": "Descriptive text about how skills are used during the application process"
+  },
+  "QzGuI5": {
+    "defaultMessage": "Profil d'employé(e)",
+    "description": "applicant dashboard card title for employee profile card"
   },
   "QzU2SL": {
     "defaultMessage": "Veuillez remplir toute l’information relative à l'annonce avant de la publier.",

--- a/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.tsx
@@ -151,6 +151,9 @@ export const DashboardPage = ({
       ? "complete"
       : "incomplete";
 
+  // NOTE: Update once employee profile is complete
+  const employeeProfileState = "complete";
+
   const careerExperienceState =
     currentUser.experiences && currentUser.experiences?.length > 0
       ? "complete"
@@ -254,6 +257,25 @@ export const DashboardPage = ({
                       "Helper instructions for an 'Personal information' card",
                   })}
                 />
+                {isVerifiedEmployee ? (
+                  <ResourceBlock.SingleLinkItem
+                    state={employeeProfileState}
+                    title={intl.formatMessage({
+                      defaultMessage: "Employee profile",
+                      id: "QzGuI5",
+                      description:
+                        "applicant dashboard card title for employee profile card",
+                    })}
+                    href={paths.employeeProfile()}
+                    description={intl.formatMessage({
+                      defaultMessage:
+                        "Talent mobility preferences and career goals.",
+                      id: "J2QmoU",
+                      description:
+                        "Helper instructions for an 'employee profile' card",
+                    })}
+                  />
+                ) : null}
                 <ResourceBlock.SingleLinkItem
                   state={careerExperienceState}
                   title={intl.formatMessage({

--- a/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.tsx
@@ -151,7 +151,7 @@ export const DashboardPage = ({
       ? "complete"
       : "incomplete";
 
-  // NOTE: Update once employee profile is complete
+  // NOTE: Update in issue #12744
   const employeeProfileState = "complete";
 
   const careerExperienceState =

--- a/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.tsx
@@ -269,8 +269,8 @@ export const DashboardPage = ({
                     href={paths.employeeProfile()}
                     description={intl.formatMessage({
                       defaultMessage:
-                        "Talent mobility preferences and career goals.",
-                      id: "J2QmoU",
+                        "Career development preferences and career goals.",
+                      id: "GBfPU+",
                       description:
                         "Helper instructions for an 'employee profile' card",
                     })}

--- a/packages/ui/src/components/ResourceBlock/Root.tsx
+++ b/packages/ui/src/components/ResourceBlock/Root.tsx
@@ -54,11 +54,13 @@ const wrapperStyleMap: Record<CardColor, Record<string, string>> = {
   },
 };
 
+type MaybeElement = ReactElement<BaseItemProps> | null;
+
 export interface RootProps {
   title: ReactNode;
   headingColor?: CardColor;
   headingAs?: HeadingLevel;
-  children: ReactElement<BaseItemProps> | ReactElement<BaseItemProps>[]; // Restricts children to only expected items;
+  children: MaybeElement | MaybeElement[]; // Restricts children to only expected items;
 }
 
 const Root = ({


### PR DESCRIPTION
🤖 Resolves #12249 

## 👋 Introduction

Adds a link to the employee profile page to the dashboard for verified government employees.

## 🕵️ Details

The state is always complete since we have success hardcoded for now. We may need a ticket to fix that :thinking: 

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as a non-employee, likely `applicant@test.com`
3. Confirm the link does not appear in the sidebar
4. Login as an employee `applicant-employee@test.com`
5. Confirm the link does appear and sends you to the appropriate page

## 📸 Screenshot

![2025-02-12_10-12](https://github.com/user-attachments/assets/fa57f766-8835-43ff-bd05-96aa4c53ba22)
