### PR TITLE
[Fix] Adds Application ID

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4939,6 +4939,10 @@
     "defaultMessage": "Compétences techniques requises",
     "description": "Heading for required technical skills section"
   },
+  "OEk0OP": {
+    "defaultMessage": "Identification de la demande",
+    "description": "Label for application ID"
+  },
   "OF7SCg": {
     "defaultMessage": "Changer votre disponibilité dans ce processus de recrutement",
     "description": "Header text for dialog to change availability in a recruitment"

--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationDialog.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationDialog.tsx
@@ -321,6 +321,16 @@ const ReviewApplicationDialog = ({
             >
               {pool?.processNumber ?? nullMessage}
             </FieldDisplay>
+            <FieldDisplay
+              label={intl.formatMessage({
+                defaultMessage: "Application ID",
+                id: "OEk0OP",
+                description: "Label for application ID",
+              })}
+              data-h2-grid-column="p-tablet(span 2)"
+            >
+              {application.id}
+            </FieldDisplay>
 
             <Separator
               decorative


### PR DESCRIPTION
🤖 Resolves #12785.

## 👋 Introduction

This PR adds Application ID to the application process dialog.

## 🧪 Testing

1. `pnpm build`
3. Sign in as applicant@test.com
4. Navigate to http://localhost:8000/en/applicant
5. Expand Job applications accordion
6. Activate trigger for Review your application dialog
7. Verify Application ID and its value are rendered

## 📸 Screenshots

<img width="985" alt="Screen Shot 2025-02-20 at 14 03 37" src="https://github.com/user-attachments/assets/d0d432f7-1a29-4204-a506-47f4d1cca024" />
<img width="980" alt="Screen Shot 2025-02-20 at 14 05 34" src="https://github.com/user-attachments/assets/f60f64fe-3129-4151-b3b7-e7278bfe18b3" />
