### PR TITLE
[a11y] Add semantic heading markup to dashboard links

### DIFF
--- a/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.tsx
@@ -244,6 +244,7 @@ export const DashboardPage = ({
                 })}
               >
                 <ResourceBlock.SingleLinkItem
+                  as="h3"
                   state={personalInformationState}
                   title={intl.formatMessage({
                     defaultMessage: "Personal information",
@@ -262,6 +263,7 @@ export const DashboardPage = ({
                 />
                 {currentUser?.isVerifiedGovEmployee ? (
                   <ResourceBlock.SingleLinkItem
+                    as="h3"
                     state={employeeProfileState}
                     title={intl.formatMessage(
                       navigationMessages.employeeProfileGC,
@@ -277,6 +279,7 @@ export const DashboardPage = ({
                   />
                 ) : null}
                 <ResourceBlock.SingleLinkItem
+                  as="h3"
                   state={careerExperienceState}
                   title={intl.formatMessage({
                     defaultMessage: "Career experience",
@@ -293,6 +296,7 @@ export const DashboardPage = ({
                   })}
                 />
                 <ResourceBlock.SingleLinkItem
+                  as="h3"
                   state={skillsPortfolioState}
                   title={intl.formatMessage(navigationMessages.skillPortfolio)}
                   href={paths.skillPortfolio()}
@@ -305,6 +309,7 @@ export const DashboardPage = ({
                   })}
                 />
                 <ResourceBlock.SingleLinkItem
+                  as="h3"
                   state="complete"
                   title={intl.formatMessage(navigationMessages.accountSettings)}
                   href={paths.accountSettings()}
@@ -327,6 +332,7 @@ export const DashboardPage = ({
                 })}
               >
                 <ResourceBlock.SingleLinkItem
+                  as="h3"
                   title={intl.formatMessage({
                     defaultMessage: "Learn about skills",
                     id: "n40Nry",
@@ -341,6 +347,7 @@ export const DashboardPage = ({
                   })}
                 />
                 <ResourceBlock.SingleLinkItem
+                  as="h3"
                   title={intl.formatMessage({
                     defaultMessage: "Contact support",
                     id: "jRnA1D",

--- a/packages/ui/src/components/ResourceBlock/SingleLinkItem.tsx
+++ b/packages/ui/src/components/ResourceBlock/SingleLinkItem.tsx
@@ -1,10 +1,25 @@
 import ArrowSmallRightIcon from "@heroicons/react/20/solid/ArrowSmallRightIcon";
+import { ReactNode } from "react";
 
 import Link, { LinkProps } from "../Link";
 import BaseItem, { BaseItemProps } from "./BaseItem";
+import { HeadingRank } from "../../types";
+
+interface WrapperProps {
+  as?: HeadingRank;
+  children: ReactNode;
+}
+
+const Wrapper = ({ as, children }: WrapperProps) => {
+  if (!as) return <>{children}</>;
+
+  const Heading = as;
+  return <Heading data-h2-font-size="base(body)">{children}</Heading>;
+};
 
 interface SingleLinkItemProps {
   title: string;
+  as?: HeadingRank;
   accessibleLabel?: BaseItemProps["accessibleLabel"];
   href: LinkProps["href"];
   description: BaseItemProps["description"];
@@ -17,34 +32,27 @@ const SingleLinkItem = ({
   href,
   description,
   state,
-}: SingleLinkItemProps) => {
-  return (
-    <BaseItem
-      title={
+  as,
+}: SingleLinkItemProps) => (
+  <BaseItem
+    title={
+      <Wrapper as={as}>
         <Link
           href={href}
           color="black"
           // yuck, style exception 😞
           data-h2-font-weight="base(bold)"
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
+          utilityIcon={ArrowSmallRightIcon}
         >
           {title}
-          {/* issue #11284 */}
-          {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
-          <ArrowSmallRightIcon
-            data-h2-width="base(auto)"
-            data-h2-height="base(x0.75)"
-            data-h2-color="base(black.light)"
-            data-h2-margin="base(x0.15)"
-            data-h2-vertical-align="base(top)"
-            aria-hidden
-          />
         </Link>
-      }
-      accessibleLabel={accessibleLabel ?? title}
-      description={description}
-      state={state}
-    />
-  );
-};
+      </Wrapper>
+    }
+    accessibleLabel={accessibleLabel ?? title}
+    description={description}
+    state={state}
+  />
+);
 
 export default SingleLinkItem;


### PR DESCRIPTION
🤖 Resolves #12886 

## 👋 Introduction

This adds heading markup to the links on the applicant dashboard.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as any role
3. Confirm links in the sidebar have the appropriate heading mark up

## 📸 Screenshot

![2025-03-06_14-52](https://github.com/user-attachments/assets/1e5f26c0-be9c-4216-bddc-7d2b7606c3e0)
