### PR TITLE
[Bug] Hide position type for term

### DIFF
--- a/apps/web/src/components/ExperienceCard/WorkContent/GovContent.tsx
+++ b/apps/web/src/components/ExperienceCard/WorkContent/GovContent.tsx
@@ -85,8 +85,7 @@ const GovContent = ({
       </>
     );
   } else if (
-    govEmploymentType?.value === WorkExperienceGovEmployeeType.Indeterminate ||
-    govEmploymentType?.value === WorkExperienceGovEmployeeType.Term
+    govEmploymentType?.value === WorkExperienceGovEmployeeType.Indeterminate
   ) {
     return (
       <>
@@ -116,6 +115,40 @@ const GovContent = ({
             data-h2-border-right="l-tablet(1px solid gray.lighter)"
           >
             {getLocalizedName(govPositionType?.label, intl)}
+          </ContentSection>
+          <ContentSection
+            title={experienceFormLabels.classification}
+            headingLevel={headingLevel}
+          >
+            {classification
+              ? `${classification.group}-${classification.level < 10 ? "0" : ""}${classification.level}`
+              : intl.formatMessage(commonMessages.notAvailable)}
+          </ContentSection>
+        </div>
+      </>
+    );
+  } else if (govEmploymentType?.value === WorkExperienceGovEmployeeType.Term) {
+    return (
+      <>
+        <ContentSection
+          title={experienceFormLabels.team}
+          headingLevel={headingLevel}
+          data-h2-border-right="l-tablet(1px solid gray.lighter)"
+        >
+          {division ?? intl.formatMessage(commonMessages.notAvailable)}
+        </ContentSection>
+        <Separator space="sm" decorative />
+        <div
+          data-h2-display="base(grid)"
+          data-h2-gap="base(x1)"
+          data-h2-grid-template-columns="l-tablet(repeat(3, 1fr))"
+        >
+          <ContentSection
+            title={experienceFormLabels.govEmploymentType}
+            headingLevel={headingLevel}
+            data-h2-border-right="l-tablet(1px solid gray.lighter)"
+          >
+            {getLocalizedName(govEmploymentType.label, intl)}
           </ContentSection>
           <ContentSection
             title={experienceFormLabels.classification}


### PR DESCRIPTION
🤖 Resolves #12905

## 👋 Introduction

Hide the position type field in the experience card view for term employment types. I split term and indeterminate render blocks

## 🧪 Testing

1. Create indeterminate and term work experiences
2. Go to view card, see change in rendering of position type

## 📸 Screenshot

### Indeterminate 

![image](https://github.com/user-attachments/assets/06d8b176-0519-41dd-9ddd-210a98031f08)

### Term

![image](https://github.com/user-attachments/assets/82fe0360-97e0-401d-97ae-9351af52b4a5)



<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the PR if deployment steps are needed

 -->
