### PR TITLE
[Copy] Add and edit community interest forms inability to remove

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -835,6 +835,10 @@
     "defaultMessage": "Parcourez une bibliothèque d’offres d'emploi préétablies avec des suggestions de tâches et de compétences essentielles.",
     "description": "Description for the page showing list of job poster templates"
   },
+  "2Kz16k": {
+    "defaultMessage": "Veuillez revoir les informations que vous avez fournies. Une fois qu'une collectivité est ajoutée à votre profil, vous pouvez mettre à jour ces informations à tout moment.",
+    "description": "Description of the 'Review and submit' section"
+  },
   "2Ljgvn": {
     "defaultMessage": "Voir l’affiche d’emploi pour ce processus de recrutement",
     "description": "Link message that shows the job poster for the recruitment process."
@@ -3694,10 +3698,6 @@
   "HDiUEc": {
     "defaultMessage": "État d'expiration",
     "description": "Label for the expiry status field"
-  },
-  "HGbGb/": {
-    "defaultMessage": "Veuillez revoir les informations que vous avez fournies. Une fois qu'une collectivité est ajoutée à votre profil, vous pouvez mettre à jour ces informations ou supprimer la collectivité de votre profil à tout moment.",
-    "description": "Description of the 'Review and submit' section"
   },
   "HHEQgM": {
     "defaultMessage": "Sélectionnez une classification",

--- a/apps/web/src/pages/CommunityInterests/sections/ReviewAndSubmit.tsx
+++ b/apps/web/src/pages/CommunityInterests/sections/ReviewAndSubmit.tsx
@@ -58,8 +58,8 @@ const ReviewAndSubmit = ({ formDisabled }: ReviewAndSubmitProps) => {
         <p>
           {intl.formatMessage({
             defaultMessage:
-              "Please review the information you've provided. Once a community is added to your profile, you can update this information or remove the community from your profile at any time.",
-            id: "HGbGb/",
+              "Please review the information you've provided. Once a community is added to your profile, you can update this information at any time.",
+            id: "2Kz16k",
             description: "Description of the 'Review and submit' section",
           })}
         </p>


### PR DESCRIPTION
🤖 Resolves #12948.

## 👋 Introduction

This PR updates copy on the add and edit community interest forms to reflect that it is not possible to remove a community interest.

## 🧪 Testing

1. `pnpm build`
2. Navigate to http://localhost:8000/en/applicant/community-interests/create
3. Verify copy indicated in the linked issue has been changed in English and French

## 📸 Screenshots

### English
<img width="1148" alt="Screen Shot 2025-03-06 at 16 12 59" src="https://github.com/user-attachments/assets/4718beca-d505-41c2-b34c-736d966d58a0" />

### French
<img width="1146" alt="Screen Shot 2025-03-06 at 16 13 27" src="https://github.com/user-attachments/assets/8fd4a223-2d43-40b5-bd0a-bc1e148ad2b0" />
