### PR TITLE
[Bug] Fix personal information url

### DIFF
--- a/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.tsx
@@ -248,7 +248,7 @@ export const DashboardPage = ({
                     description:
                       "applicant dashboard card title for profile card",
                   })}
-                  href={paths.careerTimelineAndRecruitment()}
+                  href={paths.profile()}
                   description={intl.formatMessage({
                     defaultMessage:
                       "Name, contact info, employment equity, language proficiency, and work preferences.",


### PR DESCRIPTION
🤖 Resolves #12784 

## 👋 Introduction

- Fix personal information url on applicant dashboard

## 🧪 Testing

1. Build app
2. Login as `applicant-employee@test.com`
3. Ensure link takes employee to `/en/applicant/personal-information`

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/bbdca78f-951c-4162-9b4b-c756ad6a199b)

