### PR TITLE
[Feat] Talent nomination event details page

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1427,6 +1427,10 @@
     "defaultMessage": "Je souhaite recevoir des offres d'emploi au sein de mon groupe et à mon niveau actuels ou au sein d'un groupe et à un niveau équivalents.",
     "description": "The lateral move interest described as interested."
   },
+  "4q/R7/": {
+    "defaultMessage": "Lien pour plus d'informations (français)",
+    "description": "Label for nomination event more information link in French"
+  },
   "4qdoau": {
     "defaultMessage": "Compétence introuvable",
     "description": "Link to suggestions on what to do if you can't find a skill in the skill browser."
@@ -1902,6 +1906,10 @@
   "7DYnwq": {
     "defaultMessage": "Nous avons reçu votre demande",
     "description": "Paragraph one, message to user the request was received"
+  },
+  "7E14Li": {
+    "defaultMessage": "Revoyez et modifiez les détails de l'événement de gestion des talents.",
+    "description": "Description for the details of a nomination event"
   },
   "7FtbwK": {
     "defaultMessage": "Gestionnaire",
@@ -2762,6 +2770,10 @@
   "BhWVby": {
     "defaultMessage": "Proposez-vous pour passer quelques heures à participer à une équipe interministérielle qui évaluera des candidats et exécutera des processus d’emploi sur la plateforme Talents numériques du GC.",
     "description": "Paragraph two, summary on getting hiring experience"
+  },
+  "BisYQJ": {
+    "defaultMessage": "Nom de l'événement (français)",
+    "description": "Label for nomination event name in French"
   },
   "Bkxf6p": {
     "defaultMessage": "Sélectionnez un statut de bassin",
@@ -4367,6 +4379,10 @@
     "defaultMessage": "Questions supplémentaires",
     "description": "Title of additional questions"
   },
+  "JhEMHT": {
+    "defaultMessage": "Date d'ouverture des nominations",
+    "description": "Label for nomination event date to start accepting nominations"
+  },
   "Ji2C9w": {
     "defaultMessage": "Profil linguistique",
     "description": "Title of the Language Information link section"
@@ -5558,6 +5574,10 @@
   "Pn0zAn": {
     "defaultMessage": "Tous",
     "description": "Link text for all items in a list"
+  },
+  "PnHH9A": {
+    "defaultMessage": "Détails de l'événement",
+    "description": "Subheading for nomination event details"
   },
   "PnSSPo": {
     "defaultMessage": "Renseignements manquants",
@@ -7742,6 +7762,10 @@
     "defaultMessage": "Texte de rechange en langage clair",
     "description": "Column header for plain language name in work streams table"
   },
+  "axPXQ9": {
+    "defaultMessage": "Description de l'événement (anglais)",
+    "description": "Label for nomination event description in English"
+  },
   "axQDlj": {
     "defaultMessage": "Contactez-nous pour nous faire part de votre rétroaction ou d'un problème.",
     "description": "Subtitle for the Support page"
@@ -8286,6 +8310,10 @@
     "defaultMessage": "Quelles sont les exigences en matière d’études – puis-je présenter une demande si je n’ai pas de diplôme collégial ou universitaire?",
     "description": "Learn more dialog question twelve heading"
   },
+  "dgQIEG": {
+    "defaultMessage": "Lien pour plus d'informations (anglais)",
+    "description": "Label for nomination event more information link in English"
+  },
   "dh2xc5": {
     "defaultMessage": "Ces renseignements seront communiqués aux gestionnaires d'embauche.",
     "description": "Explanation on how employment equity information will be used, item one"
@@ -8413,6 +8441,10 @@
   "e6hj69": {
     "defaultMessage": "Trouvez des talents préqualifiés pour votre équipe ou planifiez votre prochaine évolution de carrière.",
     "description": "Paragraph one, description of the managers community"
+  },
+  "e7vPeZ": {
+    "defaultMessage": "Description de l'événement (français)",
+    "description": "Label for nomination event description in French"
   },
   "e8SFXx": {
     "defaultMessage": "Inscrivez-vous en utilisant CléGC",
@@ -8993,6 +9025,10 @@
   "gV0mRk": {
     "defaultMessage": "Collectivité fonctionnelle",
     "description": "Label for Functional community value"
+  },
+  "gXF4Rj": {
+    "defaultMessage": "Nom de l'événement (anglais)",
+    "description": "Label for nomination event name in English"
   },
   "gXFpR1": {
     "defaultMessage": "Ce rôle exige un minimum d’expérience ou un diplôme pertinent. Tous les candidats doivent respecter l’un des critères énumérés dans la présente section afin qu’on en tienne compte. Si vous respectez plus d’une des options fournies, vous pourrez préciser quelle option représente le mieux votre expérience, selon vous. Vous pouvez en apprendre davantage sur la scolarité et les équivalences en visitant la <link>norme du gouvernement du Canada sur les qualifications</link>.",
@@ -10454,6 +10490,10 @@
     "defaultMessage": "<strong>Inscription</strong> : les places seront limitées. Vous devrez présenter une demande et satisfaire aux conditions préalables. Les renseignements seront affichés dans la plateforme Talents numériques du GC lorsque les cours seront disponibles à l’hiver 2024-2025.",
     "description": "An item in a list of points about instructor-led classes"
   },
+  "nhqlFu": {
+    "defaultMessage": "Programmes de perfectionnement pertinents",
+    "description": "Label for development programs relevant to a nomination event"
+  },
   "njBzmn": {
     "defaultMessage": "Collectivité fonctionnelle souhaitée",
     "description": "Label for a employee profile desired functional community field"
@@ -10901,6 +10941,10 @@
   "pp+b1H": {
     "defaultMessage": "Réduire tous<hidden> les renseignements liés à l’expérience</hidden>",
     "description": "Button label to collapse all experiences"
+  },
+  "pq/4js": {
+    "defaultMessage": "Date de clôture des nominations",
+    "description": "Label for nomination event date to stop accepting nominations"
   },
   "prb1eH": {
     "defaultMessage": "Pour nous aider à comprendre comment vous répondez aux critères minimaux d’expérience ou d’études, veuillez indiquer les options auxquelles vous répondez, ainsi que les expériences qui s’appliquent à votre parcours professionnel. <strong>Si les deux s'appliquent à vous, sélectionnez les critères d'études.</strong>",

--- a/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
@@ -7,6 +7,7 @@ import {
   CardBasic,
   CardSeparator,
   Heading,
+  Link,
   Pending,
   ThrowNotFound,
 } from "@gc-digital-talent/ui";
@@ -137,10 +138,19 @@ const TalentEventDetails = ({ query }: TalentEventDetailsProps) => {
                 "Label for nomination event more information link in English",
             })}
           >
-            <span data-h2-word-break="base(break-all)">
-              {talentEvent.learnMoreUrl?.en ??
-                intl.formatMessage(commonMessages.notProvided)}
-            </span>
+            {talentEvent.learnMoreUrl?.en ? (
+              <Link
+                mode="text"
+                external
+                newTab
+                href={talentEvent.learnMoreUrl.en}
+                data-h2-word-break="base(break-all)"
+              >
+                {talentEvent.learnMoreUrl.en}
+              </Link>
+            ) : (
+              intl.formatMessage(commonMessages.notProvided)
+            )}
           </FieldDisplay>
           <FieldDisplay
             label={intl.formatMessage({
@@ -150,10 +160,19 @@ const TalentEventDetails = ({ query }: TalentEventDetailsProps) => {
                 "Label for nomination event more information link in French",
             })}
           >
-            <span data-h2-word-break="base(break-all)">
-              {talentEvent.learnMoreUrl?.fr ??
-                intl.formatMessage(commonMessages.notProvided)}
-            </span>
+            {talentEvent.learnMoreUrl?.fr ? (
+              <Link
+                mode="text"
+                external
+                newTab
+                href={talentEvent.learnMoreUrl.fr}
+                data-h2-word-break="base(break-all)"
+              >
+                {talentEvent.learnMoreUrl.en}
+              </Link>
+            ) : (
+              intl.formatMessage(commonMessages.notProvided)
+            )}
           </FieldDisplay>
         </div>
         <CardSeparator space="sm" decorative />

--- a/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
@@ -168,7 +168,7 @@ const TalentEventDetails = ({ query }: TalentEventDetailsProps) => {
                 href={talentEvent.learnMoreUrl.fr}
                 data-h2-word-break="base(break-all)"
               >
-                {talentEvent.learnMoreUrl.en}
+                {talentEvent.learnMoreUrl.fr}
               </Link>
             ) : (
               intl.formatMessage(commonMessages.notProvided)

--- a/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
@@ -1,17 +1,49 @@
 import { useQuery } from "urql";
+import CalendarIcon from "@heroicons/react/24/outline/CalendarIcon";
+import { useIntl } from "react-intl";
 
 import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
-import { Pending, ThrowNotFound } from "@gc-digital-talent/ui";
+import {
+  CardBasic,
+  CardSeparator,
+  Heading,
+  Pending,
+  ThrowNotFound,
+} from "@gc-digital-talent/ui";
 import { ROLE_NAME } from "@gc-digital-talent/auth";
+import { commonMessages } from "@gc-digital-talent/i18n";
+import { formatDate, parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
 
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import useRequiredParams from "~/hooks/useRequiredParams";
+import FieldDisplay from "~/components/FieldDisplay/FieldDisplay";
 
 import { RouteParams } from "./types";
 
 const TalentEventDetails_Fragment = graphql(/* GraphQL */ `
   fragment TalentEventDetails on TalentNominationEvent {
     id
+    name {
+      en
+      fr
+    }
+    description {
+      en
+      fr
+    }
+    learnMoreUrl {
+      en
+      fr
+    }
+    openDate
+    closeDate
+    developmentPrograms {
+      id
+      name {
+        localized
+      }
+    }
   }
 `);
 
@@ -20,10 +52,170 @@ interface TalentEventDetailsProps {
 }
 
 const TalentEventDetails = ({ query }: TalentEventDetailsProps) => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const talentEvent = getFragment(TalentEventDetails_Fragment, query);
+  const intl = useIntl();
 
-  return null; // TO DO: Add page in #12852
+  const talentEvent = getFragment(TalentEventDetails_Fragment, query);
+  const developmentPrograms = unpackMaybes(talentEvent.developmentPrograms);
+
+  return (
+    <>
+      <Heading
+        level="h2"
+        Icon={CalendarIcon}
+        color="primary"
+        data-h2-margin-top="base(0)"
+      >
+        {intl.formatMessage({
+          defaultMessage: "Event details",
+          id: "PnHH9A",
+          description: "Subheading for nomination event details",
+        })}
+      </Heading>
+      <p data-h2-margin="base(x1 0)">
+        {intl.formatMessage({
+          defaultMessage:
+            "Review the details of the event, manage deadlines, and access talent management tools for nominations and talent placement.",
+          id: "ds0NaU",
+          description: "Description for the details of a nomination event",
+        })}
+      </p>
+      <CardBasic>
+        <div
+          data-h2-display="base(grid)"
+          data-h2-grid-template-columns="l-tablet(1fr 1fr)"
+          data-h2-gap="base(x1)"
+        >
+          <FieldDisplay
+            label={intl.formatMessage({
+              defaultMessage: "Event name (English)",
+              id: "gXF4Rj",
+              description: "Label for nomination event name in English",
+            })}
+          >
+            {talentEvent.name.en ??
+              intl.formatMessage(commonMessages.notProvided)}
+          </FieldDisplay>
+          <FieldDisplay
+            label={intl.formatMessage({
+              defaultMessage: "Event name (French)",
+              id: "BisYQJ",
+              description: "Label for nomination event name in French",
+            })}
+          >
+            {talentEvent.name.fr ??
+              intl.formatMessage(commonMessages.notProvided)}
+          </FieldDisplay>
+          <FieldDisplay
+            label={intl.formatMessage({
+              defaultMessage: "Event description (English)",
+              id: "axPXQ9",
+              description: "Label for nomination event description in English",
+            })}
+          >
+            {talentEvent.description?.en ??
+              intl.formatMessage(commonMessages.notProvided)}
+          </FieldDisplay>
+          <FieldDisplay
+            label={intl.formatMessage({
+              defaultMessage: "Event description (French)",
+              id: "e7vPeZ",
+              description: "Label for nomination event description in French",
+            })}
+          >
+            {talentEvent.description?.fr ??
+              intl.formatMessage(commonMessages.notProvided)}
+          </FieldDisplay>
+          <FieldDisplay
+            label={intl.formatMessage({
+              defaultMessage: "More information link (English)",
+              id: "dgQIEG",
+              description:
+                "Label for nomination event more information link in English",
+            })}
+          >
+            <span data-h2-word-break="base(break-all)">
+              {talentEvent.learnMoreUrl?.en ??
+                intl.formatMessage(commonMessages.notProvided)}
+            </span>
+          </FieldDisplay>
+          <FieldDisplay
+            label={intl.formatMessage({
+              defaultMessage: "More information link (French)",
+              id: "4q/R7/",
+              description:
+                "Label for nomination event more information link in French",
+            })}
+          >
+            <span data-h2-word-break="base(break-all)">
+              {talentEvent.learnMoreUrl?.fr ??
+                intl.formatMessage(commonMessages.notProvided)}
+            </span>
+          </FieldDisplay>
+        </div>
+        <CardSeparator space="sm" decorative />
+        <div
+          data-h2-display="base(grid)"
+          data-h2-grid-template-columns="l-tablet(1fr 1fr)"
+          data-h2-gap="base(x1)"
+        >
+          <FieldDisplay
+            label={intl.formatMessage({
+              defaultMessage: "Nomination open date",
+              id: "HPIGM6",
+              description:
+                "Label for nomination event date to start accepting nominations",
+            })}
+          >
+            {talentEvent.openDate
+              ? formatDate({
+                  date: parseDateTimeUtc(talentEvent.openDate),
+                  formatString: "MMMM d, yyyy",
+                  intl,
+                })
+              : intl.formatMessage(commonMessages.notProvided)}
+          </FieldDisplay>
+          <FieldDisplay
+            label={intl.formatMessage({
+              defaultMessage: "Nomination close date",
+              id: "1Tqhw6",
+              description:
+                "Label for nomination event date to stop accepting nominations",
+            })}
+          >
+            {talentEvent.closeDate
+              ? formatDate({
+                  date: parseDateTimeUtc(talentEvent.closeDate),
+                  formatString: "MMMM d, yyyy",
+                  intl,
+                })
+              : intl.formatMessage(commonMessages.notProvided)}
+          </FieldDisplay>
+        </div>
+        <CardSeparator space="sm" decorative />
+        <FieldDisplay
+          label={intl.formatMessage({
+            defaultMessage: "Relevant development programs",
+            id: "nhqlFu",
+            description:
+              "Label for development programs relevant to a nomination event",
+          })}
+        >
+          {developmentPrograms.length > 0 ? (
+            <ul>
+              {developmentPrograms.map((program) => (
+                <li key={program.id}>
+                  {program.name?.localized ??
+                    intl.formatMessage(commonMessages.notAvailable)}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            intl.formatMessage(commonMessages.notProvided)
+          )}
+        </FieldDisplay>
+      </CardBasic>
+    </>
+  );
 };
 
 const TalentEventDetails_Query = graphql(/* GraphQL */ `

--- a/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
@@ -79,8 +79,8 @@ const TalentEventDetails = ({ query }: TalentEventDetailsProps) => {
       <p data-h2-margin="base(x1 0)">
         {intl.formatMessage({
           defaultMessage:
-            "Review the details of the event, manage deadlines, and access talent management tools for nominations and talent placement.",
-          id: "ds0NaU",
+            "Review and edit the details of this talent management event.",
+          id: "7E14Li",
           description: "Description for the details of a nomination event",
         })}
       </p>

--- a/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
@@ -160,8 +160,8 @@ const TalentEventDetails = ({ query }: TalentEventDetailsProps) => {
         >
           <FieldDisplay
             label={intl.formatMessage({
-              defaultMessage: "Nomination open date",
-              id: "HPIGM6",
+              defaultMessage: "Nomination opening date",
+              id: "JhEMHT",
               description:
                 "Label for nomination event date to start accepting nominations",
             })}
@@ -176,8 +176,8 @@ const TalentEventDetails = ({ query }: TalentEventDetailsProps) => {
           </FieldDisplay>
           <FieldDisplay
             label={intl.formatMessage({
-              defaultMessage: "Nomination close date",
-              id: "1Tqhw6",
+              defaultMessage: "Nomination closing date",
+              id: "pq/4js",
               description:
                 "Label for nomination event date to stop accepting nominations",
             })}

--- a/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
@@ -55,7 +55,11 @@ const TalentEventDetails = ({ query }: TalentEventDetailsProps) => {
   const intl = useIntl();
 
   const talentEvent = getFragment(TalentEventDetails_Fragment, query);
-  const developmentPrograms = unpackMaybes(talentEvent.developmentPrograms);
+  const developmentPrograms = unpackMaybes(
+    talentEvent.developmentPrograms,
+  ).sort((a, b) =>
+    (a.name?.localized ?? "").localeCompare(b.name?.localized ?? ""),
+  );
 
   return (
     <>


### PR DESCRIPTION
🤖 Resolves #13121 

## 👋 Introduction

Adds the admin details page for talent nomination events.


## 🧪 Testing

> [!WARNING]
> It will not look exactly like the mockup since it is out of date. Look to see that it matches a layout/spacing/etc 

1. Build `pnpm run dev:fresh`
2. Login as talent coordinator (either `talent-coordinator@test.com` or any other and give yourself the role)
3. Find a talent event in the database that is assigned to a community you are the talent coordinator for
4. Navigate to `/admin/talent-events/{eventId}`
5. Confirm it displays information in a similar manner to the mock up

## 📸 Screenshot

![2025-04-01_08-51](https://github.com/user-attachments/assets/276f26a0-66fc-49f3-a56b-9db9e3938d6f)
