### PR TITLE
[Fix] Display of development program interests

### DIFF
--- a/apps/web/src/components/CommunityInterestDialog/DevelopmentProgramInterestItem.tsx
+++ b/apps/web/src/components/CommunityInterestDialog/DevelopmentProgramInterestItem.tsx
@@ -50,7 +50,7 @@ const useStatusInfo = (
         formatString: "MMMM yyyy",
         intl,
       })
-    : intl.formatMessage(commonMessages.notAvailable);
+    : null;
 
   const infoMap = new Map<DevelopmentProgramParticipationStatus, StatusInfo>([
     [
@@ -90,15 +90,23 @@ const useStatusInfo = (
         iconStyles: {
           "data-h2-color": "base(primary) base:dark(primary.light)",
         },
-        message: intl.formatMessage(
-          {
-            defaultMessage: "Currently enrolled, expected completion in {date}",
-            id: "fFihbX",
-            description:
-              "Message displayed when a user is enrolled in a development program",
-          },
-          { date },
-        ),
+        message: date
+          ? intl.formatMessage(
+              {
+                defaultMessage:
+                  "Currently enrolled, expected completion in {date}",
+                id: "fFihbX",
+                description:
+                  "Message displayed when a user is enrolled in a development program",
+              },
+              { date },
+            )
+          : intl.formatMessage({
+              defaultMessage: "Currently enrolled",
+              id: "cHKJC8",
+              description:
+                "Message displayed when a user is enrolled in a development program with no expected end date",
+            }),
       },
     ],
     [
@@ -172,8 +180,7 @@ const DevelopmentProgramInterestItem = ({
         <span>{label}</span>
         <span
           data-h2-font-size="base(caption)"
-          {...(!developmentProgramInterest?.participationStatus ||
-          !developmentProgramInterest?.completionDate
+          {...(!developmentProgramInterest?.participationStatus
             ? {
                 "data-h2-color": "base(error) base:dark(error.lightest)",
               }

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7782,6 +7782,10 @@
     "defaultMessage": "Candidature",
     "description": "Label for the application link column"
   },
+  "cHKJC8": {
+    "defaultMessage": "Programme en cours",
+    "description": "Message displayed when a user is enrolled in a development program with no expected end date"
+  },
   "cHwSqN": {
     "defaultMessage": "Type de poste visé",
     "description": "Label for a employee profile target role field"


### PR DESCRIPTION
🤖 Resolves #13008 

## 👋 Introduction

Fixes an issue with the display of development program interests lacking a date for currently enrolled status.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as employee `applicant-employee@test.com`
3. Create/edit community interest
4. Fill out different possible states
5. Confirm the display of those states matches the expected result

## 📸 Screenshot

![2025-03-14_11-42](https://github.com/user-attachments/assets/6700ce33-14eb-48cc-9671-dab0c9c5f4b9)
![2025-03-14_11-42_1](https://github.com/user-attachments/assets/50b6ebf5-6e00-4be7-9e6d-db4bbfc5765f)
![2025-03-14_11-42_2](https://github.com/user-attachments/assets/042ba825-e716-4ce2-8dd6-ba3720550f2e)
