### PR TITLE
[Feat] Nomination group admin stub pages

### DIFF
--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -797,6 +797,45 @@ const createRoute = (locale: Locales, newApplicantDashboard: boolean) =>
                     ),
                 },
                 {
+                  path: "talent-events",
+                  children: [
+                    {
+                      path: ":eventId/nominations/:talentNominationGroupId",
+                      children: [
+                        {
+                          lazy: () =>
+                            import(
+                              "../pages/TalentNominations/NominationGroup/Layout"
+                            ),
+                          children: [
+                            {
+                              index: true,
+                              lazy: () =>
+                                import(
+                                  "../pages/TalentNominations/NominationGroup/Details"
+                                ),
+                            },
+                            {
+                              path: "profile",
+                              lazy: () =>
+                                import(
+                                  "../pages/TalentNominations/NominationGroup/Profile"
+                                ),
+                            },
+                            {
+                              path: "career-experience",
+                              lazy: () =>
+                                import(
+                                  "../pages/TalentNominations/NominationGroup/CareerExperience"
+                                ),
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
                   path: "talent-requests",
                   children: [
                     {

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -351,6 +351,9 @@ const getRoutes = (lang: Locales) => {
 
     // Communities
     talentManagementEvents: () => [communitiesUrl, "talent-events"].join("/"),
+    adminTalentManagementEvents: () => `${adminUrl}/talent-events`,
+    adminTalentMangementEvent: (eventId: string) =>
+      `${adminUrl}/talent-events/${eventId}`,
     createTalentNomination: (nominationEventId: string) =>
       `${communitiesUrl}/talent-events/${nominationEventId}/create-talent-nomination`,
     talentNomination: (nominationId: string) =>

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -355,6 +355,18 @@ const getRoutes = (lang: Locales) => {
       `${communitiesUrl}/talent-events/${nominationEventId}/create-talent-nomination`,
     talentNomination: (nominationId: string) =>
       `${communitiesUrl}/talent-nominations/${nominationId}`,
+    talentNominationGroup: (eventId: string, nominationGroupId: string) =>
+      `${adminUrl}/talent-events/${eventId}/nominations/${nominationGroupId}`,
+    talentNominationGroupProfile: (
+      eventId: string,
+      nominationGroupId: string,
+    ) =>
+      `${adminUrl}/talent-events/${eventId}/nominations/${nominationGroupId}/profile`,
+    talentNominationGroupExperience: (
+      eventId: string,
+      nominationGroupId: string,
+    ) =>
+      `${adminUrl}/talent-events/${eventId}/nominations/${nominationGroupId}/career-experience`,
 
     // Comptrollership
     comptrollershipExecutivesPage: () =>

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -575,6 +575,10 @@
     "defaultMessage": "Tâches de travail (anglais)",
     "description": "Label for a process' English work tasks"
   },
+  "0m1utE": {
+    "defaultMessage": "Examinez le profil d'une personne candidate et approuver ou rejeter sa candidature.",
+    "description": "Description of a talent nomination group"
+  },
   "0ox2XB": {
     "defaultMessage": "Compétences techniques",
     "description": "Title for the technical skill rank card"
@@ -3367,6 +3371,10 @@
     "defaultMessage": "Femme autochtone qui prend une pause du programme de prestation de travail sur son portable.",
     "description": "Description of a decorative image of a woman and a laptop"
   },
+  "EtjQ8d": {
+    "defaultMessage": "Gestion des talents",
+    "description": "Heading for the talent management page"
+  },
   "EvR6qK": {
     "defaultMessage": "Qualifiez le candidat ou la candidate",
     "description": "Qualify candidate option"
@@ -4938,6 +4946,10 @@
   "MsLKAj": {
     "defaultMessage": "Voir l’expérience pour {experienceName}",
     "description": "Assistive technology link text to view a specific experience"
+  },
+  "MsiKO0": {
+    "defaultMessage": "Détails de la nomination",
+    "description": "Link text for details about a nomination"
   },
   "Msshus": {
     "defaultMessage": "Les conseillers en ressources humaines (RH) sont chargés de veiller à ce que les clients à la recherche de talents numériques soient conscients de leurs obligations dans le cadre de la <cite>Directive sur les talents numériques</cite> et d'aider les clients à tirer parti des marges de manœuvre disponibles à l'échelle des politiques RH pour embaucher des talents numériques. Ce guide de mise en œuvre est conçu pour aider les conseillers en RH à assumer ces responsabilités.",
@@ -6537,6 +6549,10 @@
   "V6wB0a": {
     "defaultMessage": "{experienceCount, plural, =0 {0 expérience de participation au sein de la collectivité} =1 {1 expérience de participation au sein de la collectivité} other {# expériences de participation au sein de la collectivité}}",
     "description": "list a number of community experiences"
+  },
+  "V8sPIH": {
+    "defaultMessage": "Expérience professionnelle",
+    "description": "Link text for the experience of a nominee"
   },
   "V8v+/g": {
     "defaultMessage": "Filtre de classification",
@@ -10221,6 +10237,10 @@
   "n4pwef": {
     "defaultMessage": "Rôle actuel",
     "description": "Label displayed on an Experience form for current role bounded box"
+  },
+  "n8Mc9q": {
+    "defaultMessage": "Profil",
+    "description": "Link text for the profile of a nominee"
   },
   "n92mcX": {
     "defaultMessage": "Responsables de l’approvisionnement",

--- a/apps/web/src/messages/pageTitles.ts
+++ b/apps/web/src/messages/pageTitles.ts
@@ -97,4 +97,9 @@ export default defineMessages({
     id: "O5yqIM",
     description: "Heading for submit page of an form",
   },
+  talentManagement: {
+    defaultMessage: "Talent management",
+    id: "EtjQ8d",
+    description: "Heading for the talent management page",
+  },
 });

--- a/apps/web/src/pages/TalentNominations/NominationGroup/CareerExperience.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/CareerExperience.tsx
@@ -1,0 +1,70 @@
+import { useQuery } from "urql";
+
+import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
+import { Pending, ThrowNotFound } from "@gc-digital-talent/ui";
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+
+import RequireAuth from "~/components/RequireAuth/RequireAuth";
+import useRequiredParams from "~/hooks/useRequiredParams";
+
+import { RouteParams } from "./types";
+
+const TalentNominationGroupCareerExperience_Fragment = graphql(/* GraphQL */ `
+  fragment TalentNominationGroupCareerExperience on TalentNominationGroup {
+    id
+  }
+`);
+
+interface TalentNominationGroupCareerExperienceProps {
+  query: FragmentType<typeof TalentNominationGroupCareerExperience_Fragment>;
+}
+
+const TalentNominationGroupCareerExperience = ({
+  query,
+}: TalentNominationGroupCareerExperienceProps) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const talentNominationGroup = getFragment(
+    TalentNominationGroupCareerExperience_Fragment,
+    query,
+  );
+
+  return null; // TO DO: Add page in #12852
+};
+
+const TalentNominationGroupCareerExperience_Query = graphql(/* GraphQL */ `
+  query TalentNominationGroupCareerExperience($talentNominationGroupId: UUID!) {
+    talentNominationGroup(id: $talentNominationGroupId) {
+      ...TalentNominationGroupCareerExperience
+    }
+  }
+`);
+
+const TalentNominationGroupCareerExperiencePage = () => {
+  const { talentNominationGroupId } = useRequiredParams<RouteParams>(
+    "talentNominationGroupId",
+  );
+  const [{ data, fetching, error }] = useQuery({
+    query: TalentNominationGroupCareerExperience_Query,
+    variables: { talentNominationGroupId },
+  });
+
+  return (
+    <Pending fetching={fetching} error={error}>
+      {data?.talentNominationGroup ? (
+        <TalentNominationGroupCareerExperience
+          query={data.talentNominationGroup}
+        />
+      ) : (
+        <ThrowNotFound />
+      )}
+    </Pending>
+  );
+};
+
+export const Component = () => (
+  <RequireAuth roles={[ROLE_NAME.CommunityTalentCoordinator]}>
+    <TalentNominationGroupCareerExperiencePage />
+  </RequireAuth>
+);
+
+Component.displayName = "TalentNominationGroupCareerExperiencePage";

--- a/apps/web/src/pages/TalentNominations/NominationGroup/CareerExperience.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/CareerExperience.tsx
@@ -28,7 +28,7 @@ const TalentNominationGroupCareerExperience = ({
     query,
   );
 
-  return null; // TO DO: Add page in #12852
+  return null; // TO DO: Add page in #12854
 };
 
 const TalentNominationGroupCareerExperience_Query = graphql(/* GraphQL */ `

--- a/apps/web/src/pages/TalentNominations/NominationGroup/Details.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/Details.tsx
@@ -1,0 +1,68 @@
+import { useQuery } from "urql";
+
+import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
+import { Pending, ThrowNotFound } from "@gc-digital-talent/ui";
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+
+import RequireAuth from "~/components/RequireAuth/RequireAuth";
+import useRequiredParams from "~/hooks/useRequiredParams";
+
+import { RouteParams } from "./types";
+
+const TalentNominationGroupDetails_Fragment = graphql(/* GraphQL */ `
+  fragment TalentNominationGroupDetails on TalentNominationGroup {
+    id
+  }
+`);
+
+interface TalentNominationGroupDetailsProps {
+  query: FragmentType<typeof TalentNominationGroupDetails_Fragment>;
+}
+
+const TalentNominationGroupDetails = ({
+  query,
+}: TalentNominationGroupDetailsProps) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const talentNominationGroup = getFragment(
+    TalentNominationGroupDetails_Fragment,
+    query,
+  );
+
+  return null; // TO DO: Add page in #12852
+};
+
+const TalentNominationGroupDetails_Query = graphql(/* GraphQL */ `
+  query TalentNominationGroupDetails($talentNominationGroupId: UUID!) {
+    talentNominationGroup(id: $talentNominationGroupId) {
+      ...TalentNominationGroupDetails
+    }
+  }
+`);
+
+const TalentNominationGroupDetailsPage = () => {
+  const { talentNominationGroupId } = useRequiredParams<RouteParams>(
+    "talentNominationGroupId",
+  );
+  const [{ data, fetching, error }] = useQuery({
+    query: TalentNominationGroupDetails_Query,
+    variables: { talentNominationGroupId },
+  });
+
+  return (
+    <Pending fetching={fetching} error={error}>
+      {data?.talentNominationGroup ? (
+        <TalentNominationGroupDetails query={data.talentNominationGroup} />
+      ) : (
+        <ThrowNotFound />
+      )}
+    </Pending>
+  );
+};
+
+export const Component = () => (
+  <RequireAuth roles={[ROLE_NAME.CommunityTalentCoordinator]}>
+    <TalentNominationGroupDetailsPage />
+  </RequireAuth>
+);
+
+Component.displayName = "TalentNominationGroupDetailsPage";

--- a/apps/web/src/pages/TalentNominations/NominationGroup/Layout.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/Layout.tsx
@@ -1,0 +1,179 @@
+import { useIntl } from "react-intl";
+import { Outlet } from "react-router";
+import { useQuery } from "urql";
+
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
+import { Pending, Sidebar, ThrowNotFound } from "@gc-digital-talent/ui";
+import { commonMessages, navigationMessages } from "@gc-digital-talent/i18n";
+
+import Hero from "~/components/Hero";
+import RequireAuth from "~/components/RequireAuth/RequireAuth";
+import SEO from "~/components/SEO/SEO";
+import useRequiredParams from "~/hooks/useRequiredParams";
+import { getFullNameLabel } from "~/utils/nameUtils";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
+import useRoutes from "~/hooks/useRoutes";
+import pageTitles from "~/messages/pageTitles";
+
+import { RouteParams } from "./types";
+
+const TalentNominationGroupLayout_Fragment = graphql(/* GraphQL */ `
+  fragment TalentNominationGroupLayout on TalentNominationGroup {
+    talentNominationEvent {
+      id
+      name {
+        localized
+      }
+    }
+    nominee {
+      firstName
+      lastName
+    }
+  }
+`);
+
+interface LayoutProps {
+  query: FragmentType<typeof TalentNominationGroupLayout_Fragment>;
+}
+
+const Layout = ({ query }: LayoutProps) => {
+  const intl = useIntl();
+  const paths = useRoutes();
+  const { talentNominationGroupId } = useRequiredParams<RouteParams>(
+    "talentNominationGroupId",
+  );
+  const talentNominationGroup = getFragment(
+    TalentNominationGroupLayout_Fragment,
+    query,
+  );
+
+  const nomineeName = getFullNameLabel(
+    talentNominationGroup.nominee?.firstName,
+    talentNominationGroup.nominee?.lastName,
+    intl,
+  );
+
+  const description = intl.formatMessage({
+    defaultMessage:
+      "Review a nominee’s profile and approve or reject their nomination.",
+    id: "0m1utE",
+    description: "Description of a talent nomination group",
+  });
+
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(navigationMessages.communityDashboard),
+        url: paths.communityDashboard(),
+      },
+      {
+        label: intl.formatMessage(pageTitles.talentManagement),
+        url: "#", // NOTE: Page doesn't exist yet
+      },
+      {
+        label:
+          talentNominationGroup.talentNominationEvent.name.localized ??
+          intl.formatMessage(commonMessages.notAvailable),
+        url: "#", // NOTE: Page does not exist yet
+      },
+      {
+        label: nomineeName,
+        url: paths.talentNominationGroup(
+          talentNominationGroup.talentNominationEvent.id,
+          talentNominationGroupId,
+        ),
+      },
+    ],
+  });
+
+  return (
+    <>
+      <SEO title={nomineeName} description={description} />
+      <Hero
+        title={nomineeName}
+        subtitle={description}
+        crumbs={crumbs}
+        navTabs={[
+          {
+            url: paths.talentNominationGroup(
+              talentNominationGroup.talentNominationEvent.id,
+              talentNominationGroupId,
+            ),
+            label: intl.formatMessage({
+              defaultMessage: "Nomination details",
+              id: "MsiKO0",
+              description: "Link text for details about a nomination",
+            }),
+          },
+          {
+            url: paths.talentNominationGroupProfile(
+              talentNominationGroup.talentNominationEvent.id,
+              talentNominationGroupId,
+            ),
+            label: intl.formatMessage({
+              defaultMessage: "Profile",
+              id: "n8Mc9q",
+              description: "Link text for the profile of a nominee",
+            }),
+          },
+          {
+            url: paths.talentNominationGroupExperience(
+              talentNominationGroup.talentNominationEvent.id,
+              talentNominationGroupId,
+            ),
+            label: intl.formatMessage({
+              defaultMessage: "Career experience",
+              id: "V8sPIH",
+              description: "Link text for the experience of a nominee",
+            }),
+          },
+        ]}
+      />
+      <Sidebar.Wrapper>
+        <Sidebar.Content>
+          <Outlet />
+        </Sidebar.Content>
+        <Sidebar.Sidebar>
+          <>{/* Put the sidebar here */}</>
+        </Sidebar.Sidebar>
+      </Sidebar.Wrapper>
+    </>
+  );
+};
+
+const TalentNominationGroupLayout_Query = graphql(/* GraphQL */ `
+  query TalentNominationGroupLayout($talentNominationGroupId: UUID!) {
+    talentNominationGroup(id: $talentNominationGroupId) {
+      ...TalentNominationGroupLayout
+    }
+  }
+`);
+
+const TalentNominationGroupLayout = () => {
+  const { talentNominationGroupId } = useRequiredParams<RouteParams>(
+    "talentNominationGroupId",
+  );
+  const [{ data, fetching, error }] = useQuery({
+    query: TalentNominationGroupLayout_Query,
+    variables: { talentNominationGroupId },
+  });
+
+  return (
+    <Pending fetching={fetching} error={error}>
+      {data?.talentNominationGroup ? (
+        <Layout query={data.talentNominationGroup} />
+      ) : (
+        <ThrowNotFound />
+      )}
+    </Pending>
+  );
+};
+
+export const Component = () => (
+  <RequireAuth roles={[ROLE_NAME.CommunityTalentCoordinator]}>
+    <TalentNominationGroupLayout />
+  </RequireAuth>
+);
+
+Component.displayName = "TalentNominationGroupLayout";

--- a/apps/web/src/pages/TalentNominations/NominationGroup/Layout.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/Layout.tsx
@@ -69,13 +69,15 @@ const Layout = ({ query }: LayoutProps) => {
       },
       {
         label: intl.formatMessage(pageTitles.talentManagement),
-        url: "#", // NOTE: Page doesn't exist yet
+        url: paths.adminTalentManagementEvents(),
       },
       {
         label:
           talentNominationGroup.talentNominationEvent.name.localized ??
           intl.formatMessage(commonMessages.notAvailable),
-        url: "#", // NOTE: Page does not exist yet
+        url: paths.adminTalentMangementEvent(
+          talentNominationGroup.talentNominationEvent.id,
+        ),
       },
       {
         label: nomineeName,

--- a/apps/web/src/pages/TalentNominations/NominationGroup/Layout.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/Layout.tsx
@@ -131,12 +131,12 @@ const Layout = ({ query }: LayoutProps) => {
         ]}
       />
       <Sidebar.Wrapper>
-        <Sidebar.Content>
-          <Outlet />
-        </Sidebar.Content>
-        <Sidebar.Sidebar>
+        <Sidebar.Sidebar data-h2-order="l-tablet(2)">
           <>{/* Put the sidebar here */}</>
         </Sidebar.Sidebar>
+        <Sidebar.Content data-h2-order="l-tablet(1)">
+          <Outlet />
+        </Sidebar.Content>
       </Sidebar.Wrapper>
     </>
   );

--- a/apps/web/src/pages/TalentNominations/NominationGroup/Profile.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/Profile.tsx
@@ -28,7 +28,7 @@ const TalentNominationGroupProfile = ({
     query,
   );
 
-  return null; // TO DO: Add page in #12852
+  return null; // TO DO: Add page in #12853
 };
 
 const TalentNominationGroupProfile_Query = graphql(/* GraphQL */ `

--- a/apps/web/src/pages/TalentNominations/NominationGroup/Profile.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/Profile.tsx
@@ -1,0 +1,68 @@
+import { useQuery } from "urql";
+
+import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
+import { Pending, ThrowNotFound } from "@gc-digital-talent/ui";
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+
+import RequireAuth from "~/components/RequireAuth/RequireAuth";
+import useRequiredParams from "~/hooks/useRequiredParams";
+
+import { RouteParams } from "./types";
+
+const TalentNominationGroupProfile_Fragment = graphql(/* GraphQL */ `
+  fragment TalentNominationGroupProfile on TalentNominationGroup {
+    id
+  }
+`);
+
+interface TalentNominationGroupProfileProps {
+  query: FragmentType<typeof TalentNominationGroupProfile_Fragment>;
+}
+
+const TalentNominationGroupProfile = ({
+  query,
+}: TalentNominationGroupProfileProps) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const talentNominationGroup = getFragment(
+    TalentNominationGroupProfile_Fragment,
+    query,
+  );
+
+  return null; // TO DO: Add page in #12852
+};
+
+const TalentNominationGroupProfile_Query = graphql(/* GraphQL */ `
+  query TalentNominationGroupProfile($talentNominationGroupId: UUID!) {
+    talentNominationGroup(id: $talentNominationGroupId) {
+      ...TalentNominationGroupProfile
+    }
+  }
+`);
+
+const TalentNominationGroupProfilePage = () => {
+  const { talentNominationGroupId } = useRequiredParams<RouteParams>(
+    "talentNominationGroupId",
+  );
+  const [{ data, fetching, error }] = useQuery({
+    query: TalentNominationGroupProfile_Query,
+    variables: { talentNominationGroupId },
+  });
+
+  return (
+    <Pending fetching={fetching} error={error}>
+      {data?.talentNominationGroup ? (
+        <TalentNominationGroupProfile query={data.talentNominationGroup} />
+      ) : (
+        <ThrowNotFound />
+      )}
+    </Pending>
+  );
+};
+
+export const Component = () => (
+  <RequireAuth roles={[ROLE_NAME.CommunityTalentCoordinator]}>
+    <TalentNominationGroupProfilePage />
+  </RequireAuth>
+);
+
+Component.displayName = "TalentNominationGroupProfilePage";

--- a/apps/web/src/pages/TalentNominations/NominationGroup/types.ts
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/types.ts
@@ -1,0 +1,3 @@
+export interface RouteParams extends Record<string, string> {
+  talentNominationGroupId: string;
+}

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -583,6 +583,10 @@
     "defaultMessage": "Un champ obligatoire est vide : Français - Note spéciale pour ce processus",
     "description": "Error message that Special note for this process in French must be filled"
   },
+  "NQspkZ": {
+    "defaultMessage": "Tableau de bord de la collectivité",
+    "description": "Name of the community dashboard page"
+  },
   "NVMKe5": {
     "defaultMessage": "Modifier la séquence de {from} à {to}",
     "description": "Button text for moving an item from one position to another"

--- a/packages/i18n/src/messages/navigationMessages.ts
+++ b/packages/i18n/src/messages/navigationMessages.ts
@@ -106,6 +106,11 @@ const navigationMessages = defineMessages({
     id: "jDYG3j",
     description: "Name of Dashboard page",
   },
+  communityDashboard: {
+    defaultMessage: "Community dashboard",
+    id: "NQspkZ",
+    description: "Name of the community dashboard page",
+  },
   contactUs: {
     defaultMessage: "Contact us",
     id: "sQt/7l",


### PR DESCRIPTION
🤖 Resolves #12851 

## 👋 Introduction

Adds blank stub pages for the admin view of a nomination group.

## 🧪 Testing

> [!TIP]
> Sometimes the nominee may not be a verified gov employee so you may need to tweak DB info. 

1. Build `pnpm run dev:fresh`
2. Login as a community talent coordinator (I just have admin@test.com this role)
3. Navigate to `/admin/talent-events/{eventId}/nominations/{nominationGroupid}
4. Confirm the page exists with bread crumbs and tabs

## 📸 Screenshot

![2025-03-24_16-42](https://github.com/user-attachments/assets/115c5d1c-f3c0-467e-a227-60b23a0ad721)
