### PR TITLE
[Fix] Browser history after nomination creation

### DIFF
--- a/apps/web/src/pages/TalentNominations/NominateTalent/NominateTalentPage.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/NominateTalentPage.tsx
@@ -112,7 +112,9 @@ const NominateTalentPage = () => {
         data?.talentNomination?.submittedSteps,
       );
       if (targetStep) {
-        void navigate(`${paths.talentNomination(id)}?step=${targetStep}`);
+        void navigate(`${paths.talentNomination(id)}?step=${targetStep}`, {
+          replace: true,
+        });
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
🤖 Resolves #13091 

## 👋 Introduction

Fixes an issue where the initial redirect was being added to history preventing the back button from functioning as expected.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as employee `applicant-employee@test.com`
3. Naivgate to `/communities/talent-events`
4. Start a nomination for an event
5. Click the browser back button
6. Confirm you are sent back to the list of events