### PR TITLE
[Bug] Fix coordinator roles on admin user pages

### DIFF
--- a/apps/web/src/pages/Users/UserEmployeeInformationPage/UserEmployeeInformationPage.tsx
+++ b/apps/web/src/pages/Users/UserEmployeeInformationPage/UserEmployeeInformationPage.tsx
@@ -282,6 +282,7 @@ export const Component = () => (
       ROLE_NAME.PlatformAdmin,
       ROLE_NAME.CommunityAdmin,
       ROLE_NAME.CommunityRecruiter,
+      ROLE_NAME.CommunityTalentCoordinator,
       ROLE_NAME.ProcessOperator,
     ]}
   >

--- a/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/UserInformationPage.tsx
@@ -599,6 +599,7 @@ export const Component = () => (
       ROLE_NAME.PlatformAdmin,
       ROLE_NAME.CommunityAdmin,
       ROLE_NAME.CommunityRecruiter,
+      ROLE_NAME.CommunityTalentCoordinator,
       ROLE_NAME.ProcessOperator,
     ]}
   >


### PR DESCRIPTION
🤖 Resolves #13066

## 👋 Introduction

Adds the ability for the community talent coordinator role to access the first three admin user tabs.

## 🧪 Testing

1. Make sure your permissions are up to date `php artisan db:seed --class=RolePermissionSeeder`
2. Log in as talent-coordinator@test.com
3. Navigate to /admin/community-talent
4.  Click on a name to go to /admin/users/{userId}/employee-profile
5. Click the other tabs
