### PR TITLE
[Bug] Updated admin training breadcrumb

### DIFF
--- a/apps/web/src/pages/TrainingOpportunities/CreateTrainingOpportunityPage.tsx
+++ b/apps/web/src/pages/TrainingOpportunities/CreateTrainingOpportunityPage.tsx
@@ -176,7 +176,7 @@ const CreateTrainingOpportunityPage = () => {
     crumbs: [
       {
         label: intl.formatMessage(pageTitles.trainingOpportunities),
-        url: routes.departmentTable(),
+        url: routes.trainingOpportunitiesIndex(),
       },
       {
         label: intl.formatMessage({


### PR DESCRIPTION
🤖 Resolves #13128 

## 👋 Introduction

Fixed breadcrumb on the admin Create Training opportunity form.


## 🧪 Testing

1. Build app `run pnpm dev`
2. Login in as admin
3. Navigate to `/en/admin/training-opportunities`
4. Click on create training opportunity to open the form
5. Hover over or click the "Training Opportunities" breadcrumb
6. URL updated to `/en/admin/training-opportunities`
 

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/3cfe1dfe-2849-459f-ad6d-44825fdb8973)



