### PR TITLE
[Bug] Handle nulls better in community interests

### DIFF
--- a/api/app/GraphQL/Validators/CreateCommunityInterestInputValidator.php
+++ b/api/app/GraphQL/Validators/CreateCommunityInterestInputValidator.php
@@ -61,7 +61,7 @@ final class CreateCommunityInterestInputValidator extends Validator
                 Rule::when($community?->key === 'finance',
                     [
                         'string',
-                        Rule::requiredIf(in_array(FinanceChiefRole::OTHER->name, $this->arg('financeOtherRoles', []))),
+                        Rule::requiredIf(in_array(FinanceChiefRole::OTHER->name, $this->arg('financeOtherRoles') ?? [])),
                     ],
                     ['prohibited']
                 ),

--- a/api/app/GraphQL/Validators/UpdateCommunityInterestInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdateCommunityInterestInputValidator.php
@@ -58,7 +58,7 @@ final class UpdateCommunityInterestInputValidator extends Validator
                 Rule::when($community?->key === 'finance',
                     [
                         'string',
-                        Rule::requiredIf(in_array(FinanceChiefRole::OTHER->name, $this->arg('financeOtherRoles', []))),
+                        Rule::requiredIf(in_array(FinanceChiefRole::OTHER->name, $this->arg('financeOtherRoles') ?? [])),
                     ],
                     ['prohibited']
                 ),

--- a/api/database/migrations/2025_03_19_160515_make_interest_columns_nullable.php
+++ b/api/database/migrations/2025_03_19_160515_make_interest_columns_nullable.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('community_interests', function (Blueprint $table) {
+            $table->jsonb('finance_additional_duties')->nullable(true)->change();
+            $table->jsonb('finance_other_roles')->nullable(true)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('community_interests', function (Blueprint $table) {
+            $table->jsonb('finance_additional_duties')->default(json_encode([]))->nullable(false)->change();
+            $table->jsonb('finance_other_roles')->default(json_encode([]))->nullable(false)->change();
+        });
+    }
+};

--- a/apps/web/src/pages/CommunityInterests/form.ts
+++ b/apps/web/src/pages/CommunityInterests/form.ts
@@ -2,8 +2,6 @@ import {
   CreateCommunityInterestInput,
   CreateDevelopmentProgramInterestInput,
   DevelopmentProgramParticipationStatus,
-  FinanceChiefDuty,
-  FinanceChiefRole,
   UpdateCommunityInterestFormData_FragmentFragment,
   UpdateCommunityInterestInput,
   UpdateDevelopmentProgramInterestHasMany,
@@ -108,22 +106,14 @@ export function formValuesToApiCreateInput(
   }
 
   // finance-only fields
-  if (formValues.financeIsChief !== null) {
-    apiInput.financeIsChief = formValues.financeIsChief;
-  }
-  if (formValues.financeAdditionalDuties !== null) {
-    apiInput.financeAdditionalDuties = stringArrayToEnumsFinanceChiefDuty(
-      formValues.financeAdditionalDuties,
-    );
-  }
-  if (formValues.financeOtherRoles !== null) {
-    apiInput.financeOtherRoles = stringArrayToEnumsFinanceChiefRole(
-      formValues.financeOtherRoles,
-    );
-  }
-  if (formValues.financeOtherRolesOther !== null) {
-    apiInput.financeOtherRolesOther = formValues.financeOtherRolesOther;
-  }
+  apiInput.financeIsChief = formValues.financeIsChief;
+  apiInput.financeAdditionalDuties = formValues.financeAdditionalDuties
+    ? stringArrayToEnumsFinanceChiefDuty(formValues.financeAdditionalDuties)
+    : null;
+  apiInput.financeOtherRoles = formValues.financeOtherRoles
+    ? stringArrayToEnumsFinanceChiefRole(formValues.financeOtherRoles)
+    : null;
+  apiInput.financeOtherRolesOther = formValues.financeOtherRolesOther;
 
   return apiInput;
 }
@@ -183,10 +173,10 @@ export function formValuesToApiUpdateInput(
     // finance-only fields
     financeIsChief: formValues.financeIsChief,
     financeAdditionalDuties: formValues.financeAdditionalDuties
-      ? (formValues.financeAdditionalDuties as FinanceChiefDuty[])
+      ? stringArrayToEnumsFinanceChiefDuty(formValues.financeAdditionalDuties)
       : null,
     financeOtherRoles: formValues.financeOtherRoles
-      ? (formValues.financeOtherRoles as FinanceChiefRole[])
+      ? stringArrayToEnumsFinanceChiefRole(formValues.financeOtherRoles)
       : null,
     financeOtherRolesOther: formValues.financeOtherRolesOther,
   };

--- a/apps/web/src/pages/CommunityInterests/util.ts
+++ b/apps/web/src/pages/CommunityInterests/util.ts
@@ -3,7 +3,7 @@ import { unpackMaybes } from "@gc-digital-talent/helpers";
 
 // test and convert a raw string the enum type FinanceChiefDuty
 export function stringToEnumFinanceChiefDuty(
-  selection: string,
+  selection: string | null | undefined,
 ): FinanceChiefDuty | undefined {
   if (Object.values(FinanceChiefDuty).includes(selection as FinanceChiefDuty)) {
     return selection as FinanceChiefDuty;
@@ -12,10 +12,10 @@ export function stringToEnumFinanceChiefDuty(
 }
 
 export function stringArrayToEnumsFinanceChiefDuty(
-  selections: string[],
+  selections: string[] | null | undefined,
 ): FinanceChiefDuty[] {
   return unpackMaybes(
-    selections.map((selection) => {
+    selections?.map((selection) => {
       return stringToEnumFinanceChiefDuty(selection);
     }),
   );
@@ -23,7 +23,7 @@ export function stringArrayToEnumsFinanceChiefDuty(
 
 // test and convert a raw string the enum type FinanceChiefRole
 export function stringToEnumFinanceChiefRole(
-  selection: string,
+  selection: string | null | undefined,
 ): FinanceChiefRole | undefined {
   if (Object.values(FinanceChiefRole).includes(selection as FinanceChiefRole)) {
     return selection as FinanceChiefRole;
@@ -32,10 +32,10 @@ export function stringToEnumFinanceChiefRole(
 }
 
 export function stringArrayToEnumsFinanceChiefRole(
-  selections: string[],
+  selections: string[] | null | undefined,
 ): FinanceChiefRole[] {
   return unpackMaybes(
-    selections.map((selection) => {
+    selections?.map((selection) => {
       return stringToEnumFinanceChiefRole(selection);
     }),
   );


### PR DESCRIPTION
🤖 Resolves #13030

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Handles nulls in community interests better, allowing community interests other than finance.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing


1. Run migration
2. Log in as applicant-employee@test.com
3. On the dashboard, navigate to the community section
4. Add different community interests
5. Edit different community interests


## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

## 🚚 Deployment

<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the PR if deployment steps are needed

 -->
