### PR TITLE
[Fix] Consistent submit button, gap value, `aria-label` style on employee profile page

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3744,7 +3744,7 @@
     "description": "Message for total estimated matching candidates in pool"
   },
   "GndGRz": {
-    "defaultMessage": "La mise à jour des informations sur votre prochain type de post a échoué.",
+    "defaultMessage": "La mise à jour des informations sur votre prochain type de poste a échoué.",
     "description": "Message displayed when a user fails to updates employee profile information"
   },
   "GplLic": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -10987,7 +10987,7 @@
     "description": "Label for process French title"
   },
   "rBtIUo": {
-    "defaultMessage": "Enregistrez les préférences en matière de développement de carrière",
+    "defaultMessage": "Sauvegardez les préférences en matière de développement de carrière",
     "description": "Text on a button to save career development preferences form"
   },
   "rCpVpZ": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8122,6 +8122,10 @@
     "defaultMessage": "Nous n'avons pas trouvé de profil correspondant pour « {email} »",
     "description": "Default error messsage when an employee could not be found"
   },
+  "dRJLsv": {
+    "defaultMessage": "Sauvegardez votre prochain type de poste",
+    "description": "Text on a button to save your next role form"
+  },
   "dT/c1r": {
     "defaultMessage": "Ces occasions favorisent l’amélioration des perspectives d’emploi et des résultats économiques des peuples autochtones, conformément aux principes énoncés dans la Déclaration des Nations unies sur les droits des peuples autochtones. Elles soutiennent également le processus de réconciliation dans notre pays.",
     "description": "Paragraph two for the self-declaration explanation dialog"
@@ -11641,6 +11645,10 @@
   "uzqiPj": {
     "defaultMessage": "Actualiser les paramètres",
     "description": "Link text for the account settings page"
+  },
+  "v+AFQT": {
+    "defaultMessage": "Sauvegardez votre objectif de carrière",
+    "description": "Text on a button to your career objective form"
   },
   "v0EVPQ": {
     "defaultMessage": "Ce programme s’adresse aux membres de Premières nations, aux Inuits et aux Métis du Canada.",

--- a/apps/web/src/pages/EmployeeProfile/components/CareerDevelopmentSection/CareerDevelopmentSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerDevelopmentSection/CareerDevelopmentSection.tsx
@@ -606,7 +606,7 @@ const CareerDevelopmentSection = ({
                 />
                 <div
                   data-h2-display="base(flex)"
-                  data-h2-gap="base(x.5)"
+                  data-h2-gap="base(x1)"
                   data-h2-align-items="base(center)"
                   data-h2-flex-wrap="base(wrap)"
                 >

--- a/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
@@ -719,7 +719,12 @@ const CareerObjectiveSection = ({
                 >
                   <Submit
                     text={intl.formatMessage(formMessages.saveChanges)}
-                    aria-label={intl.formatMessage(formMessages.saveChanges)}
+                    aria-label={intl.formatMessage({
+                      defaultMessage: "Save your career objective",
+                      id: "v+AFQT",
+                      description:
+                        "Text on a button to your career objective form",
+                    })}
                     color="secondary"
                     mode="solid"
                     isSubmitting={fetching}

--- a/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
@@ -721,7 +721,7 @@ const CareerObjectiveSection = ({
                     text={intl.formatMessage(formMessages.saveChanges)}
                     aria-label={intl.formatMessage(formMessages.saveChanges)}
                     color="secondary"
-                    mode="inline"
+                    mode="solid"
                     isSubmitting={fetching}
                   />
                   <ToggleSection.Close>

--- a/apps/web/src/pages/EmployeeProfile/components/GoalsWorkStyleSection/GoalsWorkStyleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/GoalsWorkStyleSection/GoalsWorkStyleSection.tsx
@@ -234,7 +234,7 @@ const GoalsWorkStyleSection = ({
                 <CardSeparator data-h2-margin="base(0)" />
                 <div
                   data-h2-display="base(flex)"
-                  data-h2-gap="base(x.5)"
+                  data-h2-gap="base(x1)"
                   data-h2-align-items="base(center)"
                   data-h2-flex-wrap="base(wrap)"
                 >

--- a/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
@@ -713,7 +713,12 @@ const NextRoleSection = ({
                 >
                   <Submit
                     text={intl.formatMessage(formMessages.saveChanges)}
-                    aria-label={intl.formatMessage(formMessages.saveChanges)}
+                    aria-label={intl.formatMessage({
+                      defaultMessage: "Save your next role",
+                      id: "dRJLsv",
+                      description:
+                        "Text on a button to save your next role form",
+                    })}
                     color="secondary"
                     mode="solid"
                     isSubmitting={fetching}

--- a/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
@@ -715,7 +715,7 @@ const NextRoleSection = ({
                     text={intl.formatMessage(formMessages.saveChanges)}
                     aria-label={intl.formatMessage(formMessages.saveChanges)}
                     color="secondary"
-                    mode="inline"
+                    mode="solid"
                     isSubmitting={fetching}
                   />
                   <ToggleSection.Close>


### PR DESCRIPTION
🤖 Resolves #13039.

## 👋 Introduction

This PR updates the button styles from `inline` to `solid` to match other Save changes buttons on the employee profile page.

> [!NOTE]
> The gap value and `aria-label` copy style have been updated for consistency as well and a typo in French fixed.

## 🧪 Testing

1. `pnpm build`
2. Log in as a government employee 
3. Navigate to http://localhost:8000/en/applicant/employee-profile#career-development-section
4. Verify all Save changes buttons on the page use the same style, gap value, and `aria-label` copy style

## 📸 Screenshot

![localhost_8000_en_applicant_employee-profile](https://github.com/user-attachments/assets/846bd140-a540-4a7e-a342-a228ca46a666)