### PR TITLE
[Feat] Next/Prev navigation for nominations

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1919,6 +1919,10 @@
     "defaultMessage": "Du processus suivant :",
     "description": "Follow in text for the process being updated"
   },
+  "7+jEIT": {
+    "defaultMessage": "Nomination suivante",
+    "description": "Link label to view next nomination page"
+  },
   "71+GZq": {
     "defaultMessage": "Un groupe d’Autochtones qui se tiennent debout avec un tambour à main peint.",
     "description": "Indigenous Apprenticeship hero image text alternative"
@@ -3719,6 +3723,10 @@
     "defaultMessage": "Sélectionnez les rôles à confier au membre :",
     "description": "Label for the roles select field on process team dialog"
   },
+  "FuuXpa": {
+    "defaultMessage": "Suivant",
+    "description": "Link text to navigate to the next item"
+  },
   "FvbONe": {
     "defaultMessage": "Compétences à améliorer",
     "description": "Title for skills to improve showcase section"
@@ -4999,6 +5007,10 @@
     "defaultMessage": "Retirer une compétence",
     "description": "Message in skills in details section to remove skill from the experience."
   },
+  "M0rL3I": {
+    "defaultMessage": "Nomination précédente",
+    "description": "Link label to view previous nomination page"
+  },
   "M1Q9CE": {
     "defaultMessage": "Supprimez  « {skillName} » de votre profil",
     "description": "Title for the confirmation alert to delete a skill"
@@ -5927,6 +5939,10 @@
     "defaultMessage": "La formation ou le perfectionnement m'intéresse*",
     "description": "Message when user expresses interest in training or development opportunities"
   },
+  "Qhl5J9": {
+    "defaultMessage": "Précédent",
+    "description": "Link text to navigate to the previous item"
+  },
   "Qibs21": {
     "defaultMessage": "Les exigences en matière de compétences sont classées soit comme étant <strong>essentielles</strong> (le candidat a absolument besoin de cette compétence), soit comme étant un <strong>atout</strong> (la compétence serait utile, mais n'est pas requise). Les critères de compétences seront présentés au candidat en fonction d'une combinaison du statut essentiel ou d'atout de la compétence et si la compétence sera évaluée dans le cadre de sa demande.",
     "description": "Sub title for  skill requirements"
@@ -6586,6 +6602,10 @@
   "Txu5Yq": {
     "defaultMessage": "Malgré tous les efforts déployés pour rendre notre site Web entièrement accessible, si vous avez besoin d’aide pour accéder aux renseignements ou si vous avez besoin d’un format différent, nous vous encourageons à communiquer avec nous. Votre rétroaction sur nos efforts d’accessibilité est également la bienvenue. Veuillez communiquer avec nous à :",
     "description": "Lead in text for accessibility contact information"
+  },
+  "TzlRpv": {
+    "defaultMessage": "Revenir aux nominations",
+    "description": "Link label to return to assessment tracker"
   },
   "U/Lv8i": {
     "defaultMessage": "Expérience inconnue",

--- a/apps/web/src/pages/TalentEvents/TalentEvent/NominationsPage.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/NominationsPage.tsx
@@ -89,6 +89,8 @@ const TalentEventNominations = ({ query }: TalentEventNominationsProps) => {
     [talentEventNominations],
   );
 
+  const nominationIds = talentEventNominationsData.map((nom) => nom.id);
+
   const columns = [
     columnHelper.accessor(
       ({ nominee }) =>
@@ -102,7 +104,14 @@ const TalentEventNominations = ({ query }: TalentEventNominationsProps) => {
           row: {
             original: { id, talentNominationEvent },
           },
-        }) => nomineeNameCell(talentNominationEvent.id, id, getValue(), paths),
+        }) =>
+          nomineeNameCell(
+            talentNominationEvent.id,
+            id,
+            getValue(),
+            nominationIds,
+            paths,
+          ),
         meta: {
           isRowTitle: true,
         },

--- a/apps/web/src/pages/TalentEvents/TalentEvent/util.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/util.tsx
@@ -74,10 +74,14 @@ export const nomineeNameCell = (
   eventId: string,
   nominationGroupId: string,
   nomineeName: string,
+  nominationIds: string[],
   paths: ReturnType<typeof useRoutes>,
 ) => {
   return (
-    <Link href={paths.talentNominationGroup(eventId, nominationGroupId)}>
+    <Link
+      href={paths.talentNominationGroup(eventId, nominationGroupId)}
+      state={{ nominationIds }}
+    >
       {nomineeName}
     </Link>
   );

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/NominationGroupSidebar.stories.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/NominationGroupSidebar.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryFn } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 import { faker } from "@faker-js/faker/locale/en";
 
 import {
@@ -10,6 +10,7 @@ import {
   fakeClassifications,
   fakeDepartments,
 } from "@gc-digital-talent/fake-data";
+import { RouterDecorator } from "@gc-digital-talent/storybook-helpers";
 
 import NominationGroupSidebar, {
   NominationGroupSidebar_Fragment,
@@ -57,20 +58,35 @@ const talentNominationGroup = {
   ],
 };
 
-export default {
+const ids = [faker.string.uuid(), faker.string.uuid(), faker.string.uuid()];
+
+const meta = {
   component: NominationGroupSidebar,
-};
+  parameters: {
+    defaultPath: {
+      path: `/:locale/admin/talent-events/:eventId/nominations/:talentNominationGroupId`,
+      initialEntries: [
+        {
+          pathname: `/en/admin/talent-events/${faker.string.uuid()}/nominations/${ids[1]}`,
+          state: { nominationIds: ids },
+        },
+      ],
+    },
+  },
+} satisfies Meta<typeof NominationGroupSidebar>;
 
-const Template: StoryFn<typeof NominationGroupSidebar> = (args) => (
-  <aside data-h2-width="base(50%)">
-    <NominationGroupSidebar {...args} />
-  </aside>
-);
+export default meta;
 
-export const Default = Template.bind({});
-Default.args = {
-  talentNominationGroupQuery: makeFragmentData(
-    talentNominationGroup,
-    NominationGroupSidebar_Fragment,
+export const Default: StoryObj<typeof NominationGroupSidebar> = {
+  args: {
+    talentNominationGroupQuery: makeFragmentData(
+      talentNominationGroup,
+      NominationGroupSidebar_Fragment,
+    ),
+  },
+  render: (args) => (
+    <aside data-h2-width="base(50%)">
+      <NominationGroupSidebar {...args} />
+    </aside>
   ),
 };

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/NominationGroupSidebar.stories.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/NominationGroupSidebar.stories.tsx
@@ -10,7 +10,6 @@ import {
   fakeClassifications,
   fakeDepartments,
 } from "@gc-digital-talent/fake-data";
-import { RouterDecorator } from "@gc-digital-talent/storybook-helpers";
 
 import NominationGroupSidebar, {
   NominationGroupSidebar_Fragment,

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/NominationGroupSidebar.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/NominationGroupSidebar.tsx
@@ -23,6 +23,7 @@ import FieldDisplay from "~/components/FieldDisplay/FieldDisplay";
 
 import NominatedForList from "./NominatedForList";
 import NominatorList from "./NominatorList";
+import NominationNavigation from "./NominationNavigation/NominationNavigation";
 
 type AccordionStates = "nominee-contact-information" | "comments" | "";
 
@@ -145,6 +146,7 @@ const NominationGroupSidebar = ({
       data-h2-display="base(flex)"
       data-h2-flex-direction="base(column)"
       data-h2-padding="base(0)"
+      data-h2-gap="base(x.5)"
     >
       <CardBasic
         data-h2-display="base(flex)"
@@ -327,6 +329,7 @@ const NominationGroupSidebar = ({
           </Accordion.Item>
         </Accordion.Root>
       </CardBasic>
+      <NominationNavigation />
     </div>
   );
 };

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/NominationNavigation/NominationNavigation.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/NominationNavigation/NominationNavigation.tsx
@@ -1,0 +1,108 @@
+import { defineMessages, useIntl } from "react-intl";
+import ArrowLeftCircleIcon from "@heroicons/react/20/solid/ArrowLeftCircleIcon";
+import ArrowRightCircleIcon from "@heroicons/react/20/solid/ArrowRightCircleIcon";
+import {
+  ChevronDoubleLeftIcon,
+  ChevronDoubleRightIcon,
+} from "@heroicons/react/20/solid";
+
+import { CardBasic, Link, LinkProps, Separator } from "@gc-digital-talent/ui";
+
+import useRoutes from "~/hooks/useRoutes";
+import useRequiredParams from "~/hooks/useRequiredParams";
+
+import useNominationNavigation from "./useNominationNavigation";
+
+interface RouteParams extends Record<string, string> {
+  eventId: string;
+  talentNominationGroupId: string;
+}
+
+const messages = defineMessages({
+  nextNomination: {
+    defaultMessage: "Next nomination",
+    id: "7+jEIT",
+    description: "Link label to view next nomination page",
+  },
+  previousNomination: {
+    defaultMessage: "Previous nomination",
+    id: "M0rL3I",
+    description: "Link label to view previous nomination page",
+  },
+  backToAssessments: {
+    defaultMessage: "Back to nominations",
+    id: "TzlRpv",
+    description: "Link label to return to assessment tracker",
+  },
+});
+
+const NominationNavigation = () => {
+  const intl = useIntl();
+  const paths = useRoutes();
+  const { eventId, talentNominationGroupId } = useRequiredParams<RouteParams>([
+    "eventId",
+    "talentNominationGroupId",
+  ]);
+  const nominationNavigation = useNominationNavigation(talentNominationGroupId);
+  if (!nominationNavigation) return null;
+  const { nextNomination, previousNomination, nominationIds } =
+    nominationNavigation;
+
+  const commonLinkProps: LinkProps = {
+    color: "secondary",
+    mode: "inline",
+    block: true,
+    state: { nominationIds },
+    "data-h2-padding": "base(x.75 0)",
+  };
+
+  return (
+    <CardBasic
+      data-h2-display="base(grid)"
+      data-h2-align-items="base(center)"
+      data-h2-grid-template-columns="base(1fr auto 1fr)"
+      data-h2-padding="base(0)"
+    >
+      <span data-h2-flex-shrink="base(0)">
+        {previousNomination && (
+          <Link
+            href={paths.talentNominationGroup(eventId, previousNomination)}
+            icon={ChevronDoubleLeftIcon}
+            aria-label={intl.formatMessage(messages.previousNomination)}
+            {...commonLinkProps}
+          >
+            {intl.formatMessage({
+              defaultMessage: "Previous",
+              id: "Qhl5J9",
+              description: "Link text to navigate to the previous item",
+            })}
+          </Link>
+        )}
+      </span>
+      <Separator
+        orientation="vertical"
+        space="none"
+        decorative
+        data-h2-flex-shrink="base(1)"
+      />
+      <span data-h2-flex-shrink="base(0)">
+        {nextNomination && (
+          <Link
+            href={paths.talentNominationGroup(eventId, nextNomination)}
+            utilityIcon={ChevronDoubleRightIcon}
+            aria-label={intl.formatMessage(messages.nextNomination)}
+            {...commonLinkProps}
+          >
+            {intl.formatMessage({
+              defaultMessage: "Next",
+              id: "FuuXpa",
+              description: "Link text to navigate to the next item",
+            })}
+          </Link>
+        )}
+      </span>
+    </CardBasic>
+  );
+};
+
+export default NominationNavigation;

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/NominationNavigation/NominationNavigation.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/NominationNavigation/NominationNavigation.tsx
@@ -1,10 +1,6 @@
 import { defineMessages, useIntl } from "react-intl";
-import ArrowLeftCircleIcon from "@heroicons/react/20/solid/ArrowLeftCircleIcon";
-import ArrowRightCircleIcon from "@heroicons/react/20/solid/ArrowRightCircleIcon";
-import {
-  ChevronDoubleLeftIcon,
-  ChevronDoubleRightIcon,
-} from "@heroicons/react/20/solid";
+import ChevronDoubleLeftIcon from "@heroicons/react/20/solid/ChevronDoubleLeftIcon";
+import ChevronDoubleRightIcon from "@heroicons/react/20/solid/ChevronDoubleRightIcon";
 
 import { CardBasic, Link, LinkProps, Separator } from "@gc-digital-talent/ui";
 

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/NominationNavigation/useNominationNavigation.ts
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/NominationNavigation/useNominationNavigation.ts
@@ -1,0 +1,44 @@
+import { useLocation } from "react-router";
+
+interface NominationLocation {
+  state?: {
+    nominationIds?: string[];
+  };
+}
+
+type UseNominationNavigationReturn = {
+  nominationIds?: string[];
+  previousNomination?: string;
+  nextNomination?: string;
+  lastNomination?: boolean;
+} | null;
+
+const useNominationNavigation = (
+  nominationId: string,
+): UseNominationNavigationReturn => {
+  const { state } = useLocation() as NominationLocation;
+  if (!state?.nominationIds || !nominationId) return null;
+  const { nominationIds } = state;
+
+  const currentIndex = nominationIds.findIndex((id) => id === nominationId);
+  if (currentIndex < 0) return null;
+
+  const nextNomination = nominationIds[currentIndex + 1];
+  const previousNomination = nominationIds[currentIndex - 1];
+
+  if (currentIndex === 0) {
+    return { nextNomination, nominationIds };
+  }
+
+  if (currentIndex === nominationIds.length - 1) {
+    return {
+      previousNomination,
+      nominationIds,
+      lastNomination: true,
+    };
+  }
+
+  return { previousNomination, nextNomination, nominationIds };
+};
+
+export default useNominationNavigation;


### PR DESCRIPTION
🤖 Resolves #13023 

## 👋 Introduction

Adds next and previous buttons to the nomination group layout sidebar.

## 🧪 Testing

1. Open database and ensure there are more than three talent nomination groups for a specific event
2. Make sure the talent coordinator account is assigned to the community for the event in step 1
3. Build the app `pnpm run dev:fresh`
4. Login as talent coordinator `talent-coordinator@test.com`
5. Navigate to the nominations talent for the event in step 1
6. Click on a name in the table
7. Confirm the next/previous buttons appear in the sidebar and function as expected

## 📸 Screenshot

![2025-04-10_09-00](https://github.com/user-attachments/assets/f760fedc-76af-4bf6-bbcc-b7a4ad81b01d)
