### PR TITLE
[Bug] Make `participationStatus` nullable for community interest

### DIFF
--- a/api/app/GraphQL/Validators/CreateDevelopmentProgramInterestInputValidator.php
+++ b/api/app/GraphQL/Validators/CreateDevelopmentProgramInterestInputValidator.php
@@ -18,7 +18,7 @@ final class CreateDevelopmentProgramInterestInputValidator extends Validator
     {
         return [
             // developmentProgramId validated in the Create/UpdateCommunityInterestInputValidator
-            'participationStatus' => ['required', Rule::in(array_column(DevelopmentProgramParticipationStatus::cases(), 'name'))],
+            'participationStatus' => ['nullable', Rule::in(array_column(DevelopmentProgramParticipationStatus::cases(), 'name'))],
             'completionDate' => [
                 Rule::when(
                     fn (): bool => $this->arg('participationStatus') === DevelopmentProgramParticipationStatus::COMPLETED->name,

--- a/api/app/GraphQL/Validators/UpdateDevelopmentProgramInterestInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdateDevelopmentProgramInterestInputValidator.php
@@ -17,7 +17,7 @@ final class UpdateDevelopmentProgramInterestInputValidator extends Validator
     public function rules(): array
     {
         return [
-            'participationStatus' => ['required', Rule::in(array_column(DevelopmentProgramParticipationStatus::cases(), 'name'))],
+            'participationStatus' => ['nullable', Rule::in(array_column(DevelopmentProgramParticipationStatus::cases(), 'name'))],
             'completionDate' => [
                 'present', // when updating, must specify either date or null
                 Rule::when(


### PR DESCRIPTION
🤖 Resolves #13064 

## 👋 Introduction

Make the field nullable in validation for both create and update operations

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Create a community interest and then update it, from your applicant dashboard
2. In both cases, select a community that has training programs and then do not fill them in

![image](https://github.com/user-attachments/assets/6bb9d41b-7430-4e58-a9f2-5cc14bae5d4f)


