### PR TITLE
[a11y] Include unread notification count in `aria-label`

### DIFF
--- a/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
+++ b/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
@@ -242,11 +242,26 @@ const NotificationDialog = ({
             mode={isSmallScreen ? "solid" : "icon_only"}
             color={isSmallScreen ? "black" : "secondary"}
             icon={notificationCount > 0 ? UnreadAlertBellIcon : BellAlertIconSm}
-            aria-label={intl.formatMessage({
-              defaultMessage: "View notifications",
-              id: "ztx8xL",
-              description: "Button text to open the notifications dialog",
-            })}
+            aria-label={intl.formatMessage(
+              {
+                defaultMessage: "View notifications{count}",
+                id: "l82MWI",
+                description: "Button text to open the notifications dialog",
+              },
+              {
+                count:
+                  notificationCount > 0
+                    ? ` ${intl.formatMessage(
+                        {
+                          defaultMessage: "({notificationCount} unread)",
+                          id: "Z22PPJ",
+                          description: "Number of unread notifications",
+                        },
+                        { notificationCount },
+                      )}`
+                    : "",
+              },
+            )}
             data-h2-margin-right="base:selectors[>*:first-child](-x.25) l-tablet:selectors[>*:first-child](0)"
             data-icon="true"
             {...(!isSmallScreen && linkColorStyling)}

--- a/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
+++ b/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
@@ -253,8 +253,11 @@ const NotificationDialog = ({
                   notificationCount > 0
                     ? ` ${intl.formatMessage(
                         {
-                          defaultMessage: "({notificationCount} unread)",
-                          id: "Z22PPJ",
+                          defaultMessage: `({notificationCount, plural,
+                            =0 {0 unread}
+                            one {{notificationCount, number} unread}
+                            other {{notificationCount, number} unread}})`,
+                          id: "OpemzD",
                           description: "Number of unread notifications",
                         },
                         { notificationCount },

--- a/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
+++ b/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
@@ -251,17 +251,11 @@ const NotificationDialog = ({
               {
                 count:
                   notificationCount > 0
-                    ? ` ${intl.formatMessage(
-                        {
-                          defaultMessage: `({notificationCount, plural,
-                            =0 {0 unread}
-                            one {{notificationCount, number} unread}
-                            other {{notificationCount, number} unread}})`,
-                          id: "OpemzD",
-                          description: "Number of unread notifications",
-                        },
-                        { notificationCount },
-                      )}`
+                    ? ` ${intl.formatMessage({
+                        defaultMessage: "(there are unread notifications)",
+                        id: "o+YSXN",
+                        description: "Notice of unread notifications",
+                      })}`
                     : "",
               },
             )}

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5159,6 +5159,10 @@
     "defaultMessage": "Exceptions relatives au lieu de travail",
     "description": "Work location exceptions label"
   },
+  "OpemzD": {
+    "defaultMessage": "({notificationCount, plural, =0 {0 non lue} one {{notificationCount, number} non lue} other {{notificationCount, number} non lues}})",
+    "description": "Number of unread notifications"
+  },
   "Opn8nz": {
     "defaultMessage": "Décrivez la façon dont la compétence {skillName} a été mise en valeur dans ce rôle",
     "description": "More descriptive label for the textarea in the skills in detail section"
@@ -9514,6 +9518,10 @@
     "defaultMessage": "Retirer du processus",
     "description": "Header for the form to remove a process role from a user"
   },
+  "l82MWI": {
+    "defaultMessage": "Voir les notifications{count}",
+    "description": "Button text to open the notifications dialog"
+  },
   "l9AK3C": {
     "defaultMessage": "ou",
     "description": "that appears between different experience requirements for a pool applicant"
@@ -12181,10 +12189,6 @@
   "ztQSF+": {
     "defaultMessage": "L’accessibilité, un choix et un élément clé de conception",
     "description": "Title for the accessible by design section"
-  },
-  "ztx8xL": {
-    "defaultMessage": "Voir les notifications",
-    "description": "Button text to open the notifications dialog"
   },
   "ztzRUG": {
     "defaultMessage": "Créez une classification",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5159,10 +5159,6 @@
     "defaultMessage": "Exceptions relatives au lieu de travail",
     "description": "Work location exceptions label"
   },
-  "OpemzD": {
-    "defaultMessage": "({notificationCount, plural, =0 {0 non lue} one {{notificationCount, number} non lue} other {{notificationCount, number} non lues}})",
-    "description": "Number of unread notifications"
-  },
   "Opn8nz": {
     "defaultMessage": "Décrivez la façon dont la compétence {skillName} a été mise en valeur dans ce rôle",
     "description": "More descriptive label for the textarea in the skills in detail section"
@@ -10089,6 +10085,10 @@
   "nzw1ry": {
     "defaultMessage": "Domaine d’études",
     "description": "Label displayed on education form for area of study input"
+  },
+  "o+YSXN": {
+    "defaultMessage": "(il y a des notifications non lues)",
+    "description": "Notice of unread notifications"
   },
   "o0Yt8Q": {
     "defaultMessage": "Établissement",


### PR DESCRIPTION
🤖 Resolves #12891 

## 👋 Introduction

Adds the number of unread notifications to the `aria-label` for the notification dialog trigger for screen readers.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login
3. Confirim, with no unread notifications, the label remains the same
4. Create a notification for the logged in user
5. Confirm the label updates to include a count of new/unread notifications

## 📸 Screenshot

![2025-03-06_15-55](https://github.com/user-attachments/assets/f0639911-2ee2-4d33-bc4f-d975ec9e99f6)
