### PR TITLE
[Copy] Add and edit community interest preferred work streams

### DIFF
--- a/apps/web/src/components/CommunityInterestDialog/CommunityInterestDialog.tsx
+++ b/apps/web/src/components/CommunityInterestDialog/CommunityInterestDialog.tsx
@@ -163,10 +163,10 @@ const CommunityInterestDialog = ({
               >
                 {intl.formatMessage({
                   defaultMessage:
-                    "Preferred work streams for job opportunities",
-                  id: "Nq3XrT",
+                    "Preferred work streams for job and training opportunities",
+                  id: "EoEEha",
                   description:
-                    "Label for users interest in training opportunities for a community",
+                    "Label for the input for selecting work stream referral preferences",
                 })}
               </p>
               <ul

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -771,6 +771,10 @@
     "defaultMessage": "Pour obtenir un bon, vous devez remplir le formulaire de demande. Votre profil sur Talents numériques du GC nous permettra de vérifier si vous êtes admissible. Avant de présenter votre demande, prenez le temps de revoir et de mettre à jour les renseignements dans votre profil, ou de vous en créer un si vous ne l'avez pas déjà fait.",
     "description": "First paragraph of apply and complete your profile section"
   },
+  "1vpJU6": {
+    "defaultMessage": "Veuillez sélectionner les volets de travail que vous envisageriez pour un emploi ou une formation.",
+    "description": "Introduction for a work stream referral preferences input"
+  },
   "1xI8uo": {
     "defaultMessage": "Utilisez le bouton « Ajoutez un rôle individuel » pour commencer.",
     "description": "Instructions for adding a role to a user."
@@ -4398,10 +4402,6 @@
   "Kp3Bqu": {
     "defaultMessage": "Critères essentiels",
     "description": "Essential criteria heading"
-  },
-  "KpmfLa": {
-    "defaultMessage": "Veuillez sélectionner les volets de travail dans lesquels vous aimeriez travailler.",
-    "description": "Introduction for a work stream referral preferences input"
   },
   "KqAp09": {
     "defaultMessage": "Poursuivez l’ébauche de votre demande pour le poste {applicationTitle}",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3231,6 +3231,10 @@
     "defaultMessage": "Téléphone :",
     "description": "Display text for the phone number field on users"
   },
+  "EoEEha": {
+    "defaultMessage": "Volets de travail préférés pour l'emploi ou la formation",
+    "description": "Label for the input for selecting work stream referral preferences"
+  },
   "EoGTKC": {
     "defaultMessage": "Les renseignements personnels recueillis par l’entremise de Talents numériques du GC sont utilisés aux fins des activités de dotation, de recrutement, de possibilités de formation et de mobilité interne des talents au sein des institutions fédérales, conformément au <justiceLaws7Link>paragraphe 7(1)</justiceLaws7Link> de la Loi sur la gestion des finances publiques, aux paragraphes <justiceLaws15Link>15(1)</justiceLaws15Link>, <justiceLaws29Link>29</justiceLaws29Link> et <justiceLaws30Link>30 (1), (2), and (3)</justiceLaws30Link> de la Loi sur l’emploi dans la fonction publique et de l’article 5 de la Loi sur l’équité en matière d’emploi.",
     "description": "Paragraph for privacy policy page"
@@ -4962,10 +4966,6 @@
   "NpznI5": {
     "defaultMessage": "Sauvegarder et ignorer la vérification",
     "description": "Button label for submit and skip email verification button on getting started form."
-  },
-  "Nq3XrT": {
-    "defaultMessage": "Volets de travail préférés pour l'emploi",
-    "description": "Label for users interest in training opportunities for a community"
   },
   "NuT+Rx": {
     "defaultMessage": "Procéder à la mise à jour du sujet",
@@ -9617,10 +9617,6 @@
   "loDwKe": {
     "defaultMessage": "À propos du Portail des talents autochtones",
     "description": "Talent Portal information heading"
-  },
-  "loImp5": {
-    "defaultMessage": "Volets de travail préférés pour l'emploi",
-    "description": "Label for the input for selecting work stream referral preferences"
   },
   "lr6PWk": {
     "defaultMessage": "Si vous n’avez pas encore d’application d’authentification, vous devrez en télécharger une. Des fournisseurs numériques comme Google Authenticator et Microsoft Authenticator offrent des applications d’authentification. Quelle que soit l’application que vous choisissez, veillez à ce qu’elle provienne d’un fournisseur réputé.",

--- a/apps/web/src/pages/CommunityInterests/sections/FindANewCommunity.tsx
+++ b/apps/web/src/pages/CommunityInterests/sections/FindANewCommunity.tsx
@@ -287,8 +287,8 @@ const FindANewCommunity = ({
                 <span id={workStreamListDescription}>
                   {intl.formatMessage({
                     defaultMessage:
-                      "Please select any of the work streams listed that you would consider working within.",
-                    id: "KpmfLa",
+                      "Please select any of the work streams listed that you would consider for work or training.",
+                    id: "1vpJU6",
                     description:
                       "Introduction for a work stream referral preferences input",
                   })}

--- a/apps/web/src/pages/CommunityInterests/sections/FindANewCommunity.tsx
+++ b/apps/web/src/pages/CommunityInterests/sections/FindANewCommunity.tsx
@@ -298,8 +298,8 @@ const FindANewCommunity = ({
                   name="interestInWorkStreamIds"
                   legend={intl.formatMessage({
                     defaultMessage:
-                      "Preferred work streams for job opportunities",
-                    id: "loImp5",
+                      "Preferred work streams for job and training opportunities",
+                    id: "EoEEha",
                     description:
                       "Label for the input for selecting work stream referral preferences",
                   })}


### PR DESCRIPTION
🤖 Resolves #12913.

## 👋 Introduction

This PR updates copy on the add and edit community interest forms and dialog for preferred work streams.

## 🧪 Testing

1. `pnpm build`
2. Navigate to http://localhost:8000/en/applicant/community-interests/create
3. Verify copy indicated in the linked issue has been changed in English and French

> [!NOTE]
> The Add a community, Edit a community, Dialog on applicant dashboard use the same string sources for the two strings changed in this PR.

## 📸 Screenshots

### English

<img width="1119" alt="Screen Shot 2025-03-06 at 16 33 45" src="https://github.com/user-attachments/assets/0a555077-a08c-42cd-bd59-33b7e78c422d" />

### French

<img width="1129" alt="Screen Shot 2025-03-06 at 16 33 31" src="https://github.com/user-attachments/assets/16403d6b-73ec-49e5-bf7b-b978f4e9c4c7" />