### PR TITLE
[Feat] Admin talent even stubs

### DIFF
--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -800,34 +800,62 @@ const createRoute = (locale: Locales, newApplicantDashboard: boolean) =>
                   path: "talent-events",
                   children: [
                     {
-                      path: ":eventId/nominations/:talentNominationGroupId",
+                      path: ":eventId",
                       children: [
                         {
                           lazy: () =>
-                            import(
-                              "../pages/TalentNominations/NominationGroup/Layout"
-                            ),
+                            import("../pages/TalentEvents/TalentEvent/Layout"),
                           children: [
                             {
                               index: true,
                               lazy: () =>
                                 import(
-                                  "../pages/TalentNominations/NominationGroup/Details"
+                                  "../pages/TalentEvents/TalentEvent/DetailsPage"
                                 ),
                             },
                             {
-                              path: "profile",
+                              path: "nominations",
                               lazy: () =>
                                 import(
-                                  "../pages/TalentNominations/NominationGroup/Profile"
+                                  "../pages/TalentEvents/TalentEvent/NominationsPage"
                                 ),
-                            },
-                            {
-                              path: "career-experience",
-                              lazy: () =>
-                                import(
-                                  "../pages/TalentNominations/NominationGroup/CareerExperience"
-                                ),
+                              children: [
+                                {
+                                  path: ":talentNominationGroupId",
+
+                                  children: [
+                                    {
+                                      lazy: () =>
+                                        import(
+                                          "../pages/TalentNominations/NominationGroup/Layout"
+                                        ),
+                                      children: [
+                                        {
+                                          index: true,
+                                          lazy: () =>
+                                            import(
+                                              "../pages/TalentNominations/NominationGroup/Details"
+                                            ),
+                                        },
+                                        {
+                                          path: "profile",
+                                          lazy: () =>
+                                            import(
+                                              "../pages/TalentNominations/NominationGroup/Profile"
+                                            ),
+                                        },
+                                        {
+                                          path: "career-experience",
+                                          lazy: () =>
+                                            import(
+                                              "../pages/TalentNominations/NominationGroup/CareerExperience"
+                                            ),
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                },
+                              ],
                             },
                           ],
                         },

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -354,6 +354,8 @@ const getRoutes = (lang: Locales) => {
     adminTalentManagementEvents: () => `${adminUrl}/talent-events`,
     adminTalentMangementEvent: (eventId: string) =>
       `${adminUrl}/talent-events/${eventId}`,
+    adminTalentMangementEventNominations: (eventId: string) =>
+      `${adminUrl}/talent-events/${eventId}/nominations`,
     createTalentNomination: (nominationEventId: string) =>
       `${communitiesUrl}/talent-events/${nominationEventId}/create-talent-nomination`,
     talentNomination: (nominationId: string) =>

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -352,9 +352,9 @@ const getRoutes = (lang: Locales) => {
     // Communities
     talentManagementEvents: () => [communitiesUrl, "talent-events"].join("/"),
     adminTalentManagementEvents: () => `${adminUrl}/talent-events`,
-    adminTalentMangementEvent: (eventId: string) =>
+    adminTalentManagementEvent: (eventId: string) =>
       `${adminUrl}/talent-events/${eventId}`,
-    adminTalentMangementEventNominations: (eventId: string) =>
+    adminTalentManagementEventNominations: (eventId: string) =>
       `${adminUrl}/talent-events/${eventId}/nominations`,
     createTalentNomination: (nominationEventId: string) =>
       `${communitiesUrl}/talent-events/${nominationEventId}/create-talent-nomination`,

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3151,6 +3151,10 @@
     "defaultMessage": "Ce compte d'utilisateur a été supprimé. Veuillez <inlineLink>communiquer avec nous</inlineLink> si vous avez des questions.",
     "description": "Message displayed to a user after signing into a deleted account"
   },
+  "DbS8sT": {
+    "defaultMessage": "Consultez les détails de l'événement et triez les nominations.",
+    "description": "Description of a talent event"
+  },
   "DbWxZl": {
     "defaultMessage": "Cherchez les rôles dans des processus",
     "description": "Label for the process roles table search input"
@@ -9662,6 +9666,10 @@
     "defaultMessage": "Créez le volet de travail",
     "description": "Button text to create a work stream"
   },
+  "jnd5HF": {
+    "defaultMessage": "Détails de l'événement",
+    "description": "Link text for details about a nomination event"
+  },
   "jno96W": {
     "defaultMessage": "Modifiez la planification de carrière",
     "description": "Link to a page to edit your career planning information"
@@ -11501,6 +11509,10 @@
   "tcL+WV": {
     "defaultMessage": "Détails de base",
     "description": "Title of the 'basic details' section of the job poster template page"
+  },
+  "tgPKAn": {
+    "defaultMessage": "Nominations",
+    "description": "Link text for the nominations of a specific talent nomination event"
   },
   "tgtpgb": {
     "defaultMessage": "Vous pouvez visualiser vos candidat(e)s sur la page <a>Placement de talents</a>.",

--- a/apps/web/src/lang/whitelist.yml
+++ b/apps/web/src/lang/whitelist.yml
@@ -32,3 +32,4 @@
 - d1FYv4 # Classification
 - bF/Cas # Instructions
 - fhbTHo # Instructions
+- tgPKAn # Nominations

--- a/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
@@ -1,0 +1,61 @@
+import { useQuery } from "urql";
+
+import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
+import { Pending, ThrowNotFound } from "@gc-digital-talent/ui";
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+
+import RequireAuth from "~/components/RequireAuth/RequireAuth";
+import useRequiredParams from "~/hooks/useRequiredParams";
+
+import { RouteParams } from "./types";
+
+const TalentEventDetails_Fragment = graphql(/* GraphQL */ `
+  fragment TalentEventDetails on TalentNominationEvent {
+    id
+  }
+`);
+
+interface TalentEventDetailsProps {
+  query: FragmentType<typeof TalentEventDetails_Fragment>;
+}
+
+const TalentEventDetails = ({ query }: TalentEventDetailsProps) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const talentEvent = getFragment(TalentEventDetails_Fragment, query);
+
+  return null; // TO DO: Add page in #12852
+};
+
+const TalentEventDetails_Query = graphql(/* GraphQL */ `
+  query TalentEventDetails($talentEventId: UUID!) {
+    talentNominationEvent(id: $talentEventId) {
+      ...TalentEventDetails
+    }
+  }
+`);
+
+const TalentEventDetailsPage = () => {
+  const { eventId } = useRequiredParams<RouteParams>("eventId");
+  const [{ data, fetching, error }] = useQuery({
+    query: TalentEventDetails_Query,
+    variables: { talentEventId: eventId },
+  });
+
+  return (
+    <Pending fetching={fetching} error={error}>
+      {data?.talentNominationEvent ? (
+        <TalentEventDetails query={data.talentNominationEvent} />
+      ) : (
+        <ThrowNotFound />
+      )}
+    </Pending>
+  );
+};
+
+export const Component = () => (
+  <RequireAuth roles={[ROLE_NAME.CommunityTalentCoordinator]}>
+    <TalentEventDetailsPage />
+  </RequireAuth>
+);
+
+Component.displayName = "TalentEventDetailsPage";

--- a/apps/web/src/pages/TalentEvents/TalentEvent/Layout.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/Layout.tsx
@@ -1,0 +1,133 @@
+import { useIntl } from "react-intl";
+import { Outlet } from "react-router";
+import { useQuery } from "urql";
+
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
+import { Pending, ThrowNotFound } from "@gc-digital-talent/ui";
+import { commonMessages, navigationMessages } from "@gc-digital-talent/i18n";
+
+import Hero from "~/components/Hero";
+import RequireAuth from "~/components/RequireAuth/RequireAuth";
+import SEO from "~/components/SEO/SEO";
+import useRequiredParams from "~/hooks/useRequiredParams";
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
+import useRoutes from "~/hooks/useRoutes";
+import pageTitles from "~/messages/pageTitles";
+import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
+
+import { RouteParams } from "./types";
+
+const TalentEventLayout_Fragment = graphql(/* GraphQL */ `
+  fragment TalentEventLayout on TalentNominationEvent {
+    id
+    name {
+      localized
+    }
+  }
+`);
+
+interface LayoutProps {
+  query: FragmentType<typeof TalentEventLayout_Fragment>;
+}
+
+const Layout = ({ query }: LayoutProps) => {
+  const intl = useIntl();
+  const paths = useRoutes();
+  const { eventId } = useRequiredParams<RouteParams>("eventId");
+  const talentEvent = getFragment(TalentEventLayout_Fragment, query);
+
+  const pageTitle =
+    talentEvent.name.localized ??
+    intl.formatMessage(commonMessages.notAvailable);
+
+  const description = intl.formatMessage({
+    defaultMessage: "View event details and triage nominations.",
+    id: "DbS8sT",
+    description: "Description of a talent event",
+  });
+
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: intl.formatMessage(navigationMessages.communityDashboard),
+        url: paths.communityDashboard(),
+      },
+      {
+        label: intl.formatMessage(pageTitles.talentManagement),
+        url: paths.adminTalentManagementEvents(),
+      },
+      {
+        label: pageTitle,
+        url: paths.adminTalentMangementEvent(eventId),
+      },
+    ],
+  });
+
+  return (
+    <>
+      <SEO title={pageTitle} description={description} />
+      <Hero
+        title={pageTitle}
+        subtitle={description}
+        crumbs={crumbs}
+        navTabs={[
+          {
+            url: paths.adminTalentMangementEvent(eventId),
+            label: intl.formatMessage({
+              defaultMessage: "Event details",
+              id: "jnd5HF",
+              description: "Link text for details about a nomination event",
+            }),
+          },
+          {
+            url: paths.adminTalentMangementEventNominations(eventId),
+            label: intl.formatMessage({
+              defaultMessage: "Nominations",
+              id: "tgPKAn",
+              description:
+                "Link text for the nominations of a specific talent nomination event",
+            }),
+          },
+        ]}
+      />
+      <AdminContentWrapper>
+        <Outlet />
+      </AdminContentWrapper>
+    </>
+  );
+};
+
+const TalentEventLayout_Query = graphql(/* GraphQL */ `
+  query TalentEventLayout($talentEventId: UUID!) {
+    talentNominationEvent(id: $talentEventId) {
+      ...TalentEventLayout
+    }
+  }
+`);
+
+const TalentEventLayout = () => {
+  const { eventId } = useRequiredParams<RouteParams>("eventId");
+  const [{ data, fetching, error }] = useQuery({
+    query: TalentEventLayout_Query,
+    variables: { talentEventId: eventId },
+  });
+
+  return (
+    <Pending fetching={fetching} error={error}>
+      {data?.talentNominationEvent ? (
+        <Layout query={data.talentNominationEvent} />
+      ) : (
+        <ThrowNotFound />
+      )}
+    </Pending>
+  );
+};
+
+export const Component = () => (
+  <RequireAuth roles={[ROLE_NAME.CommunityTalentCoordinator]}>
+    <TalentEventLayout />
+  </RequireAuth>
+);
+
+Component.displayName = "TalentEventLayout";

--- a/apps/web/src/pages/TalentEvents/TalentEvent/Layout.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/Layout.tsx
@@ -59,7 +59,7 @@ const Layout = ({ query }: LayoutProps) => {
       },
       {
         label: pageTitle,
-        url: paths.adminTalentMangementEvent(eventId),
+        url: paths.adminTalentManagementEvent(eventId),
       },
     ],
   });
@@ -73,7 +73,7 @@ const Layout = ({ query }: LayoutProps) => {
         crumbs={crumbs}
         navTabs={[
           {
-            url: paths.adminTalentMangementEvent(eventId),
+            url: paths.adminTalentManagementEvent(eventId),
             label: intl.formatMessage({
               defaultMessage: "Event details",
               id: "jnd5HF",
@@ -81,7 +81,7 @@ const Layout = ({ query }: LayoutProps) => {
             }),
           },
           {
-            url: paths.adminTalentMangementEventNominations(eventId),
+            url: paths.adminTalentManagementEventNominations(eventId),
             label: intl.formatMessage({
               defaultMessage: "Nominations",
               id: "tgPKAn",

--- a/apps/web/src/pages/TalentEvents/TalentEvent/NominationsPage.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/NominationsPage.tsx
@@ -1,0 +1,61 @@
+import { useQuery } from "urql";
+
+import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
+import { Pending, ThrowNotFound } from "@gc-digital-talent/ui";
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+
+import RequireAuth from "~/components/RequireAuth/RequireAuth";
+import useRequiredParams from "~/hooks/useRequiredParams";
+
+import { RouteParams } from "./types";
+
+const TalentEventNominations_Fragment = graphql(/* GraphQL */ `
+  fragment TalentEventNominations on TalentNominationEvent {
+    id
+  }
+`);
+
+interface TalentEventNominationsProps {
+  query: FragmentType<typeof TalentEventNominations_Fragment>;
+}
+
+const TalentEventNominations = ({ query }: TalentEventNominationsProps) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const talentEvent = getFragment(TalentEventNominations_Fragment, query);
+
+  return null;
+};
+
+const TalentEventNominations_Query = graphql(/* GraphQL */ `
+  query TalentEventNominations($talentEventId: UUID!) {
+    talentNominationEvent(id: $talentEventId) {
+      ...TalentEventNominations
+    }
+  }
+`);
+
+const TalentEventNominationsPage = () => {
+  const { eventId } = useRequiredParams<RouteParams>("eventId");
+  const [{ data, fetching, error }] = useQuery({
+    query: TalentEventNominations_Query,
+    variables: { talentEventId: eventId },
+  });
+
+  return (
+    <Pending fetching={fetching} error={error}>
+      {data?.talentNominationEvent ? (
+        <TalentEventNominations query={data.talentNominationEvent} />
+      ) : (
+        <ThrowNotFound />
+      )}
+    </Pending>
+  );
+};
+
+export const Component = () => (
+  <RequireAuth roles={[ROLE_NAME.CommunityTalentCoordinator]}>
+    <TalentEventNominationsPage />
+  </RequireAuth>
+);
+
+Component.displayName = "TalentEventNominationsPage";

--- a/apps/web/src/pages/TalentEvents/TalentEvent/types.ts
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/types.ts
@@ -1,0 +1,3 @@
+export interface RouteParams extends Record<string, string> {
+  eventId: string;
+}

--- a/apps/web/src/pages/TalentNominations/NominationGroup/Layout.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/Layout.tsx
@@ -75,7 +75,7 @@ const Layout = ({ query }: LayoutProps) => {
         label:
           talentNominationGroup.talentNominationEvent.name.localized ??
           intl.formatMessage(commonMessages.notAvailable),
-        url: paths.adminTalentMangementEvent(
+        url: paths.adminTalentManagementEvent(
           talentNominationGroup.talentNominationEvent.id,
         ),
       },


### PR DESCRIPTION
🤖 Resolves #13087 

## 👋 Introduction

Adds the admin stubs for a talent nomination event.

## 🧪 Testing

1. Find a talent event for a digital community (or create one)
2. Login as talent coordinator `talent-coordinator@test.com`
3. Navigate to `/admin/talent-events/{eventId}`
4. Confirm it appears with the proper layout

## 📸 Screenshot

![2025-03-27_14-13](https://github.com/user-attachments/assets/b52fafca-95bf-4b10-8b95-0460a3bc9a2a)

