### PR TITLE
[Feat] Talent nomination rationale

### DIFF
--- a/api/app/Models/Skill.php
+++ b/api/app/Models/Skill.php
@@ -88,7 +88,7 @@ class Skill extends Model
 
     public function scopeFamilies(Builder $query, ?array $keys): Builder
     {
-        if (! $keys || ! count($keys)) {
+        if (! $keys) {
             return $query;
         }
 

--- a/api/app/Models/Skill.php
+++ b/api/app/Models/Skill.php
@@ -85,4 +85,15 @@ class Skill extends Model
     {
         return $query->where('category', '=', SkillCategory::BEHAVIOURAL->name);
     }
+
+    public function scopeFamilies(Builder $query, ?array $keys): Builder
+    {
+        if (! $keys || ! count($keys)) {
+            return $query;
+        }
+
+        return $query->whereHas('families', function (Builder $query) use ($keys) {
+            $query->whereIn('key', $keys);
+        });
+    }
 }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1329,7 +1329,9 @@ type Query {
   skillFamily(id: UUID! @eq): SkillFamily @find @canModel(ability: "view")
   skillFamilies: [SkillFamily]! @all @canModel(ability: "viewAny")
   skill(id: UUID! @eq): Skill @find @canModel(ability: "view")
-  skills: [Skill]! @all @canModel(ability: "viewAny")
+  skills(families: [String!] @scope): [Skill]!
+    @all
+    @canModel(ability: "viewAny")
   genericJobTitle(id: UUID! @eq): GenericJobTitle
     @find
     @canModel(ability: "view")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -349,7 +349,7 @@ type Query {
   skillFamily(id: UUID!): SkillFamily
   skillFamilies: [SkillFamily]!
   skill(id: UUID!): Skill
-  skills: [Skill]!
+  skills(families: [UUID!]): [Skill]!
   genericJobTitle(id: UUID!): GenericJobTitle
   genericJobTitles: [GenericJobTitle]!
   community(id: UUID!): Community

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -349,7 +349,7 @@ type Query {
   skillFamily(id: UUID!): SkillFamily
   skillFamilies: [SkillFamily]!
   skill(id: UUID!): Skill
-  skills(families: [UUID!]): [Skill]!
+  skills(families: [String!]): [Skill]!
   genericJobTitle(id: UUID!): GenericJobTitle
   genericJobTitles: [GenericJobTitle]!
   community(id: UUID!): Community

--- a/apps/web/src/lang/__snapshots__/lang.test.ts.snap
+++ b/apps/web/src/lang/__snapshots__/lang.test.ts.snap
@@ -67,6 +67,13 @@ exports[`message files should have no changes to duplicate strings 1`] = `
     ]
   },
   {
+    "en": "Additional comments",
+    "fr": [
+      "Autres commentaires",
+      "Commentaires supplémentaires"
+    ]
+  },
+  {
     "en": "Minimum education",
     "fr": [
       "Niveau d'études minimal",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1691,6 +1691,10 @@
     "defaultMessage": "Nous aimerions en savoir plus sur le cheminement de carrière que vous souhaitez suivre. Fournir des renseignements sur vos préférences et vos aspirations aidera les gestionnaires de talents à prendre des décisions plus éclairées dans le cadre d'une promotion, d'une mutation latérale ou d'une occasion de perfectionnement professionnel.",
     "description": "Lead-in text explaining the users career plan"
   },
+  "6M8rIa": {
+    "defaultMessage": "Les 3 principales compétences en matière de leadership",
+    "description": "Label for a nominations leadership skill competencies"
+  },
   "6Q1N7Z": {
     "defaultMessage": "Veuillez sélectionner les expériences dans :",
     "description": "Message before skills list in application education page."
@@ -3471,6 +3475,10 @@
     "defaultMessage": "Erreur : Impossible de mettre à jour le statut du candidat du bassin",
     "description": "Message displayed when an error occurs while an admin updates a pool candidate"
   },
+  "FSvySJ": {
+    "defaultMessage": "Veuillez sélectionner exactement 3 compétences en matière de leadership",
+    "description": "Error message when the incorrect number of leadership competencies is selected"
+  },
   "FUxE8S": {
     "defaultMessage": "À partir du bassin suivant :",
     "description": "Second section of text on the change candidate status dialog"
@@ -3930,6 +3938,10 @@
   "I9e48q": {
     "defaultMessage": "Votre vitrine de compétences vous permet de créer des listes de compétences à partir de votre portfolio qui présentent de manière plus ciblée et personnalisée vos forces et vos domaines d’intérêt. Bien que votre portfolio serve d’endroit central pour gérer toutes les compétences que vous ajoutez à votre profil, la vitrine est jumelée à vos demandes d’emploi. Elle est partagée avec les membres du personnel de recrutement et les gestionnaires pour leur donner un tableau plus complet de vos talents.",
     "description": "Description on what the skills showcase is."
+  },
+  "IBLDnY": {
+    "defaultMessage": "Commentaires supplémentaires",
+    "description": "Label for additional comments on a nomination's rationale"
   },
   "IBc2sp": {
     "defaultMessage": "Nom complet",
@@ -9525,6 +9537,10 @@
   "joXPYW": {
     "defaultMessage": "Composantes clés",
     "description": "Heading for section describing the different components"
+  },
+  "jokoVA": {
+    "defaultMessage": "Justification de la nomination",
+    "description": "Label for a nomination's rationale"
   },
   "jphtnM": {
     "defaultMessage": "Travail à distance facultatif (recommandé)",

--- a/apps/web/src/pages/TalentNominations/NominateTalent/NominateTalentPage.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/NominateTalentPage.tsx
@@ -7,6 +7,7 @@ import { Pending, TableOfContents, ThrowNotFound } from "@gc-digital-talent/ui";
 import { graphql, TalentNominationStep } from "@gc-digital-talent/graphql";
 import { ROLE_NAME } from "@gc-digital-talent/auth";
 import { navigationMessages } from "@gc-digital-talent/i18n";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
 
 import useRequiredParams from "~/hooks/useRequiredParams";
 import SEO from "~/components/SEO/SEO";
@@ -71,6 +72,11 @@ const NominateTalent_Query = graphql(/* GraphQL */ `
       ...NominateTalentRationale
       ...NominateTalentReviewAndSubmit
       ...NominateTalentSuccess
+    }
+
+    # klc = Leadership - Executive behaviours
+    skills(families: ["klc"]) {
+      ...NominateTalentSkill
     }
   }
 `);
@@ -166,7 +172,10 @@ const NominateTalentPage = () => {
                 <Nominator nominatorQuery={data.talentNomination} />
                 <Nominee nomineeQuery={data.talentNomination} />
                 <Details detailsQuery={data.talentNomination} />
-                <Rationale rationaleQuery={data.talentNomination} />
+                <Rationale
+                  rationaleQuery={data.talentNomination}
+                  skillsQuery={unpackMaybes(data?.skills)}
+                />
                 <ReviewAndSubmit reviewAndSubmitQuery={data.talentNomination} />
                 <Success successQuery={data.talentNomination} />
               </TableOfContents.Content>

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Actions.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Actions.tsx
@@ -25,7 +25,7 @@ const Actions = () => {
       <div
         data-h2-display="base(flex)"
         data-h2-align-items="base(center)"
-        data-h2-gap="base(x.5 x1)"
+        data-h2-gap="base(x1)"
         data-h2-flex-direction="base(column) p-tablet(row)"
       >
         {prev && (

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Rationale.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Rationale.tsx
@@ -1,54 +1,101 @@
 import ChatBubbleBottomCenterTextIcon from "@heroicons/react/24/outline/ChatBubbleBottomCenterTextIcon";
-import { useIntl } from "react-intl";
+import { defineMessage, useIntl } from "react-intl";
 
 import {
   FragmentType,
   getFragment,
   graphql,
+  Maybe,
+  Scalars,
   TalentNominationStep,
 } from "@gc-digital-talent/graphql";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
+import { Combobox, TextArea } from "@gc-digital-talent/forms";
+import { errorMessages, getLocale } from "@gc-digital-talent/i18n";
+
+import { FRENCH_WORDS_PER_ENGLISH_WORD } from "~/constants/talentSearchConstants";
 
 import { BaseFormValues } from "../types";
 import useCurrentStep from "../useCurrentStep";
 import UpdateForm, { SubmitDataTransformer } from "./UpdateForm";
 import SubHeading from "./SubHeading";
 
-// TO DO: Populate when building form
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-interface FormValues extends BaseFormValues {}
+interface FormValues extends BaseFormValues {
+  nominationRationale?: Maybe<string>;
+  skills?: Scalars["UUID"]["input"][];
+  additionalComments?: Maybe<string>;
+}
+
+const NominateTalentSkills_Fragment = graphql(/* GraphQL */ `
+  fragment NominateTalentSkill on Skill {
+    id
+    name {
+      localized
+    }
+  }
+`);
 
 const NominateTalentRationale_Fragment = graphql(/* GraphQL */ `
   fragment NominateTalentRationale on TalentNomination {
     id
+    skills {
+      id
+    }
+    nominationRationale
+    additionalComments
+    talentNominationEvent {
+      includeLeadershipCompetencies
+    }
   }
 `);
 
-// TO DO: Values to be used when form is created
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const leadershipSkillsRangeError = defineMessage({
+  defaultMessage: "Please select exactly 3 leadership competencies",
+  id: "FSvySJ",
+  description:
+    "Error message when the incorrect number of leadership competencies is selected",
+});
+
 const transformSubmitData: SubmitDataTransformer<FormValues> = (values) => {
-  return {};
+  return {
+    nominationRationale: values.nominationRationale ?? null,
+    skills: { sync: values.skills ?? [] },
+    additionalComments: values.additionalComments ?? null,
+  };
 };
 
 interface RationaleProps {
   rationaleQuery: FragmentType<typeof NominateTalentRationale_Fragment>;
+  skillsQuery?: FragmentType<typeof NominateTalentSkills_Fragment>[];
 }
 
-const Rationale = ({ rationaleQuery }: RationaleProps) => {
+const Rationale = ({ rationaleQuery, skillsQuery }: RationaleProps) => {
   const intl = useIntl();
+  const locale = getLocale(intl);
+  const wordLimitMultiplier =
+    locale === "fr" ? FRENCH_WORDS_PER_ENGLISH_WORD : 1;
   const { current } = useCurrentStep();
-  // TO DO: Use in the form population
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const talentNomination = getFragment(
     NominateTalentRationale_Fragment,
     rationaleQuery,
   );
+  const skills = getFragment(NominateTalentSkills_Fragment, skillsQuery);
 
   if (current !== TalentNominationStep.Rationale) {
     return null;
   }
 
   return (
-    <UpdateForm<FormValues> submitDataTransformer={transformSubmitData}>
+    <UpdateForm<FormValues>
+      submitDataTransformer={transformSubmitData}
+      defaultValues={{
+        nominationRationale: talentNomination?.nominationRationale ?? "",
+        additionalComments: talentNomination?.additionalComments ?? "",
+        skills: unpackMaybes(
+          talentNomination?.skills?.flatMap((skill) => skill?.id),
+        ),
+      }}
+    >
       <SubHeading level="h2" Icon={ChatBubbleBottomCenterTextIcon}>
         {intl.formatMessage({
           defaultMessage: "Rationale and additional comments",
@@ -64,6 +111,64 @@ const Rationale = ({ rationaleQuery }: RationaleProps) => {
           description: "Subtitle for nomination rationale step",
         })}
       </p>
+      <div
+        data-h2-display="base(flex)"
+        data-h2-flex-direction="base(column)"
+        data-h2-gap="base(x1)"
+      >
+        <TextArea
+          id="nominationRationale"
+          name="nominationRationale"
+          wordLimit={1000 * wordLimitMultiplier}
+          rules={{ required: intl.formatMessage(errorMessages.required) }}
+          label={intl.formatMessage({
+            defaultMessage: "Nomination rationale",
+            id: "jokoVA",
+            description: "Label for a nomination's rationale",
+          })}
+        />
+        {talentNomination?.talentNominationEvent
+          .includeLeadershipCompetencies && (
+          <Combobox
+            isMulti
+            id="skills"
+            name="skills"
+            rules={{
+              required: intl.formatMessage(errorMessages.required),
+              max: {
+                value: 3,
+                message: intl.formatMessage(leadershipSkillsRangeError),
+              },
+              min: {
+                value: 3,
+                message: intl.formatMessage(leadershipSkillsRangeError),
+              },
+            }}
+            label={intl.formatMessage({
+              defaultMessage: "Top 3 key leadership competencies",
+              id: "6M8rIa",
+              description:
+                "Label for a nominations leadership skill competencies",
+            })}
+            options={unpackMaybes(skills).map((skill) => ({
+              value: skill.id,
+              label: skill.name.localized,
+            }))}
+          />
+        )}
+        <TextArea
+          id="additionalComments"
+          name="additionalComments"
+          wordLimit={500 * wordLimitMultiplier}
+          rules={{ required: intl.formatMessage(errorMessages.required) }}
+          label={intl.formatMessage({
+            defaultMessage: "Additional comments",
+            id: "IBLDnY",
+            description:
+              "Label for additional comments on a nomination's rationale",
+          })}
+        />
+      </div>
     </UpdateForm>
   );
 };


### PR DESCRIPTION
🤖 Resolves #12321 

## 👋 Introduction

Populates the rationale step of a talent nomination.

## 🕵️ Details

- Competencies error message is a placeholder, waiting for actual message.
- Had to add a families scope to skills so we don't query all just to show less than 10

## 🧪 Testing

1. Refresh api `make refresh-api`
2. Build `pnpm run build:fresh`
3. Login as any user
4. Navigate to talent events `/communities/talent-events`
5. Start a nomination for an event that has leadership competencies selected
6. Contiune until you get to the "Ratioinale" step
7. Complete the step confirming skills appear and only accepts exacty 3 items
8. Repeat steps 4-6 with an event that does not have leadership competencies
9. Confirm the "Rationale" step does not include skills

## 📸 Screenshot

![2025-03-17_16-21](https://github.com/user-attachments/assets/4d26fe0d-207d-4c68-9935-b0b0c18fb4a3)
