### PR TITLE
[Fix] Resetting government fields on work experience form

### DIFF
--- a/apps/web/src/components/ExperienceFormFields/WorkFields/GovFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields/GovFields.tsx
@@ -210,26 +210,14 @@ const GovFields = ({ labels }: SubExperienceFormProps) => {
     if (watchGovEmploymentType !== WorkExperienceGovEmployeeType.Contractor) {
       resetDirtyField("govContractorRoleSeniority");
       resetDirtyField("govContractorType");
-    }
-
-    if (
-      watchGovContractorType === GovContractorType.SelfEmployed ||
-      watchGovEmploymentType !== WorkExperienceGovEmployeeType.Contractor
-    ) {
-      resetField("contractorFirmAgencyName", {
-        keepDirty: false,
-        defaultValue: undefined,
-      });
+      resetDirtyField("contractorFirmAgencyName");
     }
 
     // govPositionType field only applies to INDETERMINATE
     if (
       watchGovEmploymentType !== WorkExperienceGovEmployeeType.Indeterminate
     ) {
-      resetField("govPositionType", {
-        keepDirty: false,
-        defaultValue: null,
-      });
+      resetDirtyField("govPositionType");
     }
   }, [resetField, watchGovEmploymentType, watchGovContractorType]);
 

--- a/apps/web/src/components/ExperienceFormFields/WorkFields/GovFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields/GovFields.tsx
@@ -210,14 +210,13 @@ const GovFields = ({ labels }: SubExperienceFormProps) => {
     if (watchGovEmploymentType !== WorkExperienceGovEmployeeType.Contractor) {
       resetDirtyField("govContractorRoleSeniority");
       resetDirtyField("govContractorType");
-      resetDirtyField("contractorFirmAgencyName");
     }
 
-    // govPositionType field only applies to INDETERMINATE
     if (
-      watchGovEmploymentType !== WorkExperienceGovEmployeeType.Indeterminate
+      watchGovContractorType === GovContractorType.SelfEmployed ||
+      watchGovEmploymentType !== WorkExperienceGovEmployeeType.Contractor
     ) {
-      resetDirtyField("govPositionType");
+      resetDirtyField("contractorFirmAgencyName");
     }
   }, [resetField, watchGovEmploymentType, watchGovContractorType]);
 

--- a/apps/web/src/components/ExperienceFormFields/WorkFields/GovFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields/GovFields.tsx
@@ -192,9 +192,7 @@ const GovFields = ({ labels }: SubExperienceFormProps) => {
    */
   useEffect(() => {
     const resetDirtyField = (name: keyof WorkFormValues) => {
-      resetField(name, {
-        keepDirty: false,
-      });
+      resetField(name, { keepDirty: false, defaultValue: null });
     };
 
     if (


### PR DESCRIPTION
🤖 Resolves #12769 

## 👋 Introduction

Fixes an issue that occurred when changing the employment type was resetting fields to their default values rather than nulling them causing the form to go to unrealistic states.

## 🕵️ Details

When using `resetField` from `react-hook-form` it sets it back to the default value. So, when editing an existing experience it was resetting `govContractorType` to the one that was previously selected rather then setting it to `null`. Since this was the only condition to display that field, it remained visible and the user could submit a non-contractor experience with a firm or agency name.

Using `null` as the default value fro these resets fixes that issue.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as any role
3. Create a government contractor work experience that has a form or agency name
4. Edit that experience and select any other employment type
5. Confirm the contractor fields properly get set to `null` and are hidden
