### PR TITLE
[Fix] Recruitment process dialog, Application dialog layout

### DIFF
--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationDialog.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationDialog.tsx
@@ -420,7 +420,10 @@ const ReviewApplicationDialog = ({
               </>
             )}
           </div>
-          <Dialog.Footer data-h2-gap="base(0 x1)">
+          <Dialog.Footer
+            data-h2-gap="base(x1 0) p-tablet(0 x1)"
+            data-h2-flex-direction="base(column) p-tablet(row)"
+          >
             <Link
               href={paths.application(application.id)}
               mode="solid"

--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewRecruitmentProcessDialog.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewRecruitmentProcessDialog.tsx
@@ -395,7 +395,10 @@ const ReviewRecruitmentProcessDialog = ({
                     },
                   ]}
                 />
-                <Dialog.Footer data-h2-gap="base(0 x1)">
+                <Dialog.Footer
+                  data-h2-gap="base(x1 0) p-tablet(0 x1)"
+                  data-h2-flex-direction="base(column) p-tablet(row)"
+                >
                   <Button
                     type="submit"
                     disabled={isSubmitting}


### PR DESCRIPTION
🤖 Resolves #12911.

## 👋 Introduction

This PR fixes the Recruitment process dialog layout and Application dialog layout by vertically stacking `Dialog.Footer` elements on small screens.

## 🕵️ Details

The recruitment process dialog elements that were overflowing were caused by the dialog's actions breaking out of its container.

## 🧪 Testing

1. `pnpm build`
2. Navigate to http://localhost:3000/en/applicant/
3. Create an application
4. Open Job applications accordion
5. Verify no elements of dialog break out of container on small screen (375px wide or less)
6. Create an application and set its status to **Term placed**
7. Open Recruitment processes accordion (Term placed)
8. Verify no elements of dialog break out of container on small screen (375px wide or less)

## 📸 Screenshots

<details><summary>Screenshots (4)</summary>
<p>
<img width="508" alt="Screen Shot 2025-03-05 at 16 42 38" src="https://github.com/user-attachments/assets/b187e590-65fb-46cb-965a-6473fe0a3029" />
<img width="533" alt="Screen Shot 2025-03-05 at 16 52 48" src="https://github.com/user-attachments/assets/0c17e931-e59e-4abc-98d2-ab3f25f22055" />
<img width="508" alt="Screen Shot 2025-03-05 at 16 52 59" src="https://github.com/user-attachments/assets/a512b2f7-ec42-487c-a4fb-7c12ef9eab4d" />
<img width="474" alt="Screen Shot 2025-03-05 at 16 53 05" src="https://github.com/user-attachments/assets/a46b6470-9e8a-4410-b659-6c3e86e597ec" />
</p>
</details> 