### PR TITLE
Set default value for consent checkbox based on saved job/training interest

### DIFF
--- a/apps/web/src/pages/CommunityInterests/form.ts
+++ b/apps/web/src/pages/CommunityInterests/form.ts
@@ -171,6 +171,8 @@ export function apiDataToFormValues(
             ? strToFormDate(interest.completionDate)
             : null,
       })) ?? null,
-    consent: null, // not saved in the database
+    // not saved in the database but if job or training interest is saved, they will have previously consented
+    consent:
+      !!communityInterest?.jobInterest || !!communityInterest?.trainingInterest,
   };
 }


### PR DESCRIPTION
🤖 Resolves #12860

## 👋 Introduction

Sets the initial value for the consent checkbox in the community interest form based on saved job/training interest.

## 🧪 Testing

1. Navigate to the applicant dashboard and select to add a community interest.
2. Select a functional community.
3. Confirm the consent section appears without a checkbox.
4. Select interest in job opportunities.
5. Confirm the consent checkbox appears unchecked.
6. Fill out the remaining fields and submit the form.
7. On the applicant dashboard select to edit the community interest.
8. Confirm the form starts with the consent checkbox checked.
9. Remove any job/training interest and save the form.
10. On the applicant dashboard select to edit the community interest.
11. Confirm the consent section appears without a checkbox.
12. Select interest in job opportunities.
13. Confirm the consent checkbox appears unchecked.

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/68c2d03f-270a-4b08-b152-7f21b64b0f55)
