### PR TITLE
[BUG] Creating a Financial Community Interest leading to a error page on a specific scenario

### DIFF
--- a/apps/web/src/pages/CommunityInterests/sections/AdditionalInformation.tsx
+++ b/apps/web/src/pages/CommunityInterests/sections/AdditionalInformation.tsx
@@ -100,7 +100,8 @@ const AdditionalInformation = ({
     }
 
     // if the "other" role is not selected then clear the other role input
-    if (!selectedFinanceOtherRoles?.includes(FinanceChiefRole.Other)) {
+    if (!Array.isArray(selectedFinanceOtherRoles) ||
+      !selectedFinanceOtherRoles.includes(FinanceChiefRole.Other)) {
       resetDirtyField("financeOtherRolesOther", null);
     }
   }, [resetField, selectedFinanceIsChief, selectedFinanceOtherRoles]);
@@ -228,7 +229,8 @@ const AdditionalInformation = ({
                   aria-describedby={financeOtherRolesDescription}
                 />
                 {/* Other position input only appears if the user selects "Other" in the other roles checklist */}
-                {selectedFinanceOtherRoles?.includes(FinanceChiefRole.Other) ? (
+                {Array.isArray(selectedFinanceOtherRoles) &&
+                selectedFinanceOtherRoles.includes(FinanceChiefRole.Other) ? (
                   <Input
                     id="financeOtherRolesOther"
                     name="financeOtherRolesOther"

--- a/apps/web/src/pages/CommunityInterests/sections/AdditionalInformation.tsx
+++ b/apps/web/src/pages/CommunityInterests/sections/AdditionalInformation.tsx
@@ -100,8 +100,10 @@ const AdditionalInformation = ({
     }
 
     // if the "other" role is not selected then clear the other role input
-    if (!Array.isArray(selectedFinanceOtherRoles) ||
-      !selectedFinanceOtherRoles.includes(FinanceChiefRole.Other)) {
+    if (
+      !Array.isArray(selectedFinanceOtherRoles) ||
+      !selectedFinanceOtherRoles.includes(FinanceChiefRole.Other)
+    ) {
       resetDirtyField("financeOtherRolesOther", null);
     }
   }, [resetField, selectedFinanceIsChief, selectedFinanceOtherRoles]);


### PR DESCRIPTION
🤖 Resolves [13185](https://github.com/GCTC-NTGC/gc-digital-talent/issues/13185)

## 👋 Introduction

Validate financial management community form when the consent check box is not checked .

## 🕵️ Details

Created a check that ensures that the .includes() method is only called if the selectedFinanceOtherRoles is an array, which enforces the validation check.

## 🧪 Testing

1. Click Add community in the dashboard
2. Select Finance community in the drop down ( can't be reproduced with others )
3. First 2 options can be anything
4. Check CFO status
5. Don't check anything for Additional duties and Other roles
6. Don't check consent check box
7. Click Submit
8. Should show validation error at the consent checkbox

## 📸 Screenshot

<img width="1069" alt="image" src="https://github.com/user-attachments/assets/8a04b03b-16e2-45c8-b00e-73f8e91e7060" />

