### PR TITLE
[Fix] Fallback nominator name on nomination group page

### DIFF
--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/TalentNominationAccordionItem.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/TalentNominationAccordionItem.tsx
@@ -46,6 +46,7 @@ const TalentNominationAccordionItem_Fragment = graphql(/* GraphQL */ `
       includeLeadershipCompetencies
     }
 
+    nominatorFallbackName
     nominator {
       firstName
       lastName
@@ -247,6 +248,17 @@ const TalentNominationAccordionItem = ({
     })) ?? [];
   skillListItems.sort((a, b) => a.label.localeCompare(b.label));
 
+  let nominatorName =
+    talentNomination?.nominatorFallbackName ??
+    intl.formatMessage(commonMessages.notProvided);
+  if (talentNomination?.nominator) {
+    nominatorName = getFullNameLabel(
+      talentNomination.nominator.firstName,
+      talentNomination.nominator.lastName,
+      intl,
+    );
+  }
+
   return (
     <Accordion.Item value={talentNomination.id} {...rest}>
       <Accordion.Trigger as="h3">
@@ -257,11 +269,7 @@ const TalentNominationAccordionItem = ({
             description: "Nomination group accordion trigger title ",
           },
           {
-            name: getFullNameLabel(
-              talentNomination.nominator?.firstName,
-              talentNomination.nominator?.lastName,
-              intl,
-            ),
+            name: nominatorName,
           },
         )}
       </Accordion.Trigger>


### PR DESCRIPTION
🤖 Resolves #13263 

## 👋 Introduction

Fixes the rendering of nominator name on the admin nomination group page when a fallback is provided.

## 🧪 Testing

1. Build the app `pnpm run dev:fresh`
2. Login as admin `admin@test.com`
3. Submit a nomination using the fallback for nominating on someones behalf
4. Give yourself the talent coordinator role for the community of the event you submitted the nomination for
5. Navigate to the admin view of the group for the nomination submitted in step 3
6. Confirm the fallback nominator name is used in the accordion

## 📸 Screenshot

![2025-04-16_11-46](https://github.com/user-attachments/assets/ca25b3d2-52b0-4a58-9d0d-dd757fe8f3e3)
