### PR TITLE
[Fix] Advancement reference fallback not rendering on load

### DIFF
--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
@@ -683,9 +683,7 @@ const Details = ({ detailsQuery, optionsQuery }: DetailsProps) => {
   let defaultReference: Maybe<string> | undefined;
 
   if (referenceSet) {
-    defaultReference = talentNomination.advancementReference?.id
-      ? talentNomination.advancementReference.id
-      : null;
+    defaultReference = talentNomination.advancementReference?.id ?? null;
   }
 
   return (

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
@@ -168,6 +168,7 @@ const DetailsFields = ({
       resetField("advancementReferenceReview");
     }
   }, [advancementReference, resetField]);
+
   return (
     <div
       data-h2-display="base(flex)"
@@ -675,14 +676,25 @@ const Details = ({ detailsQuery, optionsQuery }: DetailsProps) => {
     nominationOptions = [...nominationOptions, "developmentProgram"];
   }
 
+  const referenceSet =
+    !!talentNomination.advancementReference?.id ||
+    !!talentNomination.advancementReferenceFallbackName;
+
+  let defaultReference: Maybe<string> | undefined;
+
+  if (referenceSet) {
+    defaultReference = talentNomination.advancementReference?.id
+      ? talentNomination.advancementReference.id
+      : null;
+  }
+
   return (
     <UpdateForm<FormValues>
       submitDataTransformer={transformSubmitData}
       preSubmitValidation={preSubmitValidation}
       defaultValues={{
         nominationOptions,
-        advancementReference:
-          talentNomination?.advancementReference?.id ?? undefined,
+        advancementReference: defaultReference,
         advancementReferenceReview:
           talentNomination?.advancementReferenceReview?.value,
         advancementReferenceFallbackWorkEmail:


### PR DESCRIPTION
🤖 Resolves #13291 

## 👋 Introduction

Fixes as issue that was causing the fallback being rendered for the advancement reference when the page loads.

## 🧪 Testing

1. Build the app `pnpm run dev:fresh`
2. Login as an employee `applicant-employee@test.com`
3. Start a nomination, continuing to the details page
4. Select "Advancement" as the option
5. Search for a user not in the system for the reference field
6. Enter a fallback
7. Save that step
8. Reload the page
9. Confirm fallback is rendered and displayed as expected
