### PR TITLE
[Bug] Add separator to "Goals and work style" form

### DIFF
--- a/apps/web/src/pages/EmployeeProfile/components/GoalsWorkStyleSection/Display.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/GoalsWorkStyleSection/Display.tsx
@@ -3,7 +3,7 @@ import { useIntl } from "react-intl";
 import { commonMessages } from "@gc-digital-talent/i18n";
 import { RichTextRenderer, htmlToRichTextJSON } from "@gc-digital-talent/forms";
 import { EmployeeProfileGoalsWorkStyleFragment } from "@gc-digital-talent/graphql";
-import { Well } from "@gc-digital-talent/ui";
+import { CardSeparator, Well } from "@gc-digital-talent/ui";
 
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
 import employeeProfileMessages from "~/messages/employeeProfileMessages";
@@ -52,6 +52,7 @@ const Display = ({
           nullField
         )}
       </ToggleForm.FieldDisplay>
+      <CardSeparator data-h2-margin="base(0)" />
       <ToggleForm.FieldDisplay
         label={intl.formatMessage(employeeProfileMessages.learningGoals)}
       >
@@ -61,6 +62,7 @@ const Display = ({
           nullField
         )}
       </ToggleForm.FieldDisplay>
+      <CardSeparator data-h2-margin="base(0)" />
       <ToggleForm.FieldDisplay
         label={intl.formatMessage(employeeProfileMessages.workStyle)}
       >

--- a/apps/web/src/pages/EmployeeProfile/components/GoalsWorkStyleSection/GoalsWorkStyleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/GoalsWorkStyleSection/GoalsWorkStyleSection.tsx
@@ -3,7 +3,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import QuestionMarkCircleIcon from "@heroicons/react/24/outline/QuestionMarkCircleIcon";
 import { useMutation } from "urql";
 
-import { Button, ToggleSection } from "@gc-digital-talent/ui";
+import { Button, CardSeparator, ToggleSection } from "@gc-digital-talent/ui";
 import { RichTextInput, Submit } from "@gc-digital-talent/forms";
 import {
   commonMessages,
@@ -215,6 +215,7 @@ const GoalsWorkStyleSection = ({
                   name="aboutYou"
                   wordLimit={wordCountLimits[locale]}
                 />
+                <CardSeparator data-h2-margin="base(0)" />
                 <RichTextInput
                   id="learningGoals"
                   label={intl.formatMessage(
@@ -223,12 +224,14 @@ const GoalsWorkStyleSection = ({
                   name="learningGoals"
                   wordLimit={wordCountLimits[locale]}
                 />
+                <CardSeparator data-h2-margin="base(0)" />
                 <RichTextInput
                   id="workStyle"
                   label={intl.formatMessage(employeeProfileMessages.workStyle)}
                   name="workStyle"
                   wordLimit={wordCountLimits[locale]}
                 />
+                <CardSeparator data-h2-margin="base(0)" />
                 <div
                   data-h2-display="base(flex)"
                   data-h2-gap="base(x.5)"


### PR DESCRIPTION
🤖 Resolves <!-- issue # -->

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Adds the separators to the "Goals and work style" form.

> [!NOTE]
> I know that the spacing on the form should be x1.5 all around in desktop width but that's a whole other :worm: :can:.  I figure we can tackle that when we update the inline form component. 

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->


1. Log in as `applicant-employee@test.com`
2. /applicant/employee-profile#goals-work-style-section


## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
![image](https://github.com/user-attachments/assets/faa8e97b-a8fc-43f0-bb7b-e60dfd192ffd)


## 🚚 Deployment

<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the PR if deployment steps are needed

 -->
