### PR TITLE
[Copy] Updates application success alert

### DIFF
--- a/apps/playwright/tests/applicant/application-iap.spec.ts
+++ b/apps/playwright/tests/applicant/application-iap.spec.ts
@@ -253,7 +253,7 @@ test.describe("IAP Application", () => {
     await application.waitForGraphqlResponse("Application");
     await expect(
       application.page.getByRole("heading", {
-        name: /we successfully received your application/i,
+        name: /we've successfully received your application/i,
       }),
     ).toBeVisible();
     await expect(

--- a/apps/playwright/tests/applicant/application.spec.ts
+++ b/apps/playwright/tests/applicant/application.spec.ts
@@ -395,7 +395,7 @@ test.describe("Application", () => {
     await application.waitForGraphqlResponse("Application");
     await expect(
       application.page.getByRole("heading", {
-        name: /we successfully received your application/i,
+        name: /we've successfully received your application/i,
       }),
     ).toBeVisible();
     await expect(

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -375,10 +375,6 @@
     "defaultMessage": "Validité de l’examen",
     "description": "Label for exam validity in language information form"
   },
-  "/uOExm": {
-    "defaultMessage": "Votre numéro de confirmation est le suivant : <strong>{id}</strong>",
-    "description": "An application confirmation number"
-  },
   "/voRGj": {
     "defaultMessage": "Afficher tous<hidden> les filtres avancés</hidden>",
     "description": "Button text to show all advanced filters"
@@ -719,6 +715,10 @@
     "defaultMessage": "Compétences que le candidat aimerait améliorer",
     "description": "Heading for a users skills they would like to improve"
   },
+  "1cCjc/": {
+    "defaultMessage": "Formulaire de consentement et de demande de filtrage de sécurité",
+    "description": "Link text for government of canada security screening application and consent form"
+  },
   "1e84jV": {
     "defaultMessage": "Les visiteurs doivent également savoir que l’information offerte par les sites autres que ceux du gouvernement du Canada, accessibles à l’aide des liens de ce site Web, n’est pas assujettie à la <privacyActLink>Loi sur la protection des renseignements personnels</privacyActLink> ni à la <langActLink>Loi sur les langues officielles</langActLink> et pourrait ne pas être accessible aux personnes handicapées. Il est probable que l’information offerte ne soit disponible que dans les langues employées dans les sites en question. En ce qui a trait aux renseignements personnels, nous invitons les visiteurs à consulter les politiques de ces sites Web non gouvernementaux en matière de protection des renseignements personnels avant de fournir leurs renseignements personnels.",
     "description": "Paragraph two describing linking to gov section"
@@ -846,6 +846,10 @@
   "2Oubfe": {
     "defaultMessage": "Type d'emploi",
     "description": "Label for applicant's employment type"
+  },
+  "2SSm+L": {
+    "defaultMessage": "Nous avons bien reçu votre candidature",
+    "description": "Success message after submission for the application review page."
   },
   "2SnhXV": {
     "defaultMessage": "Marquer comme non lue",
@@ -1783,10 +1787,6 @@
     "defaultMessage": "Apprenez comment fonctionnent les dates limites et ce que les candidates et candidats verront au moment de présenter une demande.",
     "description": "Subtitle for the pool closing date dialog"
   },
-  "79m9jN": {
-    "defaultMessage": "Nous avons bien reçu votre candidature",
-    "description": "Page title for the application success page"
-  },
   "7DUfu+": {
     "defaultMessage": "Statut de citoyenneté",
     "description": "Legend text for citizenship status"
@@ -1898,10 +1898,6 @@
   "7tv7ct": {
     "defaultMessage": "EXposition",
     "description": "Heading for exposition section on the executive homepage"
-  },
-  "7vOa71": {
-    "defaultMessage": "Nous avons bien reçu votre candidature",
-    "description": "Success message after submission for the application review page."
   },
   "7wcfnG": {
     "defaultMessage": "Il y a deux types d'employés du <abbreviation>IT-03</abbreviation> : ceux qui suivent un cheminement en gestion et les contributeurs individuels.",
@@ -2687,6 +2683,10 @@
     "defaultMessage": "Télécharger CSV avec évaluations",
     "description": "Button label for download candidate csv with ROD data."
   },
+  "C2urGD": {
+    "defaultMessage": "Your application ID is: <strong>{id}</strong>",
+    "description": "An application confirmation number"
+  },
   "C3YsFy": {
     "defaultMessage": "Annuler la décision d’évaluation finale",
     "description": "Subtitle for view revert final decision dialog on view pool candidate page"
@@ -3114,6 +3114,10 @@
   "E2nMR3": {
     "defaultMessage": "Partager",
     "description": "Label for sharing a pool advertisement"
+  },
+  "E2uEWk": {
+    "defaultMessage": "Évaluation de langue seconde",
+    "description": "Link text for government of canada second language evaluation"
   },
   "E9I34y": {
     "defaultMessage": "Titre de la thèse",
@@ -4647,10 +4651,6 @@
     "defaultMessage": "Une fois l’apprentissage terminé avec succès, les diplômés reçoivent un certificat numérique ainsi qu’un certificat vérifiable portable. Il est approuvé par le, la dirigeant·e principal·e de l’information du Canada et officiellement reconnu comme répondant à <link>l‘alternative aux exigences d’études de la norme de qualification minimale du GC pour le groupe professionnel IT</link>.",
     "description": "Paragraph 1 of the 'Digital certificate credential' subsection"
   },
-  "M+5+nP": {
-    "defaultMessage": "Exploiter d’autres occasions",
-    "description": "Link text for browse jobs page"
-  },
   "M051tF": {
     "defaultMessage": "Retirer une compétence",
     "description": "Message in skills in details section to remove skill from the experience."
@@ -5754,6 +5754,10 @@
   "Rn5e/i": {
     "defaultMessage": "Groupe et niveau",
     "description": "Title for group and level on summary of filters section"
+  },
+  "Rped43": {
+    "defaultMessage": "Nous avons bien reçu votre candidature",
+    "description": "Page title for the application success page"
   },
   "Rq14QK": {
     "defaultMessage": "Il manque des données requises par le gouvernement",
@@ -9438,10 +9442,6 @@
     "defaultMessage": "Aucun possibilité de formation n'est actuellement affiché. Revenez plus tard.",
     "description": "Null message for instructor led training list"
   },
-  "l5R6Nc": {
-    "defaultMessage": "Veuillez remplir une demande d’habilitation",
-    "description": "Link text for government of canada security clearance forms"
-  },
   "l75mNg": {
     "defaultMessage": "Collectivité des gestionnaires",
     "description": "Title for Managers community"
@@ -9461,10 +9461,6 @@
   "lDnHjr": {
     "defaultMessage": "Vous cherchez à embaucher un·e diplômé·e du programme ou des talents autochtones pour des postes plus élevés dans le domaine des TI? Contactez notre équipe pour discuter des possibilités de placement des diplômés et des références de talents avancés.",
     "description": "Paragraph 1 of the 'Graduates and advanced talent' section"
-  },
-  "lE92J0": {
-    "defaultMessage": "Nous vous contacterons si votre candidature correspond aux critères définis par les occasions d’emploi En attendant, consultez les ressources suivantes pour en savoir sur la suite des événements.",
-    "description": "Description of review process and next steps for the applicant."
   },
   "lFFnfX": {
     "defaultMessage": "Supprimer un élément pour en ajouter un autre ({numOfSkills}/{maxSkills})",
@@ -9573,10 +9569,6 @@
   "luj0xr": {
     "defaultMessage": "Lors d’une étape ultérieure de la procédure de demande, vous aurez peut-être à fournir une preuve que vous êtes une personne autochtone. Certains moyens d’y parvenir sont inclus dans l’énoncé de définition au début de cette demande, notamment une carte de certificat de statut d’Indien, une carte de bénéficiaire inuit, une carte de citoyenneté métisse, une lettre d’un représentant autorisé d’une communauté autochtone reconnue, en plus d’un formulaire d’attestation. Aux fins d’inclusion, l’objet de ces mesures est de garantir que ce programme reste accessible aux peuples autochtones du Canada.",
     "description": "Content for the self-declaration verification dialog"
-  },
-  "lxDgNf": {
-    "defaultMessage": "* Veuillez prendre note que votre numéro de confirmation peut également se trouver dans la section « Suivi de vos candidatures » à partir de votre page de profil et de candidature.",
-    "description": "Note that the application confirmation number is available on the profile and applications page"
   },
   "lyJ0Ft": {
     "defaultMessage": "Ajouter une collectivité",
@@ -11917,10 +11909,6 @@
   "ysKXVP": {
     "defaultMessage": "Groupe de publication",
     "description": "Label for a process' publishing group"
-  },
-  "ytHyUL": {
-    "defaultMessage": "Effectuez la mise à jour de l’information de votre profil",
-    "description": "Link text to users profile to update contact information"
   },
   "ytTGvb": {
     "defaultMessage": "La « clé » est une chaîne qui identifie de manière unique un groupe de compétences. Elle devrait être fondée sur le nom anglais du groupe de compétences et devrait être concise. Un bon exemple serait « information_management ». Elle peut être utilisée dans le code pour faire référence à cette compétence particulière, et ne peut donc pas être modifiée ultérieurement.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5024,7 +5024,7 @@
     "description": "Heading for required technical skills section"
   },
   "OEk0OP": {
-    "defaultMessage": "Identification de la demande",
+    "defaultMessage": "Identifiant de candidature",
     "description": "Label for application ID"
   },
   "OF7SCg": {
@@ -6531,7 +6531,7 @@
     "description": "Heading displayed above the Create Department form."
   },
   "WJSVBr": {
-    "defaultMessage": "Copier l’identification de votre demande {title}",
+    "defaultMessage": "Copier l'identifiant de votre candidature {title}",
     "description": "Button text to copy a specific application ID"
   },
   "WKAzau": {
@@ -8399,7 +8399,7 @@
     "description": "Title for education level on summary of filters section"
   },
   "ftg8sT": {
-    "defaultMessage": "L’identification de votre demande {title} a été copiée",
+    "defaultMessage": "L'identifiant de votre candidature {title} a été copié",
     "description": "Button text to indicate that a specific application’s ID has been copied"
   },
   "fvsYkj": {
@@ -8499,7 +8499,7 @@
     "description": "Title for description in English."
   },
   "gBAz/G": {
-    "defaultMessage": "Identification de la demande copiée",
+    "defaultMessage": "Identifiant de candidature copié",
     "description": "Button text to indicate that a specific application’s ID has been copied"
   },
   "gChYmW": {
@@ -10715,7 +10715,7 @@
     "description": "Message displayed to pool after pool fails to get created."
   },
   "rvoNoQ": {
-    "defaultMessage": "Copier l’identification de la demande",
+    "defaultMessage": "Copier l'identifiant de candidature",
     "description": "Button text to copy a specific application ID"
   },
   "rxDfeN": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2684,7 +2684,7 @@
     "description": "Button label for download candidate csv with ROD data."
   },
   "C2urGD": {
-    "defaultMessage": "Your application ID is: <strong>{id}</strong>",
+    "defaultMessage": "Votre identifiant de candidature est le suivant : <strong>{id}</strong>",
     "description": "An application confirmation number"
   },
   "C3YsFy": {
@@ -7698,6 +7698,10 @@
     "defaultMessage": "Sélectionnez l’option qui représente le mieux votre raison pour soumettre la présente demande de talent",
     "description": "Legend for the options related to the reason for submitting a request."
   },
+  "cXuiuN": {
+    "defaultMessage": "Nous vous contacterons si votre candidature correspond aux critères énoncés dans l'offre d'emploi. En attendant, consultez les ressources suivantes pour en savoir plus sur la suite des événements.",
+    "description": "Description of review process and next steps for the applicant."
+  },
   "cYNDhP": {
     "defaultMessage": "Énoncé de confidentialité",
     "description": "Title for the websites privacy policy"
@@ -9061,6 +9065,10 @@
   "j3m2Ca": {
     "defaultMessage": "Lieu précis (précisez ci-dessous)",
     "description": "Label displayed for 'specific location' option"
+  },
+  "j4rest": {
+    "defaultMessage": "Votre identifiant de candidature peut également être trouvé dans les candidatures sur votre tableau de bord du (de la) candidat(e).",
+    "description": "Note where the application ID is available"
   },
   "j5Fwi6": {
     "defaultMessage": "Vos objectifs d'apprentissage",

--- a/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
@@ -127,8 +127,8 @@ const ApplicationReview = ({
         if (!res.error) {
           toast.success(
             intl.formatMessage({
-              defaultMessage: "We successfully received your application",
-              id: "7vOa71",
+              defaultMessage: "We've successfully received your application",
+              id: "2SSm+L",
               description:
                 "Success message after submission for the application review page.",
             }),

--- a/apps/web/src/pages/Applications/ApplicationSuccessPage/ApplicationSuccessPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSuccessPage/ApplicationSuccessPage.tsx
@@ -13,8 +13,8 @@ export const getPageInfo: GetPageNavInfo = ({ application, paths, intl }) => {
   const path = paths.applicationSuccess(application.id);
   return {
     title: intl.formatMessage({
-      defaultMessage: "We successfully received your application",
-      id: "79m9jN",
+      defaultMessage: "We've successfully received your application",
+      id: "Rped43",
       description: "Page title for the application success page",
     }),
     subtitle: intl.formatMessage({
@@ -57,9 +57,8 @@ const ApplicationSuccess = ({ application }: ApplicationPageProps) => {
       <p data-h2-margin="base(x.5, 0)">
         {intl.formatMessage(
           {
-            defaultMessage:
-              "Your confirmation number is: <strong>{id}</strong>",
-            id: "/uOExm",
+            defaultMessage: "Your application ID is: <strong>{id}</strong>",
+            id: "C2urGD",
             description: "An application confirmation number",
           },
           {
@@ -67,79 +66,74 @@ const ApplicationSuccess = ({ application }: ApplicationPageProps) => {
           },
         )}
       </p>
-      <p data-h2-margin="base(x.5, 0)">
-        {isIAP
-          ? intl.formatMessage({
+      {isIAP ? (
+        <p data-h2-margin="base(x.5 0 x1.5 0)">
+          {intl.formatMessage({
+            defaultMessage:
+              "Thank you for your interest in becoming an IT apprentice with the Government of Canada. Your lived experience, skills, passion and interests are warmly received and acknowledged. A member of the Office of Indigenous Initiatives team will contact you within the next three to five business days to discuss your application.",
+            id: "cTCdw5",
+            description:
+              "Description of review process and next steps for the IAP applicant.",
+          })}
+        </p>
+      ) : (
+        <>
+          <p data-h2-margin="base(x.5 0 x.5 0)">
+            {intl.formatMessage({
               defaultMessage:
-                "Thank you for your interest in becoming an IT apprentice with the Government of Canada. Your lived experience, skills, passion and interests are warmly received and acknowledged. A member of the Office of Indigenous Initiatives team will contact you within the next three to five business days to discuss your application.",
-              id: "cTCdw5",
-              description:
-                "Description of review process and next steps for the IAP applicant.",
-            })
-          : intl.formatMessage({
-              defaultMessage:
-                "We'll be in touch if your application matches the criteria outlined by the opportunity. In the meantime, check out the following resources for further information on what might be next.",
-              id: "lE92J0",
+                "We'll be in touch if your application matches the criteria outlined in the job advertisement. In the meantime, check out the following resources for further information on what might be next.",
+              id: "cXuiuN",
               description:
                 "Description of review process and next steps for the applicant.",
             })}
-      </p>
-      <ul data-h2-margin-bottom="base(x1.5)">
-        {!isIAP && (
-          <li data-h2-margin-bottom="base(x.25)">
-            <Link
-              newTab
-              external
-              href={
-                locale === "en"
-                  ? "https://www.tbs-sct.canada.ca/tbsf-fsct/330-60-eng.asp"
-                  : "https://www.tbs-sct.canada.ca/tbsf-fsct/330-60-fra.asp"
-              }
-              data-h2-display="base(inline-block)"
-              data-h2-text-align="base(left)"
-              data-h2-vertical-align="base(top)"
-            >
-              {intl.formatMessage({
-                defaultMessage: "Complete a security clearance application",
-                id: "l5R6Nc",
-                description:
-                  "Link text for government of canada security clearance forms",
-              })}
-            </Link>
-          </li>
-        )}
-        <li data-h2-margin-bottom="base(x.25)">
-          <Link
-            href={paths.profile()}
-            data-h2-display="base(inline-block)"
-            data-h2-text-align="base(left)"
-            data-h2-vertical-align="base(top)"
-          >
-            {intl.formatMessage({
-              defaultMessage: "Update your profile information",
-              id: "ytHyUL",
-              description:
-                "Link text to users profile to update contact information",
-            })}
-          </Link>
-        </li>
-        {!isIAP && (
-          <li data-h2-margin-bottom="base(x.25)">
-            <Link
-              href={paths.browsePools()}
-              data-h2-display="base(inline-block)"
-              data-h2-text-align="base(left)"
-              data-h2-vertical-align="base(top)"
-            >
-              {intl.formatMessage({
-                defaultMessage: "Browse for other opportunities",
-                id: "M+5+nP",
-                description: "Link text for browse jobs page",
-              })}
-            </Link>
-          </li>
-        )}
-      </ul>
+          </p>
+          <ul data-h2-margin-bottom="base(x1.5)">
+            <li data-h2-margin-bottom="base(x.25)">
+              <Link
+                newTab
+                external
+                href={
+                  locale === "en"
+                    ? "https://www.canada.ca/en/public-service-commission/services/second-language-testing-public-service.html"
+                    : "https://www.canada.ca/fr/commission-fonction-publique/services/evaluation-langue-seconde.html"
+                }
+                data-h2-display="base(inline-block)"
+                data-h2-text-align="base(left)"
+                data-h2-vertical-align="base(top)"
+              >
+                {intl.formatMessage({
+                  defaultMessage: "Second language evaluation",
+                  id: "E2uEWk",
+                  description:
+                    "Link text for government of canada second language evaluation",
+                })}
+              </Link>
+            </li>
+            <li data-h2-margin-bottom="base(x.25)">
+              <Link
+                newTab
+                external
+                href={
+                  locale === "en"
+                    ? "https://www.tbs-sct.canada.ca/tbsf-fsct/ssac-cdfs-eng.asp"
+                    : "https://www.tbs-sct.canada.ca/tbsf-fsct/ssac-cdfs-fra.asp"
+                }
+                data-h2-display="base(inline-block)"
+                data-h2-text-align="base(left)"
+                data-h2-vertical-align="base(top)"
+              >
+                {intl.formatMessage({
+                  defaultMessage:
+                    "Security screening application and consent form",
+                  id: "1cCjc/",
+                  description:
+                    "Link text for government of canada security screening application and consent form",
+                })}
+              </Link>
+            </li>
+          </ul>
+        </>
+      )}
       <p
         data-h2-margin="base(x.5, 0)"
         data-h2-display="base(flex)"
@@ -180,10 +174,9 @@ const ApplicationSuccess = ({ application }: ApplicationPageProps) => {
       <Alert.Footer>
         {intl.formatMessage({
           defaultMessage:
-            "* Note that your confirmation number can also be found in the Track your applications section on your Profile and applications page.",
-          id: "lxDgNf",
-          description:
-            "Note that the application confirmation number is available on the profile and applications page",
+            "Your application ID can also be found in the applications on your applicant dashboard.",
+          id: "j4rest",
+          description: "Note where the application ID is available",
         })}
       </Alert.Footer>
     </Alert.Root>


### PR DESCRIPTION
🤖 Resolves #12859.

## 👋 Introduction

This PR updates the copy on application success alert. It also updates an identical string used in a toast.

## 🧪 Testing

1. `pnpm build`
2. Apply to a job
3. Verify success message is updated with appropriate copy and URLs in English and French
4. Apply to a job with publishing group of IAP
5. Verify success message is updated with appropriate copy and URLs in English and French

## 📸 Screenshot

### Non-IAP
<img width="1193" alt="Screen Shot 2025-02-27 at 16 45 00" src="https://github.com/user-attachments/assets/b2b502f0-54eb-4b46-ba99-c9806de9a0c8" />

### IAP
<img width="1188" alt="Screen Shot 2025-02-27 at 16 58 41" src="https://github.com/user-attachments/assets/edea4316-bca5-47d6-8b35-5436c27153fb" />