### PR TITLE
[Fix] Remove required rule for rationale additional comments

### DIFF
--- a/api/app/GraphQL/Validators/Mutation/SubmitTalentNominationValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/SubmitTalentNominationValidator.php
@@ -1,4 +1,4 @@
-<?phpSubmitTal
+<?php
 
 namespace App\GraphQL\Validators\Mutation;
 

--- a/api/app/GraphQL/Validators/Mutation/SubmitTalentNominationValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/SubmitTalentNominationValidator.php
@@ -1,4 +1,4 @@
-<?php
+<?phpSubmitTal
 
 namespace App\GraphQL\Validators\Mutation;
 
@@ -163,7 +163,6 @@ final class SubmitTalentNominationValidator extends Validator
             'skills.*.skill_id' => [
                 Rule::in(SkillFamily::where('key', 'klc')->sole()->skills->pluck('id')->toArray()),
             ],
-            'additional_comments' => ['required'],
         ];
     }
 

--- a/api/app/GraphQL/Validators/UpdateTalentNominationInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdateTalentNominationInputValidator.php
@@ -131,7 +131,7 @@ final class UpdateTalentNominationInputValidator extends Validator
                 ),
             ],
             'skills.sync.*' => [Rule::in(SkillFamily::where('key', 'klc')->sole()->skills->pluck('id')->toArray())],
-            'additionalComments' => ['string'],
+            'additionalComments' => ['nullable', 'string'],
         ];
     }
 

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Rationale.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Rationale.tsx
@@ -149,7 +149,6 @@ const Rationale = ({ rationaleQuery, skillsQuery }: RationaleProps) => {
           id="additionalComments"
           name="additionalComments"
           wordLimit={500 * wordLimitMultiplier}
-          rules={{ required: intl.formatMessage(errorMessages.required) }}
           label={intl.formatMessage(labels.additionalComments)}
         />
       </div>


### PR DESCRIPTION
🤖 Resolves #13179 

## 👋 Introduction

Removes the rule making additional comments a required field for a nomination rationale.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as an employee `applicant-employee@test.com`
3. Start a nomination
4. Contiune to the rationale step
5. Observe that the additional comments field is not required