### PR TITLE
[Bug] Allow viewing own `CommunityInterest.user` field

### DIFF
--- a/api/app/Policies/CommunityInterestPolicy.php
+++ b/api/app/Policies/CommunityInterestPolicy.php
@@ -54,6 +54,11 @@ class CommunityInterestPolicy
      */
     public function viewUser(User $user, CommunityInterest $communityInterest): bool
     {
+        // if it is the user's own community interest, shortcut to allow seeing attached user
+        if (($user->isAbleTo('view-own-employeeProfile') && $user->id === $communityInterest->user_id)) {
+            return true;
+        }
+
         $communityInterest->loadMissing('community.team');
 
         return ! is_null($communityInterest->community->team)


### PR DESCRIPTION
🤖 Resolves #13261

## 👋 Introduction

The other gaps were solved, I think one corner case remains after which things should hopefully all work right

## 🧪 Testing

1. Become a talent coordinator of some community A
2. Submit a community interest in community B, consent to being searchable
3. Access community talent table without issue





