### PR TITLE
[Copy] Updates `Definition` component instances to omit three dots

### DIFF
--- a/apps/web/src/components/EmploymentEquity/dialogs/Definition.tsx
+++ b/apps/web/src/components/EmploymentEquity/dialogs/Definition.tsx
@@ -19,21 +19,23 @@ const Definition = ({ url, quotedDefinition }: DefinitionProps) => {
 
   return (
     <Well>
-      <p data-h2-margin-bottom="base(x1)" data-h2-font-weight="base(700)">
-        {intl.formatMessage(
-          {
-            defaultMessage:
-              "According to the <link>Statistics Canada definition</link>, this group:",
-            id: "0nP0Wj",
-            description:
-              "Link to Statistics Canada's employment equity definitions",
-          },
-          {
-            link: (chunks: ReactNode) => statCanLink(url, chunks),
-          },
-        )}
+      <p>
+        <span data-h2-font-weight="base(700)">
+          {intl.formatMessage(
+            {
+              defaultMessage:
+                "According to the <link>Statistics Canada definition</link>, this group ",
+              id: "X3pHUD",
+              description:
+                "Link to Statistics Canada's employment equity definitions",
+            },
+            {
+              link: (chunks: ReactNode) => statCanLink(url, chunks),
+            },
+          )}
+        </span>
+        {quotedDefinition}
       </p>
-      <p>{quotedDefinition}</p>
     </Well>
   );
 };

--- a/apps/web/src/components/EmploymentEquity/dialogs/DisabilityDialog.tsx
+++ b/apps/web/src/components/EmploymentEquity/dialogs/DisabilityDialog.tsx
@@ -64,8 +64,8 @@ const DisabilityDialog = ({
             }
             quotedDefinition={intl.formatMessage({
               defaultMessage:
-                '"... refers to a person whose daily activities are limited as a result of an impairment or difficulty with particular tasks. The only exception to this is for developmental disabilities where a person is considered to be disabled if the respondent has been diagnosed with this condition."',
-              id: "66qMwD",
+                '"refers to a person whose daily activities are limited as a result of an impairment or difficulty with particular tasks. The only exception to this is for developmental disabilities where a person is considered to be disabled if the respondent has been diagnosed with this condition."',
+              id: "JbSK7q",
               description:
                 "Definition of Person with a disability from the StatsCan 'Classification of Status of Disability' page.",
             })}

--- a/apps/web/src/components/EmploymentEquity/dialogs/IndigenousDialog.tsx
+++ b/apps/web/src/components/EmploymentEquity/dialogs/IndigenousDialog.tsx
@@ -91,8 +91,8 @@ const IndigenousDialog = ({
             }
             quotedDefinition={intl.formatMessage({
               defaultMessage:
-                '"... refers to whether the person identified with the Indigenous peoples of Canada. This includes those who identify as First Nations (North American Indian), Métis and/or Inuk (Inuit), and/or those who report being Registered or Treaty Indians (that is, registered under the Indian Act of Canada), and/or those who have membership in a First Nation or Indian band. Aboriginal peoples of Canada (referred to here as Indigenous peoples) are defined in the Constitution Act, 1982, Section 35 (2) as including the Indian, Inuit and Métis peoples of Canada."',
-              id: "AfSlkm",
+                '"refers to whether the person identified with the Indigenous peoples of Canada. This includes those who identify as First Nations (North American Indian), Métis and/or Inuk (Inuit), and/or those who report being Registered or Treaty Indians (that is, registered under the Indian Act of Canada), and/or those who have membership in a First Nation or Indian band. Aboriginal peoples of Canada (referred to here as Indigenous peoples) are defined in the Constitution Act, 1982, Section 35 (2) as including the Indian, Inuit and Métis peoples of Canada."',
+              id: "eX+V6c",
               description:
                 "Definition of Indigenous identity from the StatsCan 'Indigenous identity of person' page.",
             })}

--- a/apps/web/src/components/EmploymentEquity/dialogs/VisibleMinorityDialog.tsx
+++ b/apps/web/src/components/EmploymentEquity/dialogs/VisibleMinorityDialog.tsx
@@ -64,8 +64,8 @@ const VisibleMinorityDialog = ({
             }
             quotedDefinition={intl.formatMessage({
               defaultMessage:
-                '"... refers to whether a person is a visible minority or not, as defined by the Employment Equity Act. The Employment Equity Act defines visible minorities as "persons, other than Aboriginal peoples, who are non-Caucasian in race or non-white in colour". The visible minority population consists mainly of the following groups: South Asian, Chinese, Black, Filipino, Arab, Latin American, Southeast Asian, West Asian, Korean and Japanese."',
-              id: "uPQ1t+",
+                '"refers to whether a person is a visible minority or not, as defined by the Employment Equity Act. The Employment Equity Act defines visible minorities as "persons, other than Aboriginal peoples, who are non-Caucasian in race or non-white in colour". The visible minority population consists mainly of the following groups: South Asian, Chinese, Black, Filipino, Arab, Latin American, Southeast Asian, West Asian, Korean and Japanese."',
+              id: "3tu/Mv",
               description:
                 "Definition of Visible minority from the StatsCan 'Visible minority of person' page.",
             })}

--- a/apps/web/src/components/EmploymentEquity/dialogs/WomanDialog.tsx
+++ b/apps/web/src/components/EmploymentEquity/dialogs/WomanDialog.tsx
@@ -64,8 +64,8 @@ const WomanDialog = ({
             }
             quotedDefinition={intl.formatMessage({
               defaultMessage:
-                '"... includes persons whose reported gender is female. It includes cisgender (cis) and transgender (trans) women."',
-              id: "2yXxyQ",
+                '"includes persons whose reported gender is female. It includes cisgender (cis) and transgender (trans) women."',
+              id: "dycByE",
               description:
                 "Definition of the Woman category from the StatsCan 'Classification of gender' page.",
             })}

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -571,10 +571,6 @@
     "defaultMessage": "Tâches de travail (anglais)",
     "description": "Label for a process' English work tasks"
   },
-  "0nP0Wj": {
-    "defaultMessage": "Selon la <link>définition de Statistique Canada</link>, ce groupe :",
-    "description": "Link to Statistics Canada's employment equity definitions"
-  },
   "0ox2XB": {
     "defaultMessage": "Compétences techniques",
     "description": "Title for the technical skill rank card"
@@ -975,10 +971,6 @@
     "defaultMessage": "Le code saisi est incorrect.",
     "description": "Title for error message when the code is not valid."
   },
-  "2yXxyQ": {
-    "defaultMessage": "« ... inclut les personnes dont le genre déclaré est celui de femme. Cela inclut les femmes cisgenres (cis) et les femmes transgenres (trans). »",
-    "description": "Definition of the Woman category from the StatsCan 'Classification of gender' page."
-  },
   "2yvjfA": {
     "defaultMessage": "Cette liste permet de mettre en évidence <strong>jusqu’à 10 compétences techniques</strong> qui donnent une image claire de votre ensemble de compétences. Montrez-nous ce que vous savez faire de mieux!",
     "description": "Description of a users top technical skills"
@@ -1138,6 +1130,10 @@
   "3rbRfI": {
     "defaultMessage": "Vous recevrez un suivi sur votre demande dans 5 à 10 jours ouvrables.",
     "description": "Description of when the user should expect a response to their request"
+  },
+  "3tu/Mv": {
+    "defaultMessage": "« réfère au fait qu'une personne est ou non une minorité visible, tel que défini dans la Loi sur l'équité en matière d'emploi. Dans le cadre de la Loi sur l'équité en matière d'emploi, les minorités visibles sont définies comme « les personnes, autres que les Autochtones, qui ne sont pas de race blanche ou qui n'ont pas la peau blanche ».  La population des minorités visibles est principalement composée des groupes suivants : Sud-Asiatique, Chinois, Noir, Philippin, Arabe, Latino-Américain, Asiatique du Sud-Est, Asiatique occidental, Coréen et Japonais. »",
+    "description": "Definition of Visible minority from the StatsCan 'Visible minority of person' page."
   },
   "3u7nGm": {
     "defaultMessage": "Cette page concerne uniquement les fonctionnaires du gouvernement du Canada ci dessous.",
@@ -1610,10 +1606,6 @@
   "66kU6k": {
     "defaultMessage": "Numéro de ministère",
     "description": "Label for department number"
-  },
-  "66qMwD": {
-    "defaultMessage": "« ... réfère à une personne dont les activités quotidiennes sont limitées en raison d'un trouble ou d'une difficulté à accomplir certaines tâches. La seule exception à cet égard concerne les troubles du développement, le répondant qui a reçu un tel diagnostic étant considéré comme ayant une incapacité. »",
-    "description": "Definition of Person with a disability from the StatsCan 'Classification of Status of Disability' page."
   },
   "69BfF3": {
     "defaultMessage": "Découvrez un talent en vous servant d’un jeu de filtres détaillés, y compris la classification, les langues et les compétences.",
@@ -2462,10 +2454,6 @@
   "Af4zOR": {
     "defaultMessage": "Vous pouvez gérer les types de notifications et la façon dont elles vous sont envoyées sur la page des paramètres de votre compte.",
     "description": "Describing where to go to manage notification settings"
-  },
-  "AfSlkm": {
-    "defaultMessage": "« ... désigne les personnes s'identifiant aux peuples autochtones du Canada. Cela comprend les personnes qui s'identifient à titre de membres des Premières Nations (Indiens de l'Amérique du Nord), Métis et/ou Inuits, et/ou les personnes qui déclarent être des Indiens inscrits ou des Indiens des traités (aux termes de la Loi sur les Indiens du Canada), et/ou les personnes qui sont membres d'une Première Nation ou d'une bande indienne. Le paragraphe 35(2) de la Loi constitutionnelle de 1982 précise que l'expression « peuples autochtones du Canada » s'entend notamment des Indiens, des Inuits et des Métis du Canada. »",
-    "description": "Definition of Indigenous identity from the StatsCan 'Indigenous identity of person' page."
   },
   "Ag8BE0": {
     "defaultMessage": "Tout d’abord, demander trop de renseignements sur une demande d’emploi peut repousser de bons candidats qui estiment que le processus est trop laborieux. Si vous souhaiter recruter parmi les meilleurs candidats, vous devrez trouver le bon équilibre entre ce que vous voulez demander et le temps que les candidats devront accorder pour entreprendre le processus.",
@@ -4162,6 +4150,10 @@
   "JbHieN": {
     "defaultMessage": "Demander pour les candidats du bassin {poolName}",
     "description": "Button link message on search page that takes user to the request form."
+  },
+  "JbSK7q": {
+    "defaultMessage": "« réfère à une personne dont les activités quotidiennes sont limitées en raison d'un trouble ou d'une difficulté à accomplir certaines tâches. La seule exception à cet égard concerne les troubles du développement, le répondant qui a reçu un tel diagnostic étant considéré comme ayant une incapacité. »",
+    "description": "Definition of Person with a disability from the StatsCan 'Classification of Status of Disability' page."
   },
   "Jc9FDx": {
     "defaultMessage": "Rôles ajoutés avec succès",
@@ -6722,6 +6714,10 @@
     "defaultMessage": "Octroi de contrat pour des services numériques",
     "description": "Short name for Digital Services Contracting Form"
   },
+  "X3pHUD": {
+    "defaultMessage": "Selon la <link>définition de Statistique Canada</link>, ce groupe ",
+    "description": "Link to Statistics Canada's employment equity definitions"
+  },
   "X5tRR4": {
     "defaultMessage": "Il n’existe aucune compétence jusqu’à présent.",
     "description": "Title for no skills in a users library"
@@ -8010,6 +8006,10 @@
     "defaultMessage": "communiquent des messages racistes, haineux, sexistes, homophobes ou diffamatoires, ou contiennent du matériel obscène ou pornographique ou y font allusion",
     "description": "Comments or contributions list item"
   },
+  "dycByE": {
+    "defaultMessage": "« inclut les personnes dont le genre déclaré est celui de femme. Cela inclut les femmes cisgenres (cis) et les femmes transgenres (trans). »",
+    "description": "Definition of the Woman category from the StatsCan 'Classification of gender' page."
+  },
   "dyzeVv": {
     "defaultMessage": "Sauvegarder l’annonce à l’échelle du site",
     "description": "Text on a button to save the sitewide announcement"
@@ -8137,6 +8137,10 @@
   "eWVgyx": {
     "defaultMessage": "Objet de la demande",
     "description": "Talent request - request purpose title"
+  },
+  "eX+V6c": {
+    "defaultMessage": "« désigne les personnes s'identifiant aux peuples autochtones du Canada. Cela comprend les personnes qui s'identifient à titre de membres des Premières Nations (Indiens de l'Amérique du Nord), Métis et/ou Inuits, et/ou les personnes qui déclarent être des Indiens inscrits ou des Indiens des traités (aux termes de la Loi sur les Indiens du Canada), et/ou les personnes qui sont membres d'une Première Nation ou d'une bande indienne. Le paragraphe 35(2) de la Loi constitutionnelle de 1982 précise que l'expression « peuples autochtones du Canada » s'entend notamment des Indiens, des Inuits et des Métis du Canada. »",
+    "description": "Definition of Indigenous identity from the StatsCan 'Indigenous identity of person' page."
   },
   "eZT5Vr": {
     "defaultMessage": "Nous recommandons d'ajouter un nom de rechange en langage clair pour les utilisateurs non gouvernementaux.",
@@ -11185,10 +11189,6 @@
   "uP+q43": {
     "defaultMessage": "Lieu de travail",
     "description": "Heading for work location section of the search form."
-  },
-  "uPQ1t+": {
-    "defaultMessage": "« ... réfère au fait qu'une personne est ou non une minorité visible, tel que défini dans la Loi sur l'équité en matière d'emploi. Dans le cadre de la Loi sur l'équité en matière d'emploi, les minorités visibles sont définies comme « les personnes, autres que les Autochtones, qui ne sont pas de race blanche ou qui n'ont pas la peau blanche ».  La population des minorités visibles est principalement composée des groupes suivants : Sud-Asiatique, Chinois, Noir, Philippin, Arabe, Latino-Américain, Asiatique du Sud-Est, Asiatique occidental, Coréen et Japonais. »",
-    "description": "Definition of Visible minority from the StatsCan 'Visible minority of person' page."
   },
   "uR9G1H": {
     "defaultMessage": "Statut de supervision",


### PR DESCRIPTION
🤖 Resolves #12584.

## 👋 Introduction

This PR updates the `Definition` component instances to omit three dots.

## 🧪 Testing

1. pnpm build
2. Navigate to http://localhost:8000/en/applicant/personal-information#diversity-equity-inclusion-section
3. Open each of the four equity dialogs
4. Verify each one adheres to new format in English and French

## 📸 Screenshots

### English

<img width="769" alt="Screen Shot 2025-02-28 at 13 44 00" src="https://github.com/user-attachments/assets/706960f6-ca33-4805-b5f9-4514c9f85dba" />
<img width="767" alt="Screen Shot 2025-02-28 at 13 45 09" src="https://github.com/user-attachments/assets/3b9ccb51-0192-4829-8ac2-a99444e44ff8" />
<img width="766" alt="Screen Shot 2025-02-28 at 13 45 16" src="https://github.com/user-attachments/assets/91f17cec-c8b8-4eef-9d59-ad96cc582e0e" />
<img width="768" alt="Screen Shot 2025-02-28 at 13 45 25" src="https://github.com/user-attachments/assets/585c0530-27a6-4432-b549-f3059e02aca1" />

### French

<img width="768" alt="Screen Shot 2025-02-28 at 13 44 18" src="https://github.com/user-attachments/assets/5b32da61-040e-415a-9320-7ef9809a948d" />
<img width="764" alt="Screen Shot 2025-02-28 at 13 44 32" src="https://github.com/user-attachments/assets/1f1b5f61-75e5-4ca2-babc-1f09dbc416b1" />
<img width="769" alt="Screen Shot 2025-02-28 at 13 44 43" src="https://github.com/user-attachments/assets/75ed96a2-c72d-4e62-b134-b90335383c82" />
<img width="765" alt="Screen Shot 2025-02-28 at 13 44 51" src="https://github.com/user-attachments/assets/9b15c956-098b-402e-8cf4-9e89dd3d0346" />