### PR TITLE
[Feat] Allow past deadlines for training opportunities

### DIFF
--- a/apps/web/src/pages/TrainingOpportunities/components/TrainingOpportunityForm.tsx
+++ b/apps/web/src/pages/TrainingOpportunities/components/TrainingOpportunityForm.tsx
@@ -106,10 +106,6 @@ const TrainingOpportunityForm = ({ query }: TrainingOpportunityFormProps) => {
         show={[DATE_SEGMENT.Day, DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
         rules={{
           required: intl.formatMessage(errorMessages.required),
-          min: {
-            value: currentDate(),
-            message: intl.formatMessage(errorMessages.futureDate),
-          },
         }}
       />
       <div data-h2-display="base(none) p-tablet(inherit)">


### PR DESCRIPTION
🤖 Resolves #12703 

## 👋 Introduction

Removes the validation for training opportunity deadline to allow creating/updating with date in the past.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as admin `admin@test.com`
3. Navigate to the create form `/en/admin/training-opportunities/create`
4. Confirm you can submit with a deadline in the past
5. Edit the training opportunity
6. Confirm you can update with a deadline in the past

## 📸 Screenshot

![2025-02-28_08-32](https://github.com/user-attachments/assets/2fcec944-b713-481e-938f-d7405a360e5d)
