### PR TITLE
[Debt] Move verified gov employee to backend

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -429,7 +429,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
     protected function isVerifiedGovEmployee(): Attribute
     {
         return Attribute::make(
-            get: fn (mixed $value, array $attributes) => $attributes['computed_is_gov_employee'] && !is_null($attributes['work_email']) && !is_null($attributes['work_email_verified_at']),
+            get: fn (mixed $value, array $attributes) => $attributes['computed_is_gov_employee'] && ! is_null($attributes['work_email']) && ! is_null($attributes['work_email_verified_at']),
         );
     }
 

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -19,6 +19,7 @@ use Illuminate\Auth\Authenticatable as AuthenticatableTrait;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -65,6 +66,7 @@ use Staudenmeir\EloquentHasManyDeep\HasRelationships;
  * @property ?string $verbal_level
  * @property ?string $estimated_language_ability
  * @property ?bool $computed_is_gov_employee
+ * @property bool $isVerifiedGovEmployee
  * @property ?string $work_email
  * @property ?\Illuminate\Support\Carbon $work_email_verified_at
  * @property ?bool $has_priority_entitlement
@@ -422,6 +424,13 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
         }
 
         return $preferences;
+    }
+
+    protected function isVerifiedGovEmployee(): Attribute
+    {
+        return Attribute::make(
+            get: fn (mixed $value, array $attributes) => $attributes['computed_is_gov_employee'] && !is_null($attributes['work_email']) && !is_null($attributes['work_email_verified_at']),
+        );
     }
 
     // getIsProfileCompleteAttribute function is correspondent to isProfileComplete attribute in graphql schema

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -84,6 +84,7 @@ type User {
 
   # Gov info
   isGovEmployee: Boolean @rename(attribute: "computed_is_gov_employee")
+  isVerifiedGovEmployee: Boolean
   workEmail: Email @rename(attribute: "work_email")
   isWorkEmailVerified: Boolean
   govEmployeeType: LocalizedGovEmployeeType

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -613,6 +613,7 @@ type User {
   verbalLevel: LocalizedEvaluatedLanguageAbility
   estimatedLanguageAbility: LocalizedEstimatedLanguageAbility
   isGovEmployee: Boolean
+  isVerifiedGovEmployee: Boolean
   workEmail: Email
   isWorkEmailVerified: Boolean
   govEmployeeType: LocalizedGovEmployeeType

--- a/api/tests/Feature/UserTest.php
+++ b/api/tests/Feature/UserTest.php
@@ -2527,4 +2527,28 @@ class UserTest extends TestCase
                 ],
             ]);
     }
+
+    public function testIsVerifiedGovermentEmployeeAccessor()
+    {
+        $user = User::factory()
+            ->asGovEmployee()
+            ->create();
+
+        $this->assertTrue($user->isVerifiedGovEmployee);
+
+        $user->work_email_verified_at = null;
+        $user->save();
+        $this->assertFalse($user->isVerifiedGovEmployee);
+
+        $user->work_email_verified_at = now();
+        $user->work_email = null;
+        $user->save();
+        $this->assertFalse($user->isVerifiedGovEmployee);
+
+        $user->work_email = 'email@domain.com';
+        $user->computed_is_gov_employee = false;
+        $user->save();
+        $this->assertFalse($user->isVerifiedGovEmployee);
+
+    }
 }

--- a/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.stories.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryFn } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 
 import { fakeUser } from "@gc-digital-talent/fake-data";
 import { makeFragmentData } from "@gc-digital-talent/graphql";
@@ -11,35 +11,49 @@ import {
 
 const mockUser = fakeUser();
 
-export default {
+const meta: Meta<typeof ApplicantDashboardPage> = {
   component: ApplicantDashboardPage,
-} as Meta<typeof ApplicantDashboardPage>;
-
-const Template: StoryFn<typeof ApplicantDashboardPage> = (args) => (
-  <ApplicantDashboardPage {...args} />
-);
-
-export const Default = Template.bind({});
-Default.args = {
-  applicantDashboardQuery: makeFragmentData(
-    {
-      ...{
-        ...mockUser,
-        isGovEmployee: true,
-        workEmail: "user@domain.tld",
-        isWorkEmailVerified: true,
-        employeeProfile: {},
+  parameters: {
+    chromatic: {
+      modes: {
+        light: allModes.light,
+        "light mobile": allModes["light mobile"],
+        dark: allModes.dark,
       },
     },
-    ApplicantDashboardPage_Fragment,
-  ),
+  },
 };
-Default.parameters = {
-  chromatic: {
-    modes: {
-      light: allModes.light,
-      "light mobile": allModes["light mobile"],
-      dark: allModes.dark,
-    },
+
+export default meta;
+
+type Story = StoryObj<typeof ApplicantDashboardPage>;
+
+export const VerifiedGovernmentEmployee: Story = {
+  args: {
+    applicantDashboardQuery: makeFragmentData(
+      {
+        ...{
+          ...mockUser,
+          isVerifiedGovEmployee: true,
+          employeeProfile: {},
+        },
+      },
+      ApplicantDashboardPage_Fragment,
+    ),
+  },
+};
+
+export const NonEmployee: Story = {
+  args: {
+    applicantDashboardQuery: makeFragmentData(
+      {
+        ...{
+          ...mockUser,
+          isVerifiedGovEmployee: false,
+          employeeProfile: {},
+        },
+      },
+      ApplicantDashboardPage_Fragment,
+    ),
   },
 };

--- a/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.tsx
@@ -13,7 +13,6 @@ import SEO from "~/components/SEO/SEO";
 import { getFullNameHtml } from "~/utils/nameUtils";
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import Hero from "~/components/Hero";
-import { isVerifiedGovEmployee } from "~/utils/userUtils";
 import messages from "~/messages/profileMessages";
 import {
   aboutSectionHasEmptyRequiredFields,
@@ -32,8 +31,9 @@ export const ApplicantDashboardPage_Fragment = graphql(/* GraphQL */ `
     firstName
     lastName
     isGovEmployee
-    workEmail
-    isWorkEmailVerified
+    isVerifiedGovEmployee
+    hasPriorityEntitlement
+    priorityNumber
     employeeProfile {
       ...CareerDevelopmentTaskCard
     }
@@ -137,12 +137,6 @@ export const DashboardPage = ({
     applicantDashboardQuery,
   );
 
-  const isVerifiedEmployee = isVerifiedGovEmployee({
-    isGovEmployee: currentUser.isGovEmployee,
-    workEmail: currentUser.workEmail,
-    isWorkEmailVerified: currentUser.isWorkEmailVerified,
-  });
-
   const personalInformationState =
     aboutSectionHasEmptyRequiredFields(currentUser) ||
     governmentInformationSectionHasEmptyRequiredFields(currentUser) ||
@@ -219,7 +213,8 @@ export const DashboardPage = ({
                   currentUser?.poolCandidates,
                 )}
               />
-              {isVerifiedEmployee && currentUser?.employeeProfile ? (
+              {currentUser?.isVerifiedGovEmployee &&
+              currentUser?.employeeProfile ? (
                 <CareerDevelopmentTaskCard
                   careerDevelopmentTaskCardQuery={currentUser.employeeProfile}
                 />
@@ -257,7 +252,7 @@ export const DashboardPage = ({
                       "Helper instructions for an 'Personal information' card",
                   })}
                 />
-                {isVerifiedEmployee ? (
+                {currentUser?.isVerifiedGovEmployee ? (
                   <ResourceBlock.SingleLinkItem
                     state={employeeProfileState}
                     title={intl.formatMessage(

--- a/apps/web/src/pages/EmployeeProfile/EmployeeProfilePage.tsx
+++ b/apps/web/src/pages/EmployeeProfile/EmployeeProfilePage.tsx
@@ -22,7 +22,6 @@ import SEO from "~/components/SEO/SEO";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import useRoutes from "~/hooks/useRoutes";
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
-import { isVerifiedGovEmployee } from "~/utils/userUtils";
 import profileMessages from "~/messages/profileMessages";
 import StatusItem from "~/components/StatusItem/StatusItem";
 import {
@@ -50,9 +49,7 @@ const SECTION_ID = {
 
 const EmployeeProfile_Fragment = graphql(/** GraphQL */ `
   fragment EmployeeProfile on User {
-    isGovEmployee
-    workEmail
-    isWorkEmailVerified
+    isVerifiedGovEmployee
     employeeProfile {
       ...EmployeeProfileGoalsWorkStyle
       ...EmployeeProfileCareerDevelopment
@@ -73,13 +70,7 @@ const EmployeeProfile = ({ employeeProfileQuery }: EmployeeProfileProps) => {
     throw new NotFoundError();
   }
 
-  if (
-    !isVerifiedGovEmployee({
-      isGovEmployee: user.isGovEmployee,
-      workEmail: user.workEmail,
-      isWorkEmailVerified: user.isWorkEmailVerified,
-    })
-  ) {
+  if (!user?.isVerifiedGovEmployee) {
     throw new UnauthorizedError(
       intl.formatMessage({
         defaultMessage: "Not a verified employee",

--- a/apps/web/src/utils/userUtils.ts
+++ b/apps/web/src/utils/userUtils.ts
@@ -145,17 +145,3 @@ export const formatLocation = ({
 
   return intl.formatMessage(commonMessages.notProvided);
 };
-
-interface IsVerifiedGovEmployeeArgs {
-  isGovEmployee?: Maybe<boolean>;
-  workEmail?: Maybe<string>;
-  isWorkEmailVerified?: Maybe<boolean>;
-}
-
-export const isVerifiedGovEmployee = ({
-  isGovEmployee,
-  workEmail,
-  isWorkEmailVerified,
-}: IsVerifiedGovEmployeeArgs): boolean => {
-  return Boolean(isGovEmployee && workEmail && isWorkEmailVerified);
-};


### PR DESCRIPTION
🤖 Resolves #12828 

## 👋 Introduction

Moves the calculation of whether a user us a verified government employee to the backend instead of computing it on the server.

## 🧪 Testing

1. Rebuild `make refresh-api; make seed-fresh; pnpm dev:fresh;`
2. Login as a user who is not a verified government employee
3. Confirm the pages protected by this check cannot be accessed
4. Login as a verified government employee
5. Confirm pages protected by this check can be accessed