### PR TITLE
[Feature] Adds c-suite values to GC employee profile

### DIFF
--- a/apps/web/src/pages/Users/UserEmployeeInformationPage/components/NextRoleSection.tsx
+++ b/apps/web/src/pages/Users/UserEmployeeInformationPage/components/NextRoleSection.tsx
@@ -21,6 +21,13 @@ export const NextRole_Fragment = graphql(/* GraphQL */ `
         localized
       }
     }
+    nextRoleIsCSuiteRole
+    nextRoleCSuiteRoleTitle {
+      value
+      label {
+        localized
+      }
+    }
     nextRoleJobTitle
     nextRoleCommunity {
       name {
@@ -90,6 +97,22 @@ const NextRoleSection = ({ employeeProfileQuery }: NextRoleSectionProps) => {
         {employeeProfile.nextRoleTargetRoleOther ??
           employeeProfile.nextRoleTargetRole?.label.localized ??
           intl.formatMessage(commonMessages.notProvided)}
+      </div>
+      <div>
+        <span data-h2-display="base(block)" data-h2-font-weight="base(700)">
+          {intl.formatMessage(employeeProfileMessages.seniorManagementStatus)}
+        </span>
+        {employeeProfile.nextRoleIsCSuiteRole
+          ? intl.formatMessage(employeeProfileMessages.isCSuiteRoleTitle)
+          : intl.formatMessage(commonMessages.notProvided)}
+      </div>
+      <div>
+        <span data-h2-display="base(block)" data-h2-font-weight="base(700)">
+          {intl.formatMessage(employeeProfileMessages.cSuiteRoleTitle)}
+        </span>
+        {employeeProfile.nextRoleIsCSuiteRole
+          ? employeeProfile.nextRoleCSuiteRoleTitle?.label?.localized
+          : intl.formatMessage(commonMessages.notProvided)}
       </div>
       <div>
         <span data-h2-display="base(block)" data-h2-font-weight="base(700)">


### PR DESCRIPTION
🤖 Resolves #13037.

## 👋 Introduction

This PR adds c-suite values to GC employee profile in the Next role section.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/admin/users/
3. View GC employee profile tab of a government employee
4. Verify senior management status and c-suite role title are rendered in the Next role section

## 📸 Screenshot

<img width="1066" alt="Screen Shot 2025-03-20 at 12 20 38" src="https://github.com/user-attachments/assets/7006cc14-5c17-496c-b6ff-83a6a545437e" />