### PR TITLE
[Feature] Adds retirement values to GC employee profile

### DIFF
--- a/apps/web/src/pages/Users/UserEmployeeInformationPage/components/CareerDevelopmentSection.tsx
+++ b/apps/web/src/pages/Users/UserEmployeeInformationPage/components/CareerDevelopmentSection.tsx
@@ -15,6 +15,10 @@ import {
   Mentorship,
   OrganizationTypeInterest,
 } from "@gc-digital-talent/graphql";
+import {
+  formatDate,
+  formDateStringToDate,
+} from "@gc-digital-talent/date-helpers";
 
 import messages from "~/messages/careerDevelopmentMessages";
 import BoolCheckIcon from "~/components/BoolCheckIcon/BoolCheckIcon";
@@ -48,6 +52,8 @@ export const CareerDevelopment_Fragment = graphql(/* GraphQL */ `
         localized
       }
     }
+    eligibleRetirementYearKnown
+    eligibleRetirementYear
     mentorshipStatus {
       value
       label {
@@ -167,6 +173,19 @@ const CareerDevelopmentSection = ({
         id: "tXLRmG",
         description: "The promotion move interest described as not interested.",
       });
+
+  const eligibleRetirementYearKnownMessage =
+    employeeProfile.eligibleRetirementYearKnown
+      ? intl.formatMessage({
+          defaultMessage: "I know the year in which I'm eligible to retire.",
+          id: "f0dhMc",
+          description: "The eligible retirement year described as known.",
+        })
+      : intl.formatMessage({
+          defaultMessage: "I'm not sure about the year I'm eligible to retire.",
+          id: "a5YBuH",
+          description: "The eligible retirement year described as unknown.",
+        });
 
   const execInterestMessage = employeeProfile.execInterest
     ? intl.formatMessage({
@@ -299,6 +318,29 @@ const CareerDevelopmentSection = ({
         ) : (
           intl.formatMessage(commonMessages.notProvided)
         )}
+      </div>
+      <CardSeparator space="xs" />
+      <div>
+        <span data-h2-display="base(block)" data-h2-font-weight="base(700)">
+          {careerDevelopmentMessages.eligibleRetirementYearKnown}
+        </span>
+        {empty(employeeProfile.eligibleRetirementYearKnown)
+          ? intl.formatMessage(commonMessages.notProvided)
+          : eligibleRetirementYearKnownMessage}
+      </div>
+      <div>
+        <span data-h2-display="base(block)" data-h2-font-weight="base(700)">
+          {careerDevelopmentMessages.eligibleRetirementYear}
+        </span>
+        {employeeProfile.eligibleRetirementYear
+          ? formatDate({
+              date: formDateStringToDate(
+                employeeProfile.eligibleRetirementYear,
+              ),
+              formatString: "yyyy",
+              intl,
+            })
+          : intl.formatMessage(commonMessages.notProvided)}
       </div>
       <CardSeparator space="xs" />
       <div>


### PR DESCRIPTION
🤖 Resolves #13036.

## 👋 Introduction

This PR adds retirement values to GC employee profile in the Career development preferences section.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/admin/users/
3. View GC employee profile tab of a government employee
4. Verify retirement eligibility and year of retirement eligibility are rendered in the Career development preferences section

## 📸 Screenshots

<img width="1229" alt="Screen Shot 2025-03-20 at 11 37 27" src="https://github.com/user-attachments/assets/08c34d9c-3656-405a-bd85-1d4e7a10adee" />

<img width="1111" alt="Screen Shot 2025-03-20 at 11 40 43" src="https://github.com/user-attachments/assets/f3abe0e5-b9b0-4ad1-babd-8f5afae8f975" />
