### PR TITLE
[Copy] Update copy to correctly refer to a link rather than a button on the applicant dashboard

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -9894,6 +9894,10 @@
     "defaultMessage": "Anglais - Votre travail",
     "description": "Label for the English - Your Work textarea in the edit pool page."
   },
+  "ldgukM": {
+    "defaultMessage": "Des collectivités peuvent être suggérées en fonction de votre expérience professionnelle. Vous pouvez également ajouter des collectivités fonctionnelles en cliquant sur le lien « Ajoutez une collectivité ».",
+    "description": "Body for notice when there are no functional communities a user is a part of"
+  },
   "leFf/M": {
     "defaultMessage": "Copier l’identifiant de {title} dans le presse-papiers",
     "description": "Button text to copy a specific qualified recruitment's ID"
@@ -11865,10 +11869,6 @@
   "w63YYp": {
     "defaultMessage": "Modification des préférences en matière de travail",
     "description": "Button text to start editing work preferences"
-  },
-  "w6JVdk": {
-    "defaultMessage": "Des collectivités peuvent être suggérées en fonction de votre expérience professionnelle. Vous pouvez également ajouter des collectivités fonctionnelles en cliquant sur le bouton « Ajoutez une collectivité ».",
-    "description": "Body for notice when there are no functional communities a user is a part of"
   },
   "w7E0He": {
     "defaultMessage": "Compétences essentielles",

--- a/apps/web/src/pages/ApplicantDashboardPage/components/CareerDevelopmentTaskCard.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/CareerDevelopmentTaskCard.tsx
@@ -439,8 +439,8 @@ const CareerDevelopmentTaskCard = ({
                         <p>
                           {intl.formatMessage({
                             defaultMessage:
-                              'Communities might be suggested based on your career experience. You can also add functional communities using the "Add a community" button.',
-                            id: "w6JVdk",
+                              'Communities might be suggested based on your career experience. You can also add functional communities using the "Add a community" link.',
+                            id: "ldgukM",
                             description:
                               "Body for notice when there are no functional communities a user is a part of",
                           })}


### PR DESCRIPTION
🤖 Resolves #13089.

## 👋 Introduction

This PR update copy to correctly refer to a link rather than a button on the applicant dashboard.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/applicant
3. Verify null state copy is **Communities might be suggested based on your career experience. You can also add functional communities using the "Add a community" link.**
4. Switch to French
5. Verify null state copy is **Des collectivités peuvent être suggérées en fonction de votre expérience professionnelle. Vous pouvez également ajouter des collectivités fonctionnelles en cliquant sur le lien « Ajoutez une collectivité ».**

## 📸 Screenshots

<img width="861" alt="Screen Shot 2025-03-25 at 16 44 30" src="https://github.com/user-attachments/assets/7590bdc9-b030-4b25-a56c-33380ed4dd82" />

<img width="792" alt="Screen Shot 2025-03-25 at 16 47 05" src="https://github.com/user-attachments/assets/479ad92e-70bd-4c90-931e-9fb13a56cb4b" />