### PR TITLE
[Bug] Exclude already interested communities from "add" page

### DIFF
--- a/apps/web/src/pages/CommunityInterests/sections/FindANewCommunity.tsx
+++ b/apps/web/src/pages/CommunityInterests/sections/FindANewCommunity.tsx
@@ -29,6 +29,16 @@ const FindANewCommunityOptions_Fragment = graphql(/* GraphQL */ `
         }
       }
     }
+
+    meForOptions: me {
+      employeeProfile {
+        communityInterests {
+          community {
+            id
+          }
+        }
+      }
+    }
   }
 `);
 
@@ -60,13 +70,22 @@ const FindANewCommunity = ({
   const [selectedCommunityId] = watch(["communityId"]);
   const workStreamListDescription = useId();
 
+  const alreadyInterestedCommunityIds =
+    optionsData.meForOptions?.employeeProfile?.communityInterests?.map(
+      (interest) => interest?.community?.id,
+    ) ?? [];
+
   const communityOptions: ComponentProps<typeof Select>["options"] =
-    unpackMaybes(optionsData.communities).map((community) => ({
-      value: community.id,
-      label:
-        community.name?.localized ??
-        intl.formatMessage(commonMessages.notProvided),
-    }));
+    unpackMaybes(optionsData.communities)
+      .filter(
+        (community) => !alreadyInterestedCommunityIds.includes(community.id),
+      )
+      .map((community) => ({
+        value: community.id,
+        label:
+          community.name?.localized ??
+          intl.formatMessage(commonMessages.notProvided),
+      }));
   const workStreamOptions: ComponentProps<typeof Checklist>["items"] =
     optionsData.communities
       .find((community) => community?.id === selectedCommunityId)


### PR DESCRIPTION
🤖 Resolves #12793 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Prevents a user from attempting to add am interest in a community twice.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->


1. Log in as `applicant-employee@test.com`
2. Note on the dashboard which communities have already had interests added for them
3. Click "Add a community"
4. Observe that communities with interests already added are not available to pick

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
![image](https://github.com/user-attachments/assets/00d45026-fac9-4431-9a91-68cbb5d22fde)


## 🚚 Deployment

<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the PR if deployment steps are needed

 -->
