### PR TITLE
Fix talent events nested path

### DIFF
--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -798,31 +798,30 @@ const createRoute = (locale: Locales, newApplicantDashboard: boolean) =>
                 },
                 {
                   path: "talent-events",
-                  lazy: () =>
-                    import("../pages/TalentEvents/IndexTalentEventPage"),
                   children: [
                     {
+                      index: true,
+                      lazy: () =>
+                        import("../pages/TalentEvents/IndexTalentEventPage"),
+                    },
+                    {
                       path: ":eventId",
+                      lazy: () =>
+                        import("../pages/TalentEvents/TalentEvent/Layout"),
                       children: [
                         {
+                          index: true,
                           lazy: () =>
-                            import("../pages/TalentEvents/TalentEvent/Layout"),
-                          children: [
-                            {
-                              index: true,
-                              lazy: () =>
-                                import(
-                                  "../pages/TalentEvents/TalentEvent/DetailsPage"
-                                ),
-                            },
-                            {
-                              path: "nominations",
-                              lazy: () =>
-                                import(
-                                  "../pages/TalentEvents/TalentEvent/NominationsPage"
-                                ),
-                            },
-                          ],
+                            import(
+                              "../pages/TalentEvents/TalentEvent/DetailsPage"
+                            ),
+                        },
+                        {
+                          path: "nominations",
+                          lazy: () =>
+                            import(
+                              "../pages/TalentEvents/TalentEvent/NominationsPage"
+                            ),
                         },
                       ],
                     },


### PR DESCRIPTION
🤖 Resolves <!-- issue # -->

## 👋 Introduction

Fix the router issue enabling accessing event pages again

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Can navigate to `/en/admin/talent-events/:eventId` from the table again
2. Table and subsequent nested paths accessible




