### PR TITLE
[Copy] Add and edit community interest forms

### DIFF
--- a/apps/web/src/components/CommunityInterestDialog/CommunityInterestDialog.tsx
+++ b/apps/web/src/components/CommunityInterestDialog/CommunityInterestDialog.tsx
@@ -118,10 +118,10 @@ const CommunityInterestDialog = ({
           </BoolCheckIcon>
           <p data-h2-font-weight="base(700)" data-h2-margin-bottom="base(x.25)">
             {intl.formatMessage({
-              defaultMessage: "Interest in training opportunities",
-              id: "9whw8l",
+              defaultMessage: "Interest in training and development",
+              id: "WfX9z1",
               description:
-                "Label for users interest in training opportunities for a community",
+                "Label for user Interest in training and development for a community",
             })}
           </p>
           <BoolCheckIcon

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8682,6 +8682,10 @@
     "defaultMessage": "Le statut du placement a été enregistré avec succès",
     "description": "Message displayed when a job placement status has been saved."
   },
+  "gsjH8R": {
+    "defaultMessage": "Je souhaite bénéficier des possibilités de formation et des programmes de perfectionnement au sein de cette collectivité.",
+    "description": "Label for the community interest in training opportunities radio option"
+  },
   "gtU+9w": {
     "defaultMessage": "Bienvenue aux cadres",
     "description": "Page title for the executives homepage"
@@ -10133,10 +10137,6 @@
   "oES0/4": {
     "defaultMessage": "Les apprenti·es autochtones sont embauché·es par une organisation d’accueil au niveau d’entrée du groupe des TI (IT-01 ou équivalent) pour une période de 24 mois.",
     "description": "Paragraph 1 of the 'Hired as a term employee' subsection"
-  },
-  "oEYCLO": {
-    "defaultMessage": "Je souhaite bénéficier des possibilités de formation et de perfectionnement au sein de cette collectivité.",
-    "description": "Label for the community interest in training opportunities radio option"
   },
   "oIM22z": {
     "defaultMessage": "Disqualifiez le candidat ou la candidate",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -287,6 +287,10 @@
     "defaultMessage": "Les analystes (<abbreviation>IT-02</abbreviation>) fournissent des services techniques, des conseils, des analyses et de la recherche dans leur domaine d'expertise pour appuyer la prestation de services aux clients et aux intervenants. Les analystes de la <abbreviation>TI</abbreviation> se retrouvent dans tous les volets de travail.",
     "description": "blurb describing IT-02"
   },
+  "/SOIpV": {
+    "defaultMessage": "En indiquant que la formation ou le perfectionnement vous intéresse, vous acceptez de partager les informations de votre profil avec l'équipe de recrutement et les gestionnaires d'embauche de cette collectivité fonctionnelle.",
+    "description": "Context for the 'I'm interested in training opportunities within this community' radio option"
+  },
   "/UKT+/": {
     "defaultMessage": "Compétences",
     "description": "Title for skills"
@@ -11573,10 +11577,6 @@
   "wYohzF": {
     "defaultMessage": "Membres du processus",
     "description": "Page title for the manage process members page"
-  },
-  "wdBpAX": {
-    "defaultMessage": "En indiquant que les possibilités de formation vous intéressent, vous acceptez de partager les informations de votre profil avec l'équipe de recrutement et les gestionnaires d'embauche de cette collectivité fonctionnelle.",
-    "description": "Context for the 'I'm interested in training opportunities within this community' radio option"
   },
   "weLwJA": {
     "defaultMessage": "Recherche de talent",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2339,10 +2339,6 @@
     "defaultMessage": "Lieu actuel",
     "description": "Title displayed on the Pool Candidates table Current Location column."
   },
-  "9whw8l": {
-    "defaultMessage": "Intérêt pour les possibilités de formation",
-    "description": "Label for users interest in training opportunities for a community"
-  },
   "A+4huJ": {
     "defaultMessage": "Mettre à jour ou supprimer une expérience dans votre chronologie de carrière",
     "description": "Display text for edit experience form in breadcrumbs"
@@ -3662,10 +3658,6 @@
   "H0h1Vn": {
     "defaultMessage": "Anglais essentiel",
     "description": "English essential language requirement"
-  },
-  "H1UEd5": {
-    "defaultMessage": "Intérêt pour les possibilités de formation",
-    "description": "Label for the input for choosing interest level in a training opportunity"
   },
   "H1wLfA": {
     "defaultMessage": "Sélectionnez une province ou un territoire",
@@ -6593,6 +6585,10 @@
   "Wd/+eR": {
     "defaultMessage": "Droit de priorité",
     "description": "Label for applicant's priority entitlement status"
+  },
+  "WfX9z1": {
+    "defaultMessage": "Intérêt pour la formation ou le perfectionnement",
+    "description": "Label for user Interest in training and development for a community"
   },
   "Wg+Buu": {
     "defaultMessage": "Disponible en avril",

--- a/apps/web/src/pages/CommunityInterests/sections/FindANewCommunity.tsx
+++ b/apps/web/src/pages/CommunityInterests/sections/FindANewCommunity.tsx
@@ -238,10 +238,10 @@ const FindANewCommunity = ({
               idPrefix="trainingInterest"
               name="trainingInterest"
               legend={intl.formatMessage({
-                defaultMessage: "Interest in training opportunities",
-                id: "H1UEd5",
+                defaultMessage: "Interest in training and development",
+                id: "WfX9z1",
                 description:
-                  "Label for the input for choosing interest level in a training opportunity",
+                  "Label for user Interest in training and development for a community",
               })}
               items={[
                 {

--- a/apps/web/src/pages/CommunityInterests/sections/FindANewCommunity.tsx
+++ b/apps/web/src/pages/CommunityInterests/sections/FindANewCommunity.tsx
@@ -255,8 +255,8 @@ const FindANewCommunity = ({
                   }),
                   contentBelow: intl.formatMessage({
                     defaultMessage:
-                      "By indicating that you're interested in training opportunities, you agree to share your profile information with recruiters and hiring managers within this functional community.",
-                    id: "wdBpAX",
+                      "By indicating that you're interested in training or development, you agree to share your profile information with recruiters and hiring managers within this functional community.",
+                    id: "/SOIpV",
                     description:
                       "Context for the 'I'm interested in training opportunities within this community' radio option",
                   }),

--- a/apps/web/src/pages/CommunityInterests/sections/FindANewCommunity.tsx
+++ b/apps/web/src/pages/CommunityInterests/sections/FindANewCommunity.tsx
@@ -248,8 +248,8 @@ const FindANewCommunity = ({
                   value: "true",
                   label: intl.formatMessage({
                     defaultMessage:
-                      "I’m interested in being considered for training or development opportunities within this community.",
-                    id: "oEYCLO",
+                      "I’m interested in being considered for training opportunities or development programs within this community.",
+                    id: "gsjH8R",
                     description:
                       "Label for the community interest in training opportunities radio option",
                   }),


### PR DESCRIPTION
🤖 Resolves #12916.

## 👋 Introduction

This PR updates copy on the add and edit community interest forms. It also consolidates "Interest in training and development" into a single string to avoid divergence in translation.

## 🧪 Testing

1. `pnpm build`
2. Navigate to http://localhost:8000/en/applicant/community-interests/create
3. Verify copy indicated in the linked issue has been changed in English and French
4. Edit the community interest
5. Verify copy indicated in the linked issue has been changed in English and French

## 📸 Screenshots

### English
<img width="1170" alt="Screen Shot 2025-03-06 at 13 43 34" src="https://github.com/user-attachments/assets/adeaab0d-2b70-4939-8a45-dac55a86a64b" />

### French
<img width="1162" alt="Screen Shot 2025-03-06 at 13 43 51" src="https://github.com/user-attachments/assets/5981c47b-b90b-4119-b6e6-0d1c769cc0fa" />