### PR TITLE
[Fix] `ExperienceCard` layout fits elements on smaller screen widths

### DIFF
--- a/apps/web/src/components/ExperienceCard/ExperienceCard.tsx
+++ b/apps/web/src/components/ExperienceCard/ExperienceCard.tsx
@@ -160,15 +160,17 @@ const ExperienceCard = ({
         >
           <span>{titleHtml}</span>
         </Heading>
-        <div
-          data-h2-display="base(block) p-tablet(initial)"
-          data-h2-width="base(100%) p-tablet(initial)"
-          data-h2-text-align="base(center) p-tablet(initial)"
-          data-h2-margin="base(x1 0 x.5 0) p-tablet(initial)"
-        >
-          {showEdit && edit}
-          {view}
-        </div>
+        {(showEdit || view) && (
+          <div
+            data-h2-display="base(block) p-tablet(initial)"
+            data-h2-width="base(100%) p-tablet(initial)"
+            data-h2-text-align="base(center) p-tablet(initial)"
+            data-h2-margin="base(x1 0 x.5 0) p-tablet(initial)"
+          >
+            {showEdit && edit}
+            {view}
+          </div>
+        )}
       </div>
       <p
         data-h2-display="base(flex)"

--- a/apps/web/src/components/ExperienceCard/ExperienceCard.tsx
+++ b/apps/web/src/components/ExperienceCard/ExperienceCard.tsx
@@ -144,6 +144,7 @@ const ExperienceCard = ({
     >
       <div
         data-h2-display="base(flex)"
+        data-h2-flex-wrap="base(wrap) p-tablet(initial)"
         data-h2-align-items="base(center)"
         data-h2-justify-content="base(space-between)"
         data-h2-gap="base(0 x1)"
@@ -159,12 +160,21 @@ const ExperienceCard = ({
         >
           <span>{titleHtml}</span>
         </Heading>
-        {showEdit && edit}
-        {view}
+        <div
+          data-h2-display="base(block) p-tablet(initial)"
+          data-h2-width="base(100%) p-tablet(initial)"
+          data-h2-text-align="base(center) p-tablet(initial)"
+          data-h2-margin="base(x1 0 x.5 0) p-tablet(initial)"
+        >
+          {showEdit && edit}
+          {view}
+        </div>
       </div>
       <p
         data-h2-display="base(flex)"
+        data-h2-flex-wrap="base(wrap) p-tablet(initial)"
         data-h2-align-items="base(center)"
+        data-h2-justify-content="base(center) p-tablet(initial)"
         data-h2-gap="base(0 x.5)"
         data-h2-margin="base(x.25, 0, x1, 0)"
         data-h2-color="base(black.light)"

--- a/packages/fake-data/src/fakeExperiences.ts
+++ b/packages/fake-data/src/fakeExperiences.ts
@@ -7,7 +7,7 @@ import {
   EducationExperience,
   PersonalExperience,
   WorkExperience,
-  // required imports to generate AnExperience to export
+  // required imports to generate an Experience to export
   User,
   ExperienceSkillRecord,
   Skill,

--- a/packages/fake-data/src/fakeExperiences.ts
+++ b/packages/fake-data/src/fakeExperiences.ts
@@ -16,7 +16,9 @@ import {
   AwardedScope,
   EducationType,
   EducationStatus,
+  EmploymentCategory,
 } from "@gc-digital-talent/graphql";
+import { fakeDepartments } from "@gc-digital-talent/fake-data";
 
 import { getStaticSkills } from "./fakeSkills";
 import toLocalizedEnum from "./fakeLocalizedEnum";
@@ -167,13 +169,16 @@ const generateWork = (): GeneratedWorkExperience => {
     })),
     details: `experience details ${faker.lorem.words()}`,
     organization: faker.company.name(),
-    role: faker.person.jobTitle(),
+    role: `${faker.person.jobDescriptor()} ${faker.person.jobTitle()}`,
     division: faker.animal.bird(),
     startDate: staticDates.start,
     endDate: staticDates.end,
     experienceSkillRecord: {
       details: `experience.experienceSkillRecord ${faker.lorem.words()}`,
     },
+    department: fakeDepartments()[5],
+    employmentCategory: toLocalizedEnum(EmploymentCategory.GovernmentOfCanada),
+    contractorFirmAgencyName: faker.company.name(),
   };
 };
 

--- a/packages/fake-data/src/fakeExperiences.ts
+++ b/packages/fake-data/src/fakeExperiences.ts
@@ -17,6 +17,8 @@ import {
   EducationType,
   EducationStatus,
   EmploymentCategory,
+  WorkExperienceGovEmployeeType,
+  GovContractorType,
 } from "@gc-digital-talent/graphql";
 import { fakeDepartments } from "@gc-digital-talent/fake-data";
 
@@ -169,7 +171,7 @@ const generateWork = (): GeneratedWorkExperience => {
     })),
     details: `experience details ${faker.lorem.words()}`,
     organization: faker.company.name(),
-    role: `${faker.person.jobDescriptor()} ${faker.person.jobTitle()}`,
+    role: `${faker.person.jobDescriptor()} ${faker.person.jobType()} ${faker.person.jobTitle()} ${faker.person.jobArea()}`,
     division: faker.animal.bird(),
     startDate: staticDates.start,
     endDate: staticDates.end,
@@ -178,6 +180,10 @@ const generateWork = (): GeneratedWorkExperience => {
     },
     department: fakeDepartments()[5],
     employmentCategory: toLocalizedEnum(EmploymentCategory.GovernmentOfCanada),
+    govEmploymentType: toLocalizedEnum(
+      WorkExperienceGovEmployeeType.Contractor,
+    ),
+    govContractorType: toLocalizedEnum(GovContractorType.SelfEmployed),
     contractorFirmAgencyName: faker.company.name(),
   };
 };

--- a/packages/fake-data/src/fakeLocalizedEnum.ts
+++ b/packages/fake-data/src/fakeLocalizedEnum.ts
@@ -21,7 +21,7 @@ function enumToString(value: string, delimiter: string | RegExp = "_") {
 }
 
 /**
- * Converts a strin in PascalCase to SCREAMING_SNAKE_CASE
+ * Converts a string in PascalCase to SCREAMING_SNAKE_CASE
  *
  * @param value - The string to be transformed
  * @returns New string


### PR DESCRIPTION
🤖 Resolves #12947.

## 👋 Introduction

This PR updates the `ExperienceCard` layout to fit elements within its container on smaller screen widths.

## 🕵️ Details

The `fakeExperiences` used by the `ExperienceCard` stories have not kept up with changes to the data shape of experiences, including whether they are government, contractor, or a host of others. For the purposes of rendering as much as possible for visual testing, some of these fields have been added to `fakeExperiences` for the type work.

## 🧪 Testing

1. `pnpm storybook`
2. Navigate to http://localhost:6006/?path=/story/components-experiencecard--work-experience-card
3. Open canvas in new tab
4. Toggle device toolbar and set width to 310px (this is for Chrome, other browsers may differ)
5. Verify text does not overflow outside of container
6. Verify card on larger screen widths is the same as before

## 📸 Screenshot

<img width="944" alt="Screen Shot 2025-03-07 at 15 16 43" src="https://github.com/user-attachments/assets/42c5c47d-d3a1-471f-8c3f-92ddb85a990d" />