### PR TITLE
[Fix] Replaces `RichTextInput` with `TextArea`

### DIFF
--- a/apps/web/src/pages/Communities/CreateCommunityPage/components/CreateCommunityForm.tsx
+++ b/apps/web/src/pages/Communities/CreateCommunityPage/components/CreateCommunityForm.tsx
@@ -5,12 +5,7 @@ import kebabCase from "lodash/kebabCase";
 import IdentificationIcon from "@heroicons/react/24/outline/IdentificationIcon";
 
 import { CardBasic, CardSeparator, Heading, Link } from "@gc-digital-talent/ui";
-import {
-  BasicForm,
-  Input,
-  RichTextInput,
-  Submit,
-} from "@gc-digital-talent/forms";
+import { BasicForm, Input, Submit, TextArea } from "@gc-digital-talent/forms";
 import { toast } from "@gc-digital-talent/toast";
 import {
   CreateCommunityInput,
@@ -132,7 +127,7 @@ const CreateCommunityForm = ({ onSubmit }: CreateCommunityFormProps) => {
               required: intl.formatMessage(errorMessages.required),
             }}
           />
-          <RichTextInput
+          <TextArea
             id="description.en"
             label={intl.formatMessage(adminMessages.descriptionEn)}
             name="description.en"
@@ -141,7 +136,7 @@ const CreateCommunityForm = ({ onSubmit }: CreateCommunityFormProps) => {
             }}
             wordLimit={TEXT_AREA_MAX_WORDS_EN}
           />
-          <RichTextInput
+          <TextArea
             id="description.fr"
             label={intl.formatMessage(adminMessages.descriptionFr)}
             name="description.fr"

--- a/apps/web/src/pages/Communities/UpdateCommunityPage/UpdateCommunityPage.tsx
+++ b/apps/web/src/pages/Communities/UpdateCommunityPage/UpdateCommunityPage.tsx
@@ -5,7 +5,7 @@ import IdentificationIcon from "@heroicons/react/24/outline/IdentificationIcon";
 import { useNavigate, useOutletContext } from "react-router";
 
 import { toast } from "@gc-digital-talent/toast";
-import { Submit, Input, RichTextInput } from "@gc-digital-talent/forms";
+import { Submit, Input, TextArea } from "@gc-digital-talent/forms";
 import {
   errorMessages,
   commonMessages,
@@ -187,7 +187,7 @@ const CommunityForm = ({
                 required: intl.formatMessage(errorMessages.required),
               }}
             />
-            <RichTextInput
+            <TextArea
               id="descriptionEn"
               label={intl.formatMessage(adminMessages.descriptionEn)}
               name="descriptionEn"
@@ -196,7 +196,7 @@ const CommunityForm = ({
               }}
               wordLimit={TEXT_AREA_MAX_WORDS_EN}
             />
-            <RichTextInput
+            <TextArea
               id="descriptionFr"
               label={intl.formatMessage(adminMessages.descriptionFr)}
               name="descriptionFr"

--- a/apps/web/src/pages/CommunityInterests/sections/AdditionalInformation.tsx
+++ b/apps/web/src/pages/CommunityInterests/sections/AdditionalInformation.tsx
@@ -2,7 +2,7 @@ import { useIntl } from "react-intl";
 import ClipboardDocumentCheckIcon from "@heroicons/react/24/outline/ClipboardDocumentCheckIcon";
 
 import { Heading } from "@gc-digital-talent/ui";
-import { RichTextInput } from "@gc-digital-talent/forms";
+import { TextArea } from "@gc-digital-talent/forms";
 import { getLocale } from "@gc-digital-talent/i18n";
 
 import { FRENCH_WORDS_PER_ENGLISH_WORD } from "~/constants/talentSearchConstants";
@@ -73,7 +73,7 @@ const AdditionalInformation = ({
         data-h2-flex-direction="base(column)"
         data-h2-gap="base(x1)"
       >
-        <RichTextInput
+        <TextArea
           id="additionalInformation"
           name="additionalInformation"
           label={intl.formatMessage({

--- a/apps/web/src/pages/EmployeeProfile/components/GoalsWorkStyleSection/Display.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/GoalsWorkStyleSection/Display.tsx
@@ -1,7 +1,6 @@
 import { useIntl } from "react-intl";
 
 import { commonMessages } from "@gc-digital-talent/i18n";
-import { RichTextRenderer, htmlToRichTextJSON } from "@gc-digital-talent/forms";
 import { EmployeeProfileGoalsWorkStyleFragment } from "@gc-digital-talent/graphql";
 import { CardSeparator, Well } from "@gc-digital-talent/ui";
 
@@ -46,31 +45,19 @@ const Display = ({
       <ToggleForm.FieldDisplay
         label={intl.formatMessage(employeeProfileMessages.aboutYou)}
       >
-        {aboutYou ? (
-          <RichTextRenderer node={htmlToRichTextJSON(aboutYou)} />
-        ) : (
-          nullField
-        )}
+        {aboutYou ? aboutYou : nullField}
       </ToggleForm.FieldDisplay>
       <CardSeparator data-h2-margin="base(0)" />
       <ToggleForm.FieldDisplay
         label={intl.formatMessage(employeeProfileMessages.learningGoals)}
       >
-        {learningGoals ? (
-          <RichTextRenderer node={htmlToRichTextJSON(learningGoals)} />
-        ) : (
-          nullField
-        )}
+        {learningGoals ? learningGoals : nullField}
       </ToggleForm.FieldDisplay>
       <CardSeparator data-h2-margin="base(0)" />
       <ToggleForm.FieldDisplay
         label={intl.formatMessage(employeeProfileMessages.workStyle)}
       >
-        {workStyle ? (
-          <RichTextRenderer node={htmlToRichTextJSON(workStyle)} />
-        ) : (
-          nullField
-        )}
+        {workStyle ? workStyle : nullField}
       </ToggleForm.FieldDisplay>
     </div>
   );

--- a/apps/web/src/pages/EmployeeProfile/components/GoalsWorkStyleSection/GoalsWorkStyleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/GoalsWorkStyleSection/GoalsWorkStyleSection.tsx
@@ -4,7 +4,7 @@ import QuestionMarkCircleIcon from "@heroicons/react/24/outline/QuestionMarkCirc
 import { useMutation } from "urql";
 
 import { Button, CardSeparator, ToggleSection } from "@gc-digital-talent/ui";
-import { RichTextInput, Submit } from "@gc-digital-talent/forms";
+import { Submit, TextArea } from "@gc-digital-talent/forms";
 import {
   commonMessages,
   formMessages,
@@ -209,14 +209,14 @@ const GoalsWorkStyleSection = ({
                 data-h2-flex-direction="base(column)"
                 data-h2-gap="base(x1)"
               >
-                <RichTextInput
+                <TextArea
                   id="aboutYou"
                   label={intl.formatMessage(employeeProfileMessages.aboutYou)}
                   name="aboutYou"
                   wordLimit={wordCountLimits[locale]}
                 />
                 <CardSeparator data-h2-margin="base(0)" />
-                <RichTextInput
+                <TextArea
                   id="learningGoals"
                   label={intl.formatMessage(
                     employeeProfileMessages.learningGoals,
@@ -225,7 +225,7 @@ const GoalsWorkStyleSection = ({
                   wordLimit={wordCountLimits[locale]}
                 />
                 <CardSeparator data-h2-margin="base(0)" />
-                <RichTextInput
+                <TextArea
                   id="workStyle"
                   label={intl.formatMessage(employeeProfileMessages.workStyle)}
                   name="workStyle"


### PR DESCRIPTION
🤖 Resolves #12795.

## 👋 Introduction

This PR replaces `RichTextInput` with `TextArea` in several components.

## 🧪 Testing

1. `pnpm build`
2. Navigate to http://localhost:8000/en/applicant/community-interests/create
3. Verify 1 textarea does not allow for markup
4. Navigate to http://localhost:8000/en/admin/communities/create
5. Verify 2 textareas do not allow for markup
6. Navigate to http://localhost:8000/en/admin/communities/:community-id/edit
7. Verify 2 textareas do not allow for markup
8. Navigate to http://localhost:8000/en/applicant/employee-profile#goals-work-style-section
9. Verify 3 textareas do not allow for markup

## 📸 Screenshots

<details><summary>Screenshots (4)</summary>
<p>
<img width="1120" alt="Screen Shot 2025-02-25 at 10 25 59" src="https://github.com/user-attachments/assets/58b39456-f425-42ff-ad3b-9f1e84373065" />
<img width="1125" alt="Screen Shot 2025-02-25 at 10 30 01" src="https://github.com/user-attachments/assets/ddcb44cc-8bfe-43f9-8416-fb694c4eb3ba" />
<img width="1117" alt="Screen Shot 2025-02-25 at 10 30 29" src="https://github.com/user-attachments/assets/00c63946-f992-4388-a03c-2a9e72ddfc3e" />
<img width="1026" alt="Screen Shot 2025-02-25 at 10 36 09" src="https://github.com/user-attachments/assets/e04ac615-9456-4f36-9719-f43d0c174578" />
</p>
</details>