### PR TITLE
[Feature] Add more valid government email domains

### DIFF
--- a/api/app/GraphQL/Validators/UpdateUserAsUserInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdateUserAsUserInputValidator.php
@@ -46,7 +46,7 @@ final class UpdateUserAsUserInputValidator extends Validator
                 Rule::unique('users', 'email')->ignore($this->arg('id'), 'id'),
                 Rule::unique('users', 'work_email')->ignore($this->arg('id'), 'id'),
                 // Note: Should be kept in sync with the workEmailDomainRegex
-                'regex:/@([A-Za-z0-9-]+\.)*(gc\.ca|canada\.ca|elections\.ca|ccc\.ca|canadapost-postescanada\.ca|gg\.ca)$/i',
+                'regex:/@([A-Za-z0-9-]+\.)*(gc\.ca|canada\.ca|elections\.ca|ccc\.ca|canadapost-postescanada\.ca|gg\.ca|scics\.ca|scc-csc\.ca|ccohs\.ca|cchst\.ca|edc\.ca|invcanada\.ca|parl\.ca|telefilm\.ca|bankofcanada\.ca|banqueducanada\.ca|ncc-ccn\.ca|bank-banque-canada\.ca|cef-cce\.ca|cgc\.ca|nfb\.ca|onf\.ca|canadacouncil\.ca|conseildesarts\.ca|humanrights\.ca|droitsdelapersonne\.ca|ingeniumcanada\.org|cjc-ccm\.ca|bdc\.ca|idrc\.ca|museedelhistoire\.ca|historymuseum\.ca|cdic\.ca|sadc\.ca|scc\.ca|clc\.ca|clc-sic\.ca|cntower\.ca|latourcn\.ca)$/i',
             ],
             'sub' => [
                 'sometimes',

--- a/packages/helpers/src/constants/regularExpressions.ts
+++ b/packages/helpers/src/constants/regularExpressions.ts
@@ -8,7 +8,7 @@
 export const keyStringRegex = /^[a-z]+[_a-z0-9]*$/;
 // See: https://regex101.com/r/EAZ8ha/6
 export const phoneNumberRegex = /^\+[1-9]\d{1,14}$/;
-// See: https://regex101.com/r/T8IYJU/6
-// Note: This should be kept in sync with the check in the UpdateUserInputValidator
+// See: https://regex101.com/r/T8IYJU/7
+// Note: This should be kept in sync with the check in the UpdateUserAsUserInputValidator
 export const workEmailDomainRegex =
-  /@([A-Za-z0-9-]+\.)*(gc\.ca|canada\.ca|elections\.ca|ccc\.ca|canadapost-postescanada\.ca|gg\.ca)$/i;
+  /@([A-Za-z0-9-]+\.)*(gc\.ca|canada\.ca|elections\.ca|ccc\.ca|canadapost-postescanada\.ca|gg\.ca|scics\.ca|scc-csc\.ca|ccohs\.ca|cchst\.ca|edc\.ca|invcanada\.ca|parl\.ca|telefilm\.ca|bankofcanada\.ca|banqueducanada\.ca|ncc-ccn\.ca|bank-banque-canada\.ca|cef-cce\.ca|cgc\.ca|nfb\.ca|onf\.ca|canadacouncil\.ca|conseildesarts\.ca|humanrights\.ca|droitsdelapersonne\.ca|ingeniumcanada\.org|cjc-ccm\.ca|bdc\.ca|idrc\.ca|museedelhistoire\.ca|historymuseum\.ca|cdic\.ca|sadc\.ca|scc\.ca|clc\.ca|clc-sic\.ca|cntower\.ca|latourcn\.ca)$/i;


### PR DESCRIPTION
🤖 Resolves #12723.

## 👋 Introduction

Adds (far to many) more valid government email domains for the work email field.

## 🧪 Testing

Go through the various email domains in the list in the issue confirming:
- The domain itself is OK
- Subdomains are OK, like abc.gg.ca is OK for gg.ca
- Supersets are not OK, like digg.ca is not OK for gg.ca

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/d8b2900f-4030-4e73-b977-c31fc709c8af)