### PR TITLE
[Copy] Update recruitment process guidance copy

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -235,6 +235,10 @@
     "defaultMessage": "Les candidatures pour les possibilités de recrutement peuvent être gérées et suivies ici. Vous pourrez voir les dates limites de présentation des candidatures, le statut de votre candidature au fil du temps et les candidatures antérieures.",
     "description": "Description for the track applications section on the profile and applications, paragraph one."
   },
+  "/6obwT": {
+    "defaultMessage": "Vous trouverez les processus de recrutement pour lesquels vous avez été qualifié(e) dans l'outil « Processus de recrutement » de votre tableau de bord.",
+    "description": "Message informing applicant of the connected recruitment process in the preview list below"
+  },
   "/81xCT": {
     "defaultMessage": "« Je suis métisse ou métis »",
     "description": "Label text for Métis community declaration"
@@ -710,10 +714,6 @@
   "1b+6V1": {
     "defaultMessage": "{role} à {group}",
     "description": "Role with group"
-  },
-  "1bTFdX": {
-    "defaultMessage": "Vous pouvez trouver le processus de recrutement pour lequel vous avez été qualifié(e) dans l'outil « Processus de recrutement » de votre tableau de bord.",
-    "description": "Message informing applicant of the connected recruitment process in the preview list below"
   },
   "1bWLa3": {
     "defaultMessage": "Compétences que le candidat aimerait améliorer",

--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationDialog.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationDialog.tsx
@@ -392,19 +392,23 @@ const ReviewApplicationDialog = ({
                 </Accordion.Content>
               </Accordion.Item>
             </Accordion.Root>
-            <Separator
-              decorative
-              data-h2-grid-column="p-tablet(span 2)"
-              data-h2-margin="base(0)"
-            />
-            <p data-h2-grid-column="p-tablet(span 2)">
-              {intl.formatMessage({
-                defaultMessage: `You can find the recruitment processes you've been qualified for in the "Recruitment processes" tool on your dashboard.`,
-                id: "/6obwT",
-                description:
-                  "Message informing applicant of the connected recruitment process in the preview list below",
-              })}
-            </p>
+            {status.value === applicationStatus.SUCCESSFUL && (
+              <>
+                <Separator
+                  decorative
+                  data-h2-grid-column="p-tablet(span 2)"
+                  data-h2-margin="base(0)"
+                />
+                <p data-h2-grid-column="p-tablet(span 2)">
+                  {intl.formatMessage({
+                    defaultMessage: `You can find the recruitment processes you've been qualified for in the "Recruitment processes" tool on your dashboard.`,
+                    id: "/6obwT",
+                    description:
+                      "Message informing applicant of the connected recruitment process in the preview list below",
+                  })}
+                </p>
+              </>
+            )}
           </div>
           <Dialog.Footer data-h2-gap="base(0 x1)">
             <Link

--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationDialog.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationDialog.tsx
@@ -399,8 +399,8 @@ const ReviewApplicationDialog = ({
             />
             <p data-h2-grid-column="p-tablet(span 2)">
               {intl.formatMessage({
-                defaultMessage: `You can find the recruitment process for which you’ve been qualified for in the "Recruitment process" tool on your dashboard.`,
-                id: "1bTFdX",
+                defaultMessage: `You can find the recruitment processes you've been qualified for in the "Recruitment processes" tool on your dashboard.`,
+                id: "/6obwT",
                 description:
                   "Message informing applicant of the connected recruitment process in the preview list below",
               })}


### PR DESCRIPTION
🤖 Resolves #12819.

## 👋 Introduction

Updates the guidance copy to find recruitment processes you've been qualified for in both English and French. Also updates it so the copy only appears for applications with the "Qualified in process" status.

## 🧪 Testing

1. Ensure the FEATURE_NEW_APPLICANT_DASHBOARD flag is on.
2. Create and submit a new application.
3. Navigate to the new applicant dashboard page `/en/applicant/dashboard`.
4. View the dialog for your submitted application and confirm the guidance text does not appear.
5. As an admin mark the application as qualified.
6. View the applicant dialog for the application and confirm the updated guidance copy appears.

## 📸 Screenshot

Qualified application:
![image](https://github.com/user-attachments/assets/e2670e95-c580-42e5-9b0f-b594d789c86b)
Non-qualified application:
![image](https://github.com/user-attachments/assets/f4585572-5cde-484e-b857-cc2f2b152bf4)
