### PR TITLE
[A11y] Reload document on current breadcrumb activation

### DIFF
--- a/packages/ui/src/components/Breadcrumbs/Crumb.tsx
+++ b/packages/ui/src/components/Breadcrumbs/Crumb.tsx
@@ -21,6 +21,7 @@ const Crumb = ({ children, isCurrent, url }: CrumbProps) => (
             "data-h2-font-weight": "base(700)",
             "data-h2-text-decoration": "base(none)",
             "aria-current": "page",
+            reloadDocument: true,
           }
         : {})}
     >


### PR DESCRIPTION
🤖 Resolves #12901 

## 👋 Introduction

Forces the document to reload when activating the current page breadcrumb.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Navigate to a page with breadcrumbs i.e `/browse/pools`
3. Turn on a screen reader
4. Activate the current breadcrumb
5. Confirm the page is reloaded and the heading is announced