### PR TITLE
[Copy] Updates French Title for the comptrollership executives talent management page

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -10359,7 +10359,7 @@
     "description": "Message displayed to users to sign out of the application"
   },
   "nmokFS": {
-    "defaultMessage": "Gestion des talents des cadres exerçant une fonction de contrôle",
+    "defaultMessage": "Gestion des talents de la fonction de contrôleur",
     "description": "Title for the comptrollership executives talent management page"
   },
   "nmx1ym": {


### PR DESCRIPTION
🤖 Resolves #13072.

## 👋 Introduction

This PR updates French Title for the comptrollership executives talent management page.

## 🧪 Testing

1. `pnpm build`
2. Navigate to http://localhost:8000/fr/comptrollership-executives
3. Verify page title and `h1` are _Gestion des talents de la fonction de contrôleur_

## 📸 Screenshot

<img width="1440" alt="Screen Shot 2025-03-24 at 09 42 46" src="https://github.com/user-attachments/assets/74afd044-f12f-45ef-8cb1-ba805ab0db43" />
