### PR TITLE
[Debt] Adds one line disable to `formatjs/no-literal-string-in-jsx`

### DIFF
--- a/apps/web/src/components/ExperienceCard/WorkContent/GovContent.tsx
+++ b/apps/web/src/components/ExperienceCard/WorkContent/GovContent.tsx
@@ -157,7 +157,8 @@ const GovContent = ({
             headingLevel={headingLevel}
           >
             {classification
-              ? `${classification.group}-${classification.level < 10 ? "0" : ""}${classification.level}`
+              ? // eslint-disable-next-line formatjs/no-literal-string-in-jsx
+                `${classification.group}-${classification.level < 10 ? "0" : ""}${classification.level}`
               : intl.formatMessage(commonMessages.notAvailable)}
           </ContentSection>
         </div>


### PR DESCRIPTION
## 👋 Introduction

This PR adds disables the `formatjs/no-literal-string-in-jsx` rule for one line to be consistent which other identical lines that have been ignored in the codebase.

## 📸 Screenshot

<img width="975" alt="Screen Shot 2025-03-31 at 20 07 27" src="https://github.com/user-attachments/assets/65865dbb-4967-4b98-aa02-188da5b157ef" />
