### PR TITLE
[Fix] Development program interests

### DIFF
--- a/api/app/Models/DevelopmentProgramInterest.php
+++ b/api/app/Models/DevelopmentProgramInterest.php
@@ -25,6 +25,8 @@ class DevelopmentProgramInterest extends Model
 
     protected $keyType = 'string';
 
+    protected $fillable = ['participation_status', 'completion_date'];
+
     /**
      * The attributes that should be cast.
      */
@@ -36,12 +38,12 @@ class DevelopmentProgramInterest extends Model
     /** @return BelongsTo<CommunityInterest, $this> */
     public function communityInterest(): BelongsTo
     {
-        return $this->belongsTo(CommunityInterest::class);
+        return $this->belongsTo(CommunityInterest::class, 'community_interest_id');
     }
 
     /** @return BelongsTo<DevelopmentProgram, $this> */
     public function developmentProgram(): BelongsTo
     {
-        return $this->belongsTo(DevelopmentProgram::class);
+        return $this->belongsTo(DevelopmentProgram::class, 'development_program_id');
     }
 }

--- a/api/database/factories/CommunityInterestFactory.php
+++ b/api/database/factories/CommunityInterestFactory.php
@@ -63,9 +63,10 @@ class CommunityInterestFactory extends Factory
             $developmentPrograms = $communityInterest->community->developmentPrograms()->limit($limit)->get();
             foreach ($developmentPrograms as $developmentProgram) {
                 DevelopmentProgramInterest::factory()
-                    ->for($communityInterest)
-                    ->for($developmentProgram)
-                    ->create();
+                    ->create([
+                        'development_program_id' => $developmentProgram->id,
+                        'community_interest_id' => $communityInterest->id,
+                    ]);
             }
         });
     }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1631,7 +1631,6 @@ input CreateDevelopmentProgramInterestHasMany {
 
 input UpdateDevelopmentProgramInterestHasMany {
   create: [CreateDevelopmentProgramInterestInput!]
-  sync: [CreateDevelopmentProgramInterestInput!]
   update: [UpdateDevelopmentProgramInterestInput!]
   delete: [UUID!]
 }

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1679,7 +1679,6 @@ input CreateDevelopmentProgramInterestHasMany {
 
 input UpdateDevelopmentProgramInterestHasMany {
   create: [CreateDevelopmentProgramInterestInput!]
-  sync: [CreateDevelopmentProgramInterestInput!]
   update: [UpdateDevelopmentProgramInterestInput!]
   delete: [UUID!]
 }

--- a/apps/web/src/components/CommunityInterestDialog/CommunityInterestDialog.tsx
+++ b/apps/web/src/components/CommunityInterestDialog/CommunityInterestDialog.tsx
@@ -229,6 +229,7 @@ const CommunityInterestDialog = ({
                         interest?.developmentProgram?.id ===
                         developmentProgram.id,
                     );
+
                   return (
                     <DevelopmentProgramInterestItem
                       key={developmentProgram.id}

--- a/apps/web/src/components/CommunityInterestDialog/DevelopmentProgramInterestItem.tsx
+++ b/apps/web/src/components/CommunityInterestDialog/DevelopmentProgramInterestItem.tsx
@@ -16,18 +16,6 @@ import { commonMessages } from "@gc-digital-talent/i18n";
 import { IconType } from "@gc-digital-talent/ui";
 import { formatDate, parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 
-const hasEnrolled = (
-  status?: Maybe<DevelopmentProgramParticipationStatus>,
-): boolean => {
-  return (
-    !!status &&
-    [
-      DevelopmentProgramParticipationStatus.Enrolled,
-      DevelopmentProgramParticipationStatus.Completed,
-    ].includes(status)
-  );
-};
-
 interface StatusInfo {
   Icon: IconType;
   iconStyles: Record<string, string>;
@@ -47,7 +35,12 @@ const useStatusInfo = (
     },
     message: intl.formatMessage(commonMessages.missingInformation),
   };
-  if (!status || (!completionDate && hasEnrolled(status))) {
+
+  if (
+    !status ||
+    (!completionDate &&
+      status === DevelopmentProgramParticipationStatus.Completed)
+  ) {
     return defaultStatusInfo;
   }
 

--- a/apps/web/src/pages/CommunityInterests/UpdateCommunityInterestPage/UpdateCommunityInterestPage.tsx
+++ b/apps/web/src/pages/CommunityInterests/UpdateCommunityInterestPage/UpdateCommunityInterestPage.tsx
@@ -18,7 +18,7 @@ import {
 } from "@gc-digital-talent/graphql";
 import { errorMessages, navigationMessages } from "@gc-digital-talent/i18n";
 import { toast } from "@gc-digital-talent/toast";
-import { NotFoundError } from "@gc-digital-talent/helpers";
+import { NotFoundError, unpackMaybes } from "@gc-digital-talent/helpers";
 
 import SEO from "~/components/SEO/SEO";
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
@@ -68,6 +68,9 @@ export const UpdateCommunityInterestFormData_Fragment = graphql(/* GraphQL */ `
     interestInDevelopmentPrograms {
       developmentProgram {
         id
+        name {
+          localized
+        }
       }
       participationStatus
       completionDate
@@ -172,6 +175,12 @@ const UpdateCommunityInterest_Query = graphql(/* GraphQL */ `
         communityInterests(id: $communityInterestId) {
           ...UpdateCommunityInterestPage_Fragment
           ...UpdateCommunityInterestFormData_Fragment
+          interestInDevelopmentPrograms {
+            id
+            developmentProgram {
+              id
+            }
+          }
         }
       }
     }
@@ -244,8 +253,26 @@ export const UpdateCommunityInterestPage = () => {
   const submitForm: SubmitHandler<FormValues> = async (
     formValues: FormValues,
   ) => {
+    const interestedDevPrograms = new Map<string, string>();
+    queryData?.me?.employeeProfile?.communityInterests?.forEach(
+      (communityInterest) => {
+        communityInterest.interestInDevelopmentPrograms?.forEach(
+          (interestedDevProgram) => {
+            interestedDevPrograms.set(
+              interestedDevProgram.developmentProgram.id,
+              interestedDevProgram.id,
+            );
+          },
+        );
+      },
+    );
+
     const mutationInput: UpdateCommunityInterestInput =
-      formValuesToApiUpdateInput(communityInterestId, formValues);
+      formValuesToApiUpdateInput(
+        communityInterestId,
+        interestedDevPrograms,
+        formValues,
+      );
     const mutationPromise = executeUpdateMutation({
       communityInterest: mutationInput,
     }).then((response) => {

--- a/apps/web/src/pages/CommunityInterests/UpdateCommunityInterestPage/UpdateCommunityInterestPage.tsx
+++ b/apps/web/src/pages/CommunityInterests/UpdateCommunityInterestPage/UpdateCommunityInterestPage.tsx
@@ -18,7 +18,7 @@ import {
 } from "@gc-digital-talent/graphql";
 import { errorMessages, navigationMessages } from "@gc-digital-talent/i18n";
 import { toast } from "@gc-digital-talent/toast";
-import { NotFoundError, unpackMaybes } from "@gc-digital-talent/helpers";
+import { NotFoundError } from "@gc-digital-talent/helpers";
 
 import SEO from "~/components/SEO/SEO";
 import RequireAuth from "~/components/RequireAuth/RequireAuth";

--- a/apps/web/src/pages/CommunityInterests/form.ts
+++ b/apps/web/src/pages/CommunityInterests/form.ts
@@ -4,6 +4,7 @@ import {
   DevelopmentProgramParticipationStatus,
   UpdateCommunityInterestFormData_FragmentFragment,
   UpdateCommunityInterestInput,
+  UpdateDevelopmentProgramInterestHasMany,
 } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 import { strToFormDate } from "@gc-digital-talent/date-helpers";
@@ -83,11 +84,10 @@ export function formValuesToApiCreateInput(
             // valid interest
             return {
               developmentProgramId: interest.developmentProgramId,
-              participationStatus:
-                interest.participationStatus as DevelopmentProgramParticipationStatus,
+              participationStatus: interest.participationStatus,
               completionDate:
                 interest.participationStatus ===
-                DevelopmentProgramParticipationStatus.Completed.valueOf()
+                DevelopmentProgramParticipationStatus.Completed
                   ? interest.completionDate
                   : null,
             };
@@ -106,9 +106,47 @@ export function formValuesToApiCreateInput(
 
 export function formValuesToApiUpdateInput(
   communityInterestId: string,
+  interestedPrograms: Map<string, string>,
   formValues: FormValues,
 ): UpdateCommunityInterestInput {
-  const apiInput: UpdateCommunityInterestInput = {
+  const interestInDevelopmentPrograms: UpdateDevelopmentProgramInterestHasMany =
+    {};
+
+  formValues.interestInDevelopmentPrograms?.forEach((input) => {
+    if (!input.developmentProgramId) return;
+
+    const existingInterest = interestedPrograms.get(input.developmentProgramId);
+
+    if (existingInterest) {
+      interestInDevelopmentPrograms.update = [
+        ...(interestInDevelopmentPrograms.update ?? []),
+        {
+          id: existingInterest,
+          participationStatus: input.participationStatus,
+          completionDate:
+            input.participationStatus ===
+            DevelopmentProgramParticipationStatus.Completed
+              ? input.completionDate
+              : null,
+        },
+      ];
+    } else {
+      interestInDevelopmentPrograms.create = [
+        ...(interestInDevelopmentPrograms.create ?? []),
+        {
+          developmentProgramId: input.developmentProgramId,
+          participationStatus: input.participationStatus,
+          completionDate:
+            input.participationStatus ===
+            DevelopmentProgramParticipationStatus.Completed
+              ? input.completionDate
+              : null,
+        },
+      ];
+    }
+  });
+
+  return {
     id: communityInterestId,
     workStreams: {
       sync: formValues.interestInWorkStreamIds,
@@ -116,35 +154,8 @@ export function formValuesToApiUpdateInput(
     jobInterest: parseMaybeStringToBoolean(formValues.jobInterest),
     trainingInterest: parseMaybeStringToBoolean(formValues.trainingInterest),
     additionalInformation: formValues.additionalInformation,
-    interestInDevelopmentPrograms: {
-      sync: unpackMaybes(
-        formValues.interestInDevelopmentPrograms?.map<CreateDevelopmentProgramInterestInput | null>(
-          (interest) => {
-            if (
-              typeof interest.participationStatus === "string" &&
-              typeof interest.developmentProgramId === "string"
-            ) {
-              // valid interest
-              return {
-                developmentProgramId: interest.developmentProgramId,
-                participationStatus:
-                  interest.participationStatus as DevelopmentProgramParticipationStatus,
-                completionDate:
-                  interest.participationStatus ===
-                  DevelopmentProgramParticipationStatus.Completed.valueOf()
-                    ? interest.completionDate
-                    : null,
-              };
-            }
-            // no participation status or development program ID
-            return null;
-          },
-        ),
-      ),
-    },
+    interestInDevelopmentPrograms,
   };
-
-  return apiInput;
 }
 
 export function apiDataToFormValues(
@@ -163,14 +174,20 @@ export function apiDataToFormValues(
     trainingInterest: communityInterest?.trainingInterest?.toString() ?? null,
     additionalInformation: communityInterest?.additionalInformation ?? null,
     interestInDevelopmentPrograms:
-      communityInterest?.interestInDevelopmentPrograms?.map((interest) => ({
-        developmentProgramId: interest.developmentProgram.id,
-        participationStatus: interest.participationStatus ?? null,
-        completionDate:
-          typeof interest.completionDate === "string"
-            ? strToFormDate(interest.completionDate)
-            : null,
-      })) ?? null,
+      communityInterest?.interestInDevelopmentPrograms
+        ?.sort((a, b) =>
+          (a.developmentProgram.name?.localized ?? "").localeCompare(
+            b.developmentProgram.name?.localized ?? "",
+          ),
+        )
+        .map((interest) => ({
+          developmentProgramId: interest.developmentProgram.id,
+          participationStatus: interest.participationStatus ?? null,
+          completionDate:
+            typeof interest.completionDate === "string"
+              ? strToFormDate(interest.completionDate)
+              : null,
+        })) ?? null,
     // not saved in the database but if job or training interest is saved, they will have previously consented
     consent:
       !!communityInterest?.jobInterest || !!communityInterest?.trainingInterest,

--- a/apps/web/src/pages/CommunityInterests/sections/TrainingAndDevelopmentOpportunities.tsx
+++ b/apps/web/src/pages/CommunityInterests/sections/TrainingAndDevelopmentOpportunities.tsx
@@ -45,7 +45,7 @@ export interface SubformValues {
   interestInDevelopmentPrograms:
     | {
         developmentProgramId: string | null;
-        participationStatus: string | null;
+        participationStatus: DevelopmentProgramParticipationStatus | null;
         completionDate: string | null;
       }[]
     | null;


### PR DESCRIPTION
🤖 Resolves #12924 

## 👋 Introduction

Fixes issues with updating and displaying development program interests.

## 🕵️ Details

This was multifaceted and the scope was expanded a little to address as many issues as I discovered here.

1. Looks like laravel was having trouble resolving the relationship due to not explicitly stating the foreign key (usually uses magic to figure this out). Adding this allowed us to actually get the relationship since before it was always an empty array
2. Order of community development programs and form values were different. This was resulting in users updating the wrong development program. We were looping thourhg the community dev programs and just assuming the default form values were in the same order and using index as the key name.
3. Use of `sync` on a `HasMany`. You cannot sync a has many relationship. This was removed and refactored to combine `create` and `update`
4. The display was showing "missing information" if the user was enrolled but no complettion date. We do not ask for completion date when currently enrolled so this made no sense.

## 🧪 Testing

1. Build `make refresh-api; pnpm run dev:fresh`
2. Ensure `applicant-employee@test.com` has no community interests
3. Login and add a community interest expressing interest in only one development program
4. Confirm the value is saved and appears properly in the community interest dialog
5. Update the interest changing interest in the existing dev program and add interest in another
6. Confirm the update is reflected accurately in the dialog
