### PR TITLE
[Bug] Talent nomination group first or create fix

### DIFF
--- a/api/app/Models/TalentNomination.php
+++ b/api/app/Models/TalentNomination.php
@@ -188,8 +188,10 @@ class TalentNomination extends Model
             if (is_null($this->talent_nomination_group_id)) {
                 // not yet attached to a group
                 $talentNominationGroup = TalentNominationGroup::firstOrCreate(
-                    ['nominee_id' => $this->nominee_id],
-                    ['talent_nomination_event_id' => $this->talent_nomination_event_id],
+                    [
+                        'nominee_id' => $this->nominee_id,
+                        'talent_nomination_event_id' => $this->talent_nomination_event_id,
+                    ],
                 );
 
                 $this->talent_nomination_group_id = $talentNominationGroup->id;


### PR DESCRIPTION
🤖 Resolves #13239 

## 👋 Introduction

Fix the `firstOrCreate()` call

## 🕵️ Details

Tests `testNominationCanCreateNewGroup` and `testNominationCanAttachToExistingGroup` already provided partial coverage

## 🧪 Testing

1. Cannot replicate the issue, so, no nomination event mismatch in the event-group-nomination trio


