### PR TITLE
[Feature] Add Talent management widget

### DIFF
--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -29,8 +29,8 @@ class DatabaseSeeder extends Seeder
             // convenient test data
             CommunityTestSeeder::class,
             TalentNominationEventTestSeeder::class,
-            TalentNominationTestSeeder::class,
             UserTestSeeder::class,
+            TalentNominationTestSeeder::class,
             PoolTestSeeder::class,
             PoolCandidateTestSeeder::class,
             AssessmentResultTestSeeder::class,

--- a/api/database/seeders/TalentNominationTestSeeder.php
+++ b/api/database/seeders/TalentNominationTestSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\TalentNomination;
+use App\Models\User;
 use Illuminate\Database\Seeder;
 
 class TalentNominationTestSeeder extends Seeder
@@ -14,6 +15,8 @@ class TalentNominationTestSeeder extends Seeder
      */
     public function run()
     {
+        $admin = User::where('sub', 'admin@test.com')->sole();
+
         TalentNomination::factory()
             ->count(3)
             ->noSubmittedSteps()
@@ -49,5 +52,18 @@ class TalentNominationTestSeeder extends Seeder
             ->submittedReviewAndSubmit()
             ->create();
 
+        // seed some to a specific user
+        TalentNomination::factory()
+            ->count(1)
+            ->noSubmittedSteps()
+            ->create([
+                'submitter_id' => $admin->id,
+            ]);
+        TalentNomination::factory()
+            ->count(1)
+            ->submittedReviewAndSubmit()
+            ->create([
+                'submitter_id' => $admin->id,
+            ]);
     }
 }

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -349,7 +349,7 @@ const getRoutes = (lang: Locales) => {
     // Admin - Community Talent
     communityTalentPage: () => [adminUrl, "community-talent"].join("/"),
 
-    // Communities
+    // Talent management
     talentManagementEvents: () => [communitiesUrl, "talent-events"].join("/"),
     talentNomination: (nominationId: string) =>
       `${communitiesUrl}/talent-nominations/${nominationId}`,

--- a/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.tsx
@@ -28,6 +28,7 @@ import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 
 import CareerDevelopmentTaskCard from "./components/CareerDevelopmentTaskCard";
 import ApplicationsProcessesTaskCard from "./components/ApplicationsProcessesTaskCard";
+import TalentManagementTaskCard from "./components/TalentManagementTaskCard";
 
 export const ApplicantDashboardPage_Fragment = graphql(/* GraphQL */ `
   fragment ApplicantDashboardPage on User {
@@ -131,6 +132,10 @@ export const ApplicantDashboardPage_Fragment = graphql(/* GraphQL */ `
       id
     }
     offPlatformRecruitmentProcesses
+    talentNominationsAsSubmitter {
+      id
+    }
+    ...TalentManagementTaskCard
   }
 `);
 
@@ -161,6 +166,10 @@ export const DashboardPage = ({
   if (!currentUser) {
     throw new NotFoundError();
   }
+
+  const displayTalentManagementTaskCard =
+    !!currentUser?.talentNominationsAsSubmitter?.length &&
+    currentUser.talentNominationsAsSubmitter.length > 0;
 
   const personalInformationState =
     aboutSectionHasEmptyRequiredFields(currentUser) ||
@@ -250,6 +259,11 @@ export const DashboardPage = ({
                 <CareerDevelopmentTaskCard
                   careerDevelopmentTaskCardQuery={currentUser.employeeProfile}
                   careerDevelopmentOptionsQuery={applicantDashboardQuery}
+                />
+              ) : null}
+              {displayTalentManagementTaskCard ? (
+                <TalentManagementTaskCard
+                  talentManagementTaskCardQuery={currentUser}
                 />
               ) : null}
             </div>

--- a/apps/web/src/pages/ApplicantDashboardPage/components/TalentManagementTaskCard.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/TalentManagementTaskCard.tsx
@@ -1,0 +1,145 @@
+import { useIntl } from "react-intl";
+import Cog8ToothIcon from "@heroicons/react/24/outline/Cog8ToothIcon";
+
+import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
+import {
+  Accordion,
+  AccordionMetaData,
+  PreviewList,
+  TaskCard,
+  Well,
+} from "@gc-digital-talent/ui";
+import { commonMessages, navigationMessages } from "@gc-digital-talent/i18n";
+
+import useRoutes from "~/hooks/useRoutes";
+
+import TalentNominationListItem from "./TalentNominationListItem";
+
+const TalentManagementTaskCard_Fragment = graphql(/* GraphQL */ `
+  fragment TalentManagementTaskCard on User {
+    talentNominationsAsSubmitter {
+      id
+      ...PreviewListItemTalentNomination
+    }
+  }
+`);
+
+interface TalentManagementTaskCardProps {
+  talentManagementTaskCardQuery: FragmentType<
+    typeof TalentManagementTaskCard_Fragment
+  >;
+}
+
+const TalentManagementTaskCard = ({
+  talentManagementTaskCardQuery,
+}: TalentManagementTaskCardProps) => {
+  const intl = useIntl();
+  const paths = useRoutes();
+
+  const talentManagementTaskCardFragment = getFragment(
+    TalentManagementTaskCard_Fragment,
+    talentManagementTaskCardQuery,
+  );
+
+  const talentNominationMetaData: AccordionMetaData[] = [
+    {
+      key: "new-nomination-key",
+      type: "link",
+      href: paths.talentManagementEvents(),
+      color: "primary",
+      children: <>{intl.formatMessage(navigationMessages.newNomination)}</>,
+    },
+  ];
+
+  return (
+    <>
+      <div
+        data-h2-display="base(flex)"
+        data-h2-flex-direction="base(column)"
+        data-h2-gap="base(x1)"
+      >
+        <TaskCard.Root
+          icon={Cog8ToothIcon}
+          title={intl.formatMessage({
+            defaultMessage: "Talent management",
+            id: "voqC0s",
+            description: "Card title for Talent management",
+          })}
+          headingColor="quinary"
+          headingAs="h2"
+        >
+          <TaskCard.Item>
+            <Accordion.Root
+              type="multiple"
+              data-h2-padding-bottom="base:selectors[>.Accordion__Item > .Accordion__Content](x.5)"
+            >
+              <Accordion.Item value="your_talent_nominations">
+                <Accordion.Trigger
+                  as="h3"
+                  subtitle={intl.formatMessage({
+                    defaultMessage:
+                      "Nominate employees for advancement, lateral movement, or development programs. Track submission status or view previous nominations you've submitted.",
+                    id: "zCjdD9",
+                    description:
+                      "Subtitle explaining talent nominations expandable within Talent management card",
+                  })}
+                >
+                  {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
+                  {`${intl.formatMessage(commonMessages.talentNominations)} (${talentManagementTaskCardFragment.talentNominationsAsSubmitter?.length ?? 0})`}
+                </Accordion.Trigger>
+                <Accordion.MetaData metadata={talentNominationMetaData} />
+                <Accordion.Content>
+                  <div
+                    data-h2-display="base(flex)"
+                    data-h2-flex-direction="base(column)"
+                    data-h2-gap="base(x1)"
+                    data-h2-padding-top="base(x.5)"
+                  >
+                    {talentManagementTaskCardFragment
+                      .talentNominationsAsSubmitter?.length ? (
+                      <PreviewList.Root>
+                        {talentManagementTaskCardFragment.talentNominationsAsSubmitter.map(
+                          (talentNominationItem) => (
+                            <TalentNominationListItem
+                              key={talentNominationItem.id}
+                              headingAs="h4"
+                              talentNominationListItemQuery={
+                                talentNominationItem
+                              }
+                            />
+                          ),
+                        )}
+                      </PreviewList.Root>
+                    ) : (
+                      <Well data-h2-text-align="base(center)">
+                        <p data-h2-font-weight="base(bold)">
+                          {intl.formatMessage({
+                            defaultMessage: "You have no active nominations.",
+                            id: "mEmT94",
+                            description:
+                              "Notice's title when there are no nominations",
+                          })}
+                        </p>
+                        <p>
+                          {intl.formatMessage({
+                            defaultMessage:
+                              'You can start a nomination by browsing the currently active talent nomination events using the "New nomination" button.',
+                            id: "oQxQJM",
+                            description:
+                              "Notice's text when there are no nominations",
+                          })}
+                        </p>
+                      </Well>
+                    )}
+                  </div>
+                </Accordion.Content>
+              </Accordion.Item>
+            </Accordion.Root>
+          </TaskCard.Item>
+        </TaskCard.Root>
+      </div>
+    </>
+  );
+};
+
+export default TalentManagementTaskCard;

--- a/apps/web/src/pages/ApplicantDashboardPage/components/TalentNominationListItem.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/TalentNominationListItem.tsx
@@ -5,6 +5,7 @@ import { HeadingLevel, PreviewList } from "@gc-digital-talent/ui";
 import { commonMessages } from "@gc-digital-talent/i18n";
 
 import { getFullNameLabel } from "~/utils/nameUtils";
+import useRoutes from "~/hooks/useRoutes";
 
 import { useMetaDataDate, useMetaDataTalentNominationChip } from "./hooks";
 
@@ -37,6 +38,7 @@ const TalentNominationListItem = ({
   talentNominationListItemQuery,
 }: TalentNominationListItemProps) => {
   const intl = useIntl();
+  const paths = useRoutes();
 
   const talentNominationListItemFragment = getFragment(
     PreviewListItemTalentNomination_Fragment,
@@ -51,6 +53,9 @@ const TalentNominationListItem = ({
   const statusChip = useMetaDataTalentNominationChip({
     submittedAt: talentNominationListItemFragment.submittedAt,
   });
+  const nominationEventName =
+    talentNominationListItemFragment.talentNominationEvent?.name?.localized ??
+    intl.formatMessage(commonMessages.notFound);
   const dateElement = useMetaDataDate({
     closeDate: talentNominationListItemFragment.talentNominationEvent.closeDate,
     submittedAt: talentNominationListItemFragment.submittedAt,
@@ -70,9 +75,7 @@ const TalentNominationListItem = ({
     {
       key: "name",
       type: "text",
-      children:
-        talentNominationListItemFragment.talentNominationEvent?.name
-          ?.localized ?? intl.formatMessage(commonMessages.notFound),
+      children: nominationEventName,
     },
     {
       key: "date",
@@ -86,7 +89,22 @@ const TalentNominationListItem = ({
       <PreviewList.Item
         title={fullName}
         metaData={metaDataProps}
-        // action={}
+        action={
+          talentNominationListItemFragment.submittedAt ? null : (
+            <PreviewList.Link
+              label={intl.formatMessage(
+                {
+                  defaultMessage: "Go to draft nomination for {eventName}",
+                  id: "wtjCOv",
+                  description:
+                    "Accessibility text for preview link, points to draft nomination workflow",
+                },
+                { eventName: nominationEventName },
+              )}
+              href={paths.talentNomination(talentNominationListItemFragment.id)}
+            />
+          )
+        }
         headingAs={headingAs}
       ></PreviewList.Item>
     </>

--- a/apps/web/src/pages/ApplicantDashboardPage/components/TalentNominationListItem.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/TalentNominationListItem.tsx
@@ -1,0 +1,96 @@
+import { useIntl } from "react-intl";
+
+import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
+import { HeadingLevel, PreviewList } from "@gc-digital-talent/ui";
+import { commonMessages } from "@gc-digital-talent/i18n";
+
+import { getFullNameLabel } from "~/utils/nameUtils";
+
+import { useMetaDataDate, useMetaDataTalentNominationChip } from "./hooks";
+
+export const PreviewListItemTalentNomination_Fragment = graphql(/* GraphQL */ `
+  fragment PreviewListItemTalentNomination on TalentNomination {
+    id
+    submittedAt
+    talentNominationEvent {
+      name {
+        localized
+      }
+      closeDate
+    }
+    nominee {
+      firstName
+      lastName
+    }
+  }
+`);
+
+interface TalentNominationListItemProps {
+  headingAs?: HeadingLevel;
+  talentNominationListItemQuery: FragmentType<
+    typeof PreviewListItemTalentNomination_Fragment
+  >;
+}
+
+const TalentNominationListItem = ({
+  headingAs,
+  talentNominationListItemQuery,
+}: TalentNominationListItemProps) => {
+  const intl = useIntl();
+
+  const talentNominationListItemFragment = getFragment(
+    PreviewListItemTalentNomination_Fragment,
+    talentNominationListItemQuery,
+  );
+
+  const fullName = getFullNameLabel(
+    talentNominationListItemFragment.nominee?.firstName,
+    talentNominationListItemFragment.nominee?.lastName,
+    intl,
+  );
+  const statusChip = useMetaDataTalentNominationChip({
+    submittedAt: talentNominationListItemFragment.submittedAt,
+  });
+  const dateElement = useMetaDataDate({
+    closeDate: talentNominationListItemFragment.talentNominationEvent.closeDate,
+    submittedAt: talentNominationListItemFragment.submittedAt,
+  });
+
+  type MetaDataProps = React.ComponentProps<
+    typeof PreviewList.Item
+  >["metaData"];
+  type MetaDataPropItem = MetaDataProps[number];
+  const metaDataProps: MetaDataPropItem[] = [
+    {
+      key: "status",
+      type: "chip",
+      color: statusChip.color,
+      children: statusChip.label,
+    },
+    {
+      key: "name",
+      type: "text",
+      children:
+        talentNominationListItemFragment.talentNominationEvent?.name
+          ?.localized ?? intl.formatMessage(commonMessages.notFound),
+    },
+    {
+      key: "date",
+      type: "text",
+      children: dateElement,
+    },
+  ];
+
+  return (
+    <>
+      <PreviewList.Item
+        title={fullName}
+        metaData={metaDataProps}
+        // action={}
+        headingAs={headingAs}
+      ></PreviewList.Item>
+    </>
+  );
+};
+
+export default TalentNominationListItem;

--- a/apps/web/src/pages/ApplicantDashboardPage/components/hooks.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/hooks.tsx
@@ -1,0 +1,85 @@
+import { useIntl } from "react-intl";
+import { JSX } from "react";
+import { endOfDay } from "date-fns/endOfDay";
+import { isPast } from "date-fns/isPast";
+
+import { formatDate, parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
+import { Color } from "@gc-digital-talent/ui";
+import { commonMessages } from "@gc-digital-talent/i18n";
+
+interface MetaDataTalentNominationChipProps {
+  submittedAt: string | null | undefined;
+}
+
+interface TalentNominationChip {
+  label: string;
+  color: Color;
+}
+
+export const useMetaDataTalentNominationChip = ({
+  submittedAt,
+}: MetaDataTalentNominationChipProps): TalentNominationChip => {
+  const intl = useIntl();
+
+  return submittedAt
+    ? { label: intl.formatMessage(commonMessages.received), color: "secondary" }
+    : { label: intl.formatMessage(commonMessages.draft), color: "primary" };
+};
+
+interface useMetaDataDate {
+  closeDate: string | null | undefined;
+  submittedAt: string | null | undefined;
+}
+
+export const useMetaDataDate = ({
+  closeDate,
+  submittedAt,
+}: useMetaDataDate): JSX.Element => {
+  const intl = useIntl();
+
+  if (submittedAt) {
+    return (
+      <span>
+        {intl.formatMessage(commonMessages.submitted)}
+        {intl.formatMessage(commonMessages.dividingColon)}
+        {formatDate({
+          date: parseDateTimeUtc(submittedAt),
+          formatString: "PPP",
+          intl,
+        })}
+      </span>
+    );
+  }
+
+  if (closeDate) {
+    const closeDateParsed = parseDateTimeUtc(closeDate);
+    const closeDateEnd = endOfDay(closeDateParsed);
+
+    if (isPast(closeDateEnd)) {
+      return (
+        <span data-h2-color="base(error) base:dark(error.lightest)">
+          {intl.formatMessage(commonMessages.deadline)}
+          {intl.formatMessage(commonMessages.dividingColon)}
+          {formatDate({
+            date: closeDateParsed,
+            formatString: "PPP",
+            intl,
+          })}
+        </span>
+      );
+    }
+    return (
+      <span>
+        {intl.formatMessage(commonMessages.deadline)}
+        {intl.formatMessage(commonMessages.dividingColon)}
+        {formatDate({
+          date: closeDateParsed,
+          formatString: "PPP",
+          intl,
+        })}
+      </span>
+    );
+  }
+
+  return <span>{intl.formatMessage(commonMessages.notAvailable)}</span>;
+};

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1047,6 +1047,10 @@
     "defaultMessage": "Vous devez supprimer un élément si vous voulez en ajouter un autre",
     "description": "Message displayed when max items have been reached on repeater component."
   },
+  "fRyPvR": {
+    "defaultMessage": "Ébauche",
+    "description": "Item's state is draft"
+  },
   "fUAej4": {
     "defaultMessage": "Pas d'intérêt",
     "description": "Expressed lack of interest"

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -791,6 +791,10 @@
     "defaultMessage": "Retour",
     "description": "An action to go back to a previous location"
   },
+  "Vnygk+": {
+    "defaultMessage": "Soumis",
+    "description": "Item's state is submitted"
+  },
   "VqrVpT": {
     "defaultMessage": "Mise à jour impossible – cette adresse courriel est déjà utilisée.",
     "description": "Error message that the given email address is already in use when updating."

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -320,6 +320,11 @@ const commonMessages = defineMessages({
     id: "SD8i+/",
     description: "Title for received",
   },
+  draft: {
+    defaultMessage: "Draft",
+    id: "fRyPvR",
+    description: "Item's state is draft",
+  },
   deadlineToApply: {
     defaultMessage: "Deadline to apply",
     id: "ZoYqEo",

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -325,6 +325,11 @@ const commonMessages = defineMessages({
     id: "fRyPvR",
     description: "Item's state is draft",
   },
+  submitted: {
+    defaultMessage: "Submitted",
+    id: "Vnygk+",
+    description: "Item's state is submitted",
+  },
   deadlineToApply: {
     defaultMessage: "Deadline to apply",
     id: "ZoYqEo",

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -416,6 +416,11 @@ const commonMessages = defineMessages({
     id: "cO535E",
     description: "Message displayed to user if account fails to get updated.",
   },
+  talentNominations: {
+    defaultMessage: "Talent nominations",
+    id: "v5yYJo",
+    description: "Talent nominations label",
+  },
 });
 
 export default commonMessages;

--- a/packages/i18n/src/messages/navigationMessages.ts
+++ b/packages/i18n/src/messages/navigationMessages.ts
@@ -176,6 +176,11 @@ const navigationMessages = defineMessages({
     id: "Y66jFM",
     description: "Link text to the dashboard page",
   },
+  newNomination: {
+    defaultMessage: "New nomination",
+    id: "s3u05D",
+    description: "Link text to create a new nomination",
+  },
 });
 
 export default navigationMessages;


### PR DESCRIPTION
🤖 Resolves #13004

## 👋 Introduction

Adds the third widget for the applicant dashboard, it is conditionally rendered depending on the user having non-zero nomination submissions 

## 🕵️ Details

Talent requests will be added later
Null state well will require forcing the widget to always display to see
For submitted nominations, a dialog will be created and added at a later point https://github.com/GCTC-NTGC/gc-digital-talent/issues/13003

## 🧪 Testing

1. Testing on the new applicant dashboard page...
2. No nominations as submitted with your user hides the new widget
3. Having them renders the widget
4. Test links

admin user will always have associated nomination submissions

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/26408c76-0487-409b-b0d7-2557241d76af)

![image](https://github.com/user-attachments/assets/58ff322c-7b4b-42b9-b655-e8524fe461ba)

