### PR TITLE
[Feat] Add work streams to `ExperienceCard`

### DIFF
--- a/apps/web/src/components/ExperienceCard/ExperienceCard.tsx
+++ b/apps/web/src/components/ExperienceCard/ExperienceCard.tsx
@@ -39,6 +39,7 @@ import CommunityContent from "./CommunityContent";
 import EducationContent from "./EducationContent";
 import WorkContent from "./WorkContent";
 import EditLink from "./EditLink";
+import WorkStreamContent from "./WorkContent/WorkStreamsContent";
 
 type EditMode = "link" | "dialog";
 
@@ -347,6 +348,12 @@ const ExperienceCard = ({
               {experience.details ??
                 intl.formatMessage(commonMessages.notAvailable)}
             </ContentSection>
+            {isWorkExperience(experience) && (
+              <WorkStreamContent
+                workStreams={experience.workStreams}
+                headingLevel={headingLevel}
+              />
+            )}
             {showSkills && !singleSkill && (
               <>
                 <Separator space="sm" />

--- a/apps/web/src/components/ExperienceCard/WorkContent/WorkStreamsContent.tsx
+++ b/apps/web/src/components/ExperienceCard/WorkContent/WorkStreamsContent.tsx
@@ -1,0 +1,92 @@
+import { useIntl } from "react-intl";
+
+import { Maybe, WorkStream } from "@gc-digital-talent/graphql";
+import { HeadingRank, Separator } from "@gc-digital-talent/ui";
+import { groupBy, uniqueItems, unpackMaybes } from "@gc-digital-talent/helpers";
+import { commonMessages } from "@gc-digital-talent/i18n";
+
+import BoolCheckIcon from "~/components/BoolCheckIcon/BoolCheckIcon";
+import pageTitles from "~/messages/pageTitles";
+
+import ContentSection from "../ContentSection";
+
+interface WorkStreamsContentProps {
+  workStreams?: Maybe<WorkStream[]>;
+  headingLevel?: HeadingRank;
+}
+
+const WorkStreamContent = ({
+  workStreams,
+  headingLevel = "h3",
+}: WorkStreamsContentProps) => {
+  const intl = useIntl();
+  const na = intl.formatMessage(commonMessages.notAvailable);
+
+  if (!workStreams?.length) {
+    return null;
+  }
+
+  const communities = uniqueItems(
+    workStreams.flatMap((workStream) => workStream.community),
+  );
+
+  const groupedWorkStreams = groupBy(
+    workStreams,
+    (workStream) => workStream?.community?.id ?? "",
+  );
+
+  const workStreamsByCommunity = unpackMaybes(
+    Object.keys(groupedWorkStreams).map((id) => {
+      const community = communities.find((c) => c?.id === id);
+      const streams = groupedWorkStreams[id].sort((a, b) =>
+        (a?.name?.localized ?? "").localeCompare(b?.name?.localized ?? ""),
+      );
+      if (!community || !streams?.length) {
+        return undefined;
+      }
+
+      return {
+        community,
+        workStreams: streams,
+      };
+    }),
+  ).sort((a, b) =>
+    (a?.community?.name?.localized ?? "").localeCompare(
+      b?.community.name?.localized ?? "",
+    ),
+  );
+
+  return workStreamsByCommunity.length > 0 ? (
+    <>
+      <Separator decorative space="sm" />
+      <ContentSection
+        headingLevel={headingLevel}
+        title={intl.formatMessage(pageTitles.workStreams)}
+      >
+        <ul>
+          {workStreamsByCommunity.map((item) => (
+            <li key={item.community.id} data-h2-font-weight="base(bold)">
+              {item.community.name?.localized ?? na}
+              <ul
+                data-h2-list-style="base(none)"
+                data-h2-font-weight="base(400)"
+                data-h2-margin-bottom="base(x.5)"
+                data-h2-padding-left="base(0)"
+              >
+                {item.workStreams.map((workStream) => (
+                  <li key={workStream.id}>
+                    <BoolCheckIcon value={true}>
+                      {workStream.name?.localized ?? na}
+                    </BoolCheckIcon>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      </ContentSection>
+    </>
+  ) : null;
+};
+
+export default WorkStreamContent;

--- a/apps/web/src/pages/Applications/fragment.ts
+++ b/apps/web/src/pages/Applications/fragment.ts
@@ -342,6 +342,7 @@ const Application_PoolCandidateFragment = graphql(/* GraphQL */ `
             }
             community {
               id
+              key
               name {
                 localized
               }
@@ -590,6 +591,20 @@ const Application_PoolCandidateFragment = graphql(/* GraphQL */ `
           name {
             en
             fr
+          }
+        }
+        workStreams {
+          id
+          key
+          name {
+            localized
+          }
+          community {
+            id
+            key
+            name {
+              localized
+            }
           }
         }
       }

--- a/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelineAndRecruitmentPage/components/CareerTimelineAndRecruitment.tsx
@@ -204,6 +204,20 @@ export const CareerTimelineExperience_Fragment = graphql(/* GraphQL */ `
           fr
         }
       }
+      workStreams {
+        id
+        key
+        name {
+          localized
+        }
+        community {
+          id
+          key
+          name {
+            localized
+          }
+        }
+      }
     }
   }
 `);

--- a/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
+++ b/apps/web/src/pages/Users/AdminUserProfilePage/AdminUserProfilePage.tsx
@@ -384,6 +384,20 @@ const AdminUserProfileUser_Fragment = graphql(/* GraphQL */ `
             fr
           }
         }
+        workStreams {
+          id
+          key
+          name {
+            localized
+          }
+          community {
+            id
+            key
+            name {
+              localized
+            }
+          }
+        }
       }
     }
     topTechnicalSkillsRanking {


### PR DESCRIPTION
🤖 Resolves #12827 

## 👋 Introduction

Updates the `ExperienceCard` component to display work streams for `WorkExperience` type.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as any role
3. Create a work experienc with some woprk streams
4. Navigate to the career timeline
5. Confirm the work streams appear on the card under "Addition details"

## 📸 Screenshot

![2025-02-27_16-07](https://github.com/user-attachments/assets/975226fd-97e0-413e-976d-f47e4b81f458)
