### PR TITLE
[Fix] Sort alphabetically unordered lists on GC employee profile

### DIFF
--- a/apps/web/src/pages/Users/UserEmployeeInformationPage/components/CareerObjectiveSection.tsx
+++ b/apps/web/src/pages/Users/UserEmployeeInformationPage/components/CareerObjectiveSection.tsx
@@ -125,9 +125,15 @@ const CareerObjectiveSection = ({
               data-h2-margin-bottom="base:selectors[>li:not(:last-child)](x.125)"
               data-h2-padding-left="base(x1)"
             >
-              {employeeProfile.careerObjectiveWorkStreams.map((workStream) => (
-                <li key={workStream.id}>{workStream?.name?.localized}</li>
-              ))}
+              {employeeProfile.careerObjectiveWorkStreams
+                .sort((a, b) =>
+                  a.name?.localized && b.name?.localized
+                    ? a.name.localized.localeCompare(b.name.localized)
+                    : 0,
+                )
+                .map((workStream) => (
+                  <li key={workStream.id}>{workStream?.name?.localized}</li>
+                ))}
             </ul>
           ) : (
             intl.formatMessage(commonMessages.notProvided)
@@ -143,9 +149,15 @@ const CareerObjectiveSection = ({
             data-h2-margin-bottom="base:selectors[>li:not(:last-child)](x.125)"
             data-h2-padding-left="base(x1)"
           >
-            {employeeProfile.careerObjectiveDepartments.map((department) => (
-              <li key={department.id}>{department?.name?.localized}</li>
-            ))}
+            {employeeProfile.careerObjectiveDepartments
+              .sort((a, b) =>
+                a.name?.localized && b.name?.localized
+                  ? a.name.localized.localeCompare(b.name.localized)
+                  : 0,
+              )
+              .map((department) => (
+                <li key={department.id}>{department?.name?.localized}</li>
+              ))}
           </ul>
         ) : (
           intl.formatMessage(commonMessages.notProvided)

--- a/apps/web/src/pages/Users/UserEmployeeInformationPage/components/CareerObjectiveSection.tsx
+++ b/apps/web/src/pages/Users/UserEmployeeInformationPage/components/CareerObjectiveSection.tsx
@@ -60,6 +60,18 @@ const CareerObjectiveSection = ({
     employeeProfileQuery,
   );
 
+  employeeProfile?.careerObjectiveWorkStreams?.sort((a, b) =>
+    a.name?.localized && b.name?.localized
+      ? a.name.localized.localeCompare(b.name.localized)
+      : 0,
+  );
+
+  employeeProfile?.careerObjectiveDepartments?.sort((a, b) =>
+    a.name?.localized && b.name?.localized
+      ? a.name.localized.localeCompare(b.name.localized)
+      : 0,
+  );
+
   return (
     <CardBasic
       data-h2-display="base(grid)"
@@ -125,15 +137,9 @@ const CareerObjectiveSection = ({
               data-h2-margin-bottom="base:selectors[>li:not(:last-child)](x.125)"
               data-h2-padding-left="base(x1)"
             >
-              {employeeProfile.careerObjectiveWorkStreams
-                .sort((a, b) =>
-                  a.name?.localized && b.name?.localized
-                    ? a.name.localized.localeCompare(b.name.localized)
-                    : 0,
-                )
-                .map((workStream) => (
-                  <li key={workStream.id}>{workStream?.name?.localized}</li>
-                ))}
+              {employeeProfile.careerObjectiveWorkStreams.map((workStream) => (
+                <li key={workStream.id}>{workStream?.name?.localized}</li>
+              ))}
             </ul>
           ) : (
             intl.formatMessage(commonMessages.notProvided)
@@ -149,15 +155,9 @@ const CareerObjectiveSection = ({
             data-h2-margin-bottom="base:selectors[>li:not(:last-child)](x.125)"
             data-h2-padding-left="base(x1)"
           >
-            {employeeProfile.careerObjectiveDepartments
-              .sort((a, b) =>
-                a.name?.localized && b.name?.localized
-                  ? a.name.localized.localeCompare(b.name.localized)
-                  : 0,
-              )
-              .map((department) => (
-                <li key={department.id}>{department?.name?.localized}</li>
-              ))}
+            {employeeProfile.careerObjectiveDepartments.map((department) => (
+              <li key={department.id}>{department?.name?.localized}</li>
+            ))}
           </ul>
         ) : (
           intl.formatMessage(commonMessages.notProvided)

--- a/apps/web/src/pages/Users/UserEmployeeInformationPage/components/NextRoleSection.tsx
+++ b/apps/web/src/pages/Users/UserEmployeeInformationPage/components/NextRoleSection.tsx
@@ -118,9 +118,15 @@ const NextRoleSection = ({ employeeProfileQuery }: NextRoleSectionProps) => {
               data-h2-margin-bottom="base:selectors[>li:not(:last-child)](x.125)"
               data-h2-padding-left="base(x1)"
             >
-              {employeeProfile.nextRoleWorkStreams.map((workStream) => (
-                <li key={workStream.id}>{workStream?.name?.localized}</li>
-              ))}
+              {employeeProfile.nextRoleWorkStreams
+                .sort((a, b) =>
+                  a.name?.localized && b.name?.localized
+                    ? a.name.localized.localeCompare(b.name.localized)
+                    : 0,
+                )
+                .map((workStream) => (
+                  <li key={workStream.id}>{workStream?.name?.localized}</li>
+                ))}
             </ul>
           ) : (
             intl.formatMessage(commonMessages.notProvided)
@@ -136,9 +142,15 @@ const NextRoleSection = ({ employeeProfileQuery }: NextRoleSectionProps) => {
             data-h2-margin-bottom="base:selectors[>li:not(:last-child)](x.125)"
             data-h2-padding-left="base(x1)"
           >
-            {employeeProfile.nextRoleDepartments.map((department) => (
-              <li key={department.id}>{department?.name?.localized}</li>
-            ))}
+            {employeeProfile.nextRoleDepartments
+              .sort((a, b) =>
+                a.name?.localized && b.name?.localized
+                  ? a.name.localized.localeCompare(b.name.localized)
+                  : 0,
+              )
+              .map((department) => (
+                <li key={department.id}>{department?.name?.localized}</li>
+              ))}
           </ul>
         ) : (
           intl.formatMessage(commonMessages.notProvided)

--- a/apps/web/src/pages/Users/UserEmployeeInformationPage/components/NextRoleSection.tsx
+++ b/apps/web/src/pages/Users/UserEmployeeInformationPage/components/NextRoleSection.tsx
@@ -55,6 +55,18 @@ const NextRoleSection = ({ employeeProfileQuery }: NextRoleSectionProps) => {
 
   const employeeProfile = getFragment(NextRole_Fragment, employeeProfileQuery);
 
+  employeeProfile?.nextRoleWorkStreams?.sort((a, b) =>
+    a.name?.localized && b.name?.localized
+      ? a.name.localized.localeCompare(b.name.localized)
+      : 0,
+  );
+
+  employeeProfile?.nextRoleDepartments?.sort((a, b) =>
+    a.name?.localized && b.name?.localized
+      ? a.name.localized.localeCompare(b.name.localized)
+      : 0,
+  );
+
   return (
     <CardBasic
       data-h2-display="base(grid)"
@@ -118,15 +130,9 @@ const NextRoleSection = ({ employeeProfileQuery }: NextRoleSectionProps) => {
               data-h2-margin-bottom="base:selectors[>li:not(:last-child)](x.125)"
               data-h2-padding-left="base(x1)"
             >
-              {employeeProfile.nextRoleWorkStreams
-                .sort((a, b) =>
-                  a.name?.localized && b.name?.localized
-                    ? a.name.localized.localeCompare(b.name.localized)
-                    : 0,
-                )
-                .map((workStream) => (
-                  <li key={workStream.id}>{workStream?.name?.localized}</li>
-                ))}
+              {employeeProfile.nextRoleWorkStreams.map((workStream) => (
+                <li key={workStream.id}>{workStream?.name?.localized}</li>
+              ))}
             </ul>
           ) : (
             intl.formatMessage(commonMessages.notProvided)
@@ -142,15 +148,9 @@ const NextRoleSection = ({ employeeProfileQuery }: NextRoleSectionProps) => {
             data-h2-margin-bottom="base:selectors[>li:not(:last-child)](x.125)"
             data-h2-padding-left="base(x1)"
           >
-            {employeeProfile.nextRoleDepartments
-              .sort((a, b) =>
-                a.name?.localized && b.name?.localized
-                  ? a.name.localized.localeCompare(b.name.localized)
-                  : 0,
-              )
-              .map((department) => (
-                <li key={department.id}>{department?.name?.localized}</li>
-              ))}
+            {employeeProfile.nextRoleDepartments.map((department) => (
+              <li key={department.id}>{department?.name?.localized}</li>
+            ))}
           </ul>
         ) : (
           intl.formatMessage(commonMessages.notProvided)


### PR DESCRIPTION
🤖 Resolves #13057.

## 👋 Introduction

This PR fixes sorting for unordered lists on GC employee profile that are already sorted alphabetically on their equivalent employee profile (non-admin) page.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to a GC employee profile tab of a government employee
3. Verify all unordered lists (Desired work streams, Preferred departments or agencies) are alphabetically sorted in English and French

## 📸 Screenshot

<img width="1371" alt="Screen Shot 2025-03-20 at 13 42 00" src="https://github.com/user-attachments/assets/c222f1ac-6e06-4b41-8122-d9e4597a76e6" />