### PR TITLE
[Feature] Talent events nominations table

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -722,6 +722,7 @@ type TalentNomination {
 
 type TalentNominationGroup {
   id: UUID!
+  createdAt: DateTime @rename(attribute: "created_at")
   nominee: BasicGovEmployeeProfile
     @belongsTo
     @canQuery(ability: "viewAnyBasicGovEmployeeProfile", model: "User")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1136,6 +1136,7 @@ type TalentNomination {
 
 type TalentNominationGroup {
   id: UUID!
+  createdAt: DateTime
   nominee: BasicGovEmployeeProfile
   nominations: [TalentNomination!]
   talentNominationEvent: TalentNominationEvent!

--- a/apps/web/src/messages/talentNominationMessages.ts
+++ b/apps/web/src/messages/talentNominationMessages.ts
@@ -31,6 +31,11 @@ const messages = defineMessages({
     id: "W2s794",
     description: "Label for the development program nomination type",
   },
+  development: {
+    defaultMessage: "Development",
+    id: "Kzbu79",
+    description: "Label for the development nomination type",
+  },
   eventName: {
     defaultMessage: "Event name",
     id: "Kbt6SJ",

--- a/apps/web/src/messages/talentNominationMessages.ts
+++ b/apps/web/src/messages/talentNominationMessages.ts
@@ -66,6 +66,16 @@ const messages = defineMessages({
     id: "5j19WZ",
     description: "Label or header",
   },
+  nominee: {
+    defaultMessage: "Nominee",
+    id: "xmAF0A",
+    description: "Label or header",
+  },
+  nominator: {
+    defaultMessage: "Nominator",
+    id: "mcplV2",
+    description: "Label or header",
+  },
 });
 
 export default messages;

--- a/apps/web/src/messages/talentNominationMessages.ts
+++ b/apps/web/src/messages/talentNominationMessages.ts
@@ -61,6 +61,11 @@ const messages = defineMessages({
     id: "Ch6OCd",
     description: "Label for the nominator's work email",
   },
+  talentNominations: {
+    defaultMessage: "Talent nominations",
+    id: "5j19WZ",
+    description: "Label or header",
+  },
 });
 
 export default messages;

--- a/apps/web/src/messages/talentNominationMessages.ts
+++ b/apps/web/src/messages/talentNominationMessages.ts
@@ -71,9 +71,9 @@ const messages = defineMessages({
     id: "xmAF0A",
     description: "Label or header",
   },
-  nominator: {
-    defaultMessage: "Nominator",
-    id: "mcplV2",
+  nominators: {
+    defaultMessage: "Nominators",
+    id: "9bG59n",
     description: "Label or header",
   },
 });

--- a/apps/web/src/pages/TalentEvents/TalentEvent/NominationsPage.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/NominationsPage.tsx
@@ -23,6 +23,7 @@ import { getFullNameLabel } from "~/utils/nameUtils";
 import useRoutes from "~/hooks/useRoutes";
 import accessors from "~/components/Table/accessors";
 import cells from "~/components/Table/cells";
+import adminMessages from "~/messages/adminMessages";
 
 import { RouteParams } from "./types";
 import {
@@ -127,6 +128,7 @@ const TalentEventNominations = ({ query }: TalentEventNominationsProps) => {
           original: { createdAt },
         },
       }) => cells.date(createdAt, intl),
+      enableColumnFilter: false,
     }),
     columnHelper.accessor(
       ({ nominations }) =>
@@ -169,6 +171,10 @@ const TalentEventNominations = ({ query }: TalentEventNominationsProps) => {
       data={talentEventNominationsData}
       caption={intl.formatMessage(messages.talentNominations)}
       columns={columns}
+      search={{
+        internal: true,
+        label: intl.formatMessage(adminMessages.searchByKeyword),
+      }}
       sort={{
         internal: true,
       }}

--- a/apps/web/src/pages/TalentEvents/TalentEvent/NominationsPage.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/NominationsPage.tsx
@@ -1,40 +1,92 @@
 import { useQuery } from "urql";
+import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
+import { useMemo } from "react";
+import { useIntl } from "react-intl";
+import EnvelopeOpenIcon from "@heroicons/react/24/outline/EnvelopeOpenIcon";
 
-import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
-import { Pending, ThrowNotFound } from "@gc-digital-talent/ui";
+import {
+  FragmentType,
+  getFragment,
+  graphql,
+  TalentEventNominationsTableFragment as TalentEventNominationsTableFragmentType,
+} from "@gc-digital-talent/graphql";
+import { Heading, Pending, ThrowNotFound } from "@gc-digital-talent/ui";
 import { ROLE_NAME } from "@gc-digital-talent/auth";
+import { commonMessages } from "@gc-digital-talent/i18n";
 
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import useRequiredParams from "~/hooks/useRequiredParams";
+import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
+import messages from "~/messages/talentNominationMessages";
 
 import { RouteParams } from "./types";
 
-const TalentEventNominations_Fragment = graphql(/* GraphQL */ `
-  fragment TalentEventNominations on TalentNominationEvent {
+const TalentEventNominationsTable_Fragment = graphql(/* GraphQL */ `
+  fragment TalentEventNominationsTable on TalentNominationGroup {
     id
   }
 `);
 
+const columnHelper =
+  createColumnHelper<TalentEventNominationsTableFragmentType>();
+
 interface TalentEventNominationsProps {
-  query: FragmentType<typeof TalentEventNominations_Fragment>;
+  query: FragmentType<typeof TalentEventNominationsTable_Fragment>[];
 }
 
 const TalentEventNominations = ({ query }: TalentEventNominationsProps) => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const talentEvent = getFragment(TalentEventNominations_Fragment, query);
+  const intl = useIntl();
 
-  return null;
+  const talentEventNominations = getFragment(
+    TalentEventNominationsTable_Fragment,
+    query,
+  );
+  const talentEventNominationsData = useMemo(
+    () => talentEventNominations,
+    [talentEventNominations],
+  );
+
+  const columns = [
+    columnHelper.accessor(({ id }) => id, {
+      id: "id",
+      header: intl.formatMessage(commonMessages.name),
+      enableColumnFilter: false,
+      meta: {
+        isRowTitle: true,
+      },
+    }),
+  ] as ColumnDef<TalentEventNominationsTableFragmentType>[];
+
+  return (
+    <Table<TalentEventNominationsTableFragmentType>
+      data={talentEventNominationsData}
+      caption={intl.formatMessage(messages.talentNominations)}
+      columns={columns}
+      sort={{
+        internal: true,
+      }}
+      pagination={{
+        internal: true,
+        total: talentEventNominations.length,
+        pageSizes: [10, 20, 50],
+      }}
+    />
+  );
 };
 
 const TalentEventNominations_Query = graphql(/* GraphQL */ `
   query TalentEventNominations($talentEventId: UUID!) {
     talentNominationEvent(id: $talentEventId) {
-      ...TalentEventNominations
+      talentNominationGroups {
+        ...TalentEventNominationsTable
+      }
     }
   }
 `);
 
 const TalentEventNominationsPage = () => {
+  const intl = useIntl();
+
   const { eventId } = useRequiredParams<RouteParams>("eventId");
   const [{ data, fetching, error }] = useQuery({
     query: TalentEventNominations_Query,
@@ -42,13 +94,32 @@ const TalentEventNominationsPage = () => {
   });
 
   return (
-    <Pending fetching={fetching} error={error}>
-      {data?.talentNominationEvent ? (
-        <TalentEventNominations query={data.talentNominationEvent} />
-      ) : (
-        <ThrowNotFound />
-      )}
-    </Pending>
+    <>
+      <Heading
+        Icon={EnvelopeOpenIcon}
+        color="primary"
+        data-h2-margin-bottom="base(x1)"
+      >
+        {intl.formatMessage(messages.talentNominations)}
+      </Heading>
+      <p data-h2-margin-bottom="base(x1.5)">
+        {intl.formatMessage({
+          defaultMessage:
+            'Manage and action nominations received from managers and executives. Nominations will arrive as "Unassigned", from which you can choose to assign them to team members to triage and assess. When approved, a nomination will automatically add the candidate to the candidates table for you to talent manage.',
+          id: "1Q6Elv",
+          description: "Talent nominations table page, table information",
+        })}
+      </p>
+      <Pending fetching={fetching} error={error}>
+        {data?.talentNominationEvent?.talentNominationGroups ? (
+          <TalentEventNominations
+            query={data.talentNominationEvent.talentNominationGroups}
+          />
+        ) : (
+          <ThrowNotFound />
+        )}
+      </Pending>
+    </>
   );
 };
 

--- a/apps/web/src/pages/TalentEvents/TalentEvent/types.ts
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/types.ts
@@ -1,3 +1,11 @@
+import { TalentEventNominationsTableFragment as TalentEventNominationsTableFragmentType } from "@gc-digital-talent/graphql";
+
 export interface RouteParams extends Record<string, string> {
   eventId: string;
 }
+
+export type TalentNominator = NonNullable<
+  NonNullable<
+    TalentEventNominationsTableFragmentType["nominations"]
+  >[number]["nominator"]
+>;

--- a/apps/web/src/pages/TalentEvents/TalentEvent/util.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/util.tsx
@@ -30,7 +30,14 @@ export function nominatorsAccessor(
   nominators: TalentNominator[],
   intl: IntlShape,
 ): string {
-  const nominatorsNamesArray = nominators.map((nominator) =>
+  const nominatorsSorted = nominators.sort((a, b) => {
+    return (
+      (a.lastName ?? "").localeCompare(b.lastName ?? "") ||
+      (a.firstName ?? "").localeCompare(b.firstName ?? "")
+    );
+  });
+
+  const nominatorsNamesArray = nominatorsSorted.map((nominator) =>
     getFullNameLabel(nominator?.firstName, nominator?.lastName, intl),
   );
   const uniqueNamesToDisplay = uniqueItems(nominatorsNamesArray);

--- a/apps/web/src/pages/TalentEvents/TalentEvent/util.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/util.tsx
@@ -6,9 +6,11 @@ import {
   TalentEventNominationsTableFragment as TalentEventNominationsTableFragmentType,
   TalentNominationGroupStatus,
 } from "@gc-digital-talent/graphql";
-import { Chip } from "@gc-digital-talent/ui";
+import { Chip, Link } from "@gc-digital-talent/ui";
 
 import { getFullNameLabel } from "~/utils/nameUtils";
+import useRoutes from "~/hooks/useRoutes";
+import messages from "~/messages/talentNominationMessages";
 
 import { TalentNominator } from "./types";
 
@@ -60,4 +62,53 @@ export function statusCell(
   }
 
   return null;
+}
+
+export const nomineeNameCell = (
+  eventId: string,
+  nominationGroupId: string,
+  nominee: TalentEventNominationsTableFragmentType["nominee"],
+  paths: ReturnType<typeof useRoutes>,
+  intl: IntlShape,
+) => {
+  const nomineeName = getFullNameLabel(
+    nominee?.firstName,
+    nominee?.lastName,
+    intl,
+  );
+
+  return (
+    <Link href={paths.talentNominationGroupProfile(eventId, nominationGroupId)}>
+      {nomineeName}
+    </Link>
+  );
+};
+
+export function typesAccessor(
+  advancementNominationCount: number,
+  lateralMovementNominationCount: number,
+  developmentProgramsNominationCount: number,
+  intl: IntlShape,
+): string {
+  let arrayOfTypes: string[] = [];
+
+  if (advancementNominationCount > 0) {
+    arrayOfTypes = [
+      ...arrayOfTypes,
+      intl.formatMessage(messages.nominateForAdvancement),
+    ];
+  }
+
+  if (lateralMovementNominationCount > 0) {
+    arrayOfTypes = [
+      ...arrayOfTypes,
+      intl.formatMessage(messages.nominateForLateralMovement),
+    ];
+  }
+
+  if (developmentProgramsNominationCount > 0) {
+    arrayOfTypes = [...arrayOfTypes, intl.formatMessage(messages.development)];
+  }
+
+  return arrayOfTypes.join(", ");
 }

--- a/apps/web/src/pages/TalentEvents/TalentEvent/util.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/util.tsx
@@ -1,0 +1,63 @@
+import { IntlShape } from "react-intl";
+import { JSX } from "react";
+
+import { notEmpty, uniqueItems } from "@gc-digital-talent/helpers";
+import {
+  TalentEventNominationsTableFragment as TalentEventNominationsTableFragmentType,
+  TalentNominationGroupStatus,
+} from "@gc-digital-talent/graphql";
+import { Chip } from "@gc-digital-talent/ui";
+
+import { getFullNameLabel } from "~/utils/nameUtils";
+
+import { TalentNominator } from "./types";
+
+export function nominationsToNominators(
+  nominations: TalentEventNominationsTableFragmentType["nominations"],
+): TalentNominator[] {
+  const nominationsFiltered = nominations?.filter(notEmpty) ?? [];
+  const nominators = nominationsFiltered.map(
+    (nomination) => nomination?.nominator,
+  );
+  const nominatorsFiltered = nominators?.filter(notEmpty) ?? [];
+
+  return nominatorsFiltered;
+}
+
+export function nominatorsAccessor(
+  nominators: TalentNominator[],
+  intl: IntlShape,
+): string {
+  const nominatorsNamesArray = nominators.map((nominator) =>
+    getFullNameLabel(nominator?.firstName, nominator?.lastName, intl),
+  );
+  const uniqueNamesToDisplay = uniqueItems(nominatorsNamesArray);
+
+  return uniqueNamesToDisplay.join(", ");
+}
+
+export function statusCell(
+  status: TalentEventNominationsTableFragmentType["status"],
+): JSX.Element | null {
+  if (!status?.value || !status?.label?.localized) {
+    return null;
+  }
+
+  if (status.value === TalentNominationGroupStatus.Approved) {
+    return <Chip color="success">{status.label.localized}</Chip>;
+  }
+
+  if (status.value === TalentNominationGroupStatus.PartiallyApproved) {
+    return <Chip color="success">{status.label.localized}</Chip>;
+  }
+
+  if (status.value === TalentNominationGroupStatus.InProgress) {
+    return <Chip color="primary">{status.label.localized}</Chip>;
+  }
+
+  if (status.value === TalentNominationGroupStatus.Rejected) {
+    return <Chip color="error">{status.label.localized}</Chip>;
+  }
+
+  return null;
+}

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -421,6 +421,11 @@ const commonMessages = defineMessages({
     id: "cO535E",
     description: "Message displayed to user if account fails to get updated.",
   },
+  types: {
+    defaultMessage: "Types",
+    id: "pLM39W",
+    description: "label or header for something referred to as a type",
+  },
 });
 
 export default commonMessages;


### PR DESCRIPTION
🤖 Resolves #13122

## 👋 Introduction

Fills in the stub page to have a table of `TalentNominationGroup` records

## 🧪 Testing

1. Navigate to `/en/admin/talent-events/:eventId/nominations`
2. Observe table
3. Seed more records if needed by seeder or tinker

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/39dc2ecc-812f-48e5-8af8-d86ca86a5cff)

