### PR TITLE
[Copy] Updates nomination form labels and copy

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -276,7 +276,7 @@
     "description": "Title for skills on Experience form"
   },
   "/JDxnh": {
-    "defaultMessage": "Votre relation avec l'auteur ou l'autrice de la mise en candidature ",
+    "defaultMessage": "Votre relation avec l'auteur(trice) de la mise en candidature ",
     "description": "Label for a nomination sumitters relationship to the nominator"
   },
   "/JQ6DD": {
@@ -1604,7 +1604,7 @@
     "description": "Title for managing notification settings"
   },
   "5HhVG9": {
-    "defaultMessage": "Courriel professionnel de l'autrice ou l'auteur de la mise en candidature",
+    "defaultMessage": "Courriel professionnel de l'auteur(trice) de la mise en candidature",
     "description": "Label for the text input for the nominators work email"
   },
   "5LWxHq": {
@@ -2644,7 +2644,7 @@
     "description": "Describes selecting asset skills for a process."
   },
   "AdmbBO": {
-    "defaultMessage": "Ministère ou organisme de l'auteur ou l'autrice de la mise en candidature",
+    "defaultMessage": "Ministère ou organisme de l'auteur(trice) de la mise en candidature",
     "description": "Label for a nominators department"
   },
   "Af4zOR": {
@@ -3052,7 +3052,7 @@
     "description": "Radio group option for education requirement filter in application education form."
   },
   "Ch6OCd": {
-    "defaultMessage": "Courriel professionnel de l'autrice ou l'auteur de la mise en candidature",
+    "defaultMessage": "Courriel professionnel de l'auteur(trice) de la mise en candidature",
     "description": "Label for the nominator's work email"
   },
   "Cn73yN": {
@@ -5192,7 +5192,7 @@
     "description": "Instructions on requiring information for skills"
   },
   "N5swJ7": {
-    "defaultMessage": "L'autrice ou l'auteur de la mise en candidature ",
+    "defaultMessage": "L'auteur(trice) de la mise en candidature ",
     "description": "Link text for nominator step of a talent nomination"
   },
   "N5xj2X": {
@@ -6863,7 +6863,7 @@
     "description": "Label for First Nations community"
   },
   "VUsGFc": {
-    "defaultMessage": "Modifiez les infos sur l'autrice ou l'auteur de la mise en candidature",
+    "defaultMessage": "Modifiez les infos sur l'auteur(trice) de la mise en candidature",
     "description": "Link text to edit a nominations nominator information"
   },
   "VWEwki": {
@@ -7879,7 +7879,7 @@
     "description": "Label for an employee profile career development preference field"
   },
   "aYyceB": {
-    "defaultMessage": "Lien entre la personne candidate et l'auteur ou l'autrice de la mise en candidature",
+    "defaultMessage": "Lien entre la personne candidate et l'auteur(trice) de la mise en candidature",
     "description": "Label for the nominee's relation to the person nominating them"
   },
   "aZUxFF": {
@@ -8831,7 +8831,7 @@
     "description": "Message displayed to user after user is updated successfully."
   },
   "exPEA1": {
-    "defaultMessage": "Nom de l'autrice ou l'auteur de la mise en candidature",
+    "defaultMessage": "Nom de l'auteur(trice) de la mise en candidature",
     "description": "Label for the text input for the nominators name"
   },
   "exxM/M": {
@@ -9343,7 +9343,7 @@
     "description": "Error message if there are no experiences"
   },
   "h+pOLj": {
-    "defaultMessage": "Pour continuer, veuillez nous indiquer qui est l'auteur ou l'autrice de la mise en candidature.",
+    "defaultMessage": "Pour continuer, veuillez nous indiquer qui est l'auteur(trice) de la mise en candidature.",
     "description": "Error message when a nominator has not been set for a nomination"
   },
   "h0Mrq9": {
@@ -10943,7 +10943,7 @@
     "description": "Subtitle explaining Recruitment processes expandable within applications and processes card"
   },
   "oglvAY": {
-    "defaultMessage": "Commençons par en apprendre un peu plus sur l'autrice ou l'auteur de la mise en candidature.",
+    "defaultMessage": "Commençons par en apprendre un peu plus sur l'auteur(trice) de la mise en candidature.",
     "description": "Subtitle for nomination nominator step"
   },
   "ohLTJS": {
@@ -11691,7 +11691,7 @@
     "description": "Label for the nominee's classification"
   },
   "sjxFxr": {
-    "defaultMessage": "Classification de l'autrice ou l'auteur de la mise en candidature",
+    "defaultMessage": "Classification de l'auteur(trice) de la mise en candidature",
     "description": "Label for the nominators's classification"
   },
   "skfKnv": {
@@ -13015,7 +13015,7 @@
     "description": "Option for assessment decision when candidate has unsuccessful assessment and been removed from the process."
   },
   "zYKPdV": {
-    "defaultMessage": "Nom de l'autrice ou l'auteur de la mise en candidature",
+    "defaultMessage": "Nom de l'auteur(trice) de la mise en candidature",
     "description": "Label for the nominator's name"
   },
   "zbmWLG": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1855,10 +1855,6 @@
     "defaultMessage": "Vous n’avez pas de nouvelles notifications.",
     "description": "Title for the no notifications message"
   },
-  "6e33hP": {
-    "defaultMessage": "Courriel professionnel de l'autrice ou l'auteur de la mise en candidature",
-    "description": "Label for the nominator input field on a nomination"
-  },
   "6eCvv1": {
     "defaultMessage": "Postes bilingues (français et anglais)",
     "description": "Bilingual Positions message"
@@ -2718,6 +2714,10 @@
   "Awtr05": {
     "defaultMessage": "Veuillez prendre note qu’en supprimant une compétence de votre profil :",
     "description": "Lead-in text to points of concern when deleting a skill and what will happen"
+  },
+  "Ax4fN+": {
+    "defaultMessage": "Rechercher le courriel professionnel de la personne candidate",
+    "description": "Label for search nominee input field on a nomination"
   },
   "AxRGK2": {
     "defaultMessage": "Cacher les renseignements sur les choses à faire si vous ne trouvez pas une compétence",
@@ -7674,6 +7674,10 @@
     "defaultMessage": "Nous allons étiqueter les questions de manière à ce que vous sachiez comment vos réponses seront évaluées.",
     "description": "Application step for additional questions, introduction description, paragraph two"
   },
+  "ZPedK3": {
+    "defaultMessage": "Rechercher le courriel professionnel de la personne de référence",
+    "description": "Label for search reference input field on a nomination"
+  },
   "ZQbSfP": {
     "defaultMessage": "Lorsqu’une candidature a été évaluée avec succès, le <a>recrutement qualifié sera ajouté à votre parcours professionnel</a> automatiquement afin que les gestionnaires puissent voir vos réalisations.",
     "description": "Description for the track applications section on the applicant dashboard, paragraph two."
@@ -11873,6 +11877,10 @@
   "tmFU3R": {
     "defaultMessage": "« {email} » n'est pas une adresse de courriel valide du gouvernement du Canada",
     "description": "Label for when an employee was found"
+  },
+  "tmRaL3": {
+    "defaultMessage": "Rechercher le courriel professionnel de l'auteur(trice) de la mise en candidature",
+    "description": "Label for search nominator input field on a nomination"
   },
   "tmwk97": {
     "defaultMessage": "Les possibilités d'emploi au sein de cette collectivité m'intéressent.",

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
@@ -269,7 +269,12 @@ const DetailsFields = ({
                 id="advancementReference"
                 name="advancementReference"
                 employeeOption={fragmentToEmployee(advancementReferenceData)}
-                label={intl.formatMessage(labels.referencesWorkEmail)}
+                label={intl.formatMessage({
+                  defaultMessage: "Search reference's work email",
+                  id: "ZPedK3",
+                  description:
+                    "Label for search reference input field on a nomination",
+                })}
                 errorSeverities={{ NO_PROFILE: "warning" }}
               />
               {!advancementReferenceUnset && !advancementReferenceNotFound && (

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Nominator.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Nominator.tsx
@@ -232,9 +232,9 @@ const NominatorFields = ({
         aria-describedby="nominatorHelp"
         employeeOption={fragmentToEmployee(nominatorResult)}
         label={intl.formatMessage({
-          defaultMessage: "Nominator’s work email",
-          id: "6e33hP",
-          description: "Label for the nominator input field on a nomination",
+          defaultMessage: "Search nominator's work email",
+          id: "tmRaL3",
+          description: "Label for search nominator input field on a nomination",
         })}
         errorSeverities={{ NO_PROFILE: "warning" }}
       />

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Nominee.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Nominee.tsx
@@ -29,7 +29,6 @@ import UpdateForm, { SubmitDataTransformer } from "./UpdateForm";
 import SubHeading from "./SubHeading";
 import messages from "../messages";
 import EmployeeSearchWell from "./EmployeeSearchWell";
-import labels from "../labels";
 
 interface FormValues extends BaseFormValues {
   nominee: Scalars["UUID"]["input"];

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Nominee.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Nominee.tsx
@@ -230,7 +230,11 @@ const Nominee = ({ nomineeQuery, optionsQuery }: NomineeProps) => {
         <EmployeeSearchInput
           id="nominee"
           name="nominee"
-          label={intl.formatMessage(labels.nomineeWorkEmail)}
+          label={intl.formatMessage({
+            defaultMessage: "Search nominee's work email",
+            id: "Ax4fN+",
+            description: "Label for search nominee input field on a nomination",
+          })}
           rules={{ required: intl.formatMessage(errorMessages.required) }}
           employeeOption={fragmentToEmployee(talentNomination.nominee)}
           errorMessages={{


### PR DESCRIPTION
🤖 Resolves #13144.

## 👋 Introduction

This PR updates duplicate labels in nomination form and shortens nominator labels in French by using an abbreviated doublet.

## 🧪 Testing

1. `pnpm build:fresh`
2. Login as a verified Government of Canada employee using `applicant-employee@test.com`
3. Navigate to http://localhost:8000/en/communities/talent-events
4. Start a nomination
5. Force fallback for nominator to appear
6. Verify labels are no longer identical
7. Switch to French
8. Verify abbreviated doublet is used where requested

## 📸 Screenshots

<details><summary>English (3)</summary>
<p>

![localhost_3000_en_communities_talent-events (1)](https://github.com/user-attachments/assets/693290a4-36ab-4053-9cc7-0857ddfd8476)

![localhost_3000_en_communities_talent-events](https://github.com/user-attachments/assets/13a4082b-d705-4d17-9381-a162902c7582)

![localhost_3000_en_communities_talent-events (2)](https://github.com/user-attachments/assets/9ce585df-f4c6-42f7-9515-2a67c3f5140d)

</p>
</details> 

<details><summary>French (3)</summary>
<p>

![localhost_3000_fr_communities_talent-nominations_bb172e6b-351f-46c3-bbcc-cd4c85470425_step=REVIEW_AND_SUBMIT (1)](https://github.com/user-attachments/assets/c7de4c63-5a82-4d7c-9707-353575428898)

<img width="1169" alt="Screen Shot 2025-04-04 at 16 53 49" src="https://github.com/user-attachments/assets/8ec16d81-f28c-4b9f-a665-92d89d4f8fd5" />

<img width="1172" alt="Screen Shot 2025-04-04 at 16 52 39" src="https://github.com/user-attachments/assets/ec098d57-1fe6-4d71-a6b6-8c1c8a0d6c82" />

</p>
</details> 