### PR TITLE
[Bug] Nominator name and email on dialog

### DIFF
--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewTalentNominationDialog.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewTalentNominationDialog.tsx
@@ -28,6 +28,8 @@ const ReviewTalentNominationDialog_Fragment = graphql(/* GraphQL */ `
       lastName
       workEmail
     }
+    nominatorFallbackName
+    nominatorFallbackWorkEmail
     nominateForAdvancement
     nominateForLateralMovement
     nominateForDevelopmentPrograms
@@ -116,6 +118,15 @@ const ReviewTalentNominationDialog = ({
   const nullMessage = intl.formatMessage(commonMessages.notFound);
 
   const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  let nominatorName = talentNomination?.nominatorFallbackName ?? nullMessage;
+  if (talentNomination?.nominator) {
+    nominatorName = getFullNameLabel(
+      talentNomination.nominator.firstName,
+      talentNomination.nominator.lastName,
+      intl,
+    );
+  }
 
   return (
     <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
@@ -273,21 +284,16 @@ const ReviewTalentNominationDialog = ({
                   talentNominationMessages.nominatorName,
                 )}
               >
-                {talentNomination.nominator?.firstName ||
-                talentNomination.nominator?.lastName
-                  ? getFullNameLabel(
-                      talentNomination.nominator?.firstName,
-                      talentNomination.nominator?.lastName,
-                      intl,
-                    )
-                  : nullMessage}
+                {nominatorName}
               </FieldDisplay>
               <FieldDisplay
                 label={intl.formatMessage(
                   talentNominationMessages.nominatorWorkEmail,
                 )}
               >
-                {talentNomination.nominator?.workEmail ?? nullMessage}
+                {talentNomination?.nominator?.workEmail ??
+                  talentNomination?.nominatorFallbackWorkEmail ??
+                  intl.formatMessage(commonMessages.notProvided)}
               </FieldDisplay>
             </div>
           </div>


### PR DESCRIPTION
🤖 Resolves #13172

## 👋 Introduction

- Fix nominator name and work email on dialog when fallback name and email is selected

## 🧪 Testing

1. Build app `pnpm run build`
2. Login as `admin@test.com`
3. Go to applicant dashboard
4. View talent nominations
5. Ensure nomination dialogs have nominator name and email, when fallback  name and email are selected

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/d3c05493-1fa2-4f7d-b7d4-27a3f777d7d0)