### PR TITLE
[Feature] Next Role and Career Objective frontend

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1736,7 +1736,8 @@ input PoolBelongsToMany {
 }
 
 input CommunityBelongsTo {
-  connect: UUID!
+  connect: UUID
+  disconnect: Boolean
 }
 
 input CreateTeamInput {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1781,7 +1781,8 @@ input PoolBelongsToMany {
 }
 
 input CommunityBelongsTo {
-  connect: UUID!
+  connect: UUID
+  disconnect: Boolean
 }
 
 input CreateTeamInput {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2248,7 +2248,7 @@
     "description": "Button text to download an applicants application or profile"
   },
   "9Y3w6l": {
-    "defaultMessage": "Il y a actuellement des questions sans réponse dans cette section. Cliquez sur le bouton \"Modifiez\" pour examiner les champs obligatoires et répondre aux questions.",
+    "defaultMessage": "Il y a actuellement des questions sans réponse dans cette section. Cliquez sur le bouton « Modifiez » pour examiner les champs obligatoires et répondre aux questions.",
     "description": "Message for unanswered questions in this section"
   },
   "9aW0M6": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8150,10 +8150,6 @@
     "defaultMessage": "Le Programme s’adresse aux Premières Nations, aux Inuits et aux Métis. Si vous êtes un membre des Premières Nations, un Inuit ou un Métis et que vous avez une passion pour la technologie, ce programme est pour vous!",
     "description": "First paragraph about who the program is for"
   },
-  "f1reMg": {
-    "defaultMessage": "Poste de rêve",
-    "description": "Title for a users dream role information"
-  },
   "f3KZGn": {
     "defaultMessage": "Les cercles de partage, l’accès à un·e conseiller·ère en soutien à la formation en TI et les facilitateurs·trices de réussite pour les apprenti·es sont autant de soutiens supplémentaires. Si les facilitateurs·trices sont avant tout une ressource pour les apprenti·es, ils, elles constituent également un système de soutien pour les gestionnaires et les superviseur·es.",
     "description": "Paragraph 2 of the 'Circle of Support' subsection"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1059,6 +1059,10 @@
     "defaultMessage": "donner des outils aux membres du personnel des TI pour diriger la transformation numérique.",
     "description": "an item in a list of fund objectives"
   },
+  "3Kt+rj": {
+    "defaultMessage": "Les informations sur votre prochain type de poste ont été mises à jour avec succès!",
+    "description": "Message displayed when a user successfully updates employee profile information"
+  },
   "3MboNR": {
     "defaultMessage": "Veuillez sélectionner une date d’expiration",
     "description": "Label for date selection input for expiry date"
@@ -1234,6 +1238,10 @@
   "4L9rHO": {
     "defaultMessage": "Actif",
     "description": "Status message if the application is not suspended"
+  },
+  "4LN+P9": {
+    "defaultMessage": "Niveau de classification visé",
+    "description": "Label for a employee profile target classification level field"
   },
   "4LVc9T": {
     "defaultMessage": "{localizedName} évalué par {assessmentStepTypeLocalized}",
@@ -2239,6 +2247,10 @@
     "defaultMessage": "Télécharger",
     "description": "Button text to download an applicants application or profile"
   },
+  "9Y3w6l": {
+    "defaultMessage": "Il y a actuellement des questions sans réponse dans cette section. Cliquez sur le bouton \"Modifiez\" pour examiner les champs obligatoires et répondre aux questions.",
+    "description": "Message for unanswered questions in this section"
+  },
   "9aW0M6": {
     "defaultMessage": "Ministère",
     "description": "Title for department"
@@ -2382,6 +2394,10 @@
   "AH2U9S": {
     "defaultMessage": "Gestionnaire P M 6",
     "description": "PM-06 classification aria label including titles"
+  },
+  "AH5WDT": {
+    "defaultMessage": "Votre objectif de carrière",
+    "description": "Title for a users career objective"
   },
   "AJs1VQ": {
     "defaultMessage": "Question (FR)",
@@ -3375,6 +3391,10 @@
     "defaultMessage": "Ces champs ne seront disponibles qu’aux fins de la migration, pendant un certain temps limité.",
     "description": "Sentence to explain that status and expiry date fields are available for a specific purpose and for a limited amount of time"
   },
+  "FYCNAa": {
+    "defaultMessage": "Expliquez quel est votre objectif de carrière ultime. Votre contribution peut aider le personnel responsable de la gestion des talents à cerner la prochaine étape qui vous convient, qu'il s'agisse d'une mutation latérale, d'une occasion de perfectionnement ou d'une promotion.",
+    "description": "Describes the career objective section of employee profile"
+  },
   "FYIbdJ": {
     "defaultMessage": "Modifier<hidden> le ministère</hidden>",
     "description": "Breadcrumb title for the edit department page link."
@@ -3599,6 +3619,10 @@
     "defaultMessage": "{candidateCount, plural, one {<testId>{candidateCount}</testId> concordance approximative} other {<testId>{candidateCount}</testId> concordances approximatives} }",
     "description": "Message for total estimated matching candidates in pool"
   },
+  "GndGRz": {
+    "defaultMessage": "La mise à jour des informations sur votre prochain type de post a échoué.",
+    "description": "Message displayed when a user fails to updates employee profile information"
+  },
   "GplLic": {
     "defaultMessage": "Identifiant",
     "description": "Title for unique ID of a resource"
@@ -3686,6 +3710,10 @@
   "HJTr0Q": {
     "defaultMessage": "Les compétences en langue seconde sont également déterminées pour les compétences connexes",
     "description": "Second language proficiency related skills list for language requirements dialog"
+  },
+  "HLYDTG": {
+    "defaultMessage": "Volets de travail souhaités",
+    "description": "Label for a employee profile desired work streams field"
   },
   "HMlreE": {
     "defaultMessage": "Consentement au partage d'information",
@@ -3862,6 +3890,10 @@
   "IJyxRd": {
     "defaultMessage": "Cacher plus de renseignements sur l'équité en matière d'emploi",
     "description": "Heading for closing the accordion with information on employment equity"
+  },
+  "IO+qSg": {
+    "defaultMessage": "Parlez-nous du prochain type de poste que vous vous imaginez occuper. En communiquant vos préférences concernant votre prochain emploi, vous pouvez aider le personnel des RH à trouver le poste qui vous convient.",
+    "description": "Describes the next role section of employee profile"
   },
   "IOtzp7": {
     "defaultMessage": "Pour cette possibilité, les demandes doivent être soumises au plus tard, le :",
@@ -4318,6 +4350,10 @@
   "KehmPp": {
     "defaultMessage": "« Un ou plusieurs de mes niveaux de langue ne sont <strong>plus valides</strong>. »",
     "description": "Radio option for exam validity input on language information form."
+  },
+  "Kf+7FN": {
+    "defaultMessage": "Classification visée",
+    "description": "Label for employee profile target classification fields"
   },
   "Kf7cYc": {
     "defaultMessage": "PM-03 : Agent(e)",
@@ -6111,6 +6147,10 @@
     "defaultMessage": "Pour l’instant, sauvegardez et quittez",
     "description": "Action button to save and exit an application"
   },
+  "U8ZQ2g": {
+    "defaultMessage": "Renseignements supplémentaires sur votre objectif de carrière",
+    "description": "Additional information about your career objective"
+  },
   "U8bLT7": {
     "defaultMessage": "Comment cela fonctionnera-t-il?",
     "description": "heading for how the indigenous talent portal will work"
@@ -6126,6 +6166,10 @@
   "UA37iG": {
     "defaultMessage": "Commis C R 4",
     "description": "CR-04 classification aria label including titles"
+  },
+  "UCt8ym": {
+    "defaultMessage": "Votre prochain type de poste",
+    "description": "Title for a users next role"
   },
   "UCv0X2": {
     "defaultMessage": "L’engagement de l’équipe de Talents numériques du GC",
@@ -6366,6 +6410,10 @@
     "defaultMessage": "Il y a une exigence linguistique manquante",
     "description": "Title that appears when a user is missing a language requirement."
   },
+  "Vc44L9": {
+    "defaultMessage": "Renseignements supplémentaires sur votre prochain type de poste",
+    "description": "Additional information about your next role"
+  },
   "VcOlXA": {
     "defaultMessage": "Énoncé de confidentialité",
     "description": "Label for the privacy link in the Footer."
@@ -6573,6 +6621,10 @@
   "WoZ3pB": {
     "defaultMessage": "Les postes au niveau de la direction m'intéressent.",
     "description": "The executive interest described as interested."
+  },
+  "WokDUl": {
+    "defaultMessage": "Groupe de classification visé",
+    "description": "Label for a employee profile target classification group field"
   },
   "WovyCU": {
     "defaultMessage": "Ajouter un rôle dans la collectivité",
@@ -7454,6 +7506,10 @@
     "defaultMessage": "Date de fin de la formation",
     "description": "The training end date of the training opportunity"
   },
+  "bju7JB": {
+    "defaultMessage": "Les information sur votre objectif de carrière ont été mises à jour avec succès!",
+    "description": "Message displayed when a user successfully updates employee profile information"
+  },
   "bjwTpe": {
     "defaultMessage": "Si vous souhaitez suivre une formation, rendez-vous d'abord sur la plateforme Talents numériques du GC pour créer ou mettre à jour votre profil, lequel nous permet de confirmer votre situation d'emploi, votre classification, votre appartenance à un groupe visé par l'équité en matière d'emploi et l'expérience requise. Ensuite, remplissez le formulaire de demande et acceptez de partager votre profil.",
     "description": "First paragraph of apply and share section"
@@ -7581,6 +7637,10 @@
   "cF8idC": {
     "defaultMessage": "Candidature",
     "description": "Label for the application link column"
+  },
+  "cHwSqN": {
+    "defaultMessage": "Type de poste visé",
+    "description": "Label for a employee profile target role field"
   },
   "cL3OoZ": {
     "defaultMessage": "Notification non lue",
@@ -8494,6 +8554,10 @@
     "defaultMessage": "Ajoutez une expérience à votre parcours professionnel",
     "description": "Title for application career timeline add experience"
   },
+  "gUTOAU": {
+    "defaultMessage": "Ministères ou organismes préférés",
+    "description": "Label for a employee profile preferred departments or agencies field"
+  },
   "gUb3PY": {
     "defaultMessage": "Demande créée avec succès!",
     "description": "Message displayed to user after a pool candidate request is created successfully."
@@ -9222,6 +9286,10 @@
     "defaultMessage": "Du concept au code",
     "description": "Title for how the platform was created"
   },
+  "kJbTqn": {
+    "defaultMessage": "Autre type de poste",
+    "description": "Label for a employee profile target role other field"
+  },
   "kK1Z9U": {
     "defaultMessage": "Gérez votre carrière",
     "description": "Heading for the browse executive jobs section"
@@ -9537,6 +9605,10 @@
   "m6NZda": {
     "defaultMessage": "La formation ne m'intéresse pas",
     "description": "Message displayed when a user has expressed they are not interested in training opportunities"
+  },
+  "m6eIBH": {
+    "defaultMessage": "Votre prochain type de poste",
+    "description": "Title for the next role section"
   },
   "mAN6yW": {
     "defaultMessage": "Apprendre quoi faire si vous ne trouvez pas une compétence",
@@ -9909,6 +9981,10 @@
   "nhfKqB": {
     "defaultMessage": "<strong>Inscription</strong> : les places seront limitées. Vous devrez présenter une demande et satisfaire aux conditions préalables. Les renseignements seront affichés dans la plateforme Talents numériques du GC lorsque les cours seront disponibles à l’hiver 2024-2025.",
     "description": "An item in a list of points about instructor-led classes"
+  },
+  "njBzmn": {
+    "defaultMessage": "Collectivité fonctionnelle souhaitée",
+    "description": "Label for a employee profile desired functional community field"
   },
   "nmImtK": {
     "defaultMessage": "Se déconnecter",
@@ -11182,6 +11258,10 @@
     "defaultMessage": "Identification des talents numériques – Tables rondes sur la gestion des talents",
     "description": "Button text to open section describing identification of digital talents"
   },
+  "vKzPT0": {
+    "defaultMessage": "La mise à jour des informations sur votre objectif de carrière a échoué",
+    "description": "Message displayed when a user fails to updates employee profile information"
+  },
   "vMBiMV": {
     "defaultMessage": "Mise à jour réussie de la compétence",
     "description": "Message displayed when a user updates a skill"
@@ -11289,6 +11369,10 @@
   "vtE73H": {
     "defaultMessage": "Gestion des talents pour les cadres exerçant une fonction de contrôle",
     "description": "Title for talent management for comptrollership executives callout"
+  },
+  "vvnsjr": {
+    "defaultMessage": "Votre objectif de carrière",
+    "description": "Title for the career objective section"
   },
   "vweW8X": {
     "defaultMessage": "Veuillez contacter notre <helpLink>équipe de soutien</helpLink> qui vous aidera à récupérer votre compte.",

--- a/apps/web/src/messages/employeeProfileMessages.ts
+++ b/apps/web/src/messages/employeeProfileMessages.ts
@@ -33,6 +33,16 @@ const messages = defineMessages({
     description:
       "Label for a employee profile target classification level field",
   },
+  classificationGroup: {
+    defaultMessage: "Group",
+    id: "hgxH8y",
+    description: "Label displayed for the classification form group field.",
+  },
+  classificationLevel: {
+    defaultMessage: "Level",
+    id: "yZqUAU",
+    description: "Title displayed for the Classification table Level column.",
+  },
   targetRole: {
     defaultMessage: "Target role",
     id: "cHwSqN",
@@ -40,8 +50,8 @@ const messages = defineMessages({
   },
   jobTitle: {
     defaultMessage: "Job title",
-    id: "5zAZtv",
-    description: "Label for a employee profile job title field",
+    id: "HBuWZ0",
+    description: "Title for job title for a position",
   },
   community: {
     defaultMessage: "Desired functional community",

--- a/apps/web/src/messages/employeeProfileMessages.ts
+++ b/apps/web/src/messages/employeeProfileMessages.ts
@@ -16,6 +16,55 @@ const messages = defineMessages({
     id: "9pYZOU",
     description: "Label for a employee profile work style field",
   },
+  targetClassification: {
+    defaultMessage: "Target classification",
+    id: "Kf+7FN",
+    description: "Label for employee profile target classification fields",
+  },
+  targetClassificationGroup: {
+    defaultMessage: "Target classification group",
+    id: "WokDUl",
+    description:
+      "Label for a employee profile target classification group field",
+  },
+  targetClassificationLevel: {
+    defaultMessage: "Target classification level",
+    id: "4LN+P9",
+    description:
+      "Label for a employee profile target classification level field",
+  },
+  targetRole: {
+    defaultMessage: "Target role",
+    id: "cHwSqN",
+    description: "Label for a employee profile target role field",
+  },
+  jobTitle: {
+    defaultMessage: "Job title",
+    id: "5zAZtv",
+    description: "Label for a employee profile job title field",
+  },
+  community: {
+    defaultMessage: "Desired functional community",
+    id: "njBzmn",
+    description:
+      "Label for a employee profile desired functional community field",
+  },
+  workStreams: {
+    defaultMessage: "Desired work streams",
+    id: "HLYDTG",
+    description: "Label for a employee profile desired work streams field",
+  },
+  departments: {
+    defaultMessage: "Preferred departments or agencies",
+    id: "gUTOAU",
+    description:
+      "Label for a employee profile preferred departments or agencies field",
+  },
+  additionalInformationNextRole: {
+    defaultMessage: "Additional information about your next role",
+    id: "Vc44L9",
+    description: "Additional information about your next role",
+  },
 });
 
 export default messages;

--- a/apps/web/src/messages/employeeProfileMessages.ts
+++ b/apps/web/src/messages/employeeProfileMessages.ts
@@ -48,6 +48,11 @@ const messages = defineMessages({
     id: "cHwSqN",
     description: "Label for a employee profile target role field",
   },
+  targetRoleOther: {
+    defaultMessage: "Other role",
+    id: "kJbTqn",
+    description: "Label for a employee profile target role other field",
+  },
   jobTitle: {
     defaultMessage: "Job title",
     id: "HBuWZ0",

--- a/apps/web/src/messages/employeeProfileMessages.ts
+++ b/apps/web/src/messages/employeeProfileMessages.ts
@@ -65,6 +65,11 @@ const messages = defineMessages({
     id: "Vc44L9",
     description: "Additional information about your next role",
   },
+  additionalInformationCareerObjective: {
+    defaultMessage: "Additional information about your career objective",
+    id: "U8ZQ2g",
+    description: "Additional information about your career objective",
+  },
 });
 
 export default messages;

--- a/apps/web/src/pages/EmployeeProfile/EmployeeProfilePage.tsx
+++ b/apps/web/src/pages/EmployeeProfile/EmployeeProfilePage.tsx
@@ -42,6 +42,7 @@ import GoalsWorkStyleSection, {
 import CareerDevelopmentSection from "./components/CareerDevelopmentSection/CareerDevelopmentSection";
 import { EmployeeProfileCareerDevelopment_Fragment } from "./components/CareerDevelopmentSection/utils";
 import NextRoleSection from "./components/NextRoleSection/NextRoleSection";
+import CareerObjectiveSection from "./components/CareerObjective/CareerObjectiveSection";
 
 const SECTION_ID = {
   CAREER_PLANNING: "career-planning-section",
@@ -253,12 +254,12 @@ const EmployeeProfile = ({
                   optionsQuery={options}
                 />
               </TableOfContents.Section>
-              {/* <TableOfContents.Section id={SECTION_ID.CAREER_OBJECTIVE}>
+              <TableOfContents.Section id={SECTION_ID.CAREER_OBJECTIVE}>
                 <CareerObjectiveSection
                   employeeProfileQuery={user.employeeProfile}
+                  optionsQuery={options}
                 />
-              </TableOfContents.Section> */}
-
+              </TableOfContents.Section>
               <TableOfContents.Section id={SECTION_ID.GOALS_WORK_STYLE}>
                 <GoalsWorkStyleSection
                   employeeProfileQuery={user.employeeProfile}

--- a/apps/web/src/pages/EmployeeProfile/EmployeeProfilePage.tsx
+++ b/apps/web/src/pages/EmployeeProfile/EmployeeProfilePage.tsx
@@ -44,7 +44,6 @@ import { EmployeeProfileCareerDevelopment_Fragment } from "./components/CareerDe
 const SECTION_ID = {
   CAREER_PLANNING: "career-planning-section",
   CAREER_DEVELOPMENT: "career-development-section",
-  DREAM_ROLE: "dream-role-section",
   GOALS_WORK_STYLE: "goals-work-style-section",
 };
 
@@ -165,14 +164,6 @@ const EmployeeProfile = ({ employeeProfileQuery }: EmployeeProfileProps) => {
                   <TableOfContents.ListItem>
                     <StatusItem
                       asListItem={false}
-                      title={intl.formatMessage(messages.dreamRole)}
-                      status="success"
-                      scrollTo={SECTION_ID.DREAM_ROLE}
-                    />
-                  </TableOfContents.ListItem>
-                  <TableOfContents.ListItem>
-                    <StatusItem
-                      asListItem={false}
                       title={intl.formatMessage(messages.goalsWorkStyle)}
                       status={
                         goalsWorkStyleHasEmptyRequiredFields(goalsWorkStyle)
@@ -221,9 +212,6 @@ const EmployeeProfile = ({ employeeProfileQuery }: EmployeeProfileProps) => {
                   careerDevelopmentOptionsQuery={employeeProfileQuery}
                 />
               </TableOfContents.Section>
-              <TableOfContents.Section
-                id={SECTION_ID.DREAM_ROLE}
-              ></TableOfContents.Section>
               <TableOfContents.Section id={SECTION_ID.GOALS_WORK_STYLE}>
                 <GoalsWorkStyleSection
                   employeeProfileQuery={user.employeeProfile}

--- a/apps/web/src/pages/EmployeeProfile/EmployeeProfilePage.tsx
+++ b/apps/web/src/pages/EmployeeProfile/EmployeeProfilePage.tsx
@@ -55,6 +55,7 @@ const SECTION_ID = {
 const EmployeeProfileOptions_Fragment = graphql(/** GraphQL */ `
   fragment EmployeeProfileOptions on Query {
     ...EmployeeProfileNextRoleOptions
+    ...EmployeeProfileCareerObjectiveOptions
   }
 `);
 
@@ -67,6 +68,7 @@ const EmployeeProfile_Fragment = graphql(/** GraphQL */ `
       ...EmployeeProfileGoalsWorkStyle
       ...EmployeeProfileCareerDevelopment
       ...EmployeeProfileNextRole
+      ...EmployeeProfileCareerObjective
     }
   }
 `);

--- a/apps/web/src/pages/EmployeeProfile/EmployeeProfilePage.tsx
+++ b/apps/web/src/pages/EmployeeProfile/EmployeeProfilePage.tsx
@@ -26,6 +26,14 @@ import {
   hasEmptyRequiredFields as careerDevelopmentHasEmptyRequiredFields,
 } from "~/validators/employeeProfile/careerDevelopment";
 import {
+  hasAllEmptyFields as nextRoleHasAllEmptyFields,
+  hasEmptyRequiredFields as nextRoleHasEmptyRequiredFields,
+} from "~/validators/employeeProfile/nextRole";
+import {
+  hasAllEmptyFields as careerObjectiveHasAllEmptyFields,
+  hasEmptyRequiredFields as careerObjectiveHasEmptyRequiredFields,
+} from "~/validators/employeeProfile/careerObjective";
+import {
   hasAllEmptyFields as goalsWorkStyleHasAllEmptyFields,
   hasEmptyRequiredFields as goalsWorkStyleHasEmptyRequiredFields,
 } from "~/validators/employeeProfile/goalsWorkStyle";
@@ -36,8 +44,12 @@ import GoalsWorkStyleSection, {
 } from "./components/GoalsWorkStyleSection/GoalsWorkStyleSection";
 import CareerDevelopmentSection from "./components/CareerDevelopmentSection/CareerDevelopmentSection";
 import { EmployeeProfileCareerDevelopment_Fragment } from "./components/CareerDevelopmentSection/utils";
-import NextRoleSection from "./components/NextRoleSection/NextRoleSection";
-import CareerObjectiveSection from "./components/CareerObjective/CareerObjectiveSection";
+import NextRoleSection, {
+  EmployeeProfileNextRole_Fragment,
+} from "./components/NextRoleSection/NextRoleSection";
+import CareerObjectiveSection, {
+  EmployeeProfileCareerObjective_Fragment,
+} from "./components/CareerObjective/CareerObjectiveSection";
 
 const SECTION_ID = {
   CAREER_PLANNING: "career-planning-section",
@@ -129,12 +141,21 @@ const EmployeeProfile = ({
     ],
   });
 
-  const goalsWorkStyle = getFragment(
-    EmployeeProfileGoalsWorkStyle_Fragment,
-    user.employeeProfile,
-  );
+  // for validation
   const careerDevelopment = getFragment(
     EmployeeProfileCareerDevelopment_Fragment,
+    user.employeeProfile,
+  );
+  const nextRole = getFragment(
+    EmployeeProfileNextRole_Fragment,
+    user.employeeProfile,
+  );
+  const careerObjective = getFragment(
+    EmployeeProfileCareerObjective_Fragment,
+    user.employeeProfile,
+  );
+  const goalsWorkStyle = getFragment(
+    EmployeeProfileGoalsWorkStyle_Fragment,
     user.employeeProfile,
   );
 
@@ -180,7 +201,13 @@ const EmployeeProfile = ({
                     <StatusItem
                       asListItem={false}
                       title={intl.formatMessage(messages.yourNextRole)}
-                      status={"success"}
+                      status={
+                        nextRoleHasEmptyRequiredFields(nextRole)
+                          ? "error"
+                          : nextRoleHasAllEmptyFields(nextRole)
+                            ? "optional"
+                            : "success"
+                      }
                       scrollTo={SECTION_ID.NEXT_ROLE}
                     />
                   </TableOfContents.ListItem>
@@ -188,7 +215,13 @@ const EmployeeProfile = ({
                     <StatusItem
                       asListItem={false}
                       title={intl.formatMessage(messages.careerObjective)}
-                      status="success"
+                      status={
+                        careerObjectiveHasEmptyRequiredFields(careerObjective)
+                          ? "error"
+                          : careerObjectiveHasAllEmptyFields(careerObjective)
+                            ? "optional"
+                            : "success"
+                      }
                       scrollTo={SECTION_ID.CAREER_OBJECTIVE}
                     />
                   </TableOfContents.ListItem>

--- a/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
@@ -2,7 +2,7 @@ import { useIntl } from "react-intl";
 import { FormProvider, useForm } from "react-hook-form";
 import QuestionMarkCircleIcon from "@heroicons/react/24/outline/QuestionMarkCircleIcon";
 import { useMutation } from "urql";
-import { ComponentProps } from "react";
+import { ComponentProps, useEffect } from "react";
 
 import { Button, ToggleSection, Well } from "@gc-digital-talent/ui";
 import {
@@ -98,6 +98,7 @@ const EmployeeProfileCareerObjective_Fragment = graphql(/* GraphQL */ `
         localized
       }
     }
+    careerObjectiveTargetRoleOther
     careerObjectiveJobTitle
     careerObjectiveCommunity {
       id
@@ -138,6 +139,7 @@ interface FormValues {
   classificationGroup: string | null | undefined;
   classificationLevel: string | null | undefined;
   targetRole: string | null | undefined;
+  targetRoleOther: string | null | undefined;
   jobTitle: string | null | undefined;
   communityId: string | null | undefined;
   workStreamIds: string[] | null | undefined;
@@ -204,6 +206,7 @@ const CareerObjectiveSection = ({
     classificationLevel:
       initialData.careerObjectiveClassification?.level.toString(),
     targetRole: initialData.careerObjectiveTargetRole?.value,
+    targetRoleOther: initialData.nextRoleTargetRoleOther,
     jobTitle: initialData.careerObjectiveJobTitle,
     communityId: initialData.careerObjectiveCommunity?.id,
     workStreamIds: initialData.careerObjectiveWorkStreams?.map(
@@ -220,10 +223,20 @@ const CareerObjectiveSection = ({
   });
 
   // hooks to watch, needed for conditional rendering
-  const [watchClassificationGroup, watchCommunityId] = methods.watch([
-    "classificationGroup",
-    "communityId",
-  ]);
+  const [watchClassificationGroup, watchCommunityId, watchTargetRole] =
+    methods.watch(["classificationGroup", "communityId", "targetRole"]);
+
+  /**
+   * Reset target role other when target role changes
+   */
+  useEffect(() => {
+    if (watchTargetRole !== TargetRole.Other) {
+      methods.resetField("targetRoleOther", {
+        keepDirty: false,
+        defaultValue: null,
+      });
+    }
+  }, [watchTargetRole, methods]);
 
   const { handleSubmit } = methods;
 
@@ -231,6 +244,7 @@ const CareerObjectiveSection = ({
     classificationGroup,
     classificationLevel,
     targetRole,
+    targetRoleOther,
     jobTitle,
     communityId,
     workStreamIds,
@@ -259,6 +273,7 @@ const CareerObjectiveSection = ({
               disconnect: true,
             },
         careerObjectiveTargetRole: targetRole as TargetRole,
+        careerObjectiveTargetRoleOther: targetRoleOther,
         careerObjectiveJobTitle: jobTitle,
         careerObjectiveCommunity: communityId
           ? {
@@ -293,6 +308,7 @@ const CareerObjectiveSection = ({
               classificationGroup,
               classificationLevel,
               targetRole,
+              targetRoleOther,
               jobTitle,
               communityId,
               workStreamIds,
@@ -465,6 +481,20 @@ const CareerObjectiveSection = ({
                   }}
                   disabled={fetching}
                 />
+                {watchTargetRole === TargetRole.Other ? (
+                  <Input
+                    id="targetRoleOther"
+                    type="text"
+                    label={intl.formatMessage(
+                      employeeProfileMessages.targetRoleOther,
+                    )}
+                    name="targetRoleOther"
+                    rules={{
+                      required: intl.formatMessage(errorMessages.required),
+                    }}
+                    disabled={fetching}
+                  />
+                ) : null}
                 <Input
                   id="jobTitle"
                   type="text"

--- a/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
@@ -38,7 +38,7 @@ import {
   TextArea,
 } from "@gc-digital-talent/forms";
 
-import { hasAllEmptyFields } from "~/validators/employeeProfile/nextRole";
+import { hasAllEmptyFields } from "~/validators/employeeProfile/careerObjective";
 import useToggleSectionInfo from "~/hooks/useToggleSectionInfo";
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
 import employeeProfileMessages from "~/messages/employeeProfileMessages";
@@ -50,8 +50,8 @@ import { FRENCH_WORDS_PER_ENGLISH_WORD } from "~/constants/talentSearchConstants
 
 import Display from "./Display";
 
-const EmployeeProfileNextRoleOptions_Fragment = graphql(/* GraphQL */ `
-  fragment EmployeeProfileNextRoleOptions on Query {
+const EmployeeProfileCareerObjectiveOptions_Fragment = graphql(/* GraphQL */ `
+  fragment EmployeeProfileCareerObjectiveOptions on Query {
     classifications {
       id
       group
@@ -85,41 +85,41 @@ const EmployeeProfileNextRoleOptions_Fragment = graphql(/* GraphQL */ `
   }
 `);
 
-const EmployeeProfileNextRole_Fragment = graphql(/* GraphQL */ `
+const EmployeeProfileCareerObjective_Fragment = graphql(/* GraphQL */ `
   fragment EmployeeProfileCareerObjective on EmployeeProfile {
-    nextRoleClassification {
+    careerObjectiveClassification {
       id
       group
       level
     }
-    nextRoleTargetRole {
+    careerObjectiveTargetRole {
       value
       label {
         localized
       }
     }
-    nextRoleJobTitle
-    nextRoleCommunity {
+    careerObjectiveJobTitle
+    careerObjectiveCommunity {
       id
       key
       name {
         localized
       }
     }
-    nextRoleWorkStreams {
+    careerObjectiveWorkStreams {
       id
       name {
         localized
       }
     }
-    nextRoleDepartments {
+    careerObjectiveDepartments {
       id
       departmentNumber
       name {
         localized
       }
     }
-    nextRoleAdditionalInformation
+    careerObjectiveAdditionalInformation
   }
 `);
 
@@ -145,9 +145,13 @@ interface FormValues {
   additionalInformation: string | null | undefined;
 }
 
-interface NextRoleSectionProps {
-  employeeProfileQuery: FragmentType<typeof EmployeeProfileNextRole_Fragment>;
-  optionsQuery: FragmentType<typeof EmployeeProfileNextRoleOptions_Fragment>;
+interface CareerObjectiveSectionProps {
+  employeeProfileQuery: FragmentType<
+    typeof EmployeeProfileCareerObjective_Fragment
+  >;
+  optionsQuery: FragmentType<
+    typeof EmployeeProfileCareerObjectiveOptions_Fragment
+  >;
 }
 
 const TEXT_AREA_MAX_WORDS_EN = 300;
@@ -157,10 +161,10 @@ const wordCountLimits: Record<Locales, number> = {
   fr: Math.round(TEXT_AREA_MAX_WORDS_EN * FRENCH_WORDS_PER_ENGLISH_WORD),
 } as const;
 
-const NextRoleSection = ({
+const CareerObjectiveSection = ({
   employeeProfileQuery,
   optionsQuery,
-}: NextRoleSectionProps) => {
+}: CareerObjectiveSectionProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
   const { userAuthInfo } = useAuthorization();
@@ -169,11 +173,11 @@ const NextRoleSection = ({
   );
 
   const employeeProfile = getFragment(
-    EmployeeProfileNextRole_Fragment,
+    EmployeeProfileCareerObjective_Fragment,
     employeeProfileQuery,
   );
   const options = getFragment(
-    EmployeeProfileNextRoleOptions_Fragment,
+    EmployeeProfileCareerObjectiveOptions_Fragment,
     optionsQuery,
   );
   const isNull = hasAllEmptyFields(employeeProfile);
@@ -196,18 +200,19 @@ const NextRoleSection = ({
   };
 
   const dataToFormValues = (initialData: EmployeeProfile): FormValues => ({
-    classificationGroup: initialData.nextRoleClassification?.group,
-    classificationLevel: initialData.nextRoleClassification?.level.toString(),
-    targetRole: initialData.nextRoleTargetRole?.value,
-    jobTitle: initialData.nextRoleJobTitle,
-    communityId: initialData.nextRoleCommunity?.id,
-    workStreamIds: initialData.nextRoleWorkStreams?.map(
+    classificationGroup: initialData.careerObjectiveClassification?.group,
+    classificationLevel:
+      initialData.careerObjectiveClassification?.level.toString(),
+    targetRole: initialData.careerObjectiveTargetRole?.value,
+    jobTitle: initialData.careerObjectiveJobTitle,
+    communityId: initialData.careerObjectiveCommunity?.id,
+    workStreamIds: initialData.careerObjectiveWorkStreams?.map(
       (workStream) => workStream.id,
     ),
-    departmentIds: initialData.nextRoleDepartments?.map(
+    departmentIds: initialData.careerObjectiveDepartments?.map(
       (department) => department.id,
     ),
-    additionalInformation: initialData.nextRoleAdditionalInformation,
+    additionalInformation: initialData.careerObjectiveAdditionalInformation,
   });
 
   const methods = useForm<FormValues>({
@@ -246,29 +251,29 @@ const NextRoleSection = ({
     return executeMutation({
       id: userAuthInfo.id,
       employeeProfile: {
-        nextRoleClassification: selectedClassification?.id
+        careerObjectiveClassification: selectedClassification?.id
           ? {
               connect: selectedClassification.id,
             }
           : {
               disconnect: true,
             },
-        nextRoleTargetRole: targetRole as TargetRole,
-        nextRoleJobTitle: jobTitle,
-        nextRoleCommunity: communityId
+        careerObjectiveTargetRole: targetRole as TargetRole,
+        careerObjectiveJobTitle: jobTitle,
+        careerObjectiveCommunity: communityId
           ? {
               connect: communityId,
             }
           : {
               disconnect: true,
             },
-        nextRoleWorkStreams: {
+        careerObjectiveWorkStreams: {
           sync: workStreamIds,
         },
-        nextRoleDepartments: {
+        careerObjectiveDepartments: {
           sync: departmentIds,
         },
-        nextRoleAdditionalInformation: additionalInformation,
+        careerObjectiveAdditionalInformation: additionalInformation,
       },
     })
       .then((result) => {
@@ -555,4 +560,4 @@ const NextRoleSection = ({
   );
 };
 
-export default NextRoleSection;
+export default CareerObjectiveSection;

--- a/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
@@ -2,7 +2,7 @@ import { useIntl } from "react-intl";
 import { FormProvider, useForm } from "react-hook-form";
 import QuestionMarkCircleIcon from "@heroicons/react/24/outline/QuestionMarkCircleIcon";
 import { useMutation } from "urql";
-import { ComponentProps, useEffect } from "react";
+import { ComponentProps, useEffect, useId } from "react";
 
 import { Button, ToggleSection, Well } from "@gc-digital-talent/ui";
 import {
@@ -170,6 +170,7 @@ const CareerObjectiveSection = ({
   const intl = useIntl();
   const locale = getLocale(intl);
   const { userAuthInfo } = useAuthorization();
+  const classificationDescriptionId = useId();
   const [{ fetching }, executeMutation] = useMutation(
     UpdateEmployeeProfile_Mutation,
   );
@@ -414,8 +415,13 @@ const CareerObjectiveSection = ({
                 data-h2-flex-direction="base(column)"
                 data-h2-gap="base(x1)"
               >
-                <>
-                  <p>
+                {/* Classification subsection */}
+                <div
+                  data-h2-display="base(flex)"
+                  data-h2-flex-direction="base(column)"
+                  data-h2-gap="base(x.5)"
+                >
+                  <p id={classificationDescriptionId}>
                     {intl.formatMessage(
                       employeeProfileMessages.targetClassification,
                     )}
@@ -439,6 +445,7 @@ const CareerObjectiveSection = ({
                         )}
                         options={groupOptions}
                         disabled={fetching}
+                        aria-describedby={classificationDescriptionId}
                       />
                     </div>
                     {notEmpty(watchClassificationGroup) && (
@@ -459,7 +466,7 @@ const CareerObjectiveSection = ({
                       </div>
                     )}
                   </div>
-                </>
+                </div>
                 <RadioGroup
                   idPrefix="targetRole"
                   name="targetRole"
@@ -564,7 +571,7 @@ const CareerObjectiveSection = ({
                 />
                 <div
                   data-h2-display="base(flex)"
-                  data-h2-gap="base(x.5)"
+                  data-h2-gap="base(x1)"
                   data-h2-align-items="base(center)"
                   data-h2-flex-wrap="base(wrap)"
                 >

--- a/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
@@ -409,12 +409,9 @@ const NextRoleSection = ({
                     >
                       <Select
                         id="classificationGroup"
-                        label={intl.formatMessage({
-                          defaultMessage: "Group",
-                          id: "hgxH8y",
-                          description:
-                            "Label displayed for the classification form group field.",
-                        })}
+                        label={intl.formatMessage(
+                          employeeProfileMessages.classificationGroup,
+                        )}
                         name="classificationGroup"
                         nullSelection={intl.formatMessage(
                           uiMessages.nullSelectionOptionGroup,
@@ -427,12 +424,9 @@ const NextRoleSection = ({
                       <div style={{ width: "100%" }}>
                         <Select
                           id="classificationLevel"
-                          label={intl.formatMessage({
-                            defaultMessage: "Level",
-                            id: "yZqUAU",
-                            description:
-                              "Title displayed for the Classification table Level column.",
-                          })}
+                          label={intl.formatMessage(
+                            employeeProfileMessages.classificationLevel,
+                          )}
                           name="classificationLevel"
                           nullSelection={intl.formatMessage(
                             uiMessages.nullSelectionOptionLevel,

--- a/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
@@ -21,11 +21,7 @@ import {
   TargetRole,
 } from "@gc-digital-talent/graphql";
 import { useAuthorization } from "@gc-digital-talent/auth";
-import {
-  notEmpty,
-  UnauthorizedError,
-  unpackMaybes,
-} from "@gc-digital-talent/helpers";
+import { UnauthorizedError, unpackMaybes } from "@gc-digital-talent/helpers";
 import { toast } from "@gc-digital-talent/toast";
 import {
   Checklist,

--- a/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
@@ -228,16 +228,29 @@ const CareerObjectiveSection = ({
     methods.watch(["classificationGroup", "communityId", "targetRole"]);
 
   /**
-   * Reset target role other when target role changes
+   * Reset fields in response to changes
    */
   useEffect(() => {
+    // clear "other" field if role is not other
     if (watchTargetRole !== TargetRole.Other) {
       methods.resetField("targetRoleOther", {
         keepDirty: false,
         defaultValue: null,
       });
     }
-  }, [watchTargetRole, methods]);
+    // method to reset work streams if community changes
+    if (watchCommunityId !== employeeProfile.careerObjectiveCommunity?.id) {
+      methods.resetField("workStreamIds", {
+        keepDirty: false,
+        defaultValue: [],
+      });
+    }
+  }, [
+    watchTargetRole,
+    methods,
+    watchCommunityId,
+    employeeProfile.careerObjectiveCommunity?.id,
+  ]);
 
   const { handleSubmit } = methods;
 

--- a/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
@@ -106,6 +106,9 @@ export const EmployeeProfileCareerObjective_Fragment = graphql(/* GraphQL */ `
       name {
         localized
       }
+      workStreams {
+        id
+      }
     }
     careerObjectiveWorkStreams {
       id

--- a/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
@@ -85,7 +85,7 @@ const EmployeeProfileCareerObjectiveOptions_Fragment = graphql(/* GraphQL */ `
   }
 `);
 
-const EmployeeProfileCareerObjective_Fragment = graphql(/* GraphQL */ `
+export const EmployeeProfileCareerObjective_Fragment = graphql(/* GraphQL */ `
   fragment EmployeeProfileCareerObjective on EmployeeProfile {
     careerObjectiveClassification {
       id

--- a/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
@@ -86,7 +86,7 @@ const EmployeeProfileNextRoleOptions_Fragment = graphql(/* GraphQL */ `
 `);
 
 const EmployeeProfileNextRole_Fragment = graphql(/* GraphQL */ `
-  fragment EmployeeProfileNextRole on EmployeeProfile {
+  fragment EmployeeProfileCareerObjective on EmployeeProfile {
     nextRoleClassification {
       id
       group
@@ -124,12 +124,12 @@ const EmployeeProfileNextRole_Fragment = graphql(/* GraphQL */ `
 `);
 
 const UpdateEmployeeProfile_Mutation = graphql(/* GraphQL */ `
-  mutation UpdateEmployeeProfileNextRole(
+  mutation UpdateEmployeeProfileCareerObjective(
     $id: UUID!
     $employeeProfile: UpdateEmployeeProfileInput!
   ) {
     updateEmployeeProfile(id: $id, employeeProfile: $employeeProfile) {
-      ...EmployeeProfileNextRole
+      ...EmployeeProfileCareerObjective
     }
   }
 `);
@@ -187,8 +187,8 @@ const NextRoleSection = ({
   const handleError = () => {
     toast.error(
       intl.formatMessage({
-        defaultMessage: "Failed updating next role information",
-        id: "GndGRz",
+        defaultMessage: "Failed updating career objective information",
+        id: "vKzPT0",
         description:
           "Message displayed when a user fails to updates employee profile information",
       }),
@@ -275,8 +275,9 @@ const NextRoleSection = ({
         if (result.data?.updateEmployeeProfile) {
           toast.success(
             intl.formatMessage({
-              defaultMessage: "Next role information updated successfully!",
-              id: "3Kt+rj",
+              defaultMessage:
+                "Career objective information updated successfully!",
+              id: "bju7JB",
               description:
                 "Message displayed when a user successfully updates employee profile information",
             }),
@@ -304,9 +305,9 @@ const NextRoleSection = ({
 
   const subtitle = intl.formatMessage({
     defaultMessage:
-      "Tell us about the next role you see yourself in. Sharing your preferences for your next job can help HR staff find the right position for you.",
-    id: "IO+qSg",
-    description: "Describes the next role section of employee profile",
+      "Describe your ultimate career objective. Your input can help staff working on talent management identify the right next step for you, whether it's a lateral move, a development opportunity, or an advancement.",
+    id: "FYCNAa",
+    description: "Describes the career objective section of employee profile",
   });
 
   const groupOptions = getGroupOptions(
@@ -349,7 +350,7 @@ const NextRoleSection = ({
 
   return (
     <ToggleSection.Root
-      id="next-role-form"
+      id="career-objective-form"
       open={isEditing}
       onOpenChange={setIsEditing}
     >
@@ -361,18 +362,18 @@ const NextRoleSection = ({
         toggle={
           <ToggleForm.LabelledTrigger
             sectionTitle={intl.formatMessage({
-              defaultMessage: "Your next role",
-              id: "m6eIBH",
-              description: "Title for the next role section",
+              defaultMessage: "Your career objective",
+              id: "vvnsjr",
+              description: "Title for the career objective section",
             })}
           />
         }
         data-h2-font-weight="base(bold)"
       >
         {intl.formatMessage({
-          defaultMessage: "Your next role",
-          id: "m6eIBH",
-          description: "Title for the next role section",
+          defaultMessage: "Your career objective",
+          id: "vvnsjr",
+          description: "Title for the career objective section",
         })}
       </ToggleSection.Header>
       <p>{subtitle}</p>
@@ -526,7 +527,7 @@ const NextRoleSection = ({
                 <TextArea
                   id="additionalInformation"
                   label={intl.formatMessage(
-                    employeeProfileMessages.additionalInformationNextRole,
+                    employeeProfileMessages.additionalInformationCareerObjective,
                   )}
                   name="additionalInformation"
                   wordLimit={wordCountLimits[locale]}

--- a/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
@@ -207,7 +207,7 @@ const CareerObjectiveSection = ({
     classificationLevel:
       initialData.careerObjectiveClassification?.level.toString(),
     targetRole: initialData.careerObjectiveTargetRole?.value,
-    targetRoleOther: initialData.nextRoleTargetRoleOther,
+    targetRoleOther: initialData.careerObjectiveTargetRoleOther,
     jobTitle: initialData.careerObjectiveJobTitle,
     communityId: initialData.careerObjectiveCommunity?.id,
     workStreamIds: initialData.careerObjectiveWorkStreams?.map(

--- a/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
@@ -464,7 +464,7 @@ const CareerObjectiveSection = ({
                         aria-describedby={classificationDescriptionId}
                       />
                     </div>
-                    {notEmpty(watchClassificationGroup) && (
+                    {watchClassificationGroup ? (
                       <div style={{ width: "100%" }}>
                         <Select
                           id="classificationLevel"
@@ -480,7 +480,7 @@ const CareerObjectiveSection = ({
                           disabled={fetching}
                         />
                       </div>
-                    )}
+                    ) : null}
                   </div>
                 </div>
                 <RadioGroup

--- a/apps/web/src/pages/EmployeeProfile/components/CareerObjective/Display.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerObjective/Display.tsx
@@ -1,0 +1,162 @@
+import { useIntl } from "react-intl";
+
+import { commonMessages } from "@gc-digital-talent/i18n";
+import { EmployeeProfileNextRoleFragment } from "@gc-digital-talent/graphql";
+import { CardSeparator, Well } from "@gc-digital-talent/ui";
+
+import ToggleForm from "~/components/ToggleForm/ToggleForm";
+import employeeProfileMessages from "~/messages/employeeProfileMessages";
+import { hasAnyEmptyFields } from "~/validators/employeeProfile/nextRole";
+
+interface DisplayProps {
+  employeeProfile: EmployeeProfileNextRoleFragment;
+}
+
+const Display = ({
+  employeeProfile: {
+    nextRoleClassification,
+    nextRoleTargetRole,
+    nextRoleJobTitle,
+    nextRoleCommunity,
+    nextRoleWorkStreams,
+    nextRoleDepartments,
+    nextRoleAdditionalInformation,
+  },
+}: DisplayProps) => {
+  const intl = useIntl();
+  const notProvided = intl.formatMessage(
+    commonMessages.missingOptionalInformation,
+  );
+
+  nextRoleWorkStreams?.sort((a, b) =>
+    a.name?.localized && b.name?.localized
+      ? a.name.localized.localeCompare(b.name.localized)
+      : 0,
+  );
+
+  nextRoleDepartments?.sort((a, b) =>
+    a.name?.localized && b.name?.localized
+      ? a.name.localized.localeCompare(b.name.localized)
+      : 0,
+  );
+
+  return (
+    <div
+      data-h2-display="base(flex)"
+      data-h2-flex-direction="base(column)"
+      data-h2-gap="base(x1)"
+    >
+      {hasAnyEmptyFields({
+        nextRoleClassification,
+        nextRoleTargetRole,
+        nextRoleJobTitle,
+        nextRoleCommunity,
+        nextRoleWorkStreams,
+        nextRoleDepartments,
+        nextRoleAdditionalInformation,
+      }) && (
+        <>
+          <Well>
+            {intl.formatMessage({
+              defaultMessage:
+                'There are currently unanswered questions in this section. Use the "Edit" button to review and answer any required fields.',
+              id: "9Y3w6l",
+              description: "Message for unanswered questions in this section",
+            })}
+          </Well>
+          <CardSeparator data-h2-margin="base(0)" />
+        </>
+      )}
+      <div
+        data-h2-display="base(grid)"
+        data-h2-gap="base(x1)"
+        data-h2-grid-template-columns="base(repeat(1, 1fr)) p-tablet(repeat(2, 1fr)) "
+      >
+        <ToggleForm.FieldDisplay
+          label={intl.formatMessage(
+            employeeProfileMessages.targetClassificationGroup,
+          )}
+        >
+          {nextRoleClassification?.group
+            ? nextRoleClassification.group
+            : notProvided}
+        </ToggleForm.FieldDisplay>
+        <ToggleForm.FieldDisplay
+          label={intl.formatMessage(
+            employeeProfileMessages.targetClassificationLevel,
+          )}
+        >
+          {nextRoleClassification?.level
+            ? nextRoleClassification.level.toString().padStart(2, "0")
+            : notProvided}
+        </ToggleForm.FieldDisplay>
+        <ToggleForm.FieldDisplay
+          label={intl.formatMessage(employeeProfileMessages.targetRole)}
+        >
+          {nextRoleTargetRole?.label.localized
+            ? nextRoleTargetRole.label.localized
+            : notProvided}
+        </ToggleForm.FieldDisplay>
+        <ToggleForm.FieldDisplay
+          label={intl.formatMessage(employeeProfileMessages.jobTitle)}
+        >
+          {nextRoleJobTitle ? nextRoleJobTitle : notProvided}
+        </ToggleForm.FieldDisplay>
+        <ToggleForm.FieldDisplay
+          label={intl.formatMessage(employeeProfileMessages.community)}
+          data-h2-grid-column="l-tablet(span 2)"
+        >
+          {nextRoleCommunity?.name?.localized
+            ? nextRoleCommunity.name.localized
+            : notProvided}
+        </ToggleForm.FieldDisplay>
+        <ToggleForm.FieldDisplay
+          label={intl.formatMessage(employeeProfileMessages.workStreams)}
+          data-h2-grid-column="l-tablet(span 2)"
+        >
+          {nextRoleWorkStreams?.length ? (
+            <ul
+              data-h2-margin-bottom="base:selectors[>li:not(:last-child)](x.125)"
+              data-h2-padding-left="base(x1)"
+            >
+              {nextRoleWorkStreams.map((workStream) => (
+                <li key={workStream.id}>{workStream?.name?.localized}</li>
+              ))}
+            </ul>
+          ) : (
+            notProvided
+          )}
+        </ToggleForm.FieldDisplay>
+        <ToggleForm.FieldDisplay
+          label={intl.formatMessage(employeeProfileMessages.departments)}
+          data-h2-grid-column="l-tablet(span 2)"
+        >
+          {nextRoleDepartments?.length ? (
+            <ul
+              data-h2-margin-bottom="base:selectors[>li:not(:last-child)](x.125)"
+              data-h2-padding-left="base(x1)"
+            >
+              {nextRoleDepartments.map((department) => (
+                <li key={department.id}>{department?.name?.localized}</li>
+              ))}
+            </ul>
+          ) : (
+            notProvided
+          )}
+        </ToggleForm.FieldDisplay>
+        <ToggleForm.FieldDisplay
+          label={intl.formatMessage(
+            employeeProfileMessages.additionalInformationCareerObjective,
+          )}
+          data-h2-grid-column="l-tablet(span 2)"
+        >
+          {nextRoleAdditionalInformation
+            ? nextRoleAdditionalInformation
+            : notProvided}
+        </ToggleForm.FieldDisplay>
+      </div>
+    </div>
+  );
+};
+
+export default Display;

--- a/apps/web/src/pages/EmployeeProfile/components/CareerObjective/Display.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerObjective/Display.tsx
@@ -16,6 +16,7 @@ const Display = ({
   employeeProfile: {
     careerObjectiveClassification,
     careerObjectiveTargetRole,
+    careerObjectiveTargetRoleOther,
     careerObjectiveJobTitle,
     careerObjectiveCommunity,
     careerObjectiveWorkStreams,
@@ -93,9 +94,9 @@ const Display = ({
         <ToggleForm.FieldDisplay
           label={intl.formatMessage(employeeProfileMessages.targetRole)}
         >
-          {careerObjectiveTargetRole?.label.localized
-            ? careerObjectiveTargetRole.label.localized
-            : notProvided}
+          {careerObjectiveTargetRoleOther ??
+            careerObjectiveTargetRole?.label.localized ??
+            notProvided}
         </ToggleForm.FieldDisplay>
         <ToggleForm.FieldDisplay
           label={intl.formatMessage(employeeProfileMessages.jobTitle)}

--- a/apps/web/src/pages/EmployeeProfile/components/CareerObjective/Display.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerObjective/Display.tsx
@@ -111,23 +111,27 @@ const Display = ({
             ? careerObjectiveCommunity.name.localized
             : notProvided}
         </ToggleForm.FieldDisplay>
-        <ToggleForm.FieldDisplay
-          label={intl.formatMessage(employeeProfileMessages.workStreams)}
-          data-h2-grid-column="l-tablet(span 2)"
-        >
-          {careerObjectiveWorkStreams?.length ? (
-            <ul
-              data-h2-margin-bottom="base:selectors[>li:not(:last-child)](x.125)"
-              data-h2-padding-left="base(x1)"
-            >
-              {careerObjectiveWorkStreams.map((workStream) => (
-                <li key={workStream.id}>{workStream?.name?.localized}</li>
-              ))}
-            </ul>
-          ) : (
-            notProvided
-          )}
-        </ToggleForm.FieldDisplay>
+        {/* Only show work streams if the community has possible work streams to choose, or if there are some chosen already somehow */}
+        {careerObjectiveCommunity?.workStreams?.length ||
+        careerObjectiveWorkStreams?.length ? (
+          <ToggleForm.FieldDisplay
+            label={intl.formatMessage(employeeProfileMessages.workStreams)}
+            data-h2-grid-column="l-tablet(span 2)"
+          >
+            {careerObjectiveWorkStreams?.length ? (
+              <ul
+                data-h2-margin-bottom="base:selectors[>li:not(:last-child)](x.125)"
+                data-h2-padding-left="base(x1)"
+              >
+                {careerObjectiveWorkStreams.map((workStream) => (
+                  <li key={workStream.id}>{workStream?.name?.localized}</li>
+                ))}
+              </ul>
+            ) : (
+              notProvided
+            )}
+          </ToggleForm.FieldDisplay>
+        ) : null}
         <ToggleForm.FieldDisplay
           label={intl.formatMessage(employeeProfileMessages.departments)}
           data-h2-grid-column="l-tablet(span 2)"

--- a/apps/web/src/pages/EmployeeProfile/components/CareerObjective/Display.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerObjective/Display.tsx
@@ -1,26 +1,26 @@
 import { useIntl } from "react-intl";
 
 import { commonMessages } from "@gc-digital-talent/i18n";
-import { EmployeeProfileNextRoleFragment } from "@gc-digital-talent/graphql";
+import { EmployeeProfileCareerObjectiveFragment } from "@gc-digital-talent/graphql";
 import { CardSeparator, Well } from "@gc-digital-talent/ui";
 
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
 import employeeProfileMessages from "~/messages/employeeProfileMessages";
-import { hasAnyEmptyFields } from "~/validators/employeeProfile/nextRole";
+import { hasAnyEmptyFields } from "~/validators/employeeProfile/careerObjective";
 
 interface DisplayProps {
-  employeeProfile: EmployeeProfileNextRoleFragment;
+  employeeProfile: EmployeeProfileCareerObjectiveFragment;
 }
 
 const Display = ({
   employeeProfile: {
-    nextRoleClassification,
-    nextRoleTargetRole,
-    nextRoleJobTitle,
-    nextRoleCommunity,
-    nextRoleWorkStreams,
-    nextRoleDepartments,
-    nextRoleAdditionalInformation,
+    careerObjectiveClassification,
+    careerObjectiveTargetRole,
+    careerObjectiveJobTitle,
+    careerObjectiveCommunity,
+    careerObjectiveWorkStreams,
+    careerObjectiveDepartments,
+    careerObjectiveAdditionalInformation,
   },
 }: DisplayProps) => {
   const intl = useIntl();
@@ -28,13 +28,13 @@ const Display = ({
     commonMessages.missingOptionalInformation,
   );
 
-  nextRoleWorkStreams?.sort((a, b) =>
+  careerObjectiveWorkStreams?.sort((a, b) =>
     a.name?.localized && b.name?.localized
       ? a.name.localized.localeCompare(b.name.localized)
       : 0,
   );
 
-  nextRoleDepartments?.sort((a, b) =>
+  careerObjectiveDepartments?.sort((a, b) =>
     a.name?.localized && b.name?.localized
       ? a.name.localized.localeCompare(b.name.localized)
       : 0,
@@ -47,13 +47,13 @@ const Display = ({
       data-h2-gap="base(x1)"
     >
       {hasAnyEmptyFields({
-        nextRoleClassification,
-        nextRoleTargetRole,
-        nextRoleJobTitle,
-        nextRoleCommunity,
-        nextRoleWorkStreams,
-        nextRoleDepartments,
-        nextRoleAdditionalInformation,
+        careerObjectiveClassification,
+        careerObjectiveTargetRole,
+        careerObjectiveJobTitle,
+        careerObjectiveCommunity,
+        careerObjectiveWorkStreams,
+        careerObjectiveDepartments,
+        careerObjectiveAdditionalInformation,
       }) && (
         <>
           <Well>
@@ -77,8 +77,8 @@ const Display = ({
             employeeProfileMessages.targetClassificationGroup,
           )}
         >
-          {nextRoleClassification?.group
-            ? nextRoleClassification.group
+          {careerObjectiveClassification?.group
+            ? careerObjectiveClassification.group
             : notProvided}
         </ToggleForm.FieldDisplay>
         <ToggleForm.FieldDisplay
@@ -86,40 +86,40 @@ const Display = ({
             employeeProfileMessages.targetClassificationLevel,
           )}
         >
-          {nextRoleClassification?.level
-            ? nextRoleClassification.level.toString().padStart(2, "0")
+          {careerObjectiveClassification?.level
+            ? careerObjectiveClassification.level.toString().padStart(2, "0")
             : notProvided}
         </ToggleForm.FieldDisplay>
         <ToggleForm.FieldDisplay
           label={intl.formatMessage(employeeProfileMessages.targetRole)}
         >
-          {nextRoleTargetRole?.label.localized
-            ? nextRoleTargetRole.label.localized
+          {careerObjectiveTargetRole?.label.localized
+            ? careerObjectiveTargetRole.label.localized
             : notProvided}
         </ToggleForm.FieldDisplay>
         <ToggleForm.FieldDisplay
           label={intl.formatMessage(employeeProfileMessages.jobTitle)}
         >
-          {nextRoleJobTitle ? nextRoleJobTitle : notProvided}
+          {careerObjectiveJobTitle ? careerObjectiveJobTitle : notProvided}
         </ToggleForm.FieldDisplay>
         <ToggleForm.FieldDisplay
           label={intl.formatMessage(employeeProfileMessages.community)}
           data-h2-grid-column="l-tablet(span 2)"
         >
-          {nextRoleCommunity?.name?.localized
-            ? nextRoleCommunity.name.localized
+          {careerObjectiveCommunity?.name?.localized
+            ? careerObjectiveCommunity.name.localized
             : notProvided}
         </ToggleForm.FieldDisplay>
         <ToggleForm.FieldDisplay
           label={intl.formatMessage(employeeProfileMessages.workStreams)}
           data-h2-grid-column="l-tablet(span 2)"
         >
-          {nextRoleWorkStreams?.length ? (
+          {careerObjectiveWorkStreams?.length ? (
             <ul
               data-h2-margin-bottom="base:selectors[>li:not(:last-child)](x.125)"
               data-h2-padding-left="base(x1)"
             >
-              {nextRoleWorkStreams.map((workStream) => (
+              {careerObjectiveWorkStreams.map((workStream) => (
                 <li key={workStream.id}>{workStream?.name?.localized}</li>
               ))}
             </ul>
@@ -131,12 +131,12 @@ const Display = ({
           label={intl.formatMessage(employeeProfileMessages.departments)}
           data-h2-grid-column="l-tablet(span 2)"
         >
-          {nextRoleDepartments?.length ? (
+          {careerObjectiveDepartments?.length ? (
             <ul
               data-h2-margin-bottom="base:selectors[>li:not(:last-child)](x.125)"
               data-h2-padding-left="base(x1)"
             >
-              {nextRoleDepartments.map((department) => (
+              {careerObjectiveDepartments.map((department) => (
                 <li key={department.id}>{department?.name?.localized}</li>
               ))}
             </ul>
@@ -150,8 +150,8 @@ const Display = ({
           )}
           data-h2-grid-column="l-tablet(span 2)"
         >
-          {nextRoleAdditionalInformation
-            ? nextRoleAdditionalInformation
+          {careerObjectiveAdditionalInformation
+            ? careerObjectiveAdditionalInformation
             : notProvided}
         </ToggleForm.FieldDisplay>
       </div>

--- a/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/Display.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/Display.tsx
@@ -16,6 +16,7 @@ const Display = ({
   employeeProfile: {
     nextRoleClassification,
     nextRoleTargetRole,
+    nextRoleTargetRoleOther,
     nextRoleJobTitle,
     nextRoleCommunity,
     nextRoleWorkStreams,
@@ -93,9 +94,9 @@ const Display = ({
         <ToggleForm.FieldDisplay
           label={intl.formatMessage(employeeProfileMessages.targetRole)}
         >
-          {nextRoleTargetRole?.label.localized
-            ? nextRoleTargetRole.label.localized
-            : notProvided}
+          {nextRoleTargetRoleOther ??
+            nextRoleTargetRole?.label.localized ??
+            notProvided}
         </ToggleForm.FieldDisplay>
         <ToggleForm.FieldDisplay
           label={intl.formatMessage(employeeProfileMessages.jobTitle)}

--- a/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/Display.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/Display.tsx
@@ -1,0 +1,162 @@
+import { useIntl } from "react-intl";
+
+import { commonMessages } from "@gc-digital-talent/i18n";
+import { EmployeeProfileNextRoleFragment } from "@gc-digital-talent/graphql";
+import { CardSeparator, Well } from "@gc-digital-talent/ui";
+
+import ToggleForm from "~/components/ToggleForm/ToggleForm";
+import employeeProfileMessages from "~/messages/employeeProfileMessages";
+import { hasAnyEmptyFields } from "~/validators/employeeProfile/nextRole";
+
+interface DisplayProps {
+  employeeProfile: EmployeeProfileNextRoleFragment;
+}
+
+const Display = ({
+  employeeProfile: {
+    nextRoleClassification,
+    nextRoleTargetRole,
+    nextRoleJobTitle,
+    nextRoleCommunity,
+    nextRoleWorkStreams,
+    nextRoleDepartments,
+    nextRoleAdditionalInformation,
+  },
+}: DisplayProps) => {
+  const intl = useIntl();
+  const notProvided = intl.formatMessage(
+    commonMessages.missingOptionalInformation,
+  );
+
+  nextRoleWorkStreams?.sort((a, b) =>
+    a.name?.localized && b.name?.localized
+      ? a.name.localized.localeCompare(b.name.localized)
+      : 0,
+  );
+
+  nextRoleDepartments?.sort((a, b) =>
+    a.name?.localized && b.name?.localized
+      ? a.name.localized.localeCompare(b.name.localized)
+      : 0,
+  );
+
+  return (
+    <div
+      data-h2-display="base(flex)"
+      data-h2-flex-direction="base(column)"
+      data-h2-gap="base(x1)"
+    >
+      {hasAnyEmptyFields({
+        nextRoleClassification,
+        nextRoleTargetRole,
+        nextRoleJobTitle,
+        nextRoleCommunity,
+        nextRoleWorkStreams,
+        nextRoleDepartments,
+        nextRoleAdditionalInformation,
+      }) && (
+        <>
+          <Well>
+            {intl.formatMessage({
+              defaultMessage:
+                'There are currently unanswered questions in this section. Use the "Edit" button to review and answer any required fields.',
+              id: "9Y3w6l",
+              description: "Message for unanswered questions in this section",
+            })}
+          </Well>
+          <CardSeparator data-h2-margin="base(0)" />
+        </>
+      )}
+      <div
+        data-h2-display="base(grid)"
+        data-h2-gap="base(x1)"
+        data-h2-grid-template-columns="base(repeat(1, 1fr)) p-tablet(repeat(2, 1fr)) "
+      >
+        <ToggleForm.FieldDisplay
+          label={intl.formatMessage(
+            employeeProfileMessages.targetClassificationGroup,
+          )}
+        >
+          {nextRoleClassification?.group
+            ? nextRoleClassification.group
+            : notProvided}
+        </ToggleForm.FieldDisplay>
+        <ToggleForm.FieldDisplay
+          label={intl.formatMessage(
+            employeeProfileMessages.targetClassificationLevel,
+          )}
+        >
+          {nextRoleClassification?.level
+            ? nextRoleClassification.level.toString().padStart(2, "0")
+            : notProvided}
+        </ToggleForm.FieldDisplay>
+        <ToggleForm.FieldDisplay
+          label={intl.formatMessage(employeeProfileMessages.targetRole)}
+        >
+          {nextRoleTargetRole?.label.localized
+            ? nextRoleTargetRole.label.localized
+            : notProvided}
+        </ToggleForm.FieldDisplay>
+        <ToggleForm.FieldDisplay
+          label={intl.formatMessage(employeeProfileMessages.jobTitle)}
+        >
+          {nextRoleJobTitle ? nextRoleJobTitle : notProvided}
+        </ToggleForm.FieldDisplay>
+        <ToggleForm.FieldDisplay
+          label={intl.formatMessage(employeeProfileMessages.community)}
+          data-h2-grid-column="l-tablet(span 2)"
+        >
+          {nextRoleCommunity?.name?.localized
+            ? nextRoleCommunity.name.localized
+            : notProvided}
+        </ToggleForm.FieldDisplay>
+        <ToggleForm.FieldDisplay
+          label={intl.formatMessage(employeeProfileMessages.workStreams)}
+          data-h2-grid-column="l-tablet(span 2)"
+        >
+          {nextRoleWorkStreams?.length ? (
+            <ul
+              data-h2-margin-bottom="base:selectors[>li:not(:last-child)](x.125)"
+              data-h2-padding-left="base(x1)"
+            >
+              {nextRoleWorkStreams.map((workStream) => (
+                <li key={workStream.id}>{workStream?.name?.localized}</li>
+              ))}
+            </ul>
+          ) : (
+            notProvided
+          )}
+        </ToggleForm.FieldDisplay>
+        <ToggleForm.FieldDisplay
+          label={intl.formatMessage(employeeProfileMessages.departments)}
+          data-h2-grid-column="l-tablet(span 2)"
+        >
+          {nextRoleDepartments?.length ? (
+            <ul
+              data-h2-margin-bottom="base:selectors[>li:not(:last-child)](x.125)"
+              data-h2-padding-left="base(x1)"
+            >
+              {nextRoleDepartments.map((department) => (
+                <li key={department.id}>{department?.name?.localized}</li>
+              ))}
+            </ul>
+          ) : (
+            notProvided
+          )}
+        </ToggleForm.FieldDisplay>
+        <ToggleForm.FieldDisplay
+          label={intl.formatMessage(
+            employeeProfileMessages.additionalInformationNextRole,
+          )}
+          data-h2-grid-column="l-tablet(span 2)"
+        >
+          {nextRoleAdditionalInformation
+            ? nextRoleAdditionalInformation
+            : notProvided}
+        </ToggleForm.FieldDisplay>
+      </div>
+    </div>
+  );
+};
+
+export default Display;

--- a/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/Display.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/Display.tsx
@@ -111,23 +111,27 @@ const Display = ({
             ? nextRoleCommunity.name.localized
             : notProvided}
         </ToggleForm.FieldDisplay>
-        <ToggleForm.FieldDisplay
-          label={intl.formatMessage(employeeProfileMessages.workStreams)}
-          data-h2-grid-column="l-tablet(span 2)"
-        >
-          {nextRoleWorkStreams?.length ? (
-            <ul
-              data-h2-margin-bottom="base:selectors[>li:not(:last-child)](x.125)"
-              data-h2-padding-left="base(x1)"
-            >
-              {nextRoleWorkStreams.map((workStream) => (
-                <li key={workStream.id}>{workStream?.name?.localized}</li>
-              ))}
-            </ul>
-          ) : (
-            notProvided
-          )}
-        </ToggleForm.FieldDisplay>
+        {/* Only show work streams if the community has possible work streams to choose, or if there are some chosen already somehow */}
+        {nextRoleCommunity?.workStreams?.length ||
+        nextRoleWorkStreams?.length ? (
+          <ToggleForm.FieldDisplay
+            label={intl.formatMessage(employeeProfileMessages.workStreams)}
+            data-h2-grid-column="l-tablet(span 2)"
+          >
+            {nextRoleWorkStreams?.length ? (
+              <ul
+                data-h2-margin-bottom="base:selectors[>li:not(:last-child)](x.125)"
+                data-h2-padding-left="base(x1)"
+              >
+                {nextRoleWorkStreams.map((workStream) => (
+                  <li key={workStream.id}>{workStream?.name?.localized}</li>
+                ))}
+              </ul>
+            ) : (
+              notProvided
+            )}
+          </ToggleForm.FieldDisplay>
+        ) : null}
         <ToggleForm.FieldDisplay
           label={intl.formatMessage(employeeProfileMessages.departments)}
           data-h2-grid-column="l-tablet(span 2)"

--- a/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
@@ -223,16 +223,29 @@ const NextRoleSection = ({
     methods.watch(["classificationGroup", "communityId", "targetRole"]);
 
   /**
-   * Reset target role other when target role changes
+   * Reset fields in response to changes
    */
   useEffect(() => {
+    // clear "other" field if role is not other
     if (watchTargetRole !== TargetRole.Other) {
       methods.resetField("targetRoleOther", {
         keepDirty: false,
         defaultValue: null,
       });
     }
-  }, [watchTargetRole, methods]);
+    // method to reset work streams if community changes
+    if (watchCommunityId !== employeeProfile.nextRoleCommunity?.id) {
+      methods.resetField("workStreamIds", {
+        keepDirty: false,
+        defaultValue: [],
+      });
+    }
+  }, [
+    watchTargetRole,
+    methods,
+    watchCommunityId,
+    employeeProfile.nextRoleCommunity?.id,
+  ]);
 
   const { handleSubmit } = methods;
 

--- a/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
@@ -106,6 +106,9 @@ export const EmployeeProfileNextRole_Fragment = graphql(/* GraphQL */ `
       name {
         localized
       }
+      workStreams {
+        id
+      }
     }
     nextRoleWorkStreams {
       id

--- a/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
@@ -124,15 +124,12 @@ const EmployeeProfileNextRole_Fragment = graphql(/* GraphQL */ `
 `);
 
 const UpdateEmployeeProfile_Mutation = graphql(/* GraphQL */ `
-  mutation UpdateEmployeeProfile(
+  mutation UpdateEmployeeProfileNextRole(
     $id: UUID!
     $employeeProfile: UpdateEmployeeProfileInput!
   ) {
     updateEmployeeProfile(id: $id, employeeProfile: $employeeProfile) {
-      aboutYou
-      careerGoals
-      learningGoals
-      workStyle
+      ...EmployeeProfileNextRole
     }
   }
 `);

--- a/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
@@ -2,7 +2,7 @@ import { useIntl } from "react-intl";
 import { FormProvider, useForm } from "react-hook-form";
 import QuestionMarkCircleIcon from "@heroicons/react/24/outline/QuestionMarkCircleIcon";
 import { useMutation } from "urql";
-import { ComponentProps } from "react";
+import { ComponentProps, useEffect } from "react";
 
 import { Button, ToggleSection, Well } from "@gc-digital-talent/ui";
 import {
@@ -98,6 +98,7 @@ const EmployeeProfileNextRole_Fragment = graphql(/* GraphQL */ `
         localized
       }
     }
+    nextRoleTargetRoleOther
     nextRoleJobTitle
     nextRoleCommunity {
       id
@@ -138,6 +139,7 @@ interface FormValues {
   classificationGroup: string | null | undefined;
   classificationLevel: string | null | undefined;
   targetRole: string | null | undefined;
+  targetRoleOther: string | null | undefined;
   jobTitle: string | null | undefined;
   communityId: string | null | undefined;
   workStreamIds: string[] | null | undefined;
@@ -199,6 +201,7 @@ const NextRoleSection = ({
     classificationGroup: initialData.nextRoleClassification?.group,
     classificationLevel: initialData.nextRoleClassification?.level.toString(),
     targetRole: initialData.nextRoleTargetRole?.value,
+    targetRoleOther: initialData.nextRoleTargetRoleOther,
     jobTitle: initialData.nextRoleJobTitle,
     communityId: initialData.nextRoleCommunity?.id,
     workStreamIds: initialData.nextRoleWorkStreams?.map(
@@ -215,10 +218,20 @@ const NextRoleSection = ({
   });
 
   // hooks to watch, needed for conditional rendering
-  const [watchClassificationGroup, watchCommunityId] = methods.watch([
-    "classificationGroup",
-    "communityId",
-  ]);
+  const [watchClassificationGroup, watchCommunityId, watchTargetRole] =
+    methods.watch(["classificationGroup", "communityId", "targetRole"]);
+
+  /**
+   * Reset target role other when target role changes
+   */
+  useEffect(() => {
+    if (watchTargetRole !== TargetRole.Other) {
+      methods.resetField("targetRoleOther", {
+        keepDirty: false,
+        defaultValue: null,
+      });
+    }
+  }, [watchTargetRole, methods]);
 
   const { handleSubmit } = methods;
 
@@ -226,6 +239,7 @@ const NextRoleSection = ({
     classificationGroup,
     classificationLevel,
     targetRole,
+    targetRoleOther,
     jobTitle,
     communityId,
     workStreamIds,
@@ -254,6 +268,7 @@ const NextRoleSection = ({
               disconnect: true,
             },
         nextRoleTargetRole: targetRole as TargetRole,
+        nextRoleTargetRoleOther: targetRoleOther,
         nextRoleJobTitle: jobTitle,
         nextRoleCommunity: communityId
           ? {
@@ -287,6 +302,7 @@ const NextRoleSection = ({
               classificationGroup,
               classificationLevel,
               targetRole,
+              targetRoleOther,
               jobTitle,
               communityId,
               workStreamIds,
@@ -459,6 +475,20 @@ const NextRoleSection = ({
                   }}
                   disabled={fetching}
                 />
+                {watchTargetRole === TargetRole.Other ? (
+                  <Input
+                    id="targetRoleOther"
+                    type="text"
+                    label={intl.formatMessage(
+                      employeeProfileMessages.targetRoleOther,
+                    )}
+                    name="targetRoleOther"
+                    rules={{
+                      required: intl.formatMessage(errorMessages.required),
+                    }}
+                    disabled={fetching}
+                  />
+                ) : null}
                 <Input
                   id="jobTitle"
                   type="text"

--- a/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
@@ -408,12 +408,9 @@ const NextRoleSection = ({
                     >
                       <Select
                         id="classificationGroup"
-                        label={intl.formatMessage({
-                          defaultMessage: "Group",
-                          id: "hgxH8y",
-                          description:
-                            "Label displayed for the classification form group field.",
-                        })}
+                        label={intl.formatMessage(
+                          employeeProfileMessages.classificationGroup,
+                        )}
                         name="classificationGroup"
                         nullSelection={intl.formatMessage(
                           uiMessages.nullSelectionOptionGroup,
@@ -426,12 +423,9 @@ const NextRoleSection = ({
                       <div style={{ width: "100%" }}>
                         <Select
                           id="classificationLevel"
-                          label={intl.formatMessage({
-                            defaultMessage: "Level",
-                            id: "yZqUAU",
-                            description:
-                              "Title displayed for the Classification table Level column.",
-                          })}
+                          label={intl.formatMessage(
+                            employeeProfileMessages.classificationLevel,
+                          )}
                           name="classificationLevel"
                           nullSelection={intl.formatMessage(
                             uiMessages.nullSelectionOptionLevel,

--- a/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
@@ -2,7 +2,7 @@ import { useIntl } from "react-intl";
 import { FormProvider, useForm } from "react-hook-form";
 import QuestionMarkCircleIcon from "@heroicons/react/24/outline/QuestionMarkCircleIcon";
 import { useMutation } from "urql";
-import { ComponentProps, useEffect } from "react";
+import { ComponentProps, useEffect, useId } from "react";
 
 import { Button, ToggleSection, Well } from "@gc-digital-talent/ui";
 import {
@@ -166,6 +166,7 @@ const NextRoleSection = ({
   const intl = useIntl();
   const locale = getLocale(intl);
   const { userAuthInfo } = useAuthorization();
+  const classificationDescriptionId = useId();
   const [{ fetching }, executeMutation] = useMutation(
     UpdateEmployeeProfile_Mutation,
   );
@@ -408,8 +409,13 @@ const NextRoleSection = ({
                 data-h2-flex-direction="base(column)"
                 data-h2-gap="base(x1)"
               >
-                <>
-                  <p>
+                {/* Classification subsection */}
+                <div
+                  data-h2-display="base(flex)"
+                  data-h2-flex-direction="base(column)"
+                  data-h2-gap="base(x.5)"
+                >
+                  <p id={classificationDescriptionId}>
                     {intl.formatMessage(
                       employeeProfileMessages.targetClassification,
                     )}
@@ -433,6 +439,7 @@ const NextRoleSection = ({
                         )}
                         options={groupOptions}
                         disabled={fetching}
+                        aria-describedby={classificationDescriptionId}
                       />
                     </div>
                     {notEmpty(watchClassificationGroup) && (
@@ -453,7 +460,7 @@ const NextRoleSection = ({
                       </div>
                     )}
                   </div>
-                </>
+                </div>
                 <RadioGroup
                   idPrefix="targetRole"
                   name="targetRole"
@@ -558,7 +565,7 @@ const NextRoleSection = ({
                 />
                 <div
                   data-h2-display="base(flex)"
-                  data-h2-gap="base(x.5)"
+                  data-h2-gap="base(x1)"
                   data-h2-align-items="base(center)"
                   data-h2-flex-wrap="base(wrap)"
                 >

--- a/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
@@ -85,7 +85,7 @@ const EmployeeProfileNextRoleOptions_Fragment = graphql(/* GraphQL */ `
   }
 `);
 
-const EmployeeProfileNextRole_Fragment = graphql(/* GraphQL */ `
+export const EmployeeProfileNextRole_Fragment = graphql(/* GraphQL */ `
   fragment EmployeeProfileNextRole on EmployeeProfile {
     nextRoleClassification {
       id

--- a/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
@@ -21,11 +21,7 @@ import {
   TargetRole,
 } from "@gc-digital-talent/graphql";
 import { useAuthorization } from "@gc-digital-talent/auth";
-import {
-  notEmpty,
-  UnauthorizedError,
-  unpackMaybes,
-} from "@gc-digital-talent/helpers";
+import { UnauthorizedError, unpackMaybes } from "@gc-digital-talent/helpers";
 import { toast } from "@gc-digital-talent/toast";
 import {
   Checklist,

--- a/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
@@ -458,7 +458,7 @@ const NextRoleSection = ({
                         aria-describedby={classificationDescriptionId}
                       />
                     </div>
-                    {notEmpty(watchClassificationGroup) && (
+                    {watchClassificationGroup ? (
                       <div style={{ width: "100%" }}>
                         <Select
                           id="classificationLevel"
@@ -474,7 +474,7 @@ const NextRoleSection = ({
                           disabled={fetching}
                         />
                       </div>
-                    )}
+                    ) : null}
                   </div>
                 </div>
                 <RadioGroup

--- a/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
@@ -1,0 +1,540 @@
+import { useIntl } from "react-intl";
+import { FormProvider, useForm, useFormContext } from "react-hook-form";
+import QuestionMarkCircleIcon from "@heroicons/react/24/outline/QuestionMarkCircleIcon";
+import { useMutation } from "urql";
+import { ComponentProps } from "react";
+
+import { Button, ToggleSection, Well } from "@gc-digital-talent/ui";
+import {
+  commonMessages,
+  errorMessages,
+  formMessages,
+  getLocale,
+  Locales,
+  uiMessages,
+} from "@gc-digital-talent/i18n";
+import {
+  graphql,
+  FragmentType,
+  getFragment,
+  EmployeeProfile,
+  TargetRole,
+} from "@gc-digital-talent/graphql";
+import { useAuthorization } from "@gc-digital-talent/auth";
+import {
+  notEmpty,
+  UnauthorizedError,
+  unpackMaybes,
+} from "@gc-digital-talent/helpers";
+import { toast } from "@gc-digital-talent/toast";
+import {
+  Checklist,
+  Combobox,
+  Input,
+  localizedEnumToOptions,
+  RadioGroup,
+  Select,
+  Submit,
+  TextArea,
+} from "@gc-digital-talent/forms";
+
+import { hasAllEmptyFields } from "~/validators/employeeProfile/nextRole";
+import useToggleSectionInfo from "~/hooks/useToggleSectionInfo";
+import ToggleForm from "~/components/ToggleForm/ToggleForm";
+import employeeProfileMessages from "~/messages/employeeProfileMessages";
+import {
+  getGroupOptions,
+  getLevelOptions,
+} from "~/components/Profile/components/GovernmentInformation/utils";
+import { FRENCH_WORDS_PER_ENGLISH_WORD } from "~/constants/talentSearchConstants";
+
+import Display from "./Display";
+
+const EmployeeProfileNextRoleOptions_Fragment = graphql(/* GraphQL */ `
+  fragment EmployeeProfileNextRoleOptions on Query {
+    classifications {
+      id
+      group
+      level
+    }
+    targetRoles: localizedEnumStrings(enumName: "TargetRole") {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    communities {
+      id
+      name {
+        localized
+      }
+      workStreams {
+        id
+        name {
+          localized
+        }
+      }
+    }
+    departments {
+      id
+      name {
+        localized
+      }
+    }
+  }
+`);
+
+const EmployeeProfileNextRole_Fragment = graphql(/* GraphQL */ `
+  fragment EmployeeProfileNextRole on EmployeeProfile {
+    nextRoleClassification {
+      id
+      group
+      level
+    }
+    nextRoleTargetRole {
+      value
+      label {
+        localized
+      }
+    }
+    nextRoleJobTitle
+    nextRoleCommunity {
+      id
+      key
+      name {
+        localized
+      }
+    }
+    nextRoleWorkStreams {
+      id
+      name {
+        localized
+      }
+    }
+    nextRoleDepartments {
+      id
+      departmentNumber
+      name {
+        localized
+      }
+    }
+    nextRoleAdditionalInformation
+  }
+`);
+
+const UpdateEmployeeProfile_Mutation = graphql(/* GraphQL */ `
+  mutation UpdateEmployeeProfile(
+    $id: UUID!
+    $employeeProfile: UpdateEmployeeProfileInput!
+  ) {
+    updateEmployeeProfile(id: $id, employeeProfile: $employeeProfile) {
+      aboutYou
+      careerGoals
+      learningGoals
+      workStyle
+    }
+  }
+`);
+
+interface FormValues {
+  classificationGroup: string | null | undefined;
+  classificationLevel: string | null | undefined;
+  targetRole: string | null | undefined;
+  jobTitle: string | null | undefined;
+  communityId: string | null | undefined;
+  workStreamIds: string[] | null | undefined;
+  departments: string[] | null | undefined;
+  additionalInformation: string | null | undefined;
+}
+
+interface NextRoleSectionProps {
+  employeeProfileQuery: FragmentType<typeof EmployeeProfileNextRole_Fragment>;
+  optionsQuery: FragmentType<typeof EmployeeProfileNextRoleOptions_Fragment>;
+}
+
+const TEXT_AREA_MAX_WORDS_EN = 300;
+
+const wordCountLimits: Record<Locales, number> = {
+  en: TEXT_AREA_MAX_WORDS_EN,
+  fr: Math.round(TEXT_AREA_MAX_WORDS_EN * FRENCH_WORDS_PER_ENGLISH_WORD),
+} as const;
+
+const NextRoleSection = ({
+  employeeProfileQuery,
+  optionsQuery,
+}: NextRoleSectionProps) => {
+  const intl = useIntl();
+  const locale = getLocale(intl);
+  const { userAuthInfo } = useAuthorization();
+  const [{ fetching }, executeMutation] = useMutation(
+    UpdateEmployeeProfile_Mutation,
+  );
+
+  const employeeProfile = getFragment(
+    EmployeeProfileNextRole_Fragment,
+    employeeProfileQuery,
+  );
+  const options = getFragment(
+    EmployeeProfileNextRoleOptions_Fragment,
+    optionsQuery,
+  );
+  const isNull = hasAllEmptyFields(employeeProfile);
+  const { isEditing, setIsEditing, icon } = useToggleSectionInfo({
+    isNull,
+    emptyRequired: false,
+    fallbackIcon: QuestionMarkCircleIcon,
+    optional: true,
+  });
+
+  const handleError = () => {
+    toast.error(
+      intl.formatMessage({
+        defaultMessage: "Failed updating next role information",
+        id: "GndGRz",
+        description:
+          "Message displayed when a user fails to updates employee profile information",
+      }),
+    );
+  };
+
+  const dataToFormValues = (initialData: EmployeeProfile): FormValues => ({
+    classificationGroup: initialData.nextRoleClassification?.group,
+    classificationLevel: initialData.nextRoleClassification?.level.toString(),
+    targetRole: initialData.nextRoleTargetRole?.value,
+    jobTitle: initialData.nextRoleJobTitle,
+    communityId: initialData.nextRoleCommunity?.id,
+    workStreamIds: initialData.nextRoleWorkStreams?.map(
+      (workStream) => workStream.id,
+    ),
+    departments: initialData.nextRoleDepartments?.map(
+      (department) => department.id,
+    ),
+    additionalInformation: initialData.nextRoleAdditionalInformation,
+  });
+
+  const methods = useForm<FormValues>({
+    defaultValues: dataToFormValues(employeeProfile),
+  });
+
+  // hooks to watch, needed for conditional rendering
+  const [watchClassificationGroup, watchCommunityId] = methods.watch([
+    "classificationGroup",
+    "communityId",
+  ]);
+
+  const { handleSubmit } = methods;
+
+  const handleSave = async ({
+    classificationGroup,
+    classificationLevel,
+    targetRole,
+    jobTitle,
+    community,
+    workStreams,
+    departments,
+    additionalInformation,
+  }: FormValues) => {
+    if (!userAuthInfo?.id) {
+      throw new UnauthorizedError();
+    }
+
+    // return executeMutation({
+    //   id: userAuthInfo?.id,
+    //   employeeProfile: {
+    //     aboutYou,
+    //     careerGoals,
+    //     learningGoals,
+    //     workStyle,
+    //   },
+    // })
+    //   .then((result) => {
+    //     if (result.data?.updateEmployeeProfile) {
+    //       toast.success(
+    //         intl.formatMessage({
+    //           defaultMessage:
+    //             "Goals and work style information updated successfully!",
+    //           id: "voMSDe",
+    //           description:
+    //             "Message displayed when a user successfully updates employee profile information",
+    //         }),
+    //       );
+    //       setIsEditing(false);
+    //       methods.reset(
+    //         {
+    //           aboutYou,
+    //           careerGoals,
+    //           learningGoals,
+    //           workStyle,
+    //         },
+    //         { keepDirty: true },
+    //       );
+    //     } else {
+    //       handleError();
+    //     }
+    //   })
+    //   .catch(handleError);
+  };
+
+  const subtitle = intl.formatMessage({
+    defaultMessage:
+      "Tell us about the next role you see yourself in. Sharing your preferences for your next job can help HR staff find the right position for you.",
+    id: "IO+qSg",
+    description: "Describes the next role section of employee profile",
+  });
+
+  const groupOptions = getGroupOptions(
+    unpackMaybes(options.classifications),
+    intl,
+  );
+  const levelOptions = getLevelOptions(
+    unpackMaybes(options.classifications),
+    watchClassificationGroup ?? undefined,
+  ).sort((a, b) => a.value - b.value);
+  const communityOptions: ComponentProps<typeof Select>["options"] =
+    unpackMaybes(options.communities).map((community) => ({
+      value: community.id,
+      label:
+        community.name?.localized ??
+        intl.formatMessage(commonMessages.notProvided),
+    }));
+  const workStreamOptions: ComponentProps<typeof Checklist>["items"] =
+    options.communities
+      .find((community) => community?.id === watchCommunityId)
+      ?.workStreams?.map((workStream) => ({
+        value: workStream.id,
+        label:
+          workStream.name?.localized ??
+          intl.formatMessage(commonMessages.notProvided),
+      })) ?? [];
+  workStreamOptions.sort((a, b) =>
+    (a.label?.toString() ?? "").localeCompare(b.label?.toString() ?? ""),
+  );
+  const departmentOptions: ComponentProps<typeof Combobox>["options"] =
+    unpackMaybes(options.departments)?.map((department) => ({
+      value: department.id,
+      label:
+        department.name?.localized ??
+        intl.formatMessage(commonMessages.notProvided),
+    })) ?? [];
+  departmentOptions.sort((a, b) =>
+    (a.label?.toString() ?? "").localeCompare(b.label?.toString() ?? ""),
+  );
+
+  return (
+    <ToggleSection.Root
+      id="goals-work-style-form"
+      open={isEditing}
+      onOpenChange={setIsEditing}
+    >
+      <ToggleSection.Header
+        Icon={icon.icon}
+        color={icon.color}
+        level="h3"
+        size="h4"
+        toggle={
+          <ToggleForm.LabelledTrigger
+            sectionTitle={intl.formatMessage({
+              defaultMessage: "Your next role",
+              id: "m6eIBH",
+              description: "Title for the next role section",
+            })}
+          />
+        }
+        data-h2-font-weight="base(bold)"
+      >
+        {intl.formatMessage({
+          defaultMessage: "Your next role",
+          id: "m6eIBH",
+          description: "Title for the next role section",
+        })}
+      </ToggleSection.Header>
+      <p>{subtitle}</p>
+      <ToggleSection.Content>
+        <ToggleSection.InitialContent>
+          {isNull ? (
+            <ToggleForm.NullDisplay />
+          ) : (
+            <Display employeeProfile={employeeProfile} />
+          )}
+        </ToggleSection.InitialContent>
+        <ToggleSection.OpenContent>
+          <FormProvider {...methods}>
+            <form onSubmit={handleSubmit(handleSave)}>
+              <div
+                data-h2-display="base(flex)"
+                data-h2-flex-direction="base(column)"
+                data-h2-gap="base(x1)"
+              >
+                <>
+                  <p>
+                    {intl.formatMessage(
+                      employeeProfileMessages.targetClassification,
+                    )}
+                  </p>
+                  <div
+                    data-h2-display="base(flex)"
+                    data-h2-flex-direction="base(column) p-tablet(row)"
+                  >
+                    <div
+                      data-h2-padding="p-tablet(0, x2, 0, 0)"
+                      data-h2-width="base(100%)"
+                    >
+                      <Select
+                        id="classificationGroup"
+                        label={intl.formatMessage({
+                          defaultMessage: "Group",
+                          id: "hgxH8y",
+                          description:
+                            "Label displayed for the classification form group field.",
+                        })}
+                        name="classificationGroup"
+                        nullSelection={intl.formatMessage(
+                          uiMessages.nullSelectionOptionGroup,
+                        )}
+                        rules={{
+                          required: intl.formatMessage(errorMessages.required),
+                        }}
+                        options={groupOptions}
+                      />
+                    </div>
+                    {notEmpty(watchClassificationGroup) && (
+                      <div style={{ width: "100%" }}>
+                        <Select
+                          id="classificationLevel"
+                          label={intl.formatMessage({
+                            defaultMessage: "Level",
+                            id: "yZqUAU",
+                            description:
+                              "Title displayed for the Classification table Level column.",
+                          })}
+                          name="classificationLevel"
+                          rules={{
+                            required: intl.formatMessage(
+                              errorMessages.required,
+                            ),
+                          }}
+                          nullSelection={intl.formatMessage(
+                            uiMessages.nullSelectionOptionLevel,
+                          )}
+                          options={levelOptions}
+                          doNotSort
+                        />
+                      </div>
+                    )}
+                  </div>
+                </>
+                <RadioGroup
+                  idPrefix="targetRole"
+                  name="targetRole"
+                  legend={intl.formatMessage(
+                    employeeProfileMessages.targetRole,
+                  )}
+                  items={localizedEnumToOptions(options?.targetRoles, intl, [
+                    TargetRole.IndividualContributor,
+                    TargetRole.Manager,
+                    TargetRole.Director,
+                    TargetRole.DirectorGeneral,
+                    TargetRole.ExecutiveDirector,
+                    TargetRole.AssistantDeputyMinister,
+                    TargetRole.DeputyMinister,
+                    TargetRole.Other,
+                  ])}
+                  rules={{
+                    required: intl.formatMessage(errorMessages.required),
+                  }}
+                />
+                <Input
+                  id="jobTitle"
+                  type="text"
+                  label={intl.formatMessage(employeeProfileMessages.jobTitle)}
+                  name="jobTitle"
+                />
+                <Select
+                  id="communityId"
+                  name="communityId"
+                  label={intl.formatMessage(employeeProfileMessages.community)}
+                  nullSelection={intl.formatMessage(
+                    uiMessages.nullSelectionOption,
+                  )}
+                  options={communityOptions}
+                  rules={{
+                    required: intl.formatMessage(errorMessages.required),
+                  }}
+                />
+                {watchCommunityId ? (
+                  // Only show work streams if a community has been selected
+                  <>
+                    {workStreamOptions.length ? (
+                      <Checklist
+                        idPrefix="workStreamIds"
+                        name="workStreamIds"
+                        legend={intl.formatMessage(
+                          employeeProfileMessages.workStreams,
+                        )}
+                        items={workStreamOptions}
+                        rules={{
+                          required: intl.formatMessage(errorMessages.required),
+                        }}
+                      />
+                    ) : // no work streams
+                    null}
+                  </>
+                ) : (
+                  // no community selected
+                  <Well data-h2-text-align="base(center)">
+                    {intl.formatMessage({
+                      defaultMessage:
+                        "Please select a functional community to continue.",
+                      id: "sZhjI3",
+                      description:
+                        "Message displayed when no functional community is selected",
+                    })}
+                  </Well>
+                )}
+                <Combobox
+                  id="departments"
+                  name="departments"
+                  isMulti
+                  label={intl.formatMessage(
+                    employeeProfileMessages.departments,
+                  )}
+                  options={departmentOptions}
+                />
+                <TextArea
+                  id="additionalInformation"
+                  label={intl.formatMessage(
+                    employeeProfileMessages.additionalInformationNextRole,
+                  )}
+                  name="additionalInformation"
+                  wordLimit={wordCountLimits[locale]}
+                />
+                <div
+                  data-h2-display="base(flex)"
+                  data-h2-gap="base(x.5)"
+                  data-h2-align-items="base(center)"
+                  data-h2-flex-wrap="base(wrap)"
+                >
+                  <Submit
+                    text={intl.formatMessage(formMessages.saveChanges)}
+                    aria-label={intl.formatMessage(formMessages.saveChanges)}
+                    color="secondary"
+                    mode="solid"
+                    isSubmitting={fetching}
+                  />
+                  <ToggleSection.Close>
+                    <Button mode="inline" type="button" color="quaternary">
+                      {intl.formatMessage(commonMessages.cancel)}
+                    </Button>
+                  </ToggleSection.Close>
+                </div>
+              </div>
+            </form>
+          </FormProvider>
+        </ToggleSection.OpenContent>
+      </ToggleSection.Content>
+    </ToggleSection.Root>
+  );
+};
+
+export default NextRoleSection;

--- a/apps/web/src/pages/EmployeeProfile/messages.ts
+++ b/apps/web/src/pages/EmployeeProfile/messages.ts
@@ -21,9 +21,4 @@ export default defineMessages({
     id: "qZKabV",
     description: "Title for a users goals and work style",
   },
-  additionalInformationNextRole: {
-    defaultMessage: "Additional information about your next role",
-    id: "Vc44L9",
-    description: "Additional information about your next role",
-  },
 });

--- a/apps/web/src/pages/EmployeeProfile/messages.ts
+++ b/apps/web/src/pages/EmployeeProfile/messages.ts
@@ -6,10 +6,24 @@ export default defineMessages({
     id: "okKbgd",
     description: "Title for a users career development preferences",
   },
-
+  yourNextRole: {
+    defaultMessage: "Your next role",
+    id: "UCt8ym",
+    description: "Title for a users next role",
+  },
+  careerObjective: {
+    defaultMessage: "Your career objective",
+    id: "AH5WDT",
+    description: "Title for a users career objective",
+  },
   goalsWorkStyle: {
     defaultMessage: "Goals and work style",
     id: "qZKabV",
     description: "Title for a users goals and work style",
+  },
+  additionalInformationNextRole: {
+    defaultMessage: "Additional information about your next role",
+    id: "Vc44L9",
+    description: "Additional information about your next role",
   },
 });

--- a/apps/web/src/pages/EmployeeProfile/messages.ts
+++ b/apps/web/src/pages/EmployeeProfile/messages.ts
@@ -6,11 +6,7 @@ export default defineMessages({
     id: "okKbgd",
     description: "Title for a users career development preferences",
   },
-  dreamRole: {
-    defaultMessage: "Dream role",
-    id: "f1reMg",
-    description: "Title for a users dream role information",
-  },
+
   goalsWorkStyle: {
     defaultMessage: "Goals and work style",
     id: "qZKabV",

--- a/apps/web/src/validators/employeeProfile/careerObjective.ts
+++ b/apps/web/src/validators/employeeProfile/careerObjective.ts
@@ -1,15 +1,6 @@
 import { EmployeeProfile } from "@gc-digital-talent/graphql";
 
-export function hasAllEmptyFields({
-  careerObjectiveClassification,
-  careerObjectiveTargetRole,
-  careerObjectiveTargetRoleOther,
-  careerObjectiveJobTitle,
-  careerObjectiveCommunity,
-  careerObjectiveWorkStreams,
-  careerObjectiveDepartments,
-  careerObjectiveAdditionalInformation,
-}: Pick<
+type EmployeeProfileCareerObjectiveFragment = Pick<
   EmployeeProfile,
   | "careerObjectiveClassification"
   | "careerObjectiveTargetRole"
@@ -19,15 +10,26 @@ export function hasAllEmptyFields({
   | "careerObjectiveWorkStreams"
   | "careerObjectiveDepartments"
   | "careerObjectiveAdditionalInformation"
->): boolean {
+>;
+
+export function hasAllEmptyFields({
+  careerObjectiveClassification,
+  careerObjectiveTargetRole,
+  careerObjectiveTargetRoleOther,
+  careerObjectiveJobTitle,
+  careerObjectiveCommunity,
+  careerObjectiveWorkStreams,
+  careerObjectiveDepartments,
+  careerObjectiveAdditionalInformation,
+}: EmployeeProfileCareerObjectiveFragment): boolean {
   return (
     !careerObjectiveClassification &&
     !careerObjectiveTargetRole &&
     !careerObjectiveTargetRoleOther &&
     !careerObjectiveJobTitle &&
     !careerObjectiveCommunity &&
-    !careerObjectiveWorkStreams &&
-    !careerObjectiveDepartments &&
+    !(careerObjectiveWorkStreams?.length ?? 0 > 0) &&
+    !(careerObjectiveDepartments?.length ?? 0 > 0) &&
     !careerObjectiveAdditionalInformation
   );
 }
@@ -40,23 +42,21 @@ export function hasAnyEmptyFields({
   careerObjectiveWorkStreams,
   careerObjectiveDepartments,
   careerObjectiveAdditionalInformation,
-}: Pick<
-  EmployeeProfile,
-  | "careerObjectiveClassification"
-  | "careerObjectiveTargetRole"
-  | "careerObjectiveJobTitle"
-  | "careerObjectiveCommunity"
-  | "careerObjectiveWorkStreams"
-  | "careerObjectiveDepartments"
-  | "careerObjectiveAdditionalInformation"
->): boolean {
+}: EmployeeProfileCareerObjectiveFragment): boolean {
   return (
     !careerObjectiveClassification ||
     !careerObjectiveTargetRole ||
     !careerObjectiveJobTitle ||
     !careerObjectiveCommunity ||
-    !careerObjectiveWorkStreams ||
-    !careerObjectiveDepartments ||
+    !(careerObjectiveWorkStreams?.length ?? 0 > 0) ||
+    !(careerObjectiveDepartments?.length ?? 0 > 0) ||
     !careerObjectiveAdditionalInformation
   );
+}
+
+export function hasEmptyRequiredFields(
+  _: EmployeeProfileCareerObjectiveFragment,
+): boolean {
+  // no required fields
+  return false;
 }

--- a/apps/web/src/validators/employeeProfile/careerObjective.ts
+++ b/apps/web/src/validators/employeeProfile/careerObjective.ts
@@ -3,6 +3,7 @@ import { EmployeeProfile } from "@gc-digital-talent/graphql";
 export function hasAllEmptyFields({
   careerObjectiveClassification,
   careerObjectiveTargetRole,
+  careerObjectiveTargetRoleOther,
   careerObjectiveJobTitle,
   careerObjectiveCommunity,
   careerObjectiveWorkStreams,
@@ -12,6 +13,7 @@ export function hasAllEmptyFields({
   EmployeeProfile,
   | "careerObjectiveClassification"
   | "careerObjectiveTargetRole"
+  | "careerObjectiveTargetRoleOther"
   | "careerObjectiveJobTitle"
   | "careerObjectiveCommunity"
   | "careerObjectiveWorkStreams"
@@ -21,6 +23,7 @@ export function hasAllEmptyFields({
   return (
     !careerObjectiveClassification &&
     !careerObjectiveTargetRole &&
+    !careerObjectiveTargetRoleOther &&
     !careerObjectiveJobTitle &&
     !careerObjectiveCommunity &&
     !careerObjectiveWorkStreams &&

--- a/apps/web/src/validators/employeeProfile/careerObjective.ts
+++ b/apps/web/src/validators/employeeProfile/careerObjective.ts
@@ -1,0 +1,59 @@
+import { EmployeeProfile } from "@gc-digital-talent/graphql";
+
+export function hasAllEmptyFields({
+  careerObjectiveClassification,
+  careerObjectiveTargetRole,
+  careerObjectiveJobTitle,
+  careerObjectiveCommunity,
+  careerObjectiveWorkStreams,
+  careerObjectiveDepartments,
+  careerObjectiveAdditionalInformation,
+}: Pick<
+  EmployeeProfile,
+  | "careerObjectiveClassification"
+  | "careerObjectiveTargetRole"
+  | "careerObjectiveJobTitle"
+  | "careerObjectiveCommunity"
+  | "careerObjectiveWorkStreams"
+  | "careerObjectiveDepartments"
+  | "careerObjectiveAdditionalInformation"
+>): boolean {
+  return (
+    !careerObjectiveClassification &&
+    !careerObjectiveTargetRole &&
+    !careerObjectiveJobTitle &&
+    !careerObjectiveCommunity &&
+    !careerObjectiveWorkStreams &&
+    !careerObjectiveDepartments &&
+    !careerObjectiveAdditionalInformation
+  );
+}
+
+export function hasAnyEmptyFields({
+  careerObjectiveClassification,
+  careerObjectiveTargetRole,
+  careerObjectiveJobTitle,
+  careerObjectiveCommunity,
+  careerObjectiveWorkStreams,
+  careerObjectiveDepartments,
+  careerObjectiveAdditionalInformation,
+}: Pick<
+  EmployeeProfile,
+  | "careerObjectiveClassification"
+  | "careerObjectiveTargetRole"
+  | "careerObjectiveJobTitle"
+  | "careerObjectiveCommunity"
+  | "careerObjectiveWorkStreams"
+  | "careerObjectiveDepartments"
+  | "careerObjectiveAdditionalInformation"
+>): boolean {
+  return (
+    !careerObjectiveClassification ||
+    !careerObjectiveTargetRole ||
+    !careerObjectiveJobTitle ||
+    !careerObjectiveCommunity ||
+    !careerObjectiveWorkStreams ||
+    !careerObjectiveDepartments ||
+    !careerObjectiveAdditionalInformation
+  );
+}

--- a/apps/web/src/validators/employeeProfile/careerObjective.ts
+++ b/apps/web/src/validators/employeeProfile/careerObjective.ts
@@ -48,7 +48,8 @@ export function hasAnyEmptyFields({
     !careerObjectiveTargetRole ||
     !careerObjectiveJobTitle ||
     !careerObjectiveCommunity ||
-    !(careerObjectiveWorkStreams?.length ?? 0 > 0) ||
+    ((careerObjectiveCommunity.workStreams?.length ?? 0 > 0) &&
+      !(careerObjectiveWorkStreams?.length ?? 0 > 0)) ||
     !(careerObjectiveDepartments?.length ?? 0 > 0) ||
     !careerObjectiveAdditionalInformation
   );

--- a/apps/web/src/validators/employeeProfile/nextRole.ts
+++ b/apps/web/src/validators/employeeProfile/nextRole.ts
@@ -3,6 +3,7 @@ import { EmployeeProfile } from "@gc-digital-talent/graphql";
 export function hasAllEmptyFields({
   nextRoleClassification,
   nextRoleTargetRole,
+  nextRoleTargetRoleOther,
   nextRoleJobTitle,
   nextRoleCommunity,
   nextRoleWorkStreams,
@@ -12,6 +13,7 @@ export function hasAllEmptyFields({
   EmployeeProfile,
   | "nextRoleClassification"
   | "nextRoleTargetRole"
+  | "nextRoleTargetRoleOther"
   | "nextRoleJobTitle"
   | "nextRoleCommunity"
   | "nextRoleWorkStreams"
@@ -21,6 +23,7 @@ export function hasAllEmptyFields({
   return (
     !nextRoleClassification &&
     !nextRoleTargetRole &&
+    !nextRoleTargetRoleOther &&
     !nextRoleJobTitle &&
     !nextRoleCommunity &&
     !nextRoleWorkStreams &&

--- a/apps/web/src/validators/employeeProfile/nextRole.ts
+++ b/apps/web/src/validators/employeeProfile/nextRole.ts
@@ -1,15 +1,6 @@
 import { EmployeeProfile } from "@gc-digital-talent/graphql";
 
-export function hasAllEmptyFields({
-  nextRoleClassification,
-  nextRoleTargetRole,
-  nextRoleTargetRoleOther,
-  nextRoleJobTitle,
-  nextRoleCommunity,
-  nextRoleWorkStreams,
-  nextRoleDepartments,
-  nextRoleAdditionalInformation,
-}: Pick<
+type EmployeeProfileNextRoleFragment = Pick<
   EmployeeProfile,
   | "nextRoleClassification"
   | "nextRoleTargetRole"
@@ -19,15 +10,26 @@ export function hasAllEmptyFields({
   | "nextRoleWorkStreams"
   | "nextRoleDepartments"
   | "nextRoleAdditionalInformation"
->): boolean {
+>;
+
+export function hasAllEmptyFields({
+  nextRoleClassification,
+  nextRoleTargetRole,
+  nextRoleTargetRoleOther,
+  nextRoleJobTitle,
+  nextRoleCommunity,
+  nextRoleWorkStreams,
+  nextRoleDepartments,
+  nextRoleAdditionalInformation,
+}: EmployeeProfileNextRoleFragment): boolean {
   return (
     !nextRoleClassification &&
     !nextRoleTargetRole &&
     !nextRoleTargetRoleOther &&
     !nextRoleJobTitle &&
     !nextRoleCommunity &&
-    !nextRoleWorkStreams &&
-    !nextRoleDepartments &&
+    !(nextRoleWorkStreams?.length ?? 0 > 0) &&
+    !(nextRoleDepartments?.length ?? 0 > 0) &&
     !nextRoleAdditionalInformation
   );
 }
@@ -40,23 +42,21 @@ export function hasAnyEmptyFields({
   nextRoleWorkStreams,
   nextRoleDepartments,
   nextRoleAdditionalInformation,
-}: Pick<
-  EmployeeProfile,
-  | "nextRoleClassification"
-  | "nextRoleTargetRole"
-  | "nextRoleJobTitle"
-  | "nextRoleCommunity"
-  | "nextRoleWorkStreams"
-  | "nextRoleDepartments"
-  | "nextRoleAdditionalInformation"
->): boolean {
+}: EmployeeProfileNextRoleFragment): boolean {
   return (
     !nextRoleClassification ||
     !nextRoleTargetRole ||
     !nextRoleJobTitle ||
     !nextRoleCommunity ||
-    !nextRoleWorkStreams ||
-    !nextRoleDepartments ||
+    !(nextRoleWorkStreams?.length ?? 0 > 0) ||
+    !(nextRoleDepartments?.length ?? 0 > 0) ||
     !nextRoleAdditionalInformation
   );
+}
+
+export function hasEmptyRequiredFields(
+  _: EmployeeProfileNextRoleFragment,
+): boolean {
+  // no required fields
+  return false;
 }

--- a/apps/web/src/validators/employeeProfile/nextRole.ts
+++ b/apps/web/src/validators/employeeProfile/nextRole.ts
@@ -48,7 +48,8 @@ export function hasAnyEmptyFields({
     !nextRoleTargetRole ||
     !nextRoleJobTitle ||
     !nextRoleCommunity ||
-    !(nextRoleWorkStreams?.length ?? 0 > 0) ||
+    ((nextRoleCommunity.workStreams?.length ?? 0 > 0) &&
+      !(nextRoleWorkStreams?.length ?? 0 > 0)) ||
     !(nextRoleDepartments?.length ?? 0 > 0) ||
     !nextRoleAdditionalInformation
   );

--- a/apps/web/src/validators/employeeProfile/nextRole.ts
+++ b/apps/web/src/validators/employeeProfile/nextRole.ts
@@ -1,0 +1,59 @@
+import { EmployeeProfile } from "@gc-digital-talent/graphql";
+
+export function hasAllEmptyFields({
+  nextRoleClassification,
+  nextRoleTargetRole,
+  nextRoleJobTitle,
+  nextRoleCommunity,
+  nextRoleWorkStreams,
+  nextRoleDepartments,
+  nextRoleAdditionalInformation,
+}: Pick<
+  EmployeeProfile,
+  | "nextRoleClassification"
+  | "nextRoleTargetRole"
+  | "nextRoleJobTitle"
+  | "nextRoleCommunity"
+  | "nextRoleWorkStreams"
+  | "nextRoleDepartments"
+  | "nextRoleAdditionalInformation"
+>): boolean {
+  return (
+    !nextRoleClassification &&
+    !nextRoleTargetRole &&
+    !nextRoleJobTitle &&
+    !nextRoleCommunity &&
+    !nextRoleWorkStreams &&
+    !nextRoleDepartments &&
+    !nextRoleAdditionalInformation
+  );
+}
+
+export function hasAnyEmptyFields({
+  nextRoleClassification,
+  nextRoleTargetRole,
+  nextRoleJobTitle,
+  nextRoleCommunity,
+  nextRoleWorkStreams,
+  nextRoleDepartments,
+  nextRoleAdditionalInformation,
+}: Pick<
+  EmployeeProfile,
+  | "nextRoleClassification"
+  | "nextRoleTargetRole"
+  | "nextRoleJobTitle"
+  | "nextRoleCommunity"
+  | "nextRoleWorkStreams"
+  | "nextRoleDepartments"
+  | "nextRoleAdditionalInformation"
+>): boolean {
+  return (
+    !nextRoleClassification ||
+    !nextRoleTargetRole ||
+    !nextRoleJobTitle ||
+    !nextRoleCommunity ||
+    !nextRoleWorkStreams ||
+    !nextRoleDepartments ||
+    !nextRoleAdditionalInformation
+  );
+}


### PR DESCRIPTION
🤖 Resolves #12012 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Adds the frontend UI for the "Next Role" and "Career Objective" sections.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->


1. Log in as 'applicant-employee@test.com'
2. Navigate to /applicant/employee-profile
3. Test updating fields in the Next Role and Career Objective sections.


## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
![image](https://github.com/user-attachments/assets/94ff4ac7-65e4-4512-8fdc-b8ef9708b316)


## 🚚 Deployment

<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the PR if deployment steps are needed

 -->
