### PR TITLE
[Fix] Adds work streams to application snapshot

### DIFF
--- a/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
+++ b/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
@@ -355,6 +355,20 @@ query getProfile($userId: UUID!) {
           }
           departmentNumber
         }
+        workStreams {
+          id
+          key
+          name {
+            localized
+          }
+          community {
+            id
+            key
+            name {
+              localized
+            }
+          }
+        }
       }
     }
     isProfileComplete

--- a/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
+++ b/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
@@ -359,12 +359,21 @@ query getProfile($userId: UUID!) {
           id
           key
           name {
+            en
+            fr
             localized
           }
           community {
             id
             key
             name {
+              en
+              fr
+              localized
+            }
+            description {
+              en
+              fr
               localized
             }
           }

--- a/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
+++ b/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
@@ -361,7 +361,10 @@ query getProfile($userId: UUID!) {
           name {
             en
             fr
-            localized
+          }
+          plainLanguageName {
+            en
+            fr
           }
           community {
             id
@@ -369,12 +372,10 @@ query getProfile($userId: UUID!) {
             name {
               en
               fr
-              localized
             }
             description {
               en
               fr
-              localized
             }
           }
         }

--- a/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
+++ b/api/app/GraphQL/Mutations/PoolCandidateSnapshot.graphql
@@ -362,10 +362,6 @@ query getProfile($userId: UUID!) {
             en
             fr
           }
-          plainLanguageName {
-            en
-            fr
-          }
           community {
             id
             key
@@ -377,6 +373,10 @@ query getProfile($userId: UUID!) {
               en
               fr
             }
+          }
+          plainLanguageName {
+            en
+            fr
           }
         }
       }

--- a/api/app/Http/Resources/CommunityResource.php
+++ b/api/app/Http/Resources/CommunityResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\Community */
+class CommunityResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'key' => $this->key,
+            'name' => $this->name,
+            'description' => $this->description,
+        ];
+    }
+}

--- a/api/app/Http/Resources/WorkExperienceResource.php
+++ b/api/app/Http/Resources/WorkExperienceResource.php
@@ -40,6 +40,7 @@ class WorkExperienceResource extends JsonResource
             'cafRank' => $this->caf_rank,
             'classification' => $this->classification_id ? (new ClassificationResource(Classification::find($this->classification_id))) : null,
             'department' => $this->department_id ? (new DepartmentResource(Department::find($this->department_id))) : null,
+            'workStreams' => WorkStreamResource::collection($this->workStreams),
         ];
     }
 }

--- a/api/app/Http/Resources/WorkStreamResource.php
+++ b/api/app/Http/Resources/WorkStreamResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\Community;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\WorkStream */
+class WorkStreamResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'key' => $this->key,
+            'name' => $this->name,
+            'plain_language_name' => $this->plain_language_name,
+            'community' => $this->community_id ? (new CommunityResource(Community::find($this->community_id))) : null,
+        ];
+    }
+}

--- a/api/app/Http/Resources/WorkStreamResource.php
+++ b/api/app/Http/Resources/WorkStreamResource.php
@@ -20,7 +20,7 @@ class WorkStreamResource extends JsonResource
             'id' => $this->id,
             'key' => $this->key,
             'name' => $this->name,
-            'plain_language_name' => $this->plain_language_name,
+            'plainLanguageName' => $this->plain_language_name,
             'community' => $this->community_id ? (new CommunityResource(Community::find($this->community_id))) : null,
         ];
     }

--- a/api/app/ValueObjects/ProfileSnapshot.php
+++ b/api/app/ValueObjects/ProfileSnapshot.php
@@ -116,6 +116,7 @@ class ProfileSnapshot implements Castable
                     'personalExperiences.skills',
                     'workExperiences',
                     'workExperiences.skills',
+                    'workExperiences.workStreams',
                 ])->findOrFail($value['userId']);
 
                 // collect skills attached to the Pool to pass into resource collection

--- a/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
+++ b/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
@@ -384,6 +384,30 @@ export const UserProfile_FragmentText = /* GraphQL */ `
           }
           departmentNumber
         }
+        workStreams {
+          id
+          key
+          name {
+            en
+            fr
+          }
+          community {
+            id
+            key
+            name {
+              en
+              fr
+            }
+            description {
+              en
+              fr
+            }
+          }
+          plainLanguageName {
+            en
+            fr
+          }
+        }
       }
     }
     isProfileComplete


### PR DESCRIPTION
🤖 Resolves #12914 

## 👋 Introduction

Adds work experience work streams and community to the application snapshot so they can be rendered.

## 🧪 Testing

1. Login as admin `admin@test.com`
2. Add a work experience with work streams
3. Submit an application'
4. Navigate to the application on the admin interface
5. Confirm work streams appear on the card under "Career timeline"
