### PR TITLE
[Bug] Limit application edit after submission

### DIFF
--- a/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
@@ -180,6 +180,7 @@ export const ApplicationCareerTimeline = ({
   const [{ fetching: mutating }, executeMutation] =
     useUpdateApplicationMutation();
   const cancelPath = paths.profileAndApplications({ fromIapDraft: isIAP });
+  const applicationWasSubmitted = !!application.submittedAt;
 
   const methods = useForm<FormValues>();
   const {
@@ -364,6 +365,7 @@ export const ApplicationCareerTimeline = ({
                     application.id,
                     experience.id,
                   )}
+                  showEdit={!applicationWasSubmitted}
                 />
               );
             })

--- a/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
@@ -114,6 +114,8 @@ export const ApplicationSkills = ({
     application.pool,
   );
 
+  const applicationWasSubmitted = !!application.submittedAt;
+
   const methods = useForm<FormValues>();
   const {
     setValue,
@@ -242,6 +244,8 @@ export const ApplicationSkills = ({
                 skill={requiredTechnicalSkill}
                 experiences={experiences}
                 showDisclaimer
+                hideEdit={applicationWasSubmitted}
+                hideConnectButton={applicationWasSubmitted}
               />
             ),
           )}
@@ -268,6 +272,8 @@ export const ApplicationSkills = ({
                 key={optionalTechnicalSkill.id}
                 skill={optionalTechnicalSkill}
                 experiences={experiences}
+                hideEdit={applicationWasSubmitted}
+                hideConnectButton={applicationWasSubmitted}
               />
             ),
           )}

--- a/apps/web/src/pages/Applications/fragment.ts
+++ b/apps/web/src/pages/Applications/fragment.ts
@@ -3,6 +3,7 @@ import { graphql } from "@gc-digital-talent/graphql";
 const Application_PoolCandidateFragment = graphql(/* GraphQL */ `
   fragment Application_PoolCandidate on PoolCandidate {
     id
+    submittedAt
     user {
       id
       firstName


### PR DESCRIPTION
🤖 Resolves #12138

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Limit the things a user can attempt to edit. 
Application skills page, but also the edit button on the career timeline page. So the user can't edit prior experiences in both places

## 🧪 Testing

1. Go through the application process, submit it
2. Step through the submitted application
3. Be attentive

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/56626993-22af-4413-8a9d-cbb7e95973fb)

![image](https://github.com/user-attachments/assets/136ad739-454b-4683-97f7-bf8000c16199)

![image](https://github.com/user-attachments/assets/4e7458f4-547d-435b-b411-4cfc477c003d)


