### PR TITLE
[Fix] Remove logic that changes home link in breadcrumbs

### DIFF
--- a/apps/web/src/hooks/useBreadcrumbs.ts
+++ b/apps/web/src/hooks/useBreadcrumbs.ts
@@ -4,8 +4,6 @@ import { useSearchParams } from "react-router";
 import type { BreadcrumbsProps } from "@gc-digital-talent/ui";
 import { navigationMessages } from "@gc-digital-talent/i18n";
 
-import useNavContext from "~/components/NavContext/useNavContext";
-
 import useRoutes from "./useRoutes";
 
 type Crumbs = BreadcrumbsProps["crumbs"];
@@ -18,26 +16,12 @@ const useBreadcrumbs = ({ crumbs }: useBreadcrumbsProps) => {
   const intl = useIntl();
   const paths = useRoutes();
   const [searchParams] = useSearchParams();
-  const { navRole } = useNavContext();
 
   const iapPersonality = searchParams.get("personality") === "iap";
-  let homePath = paths.home();
-
-  switch (navRole) {
-    case "applicant":
-      homePath = paths.home();
-      break;
-    case "community":
-      homePath = paths.communityDashboard();
-      break;
-    case "admin":
-      homePath = paths.adminDashboard();
-      break;
-  }
 
   return [
     {
-      url: !iapPersonality ? homePath : paths.iap(),
+      url: !iapPersonality ? paths.home() : paths.iap(),
       label: intl.formatMessage(navigationMessages.home),
     },
     ...crumbs,


### PR DESCRIPTION
🤖 Resolves #13098 

## 👋 Introduction

Removes the logic that changed the path of the home link in breadcrumbs to be the current nav roles dashboard.

## 🧪 Testing

1. Build app` pnpm run dev:fresh`
2. Login as admin `admin@test.com`
3. Change your nav role
4. Confirm the home link in breadcrumbs always points to `/`