### PR TITLE
[Bug] Prevent community roles viewing other communities interests

### DIFF
--- a/api/app/Policies/CommunityInterestPolicy.php
+++ b/api/app/Policies/CommunityInterestPolicy.php
@@ -48,8 +48,11 @@ class CommunityInterestPolicy
     /**
      * Determine whether the user can access user profiles associated with models.
      */
-    public function viewUser(User $user): bool
+    public function viewUser(User $user, CommunityInterest $communityInterest): bool
     {
-        return $user->isAbleTo('view-team-communityInterest');
+        $communityInterest->loadMissing('community.team');
+
+        return ! is_null($communityInterest->community->team)
+            && $user->isAbleTo('view-team-communityInterest', $communityInterest->community->team);
     }
 }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -254,7 +254,9 @@ type EmployeeProfile {
   careerObjectiveCSuiteRoleTitle: LocalizedCSuiteRoleTitle
     @rename(attribute: "career_objective_c_suite_role_title")
 
-  communityInterests(id: UUID @eq): [CommunityInterest!] @belongsToMany
+  communityInterests(id: UUID @eq): [CommunityInterest!]
+    @belongsToMany
+    @canResolved(ability: "view")
 
   userPublicProfile: UserPublicProfile
 }


### PR DESCRIPTION
🤖 Resolves #13078.

## 👋 Introduction

Prevents community roles from viewing other communities interests.

## 🧪 Testing

Confirm the acceptance criteria from the issue are met:
*  Both "Community talent coordinators" and "Community recruiters" can:
   * view the user profile of those who have expressed interest in their community (view-team-communityTalent)
   * cannot view the user profile of those who have not expressed interest in their community
   * cannot view the user profile of those who have expressed interest in a different community
   * view the community talent table to see users who have expressed interest in their community
   * view the community talent table and not see users who have not expressed interest in their community
   * view the community talent table and not see users who have expressed interest in a different community
   * click through the table to see the first three user profile tabs of those users
   * can only see the community interests of a user that correspond to their communities
* Community recruiters can also: 
   * view the user profile of those who have submitted an application in their community's pools (view-team-applicantProfile)