### PR TITLE
[Bug] Stop resetting all date fields on experience category change 

### DIFF
--- a/apps/web/src/components/ExperienceFormFields/WorkFields/WorkFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields/WorkFields.tsx
@@ -107,9 +107,7 @@ const WorkFields = ({
   );
   const watchEmploymentCategory = useWatch<{
     employmentCategory: EmploymentCategory;
-  }>({
-    name: "employmentCategory",
-  });
+  }>({ name: "employmentCategory" });
 
   const employmentCategories: Radio[] = unpackMaybes(
     data?.employmentCategoryTypes,
@@ -153,11 +151,6 @@ const WorkFields = ({
       resetDirtyField("cafEmploymentType");
       resetDirtyField("cafForce");
       resetDirtyField("cafRank");
-
-      // all categories
-      resetDirtyField("startDate");
-      resetDirtyField("currentRole");
-      resetDirtyField("endDate");
     }
 
     prevEmploymentCategory.current = watchEmploymentCategory;


### PR DESCRIPTION
🤖 Resolves #12770

## 👋 Introduction

A change of value for `employmentCategory` would trigger a reset of many fields, most necessary but some should not have been reset. 
Fields `startDate`, `endDate`, and `currentRole` no longer reset

## 🕵️ Details

I didn't have issues with the date input reset not matching the display state 🤷 , but I got this sorted out

## 🧪 Testing

1. Edit work experiences


