### PR TITLE
[Fix] `opportunityLength` value in `ReviewApplicationDialog`

### DIFF
--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationDialog.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationDialog.tsx
@@ -117,6 +117,11 @@ const ReviewApplicationDialog_Fragment = graphql(/* GraphQL */ `
       screeningQuestions {
         id
       }
+      opportunityLength {
+        label {
+          localized
+        }
+      }
     }
   }
 `);
@@ -299,7 +304,7 @@ const ReviewApplicationDialog = ({
               label={intl.formatMessage(commonMessages.employmentLength)}
               data-h2-grid-column="p-tablet(span 2)"
             >
-              {pool.workStream?.name?.localized}
+              {pool.opportunityLength?.label.localized}
             </FieldDisplay>
             <FieldDisplay
               label={intl.formatMessage(talentRequestMessages.workLocation)}


### PR DESCRIPTION
🤖 Resolves #12836.

## 👋 Introduction

This PR fixes the value rendered for **Employment length** to use `opportunityLength` value in `ReviewApplicationDialog`.

## 🧪 Testing

1. Navigate to http://localhost:8000/en/applicant
2. Click on a submitted application
3. Verify **Employment length** renders correct value

## 📸 Screenshot

<img width="937" alt="Screen Shot 2025-02-25 at 10 14 21" src="https://github.com/user-attachments/assets/b1e6ab94-5125-45ae-8808-dd98f5d8283d" />