### PR TITLE
[Feature] Artisan command to send access to employee tools notifications

### DIFF
--- a/api/app/Console/Commands/SendNotificationsEmployeeToolsAvailable.php
+++ b/api/app/Console/Commands/SendNotificationsEmployeeToolsAvailable.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use App\Notifications\System as SystemNotification;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection;
+use Throwable;
+
+class SendNotificationsEmployeeToolsAvailable extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'send-notifications:employee-tools-available';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send in-app notification to government users with verified work emails';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $successCount = 0;
+        $failureCount = 0;
+
+        $viewGroup = 'notification_employee_tools_available';
+        $now = Carbon::now();
+
+        User::where('computed_is_gov_employee', true)
+            ->whereNotNull('work_email_verified_at')
+            ->where('work_email_verified_at', '<=', $now)
+            ->chunk(200, function (Collection $users) use (&$successCount, &$failureCount, $viewGroup) {
+                foreach ($users as $user) {
+                    try {
+                        $notification = new SystemNotification(
+                            channelEmail: false,
+                            channelApp: true,
+                            emailSubjectEn: '',
+                            emailSubjectFr: '',
+                            emailContentEn: '',
+                            emailContentFr: '',
+                            inAppMessageEn: $viewGroup.'.in_app_message_en',
+                            inAppMessageFr: $viewGroup.'.in_app_message_fr',
+                            inAppHrefEn: $viewGroup.'.in_app_href_en',
+                            inAppHrefFr: $viewGroup.'.in_app_href_fr',
+                        );
+                        $user->notify($notification);
+                        $successCount++;
+                    } catch (Throwable $e) {
+                        $this->error($e->getMessage().' User id: '.$user->id);
+                        $failureCount++;
+                    }
+                }
+            });
+
+        $this->info("Success: $successCount Failure: $failureCount");
+        if ($failureCount > 0) {
+            return Command::FAILURE;
+        } else {
+            return Command::SUCCESS;
+        }
+    }
+}

--- a/api/resources/views/notification_employee_tools_available/in_app_href_en.blade.php
+++ b/api/resources/views/notification_employee_tools_available/in_app_href_en.blade.php
@@ -1,0 +1,1 @@
+/en/applicant/dashboard

--- a/api/resources/views/notification_employee_tools_available/in_app_href_fr.blade.php
+++ b/api/resources/views/notification_employee_tools_available/in_app_href_fr.blade.php
@@ -1,0 +1,1 @@
+/fr/applicant/dashboard

--- a/api/resources/views/notification_employee_tools_available/in_app_message_en.blade.php
+++ b/api/resources/views/notification_employee_tools_available/in_app_message_en.blade.php
@@ -1,0 +1,1 @@
+According to your profile, you currently work for the Government of Canada. You now have access to employee-only tools on your dashboard.

--- a/api/resources/views/notification_employee_tools_available/in_app_message_fr.blade.php
+++ b/api/resources/views/notification_employee_tools_available/in_app_message_fr.blade.php
@@ -1,0 +1,1 @@
+Selon votre profil, vous travaillez actuellement pour le gouvernement du Canada. Vous avez maintenant accès aux outils réservés aux employées et employés sur votre tableau de bord.

--- a/api/tests/Feature/Notifications/EmployeeToolsAvailableTest.php
+++ b/api/tests/Feature/Notifications/EmployeeToolsAvailableTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature\Notifications;
+
+use App\Models\Notification;
+use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Console\Command;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
+use Tests\TestCase;
+
+use function PHPUnit\Framework\assertEquals;
+
+class EmployeeToolsAvailableTest extends TestCase
+{
+    use RefreshDatabase;
+    use RefreshesSchemaCache;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(RolePermissionSeeder::class);
+    }
+
+    // test database notification creation after running the artisan command
+    public function testSendNotificationsEmployeeToolsAvailable(): void
+    {
+        $userToNotify = User::factory()
+            ->create([
+                'computed_is_gov_employee' => true,
+                'work_email_verified_at' => config('constants.far_past_datetime'),
+            ]);
+        User::factory()
+            ->create([
+                'computed_is_gov_employee' => true,
+                'work_email_verified_at' => config('constants.far_future_datetime'),
+            ]);
+        User::factory()
+            ->create([
+                'computed_is_gov_employee' => true,
+                'work_email_verified_at' => null,
+            ]);
+        User::factory()
+            ->create([
+                'computed_is_gov_employee' => false,
+                'work_email_verified_at' => config('constants.far_past_datetime'),
+            ]);
+        User::factory()
+            ->create([
+                'computed_is_gov_employee' => false,
+                'work_email_verified_at' => null,
+            ]);
+
+        // command successful
+        $exitCode = Artisan::call('send-notifications:employee-tools-available');
+        assertEquals(Command::SUCCESS, $exitCode);
+
+        // only one notification was sent
+        $notifications = Notification::all();
+        assertEquals(1, count($notifications));
+
+        // created notification was to the expected user
+        assertEquals($userToNotify->id, $notifications[0]->notifiable_id);
+    }
+}


### PR DESCRIPTION
🤖 Resolves #12682

## 👋 Introduction

Adds a command to send notifications to government users with verified work emails to check out the applicant dashboard
Basically the same formula as https://github.com/GCTC-NTGC/gc-digital-talent/pull/12696 with some tweaks

If you've got your env up to date, it'll send you to the new dashboard

## 🧪 Testing

1. Run command
2. Login in as relevant user, say, applicant-employee
3. Check notifications and redirect

`php artisan send-notifications:employee-tools-available`

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/8ca30f98-7770-4243-a696-2c6d44414ef3)

## 🚚 Deployment

Will require manual execution, but at a later time. Sometime after the new dashboard is live
