### PR TITLE
[Fix] Constrain start/end dates to edges of month ranges

### DIFF
--- a/apps/web/src/components/ExperienceFormFields/CommunityFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/CommunityFields.tsx
@@ -103,6 +103,7 @@ const CommunityFields = ({
               id="endDate"
               legend={labels.endDate}
               name="endDate"
+              round="ceil"
               show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
               rules={
                 isCurrent && startDate

--- a/apps/web/src/components/ExperienceFormFields/CommunityFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/CommunityFields.tsx
@@ -86,6 +86,7 @@ const CommunityFields = ({
             id="startDate"
             legend={labels.startDate}
             name="startDate"
+            round="floor"
             show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
             rules={{
               required: intl.formatMessage(errorMessages.required),

--- a/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
@@ -145,6 +145,7 @@ const EducationFields = ({
             id="startDate"
             legend={labels.startDate}
             name="startDate"
+            round="floor"
             show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
             rules={{
               required: intl.formatMessage(errorMessages.required),

--- a/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/EducationFields.tsx
@@ -161,6 +161,7 @@ const EducationFields = ({
               id="endDate"
               legend={labels.endDate}
               name="endDate"
+              round="ceil"
               show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
               rules={
                 isCurrent

--- a/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
@@ -103,6 +103,7 @@ const PersonalFields = ({ labels }: SubExperienceFormProps) => {
               id="endDate"
               legend={labels.endDate}
               name="endDate"
+              round="ceil"
               show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
               rules={
                 isCurrent

--- a/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/PersonalFields.tsx
@@ -87,6 +87,7 @@ const PersonalFields = ({ labels }: SubExperienceFormProps) => {
             id="startDate"
             legend={labels.startDate}
             name="startDate"
+            round="floor"
             show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
             rules={{
               required: intl.formatMessage(errorMessages.required),

--- a/apps/web/src/components/ExperienceFormFields/WorkFields/CafFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields/CafFields.tsx
@@ -130,6 +130,7 @@ const CafFields = ({ labels }: SubExperienceFormProps) => {
                 legend={labels.endDate}
                 name="endDate"
                 show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
+                round="ceil"
                 rules={
                   watchCurrentRole
                     ? {}

--- a/apps/web/src/components/ExperienceFormFields/WorkFields/CafFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields/CafFields.tsx
@@ -97,6 +97,7 @@ const CafFields = ({ labels }: SubExperienceFormProps) => {
               id="startDate"
               legend={labels.startDate}
               name="startDate"
+              round="floor"
               show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
               rules={{
                 required: intl.formatMessage(errorMessages.required),

--- a/apps/web/src/components/ExperienceFormFields/WorkFields/ExternalFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields/ExternalFields.tsx
@@ -118,6 +118,7 @@ const ExternalFields = ({
               id="startDate"
               legend={labels.startDate}
               name="startDate"
+              round="floor"
               show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
               rules={{
                 required: intl.formatMessage(errorMessages.required),

--- a/apps/web/src/components/ExperienceFormFields/WorkFields/ExternalFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields/ExternalFields.tsx
@@ -151,6 +151,7 @@ const ExternalFields = ({
                 legend={labels.endDate}
                 name="endDate"
                 show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
+                round="ceil"
                 rules={
                   watchCurrentRole
                     ? {}

--- a/apps/web/src/components/ExperienceFormFields/WorkFields/GovFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields/GovFields.tsx
@@ -455,6 +455,7 @@ const GovFields = ({ labels }: SubExperienceFormProps) => {
                 legend={labels.expectedEndDate}
                 name="endDate"
                 show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
+                round="ceil"
                 rules={
                   watchCurrentRole
                     ? {

--- a/apps/web/src/components/ExperienceFormFields/WorkFields/GovFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields/GovFields.tsx
@@ -423,6 +423,7 @@ const GovFields = ({ labels }: SubExperienceFormProps) => {
               id="startDate"
               legend={labels.startDate}
               name="startDate"
+              round="floor"
               show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
               rules={{
                 required: intl.formatMessage(errorMessages.required),

--- a/apps/web/src/components/ExperienceFormFields/WorkFields/GovFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields/GovFields.tsx
@@ -488,6 +488,7 @@ const GovFields = ({ labels }: SubExperienceFormProps) => {
                     id="endDate"
                     legend={labels.endDate}
                     name="endDate"
+                    round="ceil"
                     show={[DATE_SEGMENT.Month, DATE_SEGMENT.Year]}
                     rules={{
                       required: intl.formatMessage(errorMessages.required),

--- a/packages/forms/src/components/DateInput/ControlledInput.tsx
+++ b/packages/forms/src/components/DateInput/ControlledInput.tsx
@@ -59,6 +59,7 @@ const ControlledInput = ({
       value: segmentValue,
       segment,
       show,
+      round,
     });
 
     onChange(newValue);

--- a/packages/forms/src/components/DateInput/ControlledInput.tsx
+++ b/packages/forms/src/components/DateInput/ControlledInput.tsx
@@ -11,7 +11,7 @@ import get from "lodash/get";
 import { dateMessages } from "@gc-digital-talent/i18n";
 
 import useInputStyles from "../../hooks/useInputStyles";
-import { DateSegment, DATE_SEGMENT } from "./types";
+import { DateSegment, DATE_SEGMENT, RoundingMethod } from "./types";
 import {
   getMonthOptions,
   getMonthSpan,
@@ -26,12 +26,14 @@ interface ControlledInputProps {
   formState: UseFormStateReturn<FieldValues>;
   show: DateSegment[];
   stateStyles: StyleRecord;
+  round?: RoundingMethod;
 }
 
 const ControlledInput = ({
   field: { onChange, value, name },
   formState: { defaultValues },
   show,
+  round,
   stateStyles,
 }: ControlledInputProps) => {
   const intl = useIntl();

--- a/packages/forms/src/components/DateInput/DateInput.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.tsx
@@ -18,7 +18,12 @@ import useFieldState from "../../hooks/useFieldState";
 import useInputDescribedBy from "../../hooks/useInputDescribedBy";
 import ControlledInput from "./ControlledInput";
 import { splitSegments } from "./utils";
-import { DateRegisterOptions, DateSegment, DATE_SEGMENT } from "./types";
+import {
+  DateRegisterOptions,
+  DateSegment,
+  DATE_SEGMENT,
+  RoundingMethod,
+} from "./types";
 import useFieldStateStyles from "../../hooks/useFieldStateStyles";
 
 export type DateInputProps = Omit<CommonInputProps, "rules" | "label"> &
@@ -31,6 +36,8 @@ export type DateInputProps = Omit<CommonInputProps, "rules" | "label"> &
     rules?: DateRegisterOptions;
     /** Select which segments are visible to the user */
     show?: DateSegment[];
+    /** Round the date to the nearest segment */
+    round?: RoundingMethod;
   };
 
 /**
@@ -45,6 +52,7 @@ const DateInput = ({
   context,
   hideLegend,
   show = [DATE_SEGMENT.Year, DATE_SEGMENT.Month, DATE_SEGMENT.Day],
+  round,
   trackUnsaved = true,
   ...rest
 }: DateInputProps) => {
@@ -155,6 +163,7 @@ const DateInput = ({
             render={(props) => (
               <ControlledInput
                 {...props}
+                round={round}
                 show={show}
                 stateStyles={stateStyles}
               />

--- a/packages/forms/src/components/DateInput/types.ts
+++ b/packages/forms/src/components/DateInput/types.ts
@@ -23,3 +23,5 @@ interface DateMinMax {
 
 export type DateRegisterOptions = Omit<RegisterOptions, "min" | "max"> &
   Partial<DateMinMax>;
+
+export type RoundingMethod = "floor" | "ceil";

--- a/packages/forms/src/components/DateInput/utils.ts
+++ b/packages/forms/src/components/DateInput/utils.ts
@@ -4,6 +4,7 @@ import { IntlShape } from "react-intl";
 import { getDaysInMonth } from "date-fns/getDaysInMonth";
 
 import { dateMessages } from "@gc-digital-talent/i18n";
+import { formDateStringToDate } from "@gc-digital-talent/date-helpers";
 
 import {
   DateSegment,
@@ -110,35 +111,33 @@ export const setComputedValue: SetComputedValueFunc = ({
     show: show.includes(DATE_SEGMENT.Year),
   });
 
-  let defaultMonth = "01";
+  let currentMonth = month;
   if (!show.includes(DATE_SEGMENT.Month) && round) {
-    defaultMonth = "12";
+    currentMonth = round === "ceil" ? "12" : "01";
   }
   const newMonth = getComputedSegmentValue({
     values: {
       new: segment === DATE_SEGMENT.Month ? value : null,
-      current: month,
-      default: defaultMonth,
+      current: currentMonth,
+      default: "01",
     },
     show: show.includes(DATE_SEGMENT.Month),
   });
 
-  let defaultDay = "01";
+  let currentDay = day;
   if (!show.includes(DATE_SEGMENT.Day) && round) {
     if (round === "ceil") {
-      const currentDay = parse(
-        `${newYear || defaultYear}-${newMonth || defaultMonth}-${defaultDay}`,
-        "yyyy-MM-dd",
-        new Date(),
-      );
-      defaultDay = String(getDaysInMonth(currentDay));
+      const currentDate = formDateStringToDate(`${newYear || defaultYear}-${newMonth}-01`);
+      currentDay = String(getDaysInMonth(currentDate));
+    } else {
+      currentDay = "01";
     }
   }
   const newDay = getComputedSegmentValue({
     values: {
       new: segment === DATE_SEGMENT.Day ? value : null,
-      current: day,
-      default: defaultDay,
+      current: currentDay,
+      default: "01",
     },
     show: show.includes(DATE_SEGMENT.Day),
   });

--- a/packages/forms/src/components/DateInput/utils.ts
+++ b/packages/forms/src/components/DateInput/utils.ts
@@ -1,5 +1,4 @@
 import { format } from "date-fns/format";
-import { parse } from "date-fns/parse";
 import { IntlShape } from "react-intl";
 import { getDaysInMonth } from "date-fns/getDaysInMonth";
 

--- a/packages/forms/src/components/DateInput/utils.ts
+++ b/packages/forms/src/components/DateInput/utils.ts
@@ -100,11 +100,12 @@ export const setComputedValue: SetComputedValueFunc = ({
 }) => {
   const { year, month, day } = splitSegments(initialValue);
 
+  const defaultYear = format(new Date(), "yyyy");
   const newYear = getComputedSegmentValue({
     values: {
       new: segment === DATE_SEGMENT.Year ? value : null,
       current: year,
-      default: format(new Date(), "yyyy"),
+      default: defaultYear,
     },
     show: show.includes(DATE_SEGMENT.Year),
   });
@@ -126,7 +127,7 @@ export const setComputedValue: SetComputedValueFunc = ({
   if (!show.includes(DATE_SEGMENT.Day) && round) {
     if (round === "ceil") {
       const currentDay = parse(
-        `${newYear}-${newMonth}-${defaultDay}`,
+        `${newYear || defaultYear}-${newMonth || defaultMonth}-${defaultDay}`,
         "yyyy-MM-dd",
         new Date(),
       );

--- a/packages/forms/src/components/DateInput/utils.ts
+++ b/packages/forms/src/components/DateInput/utils.ts
@@ -1,9 +1,16 @@
 import { format } from "date-fns/format";
+import { parse } from "date-fns/parse";
 import { IntlShape } from "react-intl";
+import { getDaysInMonth } from "date-fns/getDaysInMonth";
 
 import { dateMessages } from "@gc-digital-talent/i18n";
 
-import { DateSegment, DATE_SEGMENT, SegmentObject } from "./types";
+import {
+  DateSegment,
+  DATE_SEGMENT,
+  SegmentObject,
+  RoundingMethod,
+} from "./types";
 
 /**
  * Split the form value into each segment
@@ -73,6 +80,7 @@ interface SetComputedValueArgs {
   show: DateSegment[];
   segment: DateSegment;
   value: string | null;
+  round?: RoundingMethod;
 }
 
 type SetComputedValueFunc = (args: SetComputedValueArgs) => string | undefined;
@@ -88,6 +96,7 @@ export const setComputedValue: SetComputedValueFunc = ({
   value,
   segment,
   show,
+  round,
 }) => {
   const { year, month, day } = splitSegments(initialValue);
 
@@ -100,20 +109,35 @@ export const setComputedValue: SetComputedValueFunc = ({
     show: show.includes(DATE_SEGMENT.Year),
   });
 
+  let defaultMonth = "01";
+  if (!show.includes(DATE_SEGMENT.Month) && round) {
+    defaultMonth = "12";
+  }
   const newMonth = getComputedSegmentValue({
     values: {
       new: segment === DATE_SEGMENT.Month ? value : null,
       current: month,
-      default: "01",
+      default: defaultMonth,
     },
     show: show.includes(DATE_SEGMENT.Month),
   });
 
+  let defaultDay = "01";
+  if (!show.includes(DATE_SEGMENT.Day) && round) {
+    if (round === "ceil") {
+      const currentDay = parse(
+        `${newYear}-${newMonth}-${defaultDay}`,
+        "yyyy-MM-dd",
+        new Date(),
+      );
+      defaultDay = String(getDaysInMonth(currentDay));
+    }
+  }
   const newDay = getComputedSegmentValue({
     values: {
       new: segment === DATE_SEGMENT.Day ? value : null,
       current: day,
-      default: "01",
+      default: defaultDay,
     },
     show: show.includes(DATE_SEGMENT.Day),
   });

--- a/packages/forms/src/components/DateInput/utils.ts
+++ b/packages/forms/src/components/DateInput/utils.ts
@@ -127,7 +127,9 @@ export const setComputedValue: SetComputedValueFunc = ({
   let currentDay = day;
   if (!show.includes(DATE_SEGMENT.Day) && round) {
     if (round === "ceil") {
-      const currentDate = formDateStringToDate(`${newYear || defaultYear}-${newMonth}-01`);
+      const currentDate = formDateStringToDate(
+        `${newYear || defaultYear}-${newMonth}-01`,
+      );
       currentDay = String(getDaysInMonth(currentDate));
     } else {
       currentDay = "01";


### PR DESCRIPTION
🤖 Resolves #13058 

## 👋 Introduction

Updates the date ranges for experiences to always be set to the start and end of a month.

## 🕵️ Details

We previously would store both start and end dates to the start of the month. This was causing issues with "current role" when the end date was the current month since it looked like a past experience.

This updates both start and end date to always be set to the start/end of a month to avoid this.

## 🧪 Testing

1. Refresh api `make refresh-api`
2. Attempt to set an experience start/end dates to middle of the month days (e.g. January 15th)
3. Confirm start date is constrained tot he first day of that month and end date is constrained to the last day in the month
4. Set expected end date of experience to the current month
5. Confirm fronted is still able to discern that the experience is current