### PR TITLE
[Fix] Removes `CommunityAdmin` from `viewCommunityTalent`

### DIFF
--- a/apps/web/src/constants/permissionConstants.ts
+++ b/apps/web/src/constants/permissionConstants.ts
@@ -37,7 +37,6 @@ const permissionConstants: Readonly<Record<string, RoleName[]>> = {
     ROLE_NAME.PlatformAdmin,
   ],
   viewCommunityTalent: [
-    ROLE_NAME.CommunityAdmin,
     ROLE_NAME.CommunityRecruiter,
     ROLE_NAME.CommunityTalentCoordinator,
   ],


### PR DESCRIPTION
🤖 Resolves #13221.

## 👋 Introduction

This PR removes `CommunityAdmin` role from `viewCommunityTalent` permission group.

## 🧪 Testing

1. Log in as community@test.com
2. Verify community talent link under Recruitment header does not appear

## 📸 Screenshot

<img width="1247" alt="Screen Shot 2025-04-10 at 15 09 47" src="https://github.com/user-attachments/assets/ebd86d30-f791-4f8a-8638-68cf816b526c" />
