### PR TITLE
[Fix] Nominee count on talent events table

### DIFF
--- a/apps/web/src/pages/TalentEvents/components/TalentEventTable.tsx
+++ b/apps/web/src/pages/TalentEvents/components/TalentEventTable.tsx
@@ -82,8 +82,12 @@ export const TalentEventTable = ({
           id: "KxsYhl",
           description: "Header for Nominations",
         }),
-        cell: ({ row: { id }, getValue }) =>
-          nominationsCell(id, getValue(), routes, intl),
+        cell: ({
+          row: {
+            original: { id },
+          },
+          getValue,
+        }) => nominationsCell(id, getValue(), routes, intl),
         meta: {
           isRowTitle: true,
         },

--- a/apps/web/src/pages/TalentEvents/components/TalentEventTable.tsx
+++ b/apps/web/src/pages/TalentEvents/components/TalentEventTable.tsx
@@ -1,7 +1,7 @@
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { useIntl } from "react-intl";
 
-import { notEmpty } from "@gc-digital-talent/helpers";
+import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 import { Link } from "@gc-digital-talent/ui";
 import {
   graphql,
@@ -15,7 +15,7 @@ import { formatDate, parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import useRoutes from "~/hooks/useRoutes";
 
-import { getNominationCount, nominationsCell, statusCell } from "./helpers";
+import { nominationsCell, statusCell } from "./helpers";
 
 const columnHelper = createColumnHelper<TalentEventTableRowFragment>();
 
@@ -74,7 +74,7 @@ export const TalentEventTable = ({
       },
     }),
     columnHelper.accessor(
-      (row) => getNominationCount(row?.talentNominationGroups ?? null),
+      (row) => unpackMaybes(row?.talentNominationGroups).length,
       {
         id: "nominations",
         header: intl.formatMessage({
@@ -83,13 +83,12 @@ export const TalentEventTable = ({
           description: "Header for Nominations",
         }),
         cell: ({
-          row: {
-            original: { id, talentNominationGroups },
-          },
+          row: { id },
+          getValue
         }) =>
           nominationsCell(
             id,
-            getNominationCount(talentNominationGroups ?? null),
+            getValue(),
             routes,
             intl,
           ),

--- a/apps/web/src/pages/TalentEvents/components/TalentEventTable.tsx
+++ b/apps/web/src/pages/TalentEvents/components/TalentEventTable.tsx
@@ -82,16 +82,8 @@ export const TalentEventTable = ({
           id: "KxsYhl",
           description: "Header for Nominations",
         }),
-        cell: ({
-          row: { id },
-          getValue
-        }) =>
-          nominationsCell(
-            id,
-            getValue(),
-            routes,
-            intl,
-          ),
+        cell: ({ row: { id }, getValue }) =>
+          nominationsCell(id, getValue(), routes, intl),
         meta: {
           isRowTitle: true,
         },

--- a/apps/web/src/pages/TalentEvents/components/helpers.tsx
+++ b/apps/web/src/pages/TalentEvents/components/helpers.tsx
@@ -4,22 +4,10 @@ import { Chip, Color, Link } from "@gc-digital-talent/ui";
 import {
   LocalizedTalentNominationEventStatus,
   Maybe,
-  TalentNomination,
   TalentNominationEventStatus,
 } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
-
-interface TalentNominationGrouping {
-  nominations?: Partial<TalentNomination>[] | null;
-}
-
-export const getNominationCount = (
-  talentNominationGroups?: TalentNominationGrouping[] | null,
-) =>
-  talentNominationGroups?.reduce((acc, i) => {
-    return acc + (i.nominations?.length ?? 0);
-  }, 0) ?? 0;
 
 const getTalentNominationEventStatusColor = (
   talentNominationEventStatus?: Maybe<TalentNominationEventStatus>,


### PR DESCRIPTION
🤖 Resolves #13265 

## 👋 Introduction

Updates the count of nominees on the talent events table to use `TalentNominationGroup` instead of `TalentNomination`. This effectively counts unique nominees instead of individual nominations.

## 🧪 Testing

1. Build app `pnpm run dev:fresh`
2. Login as `talent-coordinator@test.com`
3. Create multiple nomination groups for an event, making sure some contain multiple nominations
4. Navigate to `/admin/talent-events`
5. Confirm the nominations column counts only the groups and not individual nominations

