### PR TITLE
[Feature] Make consent mandatory for community interests

### DIFF
--- a/api/app/GraphQL/Validators/CreateCommunityInterestInputValidator.php
+++ b/api/app/GraphQL/Validators/CreateCommunityInterestInputValidator.php
@@ -66,6 +66,7 @@ final class CreateCommunityInterestInputValidator extends Validator
                     ['prohibited']
                 ),
             ],
+            'consentToShareProfile' => ['accepted'],
         ];
     }
 

--- a/api/app/GraphQL/Validators/UpdateCommunityInterestInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdateCommunityInterestInputValidator.php
@@ -63,6 +63,7 @@ final class UpdateCommunityInterestInputValidator extends Validator
                     ['prohibited']
                 ),
             ],
+            'consentToShareProfile' => ['accepted'],
         ];
     }
 

--- a/api/app/Models/CommunityInterest.php
+++ b/api/app/Models/CommunityInterest.php
@@ -25,6 +25,7 @@ use Illuminate\Support\Facades\Auth;
  * @property array $finance_additional_duties
  * @property array $finance_other_roles
  * @property string $finance_other_roles_other
+ * @property bool $consent_to_share_profile
  */
 class CommunityInterest extends Model
 {

--- a/api/app/Models/CommunityInterest.php
+++ b/api/app/Models/CommunityInterest.php
@@ -119,12 +119,7 @@ class CommunityInterest extends Model
                 return $query->whereIn('community_id', $communityIds);
             });
 
-            $query->where(function (Builder $query) {
-                $query->orWhere('job_interest', true);
-                $query->orWhere('training_interest', true);
-
-                return $query;
-            });
+            $query->where('consent_to_share_profile', true);
 
             return $query;
         }

--- a/api/app/Policies/UserPolicy.php
+++ b/api/app/Policies/UserPolicy.php
@@ -181,12 +181,7 @@ class UserPolicy
     {
         return CommunityInterest::where('user_id', $user->id)
             ->whereIn('community_id', $communityIds)
-            ->where(function ($query) {
-                $query->orWhere('job_interest', true);
-                $query->orWhere('training_interest', true);
-
-                return $query;
-            })
+            ->where('consent_to_share_profile', true)
             ->exists();
     }
 

--- a/api/database/factories/CommunityInterestFactory.php
+++ b/api/database/factories/CommunityInterestFactory.php
@@ -44,6 +44,7 @@ class CommunityInterestFactory extends Factory
             'finance_other_roles_other' => fn ($attributes) => in_array(FinanceChiefRole::OTHER->name, $attributes['finance_other_roles'])
                 ? $this->faker->jobTitle()
                 : null,
+            'consent_to_share_profile' => true,
         ];
     }
 

--- a/api/database/migrations/2025_04_02_132147_add_community_interest_consent.php
+++ b/api/database/migrations/2025_04_02_132147_add_community_interest_consent.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // create new column
+        Schema::table('community_interests', function (Blueprint $table) {
+            $table->boolean('consent_to_share_profile')->nullable()->default(false);
+        });
+
+        // fill column for existing rows
+        DB::table('community_interests')
+            ->update(['consent_to_share_profile' => new Expression('case when job_interest = true or training_interest = true then true else false end')]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('community_interests', function (Blueprint $table) {
+            $table->dropColumn('consent_to_share_profile');
+        });
+    }
+};

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -177,6 +177,7 @@ type CommunityInterest {
   financeOtherRoles: [LocalizedFinanceChiefRole!]
     @rename(attribute: "finance_other_roles")
   financeOtherRolesOther: String @rename(attribute: "finance_other_roles_other")
+  consentToShareProfile: Boolean @rename(attribute: "consent_to_share_profile")
 }
 
 # A pivot table for employees to express interest in the development programs of a community.
@@ -1795,6 +1796,7 @@ input CreateCommunityInterestInput @validator {
   financeOtherRoles: [FinanceChiefRole!]
     @rename(attribute: "finance_other_roles")
   financeOtherRolesOther: String @rename(attribute: "finance_other_roles_other")
+  consentToShareProfile: Boolean @rename(attribute: "consent_to_share_profile")
 }
 
 input UpdateCommunityInterestInput @validator {
@@ -1812,6 +1814,7 @@ input UpdateCommunityInterestInput @validator {
   financeOtherRoles: [FinanceChiefRole!]
     @rename(attribute: "finance_other_roles")
   financeOtherRolesOther: String @rename(attribute: "finance_other_roles_other")
+  consentToShareProfile: Boolean @rename(attribute: "consent_to_share_profile")
 }
 
 input CreateDevelopmentProgramInterestHasMany {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -727,6 +727,7 @@ type CommunityInterest {
   financeAdditionalDuties: [LocalizedFinanceChiefDuty!]
   financeOtherRoles: [LocalizedFinanceChiefRole!]
   financeOtherRolesOther: String
+  consentToShareProfile: Boolean
 }
 
 type DevelopmentProgramInterest {
@@ -1818,6 +1819,7 @@ input CreateCommunityInterestInput {
   financeAdditionalDuties: [FinanceChiefDuty!]
   financeOtherRoles: [FinanceChiefRole!]
   financeOtherRolesOther: String
+  consentToShareProfile: Boolean
 }
 
 input UpdateCommunityInterestInput {
@@ -1831,6 +1833,7 @@ input UpdateCommunityInterestInput {
   financeAdditionalDuties: [FinanceChiefDuty!]
   financeOtherRoles: [FinanceChiefRole!]
   financeOtherRolesOther: String
+  consentToShareProfile: Boolean
 }
 
 input CreateDevelopmentProgramInterestHasMany {

--- a/api/tests/Feature/CommunityInterestTest.php
+++ b/api/tests/Feature/CommunityInterestTest.php
@@ -142,6 +142,7 @@ class CommunityInterestTest extends TestCase
                         ...$this->input,
                         'userId' => $this->applicant->id,
                         'community' => ['connect' => $this->communityId],
+                        'consentToShareProfile' => true,
                         'workStreams' => [
                             'sync' => [
                                 $this->workStreamIds[0],
@@ -179,6 +180,7 @@ class CommunityInterestTest extends TestCase
                 'communityInterest' => [
                     'id' => $communityInterestId,
                     'additionalInformation' => 'new info',
+                    'consentToShareProfile' => true,
                 ],
             ])
             ->assertJson([
@@ -229,6 +231,7 @@ class CommunityInterestTest extends TestCase
                 'communityInterest' => [
                     ...$this->input,
                     'userId' => $otherId,
+                    'consentToShareProfile' => true,
                     'community' => ['connect' => $this->communityId],
                     'workStreams' => ['sync' => $this->workStreamIds],
                 ],
@@ -291,8 +294,7 @@ class CommunityInterestTest extends TestCase
         CommunityInterest::truncate();
         $communityInterestModel = CommunityInterest::factory()->create([
             'community_id' => $this->communityId,
-            'job_interest' => true,
-            'training_interest' => true,
+            'consent_to_share_profile' => true,
         ]);
 
         // these roles cannot see the created model
@@ -359,68 +361,45 @@ class CommunityInterestTest extends TestCase
     public function testCommunityInterestsPaginatedAuthorizedToView(): void
     {
         CommunityInterest::truncate();
-        $communityInterestWithBothInterests = CommunityInterest::factory()->create([
+        $communityInterestWithConsent = CommunityInterest::factory()->create([
             'user_id' => User::factory(),
             'community_id' => $this->communityId,
-            'job_interest' => true,
-            'training_interest' => true,
+            'consent_to_share_profile' => true,
         ]);
-        $communityInterestWithJobInterest = CommunityInterest::factory()->create([
+        $communityInterestWithoutConsent = CommunityInterest::factory()->create([
             'user_id' => User::factory(),
             'community_id' => $this->communityId,
-            'job_interest' => true,
-            'training_interest' => false,
-        ]);
-        $communityInterestWithTrainingInterest = CommunityInterest::factory()->create([
-            'user_id' => User::factory(),
-            'community_id' => $this->communityId,
-            'job_interest' => false,
-            'training_interest' => true,
-        ]);
-        $communityInterestWithNoInterests = CommunityInterest::factory()->create([
-            'user_id' => User::factory(),
-            'community_id' => $this->communityId,
-            'job_interest' => false,
-            'training_interest' => false,
+            'consent_to_share_profile' => false,
         ]);
         $otherCommunityInterest = CommunityInterest::factory()->create([
             'user_id' => User::factory(),
             'community_id' => Community::factory(),
-            'job_interest' => false,
-            'training_interest' => false,
+            'consent_to_share_profile' => false,
         ]);
 
-        // five records in total
-        assertEquals(5, count(CommunityInterest::all()));
+        // three records in total
+        assertEquals(3, count(CommunityInterest::all()));
 
-        // three results should be returned in total for both roles
-        // communityInterestWithBothInterests
-        // communityInterestWithJobInterest
-        // communityInterestWithTrainingInterest
+        // one result should be returned in total for both roles
+        // communityInterestWithConsent
 
         $this->actingAs($this->communityRecruiter, 'api')->graphQL(
             $this->paginatedCommunityInterestsQuery,
             [],
-        )->assertJsonFragment(['total' => 3])
-            ->assertJsonFragment(['id' => $communityInterestWithBothInterests->id])
-            ->assertJsonFragment(['id' => $communityInterestWithJobInterest->id])
-            ->assertJsonFragment(['id' => $communityInterestWithTrainingInterest->id]);
+        )->assertJsonFragment(['total' => 1])
+            ->assertJsonFragment(['id' => $communityInterestWithConsent->id]);
 
         $this->actingAs($this->communityAdmin, 'api')->graphQL(
             $this->paginatedCommunityInterestsQuery,
             [],
-        )->assertJsonFragment(['total' => 3])
-            ->assertJsonFragment(['id' => $communityInterestWithBothInterests->id])
-            ->assertJsonFragment(['id' => $communityInterestWithJobInterest->id])
-            ->assertJsonFragment(['id' => $communityInterestWithTrainingInterest->id]);
+        )->assertJsonFragment(['total' => 1])
+            ->assertJsonFragment(['id' => $communityInterestWithConsent->id]);
 
         $this->actingAs($this->communityTalentCoordinator, 'api')->graphQL(
             $this->paginatedCommunityInterestsQuery,
             [],
-        )->assertJsonFragment(['total' => 3])
-            ->assertJsonFragment(['id' => $communityInterestWithBothInterests->id])
-            ->assertJsonFragment(['id' => $communityInterestWithJobInterest->id])
-            ->assertJsonFragment(['id' => $communityInterestWithTrainingInterest->id]);
+        )->assertJsonFragment(['total' => 1])
+            ->assertJsonFragment(['id' => $communityInterestWithConsent->id]);
     }
 
     // test mobility type and mobility interest in community interest filter
@@ -430,24 +409,28 @@ class CommunityInterestTest extends TestCase
         $communityInterestWithJobInterest = CommunityInterest::factory()->create([
             'user_id' => User::factory(),
             'community_id' => $this->communityId,
+            'consent_to_share_profile' => true,
             'job_interest' => true,
             'training_interest' => false,
         ]);
         $communityInterestWithTrainingInterest = CommunityInterest::factory()->create([
             'user_id' => User::factory(),
             'community_id' => $this->communityId,
+            'consent_to_share_profile' => true,
             'job_interest' => false,
             'training_interest' => true,
         ]);
         $communityInterestWithBothInterests = CommunityInterest::factory()->create([
             'user_id' => User::factory(),
             'community_id' => $this->communityId,
+            'consent_to_share_profile' => true,
             'job_interest' => true,
             'training_interest' => true,
         ]);
         $communityInterestWithNoInterests = CommunityInterest::factory()->create([
             'user_id' => User::factory(),
             'community_id' => $this->communityId,
+            'consent_to_share_profile' => false,
             'job_interest' => false,
             'training_interest' => false,
         ]);

--- a/api/tests/Feature/CommunityInterestTest.php
+++ b/api/tests/Feature/CommunityInterestTest.php
@@ -374,7 +374,7 @@ class CommunityInterestTest extends TestCase
         $otherCommunityInterest = CommunityInterest::factory()->create([
             'user_id' => User::factory(),
             'community_id' => Community::factory(),
-            'consent_to_share_profile' => false,
+            'consent_to_share_profile' => true,
         ]);
 
         // three records in total
@@ -430,7 +430,7 @@ class CommunityInterestTest extends TestCase
         $communityInterestWithNoInterests = CommunityInterest::factory()->create([
             'user_id' => User::factory(),
             'community_id' => $this->communityId,
-            'consent_to_share_profile' => false,
+            'consent_to_share_profile' => true,
             'job_interest' => false,
             'training_interest' => false,
         ]);
@@ -462,7 +462,7 @@ class CommunityInterestTest extends TestCase
             ->assertJsonFragment(['id' => $communityInterestWithBothInterests->id]);
 
         // Test community interest filter where job interest is false and training interest is false
-        // NOTE: Should only assert a total of 3 results since we only show users with at least one of the interests
+        // NOTE: Should assert a total of 4 results since show any user as long as they consented to share their profile
         $this->actingAs($this->communityAdmin, 'api')->graphQL(
             $this->paginatedCommunityInterestsQuery,
             [
@@ -471,7 +471,7 @@ class CommunityInterestTest extends TestCase
                     'trainingInterest' => false,
                 ],
             ]
-        )->assertJsonFragment(['total' => 3])
+        )->assertJsonFragment(['total' => 4])
             ->assertJsonFragment(['id' => $communityInterestWithJobInterest->id])
             ->assertJsonFragment(['id' => $communityInterestWithTrainingInterest->id])
             ->assertJsonFragment(['id' => $communityInterestWithBothInterests->id]);

--- a/api/tests/Feature/CommunityInterestTest.php
+++ b/api/tests/Feature/CommunityInterestTest.php
@@ -462,7 +462,7 @@ class CommunityInterestTest extends TestCase
             ->assertJsonFragment(['id' => $communityInterestWithBothInterests->id]);
 
         // Test community interest filter where job interest is false and training interest is false
-        // NOTE: Should assert a total of 4 results since show any user as long as they consented to share their profile
+        // NOTE: Should assert a total of 4 results since we show any user as long as they consented to share their profile
         $this->actingAs($this->communityAdmin, 'api')->graphQL(
             $this->paginatedCommunityInterestsQuery,
             [
@@ -474,7 +474,8 @@ class CommunityInterestTest extends TestCase
         )->assertJsonFragment(['total' => 4])
             ->assertJsonFragment(['id' => $communityInterestWithJobInterest->id])
             ->assertJsonFragment(['id' => $communityInterestWithTrainingInterest->id])
-            ->assertJsonFragment(['id' => $communityInterestWithBothInterests->id]);
+            ->assertJsonFragment(['id' => $communityInterestWithBothInterests->id])
+            ->assertJsonFragment(['id' => $communityInterestWithNoInterests->id]);
 
         // Test community interest filter where job interest is true and training interest is true
         $this->actingAs($this->communityAdmin, 'api')->graphQL(

--- a/api/tests/Feature/DevelopmentProgramInterestTest.php
+++ b/api/tests/Feature/DevelopmentProgramInterestTest.php
@@ -70,6 +70,7 @@ class DevelopmentProgramInterestTest extends TestCase
                                 ],
                             ],
                         ],
+                        'consentToShareProfile' => true,
                     ],
                 ])
             ->assertJson([

--- a/api/tests/Unit/UserPolicyTest.php
+++ b/api/tests/Unit/UserPolicyTest.php
@@ -155,8 +155,7 @@ class UserPolicyTest extends TestCase
         CommunityInterest::factory()->create([
             'user_id' => $this->applicant->id,
             'community_id' => $this->community->id,
-            'job_interest' => true,
-            'training_interest' => true,
+            'consent_to_share_profile' => true,
         ]);
 
         // admin/recruiter/coordinator but not process operator can now view applicant as they are a community talent (CommunityInterest with interest)

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -267,10 +267,6 @@
     "defaultMessage": "Tâches principales - Exemples",
     "description": "Long title of the 'key tasks' section of the job poster template page"
   },
-  "/HKgWb": {
-    "defaultMessage": "Vous avez indiqué que les possibilités d'emploi ou de formation dans cette collectivité ne vous intéressent pas, de sorte que les informations de votre profil ne seront <strong>pas partagées</strong> dans le cadre de ces fonctionnalités.",
-    "description": "Message displayed when consent is not required"
-  },
   "/I7wrY": {
     "defaultMessage": "Lier des compétences en vedette",
     "description": "Title for skills on Experience form"
@@ -870,6 +866,10 @@
   "2B+d2V": {
     "defaultMessage": "Vous avez un profil sur Talents numériques du GC.",
     "description": "Second item in list of eligibility requirements section"
+  },
+  "2BCHZm": {
+    "defaultMessage": "En ajoutant la {communityname} à mon profil, j’accepte mes informations soient partagés avec les gestionnaires de talents, le personnel des ressources humaines et les gestionnaires d'embauche de cette collectivité fonctionnelle.",
+    "description": "Statement for the input for the consent check"
   },
   "2CzVQo": {
     "defaultMessage": "Indiquez une ou plusieurs options de mutation latérale recommandées pour la candidate ou le candidat.",
@@ -2914,10 +2914,6 @@
   "CBedVL": {
     "defaultMessage": "Votre compte",
     "description": "Nav menu trigger for account links sub menu"
-  },
-  "CCSgzj": {
-    "defaultMessage": "En indiquant mon intérêt pour des possibilités d'emploi ou de formation, j'accepte mon profil soit partagé avec le personnel des ressources humaines et les gestionnaires d'embauche de cette collectivité fonctionnelle.",
-    "description": "Statement for the input for the consent check"
   },
   "CCyraT": {
     "defaultMessage": "Sélectionnez la méthode qui décrit le mieux la façon dont votre organisation prévoit évaluer ces compétences. Vous pouvez renommer cette évaluation au besoin.",
@@ -5974,6 +5970,10 @@
   "R5sGKY": {
     "defaultMessage": "Information sur le processus",
     "description": "Title for the pool info page"
+  },
+  "R6kZ1/": {
+    "defaultMessage": "Lorsque vous ajoutez une collectivité fonctionnelle à votre profil, vous acceptez de partager vos informations avec ses gestionnaires de talents, son personnel de recrutement et ses gestionnaires d'embauche potentiels. Il s'agit notamment des informations de votre profil, de votre expérience professionnelle et de votre portfolio de compétences. Vos informations peuvent être utilisées pour vous mettre en relation avec des possibilités pertinentes et pour recueillir des informations sur la main-d'œuvre de la collectivité fonctionnelle.",
+    "description": "statement for the 'Review and submit' consent section, paragraph 1"
   },
   "R75HsV": {
     "defaultMessage": "Aidez-nous à vous apparier avec les meilleurs candidats en partageant de plus amples renseignements avec notre équipe sur les compétences particulières dont vous recherchez.",
@@ -10454,10 +10454,6 @@
     "defaultMessage": "Candidat(e) precedent(e)",
     "description": "Link label to view previous candidate on view pool candidate page"
   },
-  "mv2nt/": {
-    "defaultMessage": "Lorsque vous manifestez votre intérêt pour des possibilités d'emploi ou de formation par l'intermédiaire d'une collectivité fonctionnelle, vous acceptez de partager les informations de votre profil avec le personnel de recrutement et les gestionnaires d'embauche potentiels. Il s'agit notamment des informations communiquées dans votre profil, de votre expérience professionnelle et de votre portfolio de compétences.",
-    "description": "statement for the 'Review and submit' consent section, paragraph 1"
-  },
   "mwVSMJ": {
     "defaultMessage": "Retourner au portfolio de compétences",
     "description": "Link text to navigate from skill showcase to the skill portfolio page"
@@ -10861,10 +10857,6 @@
   "osGGIt": {
     "defaultMessage": "Programme d’apprentissage en TI pour les personnes autochtones + Portail des talents autochtones",
     "description": "heading for indigenous talent portal section"
-  },
-  "ot7s0V": {
-    "defaultMessage": "Vous pouvez annuler ce consentement à tout moment en vous retirant des possibilités d'emploi et de formation.",
-    "description": "statement for the 'Review and submit' consent section, paragraph 2"
   },
   "ow4z7W": {
     "defaultMessage": "Modifier<hidden> la classification</hidden>",

--- a/apps/web/src/pages/CommunityInterests/CreateCommunityInterestPage/CreateCommunityInterestPage.tsx
+++ b/apps/web/src/pages/CommunityInterests/CreateCommunityInterestPage/CreateCommunityInterestPage.tsx
@@ -33,6 +33,7 @@ const CreateCommunityInterestFormOptions_Fragment = graphql(/* GraphQL */ `
     ...FindANewCommunityOptions_Fragment
     ...TrainingAndDevelopmentOpportunitiesOptions_Fragment
     ...AdditionalInformationOptions_Fragment
+    ...ReviewAndSubmitOptions_Fragment
 
     communities {
       id
@@ -109,7 +110,10 @@ const CreateCommunityInterestForm = ({
                     formDisabled={formDisabled}
                   />
                   <CardFormSeparator />
-                  <ReviewAndSubmit formDisabled={formDisabled} />
+                  <ReviewAndSubmit
+                    optionsQuery={formOptions}
+                    formDisabled={formDisabled}
+                  />
                 </>
               )}
             </div>

--- a/apps/web/src/pages/CommunityInterests/UpdateCommunityInterestPage/UpdateCommunityInterestPage.tsx
+++ b/apps/web/src/pages/CommunityInterests/UpdateCommunityInterestPage/UpdateCommunityInterestPage.tsx
@@ -43,6 +43,7 @@ const UpdateCommunityInterestFormOptions_Fragment = graphql(/* GraphQL */ `
     ...FindANewCommunityOptions_Fragment
     ...TrainingAndDevelopmentOpportunitiesOptions_Fragment
     ...AdditionalInformationOptions_Fragment
+    ...ReviewAndSubmitOptions_Fragment
 
     communities {
       id
@@ -90,6 +91,7 @@ export const UpdateCommunityInterestFormData_Fragment = graphql(/* GraphQL */ `
       }
     }
     financeOtherRolesOther
+    consentToShareProfile
   }
 `);
 
@@ -165,7 +167,10 @@ const UpdateCommunityInterestForm = ({
                 formDisabled={formDisabled}
               />
               <CardFormSeparator />
-              <ReviewAndSubmit formDisabled={formDisabled} />
+              <ReviewAndSubmit
+                optionsQuery={formOptions}
+                formDisabled={formDisabled}
+              />
             </div>
           </CardForm>
         </form>

--- a/apps/web/src/pages/CommunityInterests/form.ts
+++ b/apps/web/src/pages/CommunityInterests/form.ts
@@ -115,6 +115,8 @@ export function formValuesToApiCreateInput(
     : null;
   apiInput.financeOtherRolesOther = formValues.financeOtherRolesOther;
 
+  apiInput.consentToShareProfile = formValues.consent;
+
   return apiInput;
 }
 
@@ -179,6 +181,8 @@ export function formValuesToApiUpdateInput(
       ? stringArrayToEnumsFinanceChiefRole(formValues.financeOtherRoles)
       : null,
     financeOtherRolesOther: formValues.financeOtherRolesOther,
+
+    consentToShareProfile: formValues.consent,
   };
 }
 
@@ -221,8 +225,7 @@ export function apiDataToFormValues(
       ? communityInterest.financeOtherRoles.map((role) => role.value)
       : null,
     financeOtherRolesOther: communityInterest?.financeOtherRolesOther ?? null,
-    // not saved in the database but if job or training interest is saved, they will have previously consented
-    consent:
-      !!communityInterest?.jobInterest || !!communityInterest?.trainingInterest,
+
+    consent: communityInterest?.consentToShareProfile ?? false,
   };
 }

--- a/apps/web/src/pages/CommunityInterests/sections/ReviewAndSubmit.tsx
+++ b/apps/web/src/pages/CommunityInterests/sections/ReviewAndSubmit.tsx
@@ -106,8 +106,8 @@ const ReviewAndSubmit = ({
           <p>
             {intl.formatMessage({
               defaultMessage:
-                "When you express interest in job or training opportunities through a functional community, you’re agreeing to share your profile information with recruiters and potential hiring managers. This includes information shared in your profile, your career experience, and your skills portfolio.",
-              id: "mv2nt/",
+                "When you add a functional community to your profile, you agree to share your information with its talent managers, recruiters, and potential hiring managers. This includes your profile information, career experience, and skills portfolio. Your information may be used to connect you with relevant opportunities and gather insights on the functional community’s workforce.",
+              id: "R6kZ1/",
               description:
                 "statement for the 'Review and submit' consent section, paragraph 1",
             })}


### PR DESCRIPTION
🤖 Resolves #13136 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Adds database storage for the consent checkbox, makes it mandatory, and uses it for policies.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

1. Run migrations
2. Log in as applicant-employee@test.com

- [ ] Existing rows in the database have boolean correctly populated.
- [ ] Can create a new community interest
- [ ] Can edit an existing community interest

3. Log in as talent-coordinator@test.com

- [ ] Can see the users in the community table and click through to profile with consented community interest
- [ ] Can't see the users in the community table or click through to profile with unconsented community interest
- [ ] Can't see the users in the community table or click through to profile without any community interest


## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
![image](https://github.com/user-attachments/assets/1d823662-a70c-4709-9442-c84d0610cd53)
