### PR TITLE
[Copy] Updates `WorkRegionsDetailed` and telework copy

### DIFF
--- a/apps/web/src/components/Profile/components/WorkPreferences/Display.tsx
+++ b/apps/web/src/components/Profile/components/WorkPreferences/Display.tsx
@@ -85,15 +85,7 @@ const Display = ({
           <ul>
             {locations.map((location) => (
               <li key={location.value}>
-                {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
-                {`${intl.formatMessage({
-                  defaultMessage: "I am willing to work in the",
-                  id: "cS73MC",
-                  description:
-                    "Start of sentence describing a users accepted work regions",
-                })} ${intl.formatMessage(
-                  getWorkRegionsDetailed(location.value),
-                )}.`}
+                {intl.formatMessage(getWorkRegionsDetailed(location.value))}
               </li>
             ))}
           </ul>

--- a/apps/web/src/components/Profile/components/WorkPreferences/Display.tsx
+++ b/apps/web/src/components/Profile/components/WorkPreferences/Display.tsx
@@ -92,7 +92,7 @@ const Display = ({
                   description:
                     "Start of sentence describing a users accepted work regions",
                 })} ${intl.formatMessage(
-                  getWorkRegionsDetailed(location.value, false),
+                  getWorkRegionsDetailed(location.value),
                 )}.`}
               </li>
             ))}

--- a/apps/web/src/components/Profile/components/WorkPreferences/FormFields.tsx
+++ b/apps/web/src/components/Profile/components/WorkPreferences/FormFields.tsx
@@ -150,7 +150,7 @@ const FormFields = ({
         </Field.Legend>
         <Checklist
           idPrefix="work-location"
-          legend={labels.locationPreferences}
+          legend={labels.workLocationPreferences}
           name="locationPreferences"
           id="locationPreferences"
           items={localizedEnumToOptions(

--- a/apps/web/src/components/Profile/components/WorkPreferences/utils.ts
+++ b/apps/web/src/components/Profile/components/WorkPreferences/utils.ts
@@ -35,11 +35,6 @@ export const getLabels = (intl: IntlShape) => ({
     id: "ahK7mI",
     description: "Legend for the work location preferences section",
   }),
-  locationPreferences: intl.formatMessage({
-    defaultMessage: "I am willing to work in the…",
-    id: "OhN2Ud",
-    description: "Legend for work regions check list in work preferences form",
-  }),
   locationExemptions: intl.formatMessage({
     defaultMessage:
       "Please indicate if there is a city that you would like to exclude from a region.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5431,10 +5431,6 @@
     "defaultMessage": "Vous êtes à l'aise de partager vos renseignements sur l'équité en matière d'emploi pour des possibilités de recrutement et à des fins de statistiques anonymisées.",
     "description": "Second condition for selecting an employment equity group"
   },
-  "OhN2Ud": {
-    "defaultMessage": "Je consens à travailler dans…",
-    "description": "Legend for work regions check list in work preferences form"
-  },
   "Ok+Ojl": {
     "defaultMessage": "{skill} est défini comme :",
     "description": "Heading for a specific skills definition"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8154,10 +8154,6 @@
     "defaultMessage": "Toute expérience que vous avez ajoutée à votre parcours professionnel et qui met en avant cette compétence peut être gérée dans cette section. Vous pouvez également associer cette compétence à d’autres expériences à l’aide du bouton à cet effet.",
     "description": "Lead-in text describing how to link experiences to a skill"
   },
-  "cS73MC": {
-    "defaultMessage": "Je consens à travailler dans",
-    "description": "Start of sentence describing a users accepted work regions"
-  },
   "cT6KeA": {
     "defaultMessage": "Veuillez choisir une option pour continuer.",
     "description": "Alert message informing user to select an option first in application education page."

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -275,6 +275,10 @@
     "defaultMessage": "Une erreur s’est produite au moment de placer le candidat. Veuillez communiquer avec le personnel de soutien si le problème persiste.",
     "description": "Error message that placing a candidate failed"
   },
+  "8shuWS": {
+    "defaultMessage": "Je consens à travailler à distance.",
+    "description": "The work region of Canada described as Telework."
+  },
   "9QsHXO": {
     "defaultMessage": "Une erreur s’est produite pendant l'attribution de rôles. Veuillez communiquer avec le personnel de soutien si le problème persiste.",
     "description": "Error message for when an error occurs during role assignment"
@@ -335,6 +339,10 @@
     "defaultMessage": "Aucun nom n'a été fourni",
     "description": "Message for when no name value"
   },
+  "BY7pT4": {
+    "defaultMessage": "Je consens à travailler dans la Région de la Colombie-Britannique.",
+    "description": "The work region of Canada described as British Columbia."
+  },
   "C/2HT9": {
     "defaultMessage": "Cette clé de collectivité est déjà utilisé",
     "description": "Error message that the given community key is already in use"
@@ -355,17 +363,9 @@
     "defaultMessage": "Administration des programmes",
     "description": "Full name of abbreviation for PM"
   },
-  "CGNfbu": {
-    "defaultMessage": "Région de l'Ontario (excluant Ottawa)",
-    "description": "The work region of Canada described as Ontario."
-  },
   "CYirJF": {
     "defaultMessage": "Vous devez indiquer le lieu précis en anglais et en français si l'annonce ne vise pas un poste à distance.",
     "description": "Error message that advertisement locations must be filled in English and French."
-  },
-  "ChFxsM": {
-    "defaultMessage": "Région de l'Atlantique (Nouveau-Brunswick, Terre-Neuve-et-Labrador, Nouvelle-Écosse et Île-du-Prince-Édouard)",
-    "description": "The work region of Canada described as Atlantic."
   },
   "CrzH4k": {
     "defaultMessage": "Constamment démontrée comme étant bien développée auprès de tous les publics, même dans des conditions de stress important et dans des situations difficiles. Le comportement est nuancé et adapté à la situation sans s’éloigner de sa valeur fondamentale.",
@@ -398,6 +398,10 @@
   "F6j96P": {
     "defaultMessage": "Refaire",
     "description": "Label for redoing an action in the rich text editor"
+  },
+  "F9efQO": {
+    "defaultMessage": "Je consens à travailler dans la Région de la capitale nationale (Ottawa, en Ontario et Gatineau, au Québec).",
+    "description": "The work region of Canada described as National Capital."
   },
   "FYrmhH": {
     "defaultMessage": "{total, plural, =0 {<strong>0</strong> options disponibles} =1 {<strong>1</strong> option disponible} other { <strong>#</strong> options disponibles}}",
@@ -502,10 +506,6 @@
   "JYpEeW": {
     "defaultMessage": "Français",
     "description": "Name of French language"
-  },
-  "Jpq6MK": {
-    "defaultMessage": "Région de Québec (excluant Gatineau)",
-    "description": "The work region of Canada described as Quebec."
   },
   "JqjYZq": {
     "defaultMessage": "Ce champ est obligatoire. Veuillez inscrire une valeur.",
@@ -651,10 +651,6 @@
     "defaultMessage": "Je ne souhaite pas que quelqu'un me serve de mentor ou mentore.",
     "description": "The mentorship interest described as mentee."
   },
-  "P9roJ7": {
-    "defaultMessage": "Région du Nord (Yukon, Territoires du Nord-Ouest et Nunavut)",
-    "description": "The work region of Canada described as North."
-  },
   "PAXoFY": {
     "defaultMessage": "L’article a été déplacé de {from} à {to}.",
     "description": "Message announced to assistive technology when a repeatable field has moved position"
@@ -671,6 +667,14 @@
     "defaultMessage": "Accepté",
     "description": "Indicates a user has accepted some criteria"
   },
+  "Prrttj": {
+    "defaultMessage": "Je consens à travailler dans la Région de l'Ontario (excluant Ottawa).",
+    "description": "The work region of Canada described as Ontario."
+  },
+  "Q17Nro": {
+    "defaultMessage": "Je consens à travailler dans la Région des Prairies (Manitoba, Saskatchewan, Alberta).",
+    "description": "The work region of Canada described as Prairie."
+  },
   "QP+Skh": {
     "defaultMessage": "J'accepte de faire des heures supplémentaires régulièrement.",
     "description": "The operational requirement described as regular overtime."
@@ -686,6 +690,10 @@
   "QhRU19": {
     "defaultMessage": "Doit posséder un permis de conduire valide ou une mobilité personnelle du degré normalement associé à la possession d'un permis de conduire valide.",
     "description": "The operational requirement described as driver's license."
+  },
+  "QlXPG6": {
+    "defaultMessage": "Je consens à travailler dans la Région du Nord (Yukon, Territoires du Nord-Ouest et Nunavut).",
+    "description": "The work region of Canada described as North."
   },
   "Qn/95I": {
     "defaultMessage": "Équité en matière d'emploi",
@@ -722,6 +730,10 @@
   "S0w3o5": {
     "defaultMessage": "Complet",
     "description": "Simple status label for a complete item"
+  },
+  "S1y92B": {
+    "defaultMessage": "Je consens à travailler dans la Région de l'Atlantique (Nouveau-Brunswick, Terre-Neuve-et-Labrador, Nouvelle-Écosse et Île-du-Prince-Édouard).",
+    "description": "The work region of Canada described as Atlantic."
   },
   "S2BTqm": {
     "defaultMessage": "Un champ obligatoire est vide : Anglais – Note spéciale pour ce processus",
@@ -915,6 +927,10 @@
     "defaultMessage": "Je ne participe à aucun programme de mentorat.",
     "description": "The mentorship status described as not participating."
   },
+  "ZSU242": {
+    "defaultMessage": "Je consens à travailler dans la Région de Québec (excluant Gatineau).",
+    "description": "The work region of Canada described as Quebec."
+  },
   "ZhOciS": {
     "defaultMessage": "Modèles d'offres d'emploi",
     "description": "Name of job advertisement templates page"
@@ -1022,10 +1038,6 @@
   "dwYJOo": {
     "defaultMessage": "Exigences en matière de travail pratique",
     "description": "Title for the applied work experience requirements"
-  },
-  "dxjUnU": {
-    "defaultMessage": "Région de la capitale nationale (Ottawa, en Ontario et Gatineau, au Québec)",
-    "description": "The work region of Canada described as National Capital."
   },
   "dyGR7U": {
     "defaultMessage": "Recherche…",
@@ -1335,10 +1347,6 @@
     "defaultMessage": "Alerte de fermeture",
     "description": "Text for the close button on alerts"
   },
-  "oPhurq": {
-    "defaultMessage": "Région des Prairies (Manitoba, Saskatchewan, Alberta)",
-    "description": "The work region of Canada described as Prairie."
-  },
   "oR0evm": {
     "defaultMessage": "La date doit être égale ou supérieure au {date}",
     "description": "Error message when a date was entered that is less than the minimum required"
@@ -1374,10 +1382,6 @@
   "qmEyxS": {
     "defaultMessage": "Le bassin doit avoir une date de clôture postérieure à aujourd’hui.",
     "description": "Error message that the pool closing date isn't in the future."
-  },
-  "qtJrUr": {
-    "defaultMessage": "Région de la Colombie-Britannique",
-    "description": "The work region of Canada described as British Columbia."
   },
   "qtqJ6q": {
     "defaultMessage": "Compétences",
@@ -1582,10 +1586,6 @@
   "x61BXA": {
     "defaultMessage": "Mars",
     "description": "Name of the third month"
-  },
-  "x8v6Qp": {
-    "defaultMessage": "Virtuel (travail à domicile, partout au Canada)",
-    "description": "The work region of Canada described as Telework."
   },
   "xAxxmc": {
     "defaultMessage": "Oups! Vous avez des erreurs!",

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -215,6 +215,10 @@
     "defaultMessage": "Décision finale relative à l’évaluation",
     "description": "Final assessment decision"
   },
+  "64H+pl": {
+    "defaultMessage": "Je consens à travailler dans la région de Québec (excluant Gatineau).",
+    "description": "The work region of Canada described as Quebec."
+  },
   "6O1sjV": {
     "defaultMessage": "Impossible de mettre à jour – cet identifiant d’utilisateur (sub) est déjà utilisé.",
     "description": "Error message that the given user identifier is already in use when updating."
@@ -339,10 +343,6 @@
     "defaultMessage": "Aucun nom n'a été fourni",
     "description": "Message for when no name value"
   },
-  "BY7pT4": {
-    "defaultMessage": "Je consens à travailler dans la Région de la Colombie-Britannique.",
-    "description": "The work region of Canada described as British Columbia."
-  },
   "C/2HT9": {
     "defaultMessage": "Cette clé de collectivité est déjà utilisé",
     "description": "Error message that the given community key is already in use"
@@ -370,6 +370,10 @@
   "CrzH4k": {
     "defaultMessage": "Constamment démontrée comme étant bien développée auprès de tous les publics, même dans des conditions de stress important et dans des situations difficiles. Le comportement est nuancé et adapté à la situation sans s’éloigner de sa valeur fondamentale.",
     "description": "The behavioural skill level definition for lead"
+  },
+  "D3+nw/": {
+    "defaultMessage": "Je consens à travailler dans la région du Nord (Yukon, Territoires du Nord-Ouest et Nunavut).",
+    "description": "The work region of Canada described as North."
   },
   "DIK7Z1": {
     "defaultMessage": "Une erreur s’est produite dans le téléchargement de votre fichier. Si ce message d’erreur persiste, veuillez communiquer avec l’équipe de soutien.",
@@ -603,6 +607,10 @@
     "defaultMessage": "J'ai un poste doté pour une période déterminée.",
     "description": "Term selection for government employee type."
   },
+  "O5Lq+h": {
+    "defaultMessage": "Je consens à travailler dans la région de l'Atlantique (Nouveau-Brunswick, Terre-Neuve-et-Labrador, Nouvelle-Écosse et Île-du-Prince-Édouard).",
+    "description": "The work region of Canada described as Atlantic."
+  },
   "OAoFzw": {
     "defaultMessage": "Je suis actuellement en train de coacher quelqu'un d'autre.",
     "description": "The executive coaching status described as coaching."
@@ -663,17 +671,13 @@
     "defaultMessage": "La date doit être avant ou égale au {date}",
     "description": "Error message when a date was entered that is greater than the maximum required"
   },
+  "PPSXML": {
+    "defaultMessage": "Je consens à travailler dans la région des Prairies (Manitoba, Saskatchewan, Alberta).",
+    "description": "The work region of Canada described as Prairie."
+  },
   "Pj4lW9": {
     "defaultMessage": "Accepté",
     "description": "Indicates a user has accepted some criteria"
-  },
-  "Prrttj": {
-    "defaultMessage": "Je consens à travailler dans la Région de l'Ontario (excluant Ottawa).",
-    "description": "The work region of Canada described as Ontario."
-  },
-  "Q17Nro": {
-    "defaultMessage": "Je consens à travailler dans la Région des Prairies (Manitoba, Saskatchewan, Alberta).",
-    "description": "The work region of Canada described as Prairie."
   },
   "QP+Skh": {
     "defaultMessage": "J'accepte de faire des heures supplémentaires régulièrement.",
@@ -690,10 +694,6 @@
   "QhRU19": {
     "defaultMessage": "Doit posséder un permis de conduire valide ou une mobilité personnelle du degré normalement associé à la possession d'un permis de conduire valide.",
     "description": "The operational requirement described as driver's license."
-  },
-  "QlXPG6": {
-    "defaultMessage": "Je consens à travailler dans la Région du Nord (Yukon, Territoires du Nord-Ouest et Nunavut).",
-    "description": "The work region of Canada described as North."
   },
   "Qn/95I": {
     "defaultMessage": "Équité en matière d'emploi",
@@ -730,10 +730,6 @@
   "S0w3o5": {
     "defaultMessage": "Complet",
     "description": "Simple status label for a complete item"
-  },
-  "S1y92B": {
-    "defaultMessage": "Je consens à travailler dans la Région de l'Atlantique (Nouveau-Brunswick, Terre-Neuve-et-Labrador, Nouvelle-Écosse et Île-du-Prince-Édouard).",
-    "description": "The work region of Canada described as Atlantic."
   },
   "S2BTqm": {
     "defaultMessage": "Un champ obligatoire est vide : Anglais – Note spéciale pour ce processus",
@@ -926,10 +922,6 @@
   "ZMVV2z": {
     "defaultMessage": "Je ne participe à aucun programme de mentorat.",
     "description": "The mentorship status described as not participating."
-  },
-  "ZSU242": {
-    "defaultMessage": "Je consens à travailler dans la Région de Québec (excluant Gatineau).",
-    "description": "The work region of Canada described as Quebec."
   },
   "ZhOciS": {
     "defaultMessage": "Modèles d'offres d'emploi",
@@ -1579,6 +1571,10 @@
     "defaultMessage": "La compétence que vous avez sélectionnée est déjà reliée à votre profil.",
     "description": "Error message that the skill selected is already linked to the user profile."
   },
+  "wdfDZH": {
+    "defaultMessage": "Je consens à travailler dans la région de la Colombie-Britannique.",
+    "description": "The work region of Canada described as British Columbia."
+  },
   "wqBryV": {
     "defaultMessage": "Tableau de bord du (de la) candidat(e)",
     "description": "Name of applicant dashboard page"
@@ -1586,6 +1582,10 @@
   "x61BXA": {
     "defaultMessage": "Mars",
     "description": "Name of the third month"
+  },
+  "x9dfvs": {
+    "defaultMessage": "Je consens à travailler dans la région de l'Ontario (excluant Ottawa).",
+    "description": "The work region of Canada described as Ontario."
   },
   "xAxxmc": {
     "defaultMessage": "Oups! Vous avez des erreurs!",

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -163,17 +163,9 @@
     "defaultMessage": "Parcourir la bibliothèque de compétences",
     "description": "Name of skill library page"
   },
-  "3agw4G": {
-    "defaultMessage": "<strong> Région de l'Ontario</strong>(excluant Ottawa)",
-    "description": "The work region of Canada described as Ontario."
-  },
   "3e4sM7": {
     "defaultMessage": "Le lieu doit être indiqué ou l’option « À distance » doit être sélectionnée",
     "description": "Error message that the pool advertisement must have location filled."
-  },
-  "3f6YzQ": {
-    "defaultMessage": "<strong> Région de l'Atlantique</strong> (Nouveau-Brunswick, Terre-Neuve-et-Labrador, Nouvelle-Écosse et Île-du-Prince-Édouard).",
-    "description": "La région de travail du Canada décrite comme l'Atlantique."
   },
   "45ZCXX": {
     "defaultMessage": "Options",
@@ -274,10 +266,6 @@
   "7woRF/": {
     "defaultMessage": "Je ne participe à aucun programme de coaching des cadres.",
     "description": "The executive coaching status described as not participating."
-  },
-  "8JxN4A": {
-    "defaultMessage": "<strong> Région de la capitale nationale</strong>(Ottawa, en Ontario et Gatineau, au Québec).",
-    "description": "The work region of Canada described as National Capital."
   },
   "8WC+Ty": {
     "defaultMessage": "La date limite de soumission est passée.",
@@ -935,10 +923,6 @@
     "defaultMessage": "Ce champ requiert des dates ultérieures seulement.",
     "description": "Error message that the provided date must be in the future."
   },
-  "ZoFcYn": {
-    "defaultMessage": "<strong> Région de Québec</strong>(excluant Gatineau)",
-    "description": "The work region of Canada described as Quebec."
-  },
   "ZoYqEo": {
     "defaultMessage": "Date limite",
     "description": "Title for deadline to apply"
@@ -1383,10 +1367,6 @@
     "defaultMessage": "Sélectionnez",
     "description": "Default placeholder shown when Select field has nothing actively selected."
   },
-  "pmoexB": {
-    "defaultMessage": "<strong>Virtuel</strong> (travail à domicile, partout au Canada)",
-    "description": "The work region of Canada described as Telework."
-  },
   "qIOz/5": {
     "defaultMessage": "Demandes",
     "description": "Name of Requests page"
@@ -1491,10 +1471,6 @@
     "defaultMessage": "Tous les types",
     "description": "Select the option to sort or filter by all types"
   },
-  "suvoSt": {
-    "defaultMessage": "<strong> Région des Prairies</strong> (Manitoba, Saskatchewan, Alberta)",
-    "description": "The work region of Canada described as Prairie."
-  },
   "t4F/0R": {
     "defaultMessage": "Un champ obligatoire est vide : Exigence relative à la sécurité",
     "description": "Error message that the pool advertisement must have a security clearance."
@@ -1514,10 +1490,6 @@
   "tW4k56": {
     "defaultMessage": "Un champ obligatoire est vide : Anglais – Votre travail",
     "description": "Error message that Work Tasks in English must be filled"
-  },
-  "tgt0og": {
-    "defaultMessage": "<strong>Région de la Colombie-Britannique</strong>",
-    "description": "The work region of Canada described as British Columbia."
   },
   "tpVujp": {
     "defaultMessage": "Renseignements manquants",
@@ -1542,10 +1514,6 @@
   "ukd1kY": {
     "defaultMessage": "Événements axés sur la gestion des talents",
     "description": "Name of talent management events page"
-  },
-  "us8fY4": {
-    "defaultMessage": "<strong> Région du Nord</strong> (Yukon, Territoires du Nord-Ouest et Nunavut)",
-    "description": "The work region of Canada described as North."
   },
   "uu2OuP": {
     "defaultMessage": "J'accepte d'avoir un emploi dans le cadre duquel je dois détenir un permis de conduire valide ou profiter d'une mobilité personnelle qui est normalement associée à la possession d'un permis de conduire valide.",

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -376,7 +376,7 @@
     "description": "Error message that advertisement locations must be filled in English and French."
   },
   "ChFxsM": {
-    "defaultMessage": "Région de l'Atlantique (Nouveau-Brunswick, Terre-Neuve-et-Labrador, Nouvelle-Écosse et Île-du-Prince-Édouard.)",
+    "defaultMessage": "Région de l'Atlantique (Nouveau-Brunswick, Terre-Neuve-et-Labrador, Nouvelle-Écosse et Île-du-Prince-Édouard)",
     "description": "The work region of Canada described as Atlantic."
   },
   "CrzH4k": {
@@ -1040,7 +1040,7 @@
     "description": "Title for the applied work experience requirements"
   },
   "dxjUnU": {
-    "defaultMessage": "Région de la capitale nationale (Ottawa, en Ontario et Gatineau, au Québec.)",
+    "defaultMessage": "Région de la capitale nationale (Ottawa, en Ontario et Gatineau, au Québec)",
     "description": "The work region of Canada described as National Capital."
   },
   "dyGR7U": {
@@ -1352,7 +1352,7 @@
     "description": "Text for the close button on alerts"
   },
   "oPhurq": {
-    "defaultMessage": "Région des Prairies (Manitoba, Saskatchewan, Alberta.)",
+    "defaultMessage": "Région des Prairies (Manitoba, Saskatchewan, Alberta)",
     "description": "The work region of Canada described as Prairie."
   },
   "oR0evm": {
@@ -1384,7 +1384,7 @@
     "description": "Default placeholder shown when Select field has nothing actively selected."
   },
   "pmoexB": {
-    "defaultMessage": "<strong> Virtuel</strong>  (travail à domicile, partout au Canada.)",
+    "defaultMessage": "<strong>Virtuel</strong> (travail à domicile, partout au Canada)",
     "description": "The work region of Canada described as Telework."
   },
   "qIOz/5": {
@@ -1492,7 +1492,7 @@
     "description": "Select the option to sort or filter by all types"
   },
   "suvoSt": {
-    "defaultMessage": "<strong> Région des Prairies</strong> (Manitoba, Saskatchewan, Alberta.)",
+    "defaultMessage": "<strong> Région des Prairies</strong> (Manitoba, Saskatchewan, Alberta)",
     "description": "The work region of Canada described as Prairie."
   },
   "t4F/0R": {
@@ -1544,7 +1544,7 @@
     "description": "Name of talent management events page"
   },
   "us8fY4": {
-    "defaultMessage": "<strong> Région du Nord</strong> (Yukon, Territoires du Nord-Ouest et Nunavut.)",
+    "defaultMessage": "<strong> Région du Nord</strong> (Yukon, Territoires du Nord-Ouest et Nunavut)",
     "description": "The work region of Canada described as North."
   },
   "uu2OuP": {
@@ -1616,7 +1616,7 @@
     "description": "Name of the third month"
   },
   "x8v6Qp": {
-    "defaultMessage": "Virtuel (travail à domicile, partout au Canada.)",
+    "defaultMessage": "Virtuel (travail à domicile, partout au Canada)",
     "description": "The work region of Canada described as Telework."
   },
   "xAxxmc": {

--- a/packages/i18n/src/messages/localizedConstants.tsx
+++ b/packages/i18n/src/messages/localizedConstants.tsx
@@ -280,7 +280,7 @@ export const getEmploymentDuration = (
   );
 };
 
-const workRegionsDetailedNoBold = defineMessages({
+const workRegionsDetailed = defineMessages({
   [WorkRegion.Telework]: {
     defaultMessage: "Virtual (work from home, anywhere in Canada)",
     id: "x8v6Qp",
@@ -329,7 +329,7 @@ export const getWorkRegionsDetailed = (
   workRegionId: string | number,
 ): MessageDescriptor =>
   getOrDisplayError(
-    workRegionsDetailedNoBold,
+    workRegionsDetailed,
     workRegionId,
     `Invalid Work Region '${workRegionId}'`,
   );

--- a/packages/i18n/src/messages/localizedConstants.tsx
+++ b/packages/i18n/src/messages/localizedConstants.tsx
@@ -378,7 +378,7 @@ export const getWorkRegionsDetailed = (
   showBold = true,
 ): MessageDescriptor =>
   getOrDisplayError(
-    showBold ? workRegionsDetailed : workRegionsDetailedNoBold,
+    workRegionsDetailedNoBold,
     workRegionId,
     `Invalid Work Region '${workRegionId}'`,
   );

--- a/packages/i18n/src/messages/localizedConstants.tsx
+++ b/packages/i18n/src/messages/localizedConstants.tsx
@@ -375,7 +375,6 @@ const workRegionsDetailedNoBold = defineMessages({
 
 export const getWorkRegionsDetailed = (
   workRegionId: string | number,
-  showBold = true,
 ): MessageDescriptor =>
   getOrDisplayError(
     workRegionsDetailedNoBold,

--- a/packages/i18n/src/messages/localizedConstants.tsx
+++ b/packages/i18n/src/messages/localizedConstants.tsx
@@ -280,54 +280,6 @@ export const getEmploymentDuration = (
   );
 };
 
-const workRegionsDetailed = defineMessages({
-  [WorkRegion.Telework]: {
-    defaultMessage:
-      "<strong>Virtual</strong> (work from home, anywhere in Canada)",
-    id: "pmoexB",
-    description: "The work region of Canada described as Telework.",
-  },
-  [WorkRegion.NationalCapital]: {
-    defaultMessage:
-      "<strong>National Capital Region</strong> (Ottawa, Ontario and Gatineau, Quebec)",
-    id: "8JxN4A",
-    description: "The work region of Canada described as National Capital.",
-  },
-  [WorkRegion.Atlantic]: {
-    defaultMessage:
-      "<strong>Atlantic Region</strong> (New Brunswick, Newfoundland and Labrador, Nova Scotia and Prince Edward Island)",
-    id: "3f6YzQ",
-    description: "The work region of Canada described as Atlantic.",
-  },
-  [WorkRegion.Quebec]: {
-    defaultMessage: "<strong>Quebec Region</strong> (excluding Gatineau)",
-    id: "ZoFcYn",
-    description: "The work region of Canada described as Quebec.",
-  },
-  [WorkRegion.Ontario]: {
-    defaultMessage: "<strong>Ontario Region</strong> (excluding Ottawa)",
-    id: "3agw4G",
-    description: "The work region of Canada described as Ontario.",
-  },
-  [WorkRegion.Prairie]: {
-    defaultMessage:
-      "<strong>Prairie Region</strong> (Manitoba, Saskatchewan, Alberta)",
-    id: "suvoSt",
-    description: "The work region of Canada described as Prairie.",
-  },
-  [WorkRegion.BritishColumbia]: {
-    defaultMessage: "<strong>British Columbia Region</strong>",
-    id: "tgt0og",
-    description: "The work region of Canada described as British Columbia.",
-  },
-  [WorkRegion.North]: {
-    defaultMessage:
-      "<strong>North Region</strong> (Yukon, Northwest Territories and Nunavut)",
-    id: "us8fY4",
-    description: "The work region of Canada described as North.",
-  },
-});
-
 const workRegionsDetailedNoBold = defineMessages({
   [WorkRegion.Telework]: {
     defaultMessage: "Virtual (work from home, anywhere in Canada)",

--- a/packages/i18n/src/messages/localizedConstants.tsx
+++ b/packages/i18n/src/messages/localizedConstants.tsx
@@ -294,37 +294,37 @@ const workRegionsDetailed = defineMessages({
   },
   [WorkRegion.Atlantic]: {
     defaultMessage:
-      "I am willing to work in the Atlantic Region (New Brunswick, Newfoundland and Labrador, Nova Scotia and Prince Edward Island).",
-    id: "S1y92B",
+      "I am willing to work in the Atlantic region (New Brunswick, Newfoundland and Labrador, Nova Scotia and Prince Edward Island).",
+    id: "O5Lq+h",
     description: "The work region of Canada described as Atlantic.",
   },
   [WorkRegion.Quebec]: {
     defaultMessage:
-      "I am willing to work in the Quebec Region (excluding Gatineau).",
-    id: "ZSU242",
+      "I am willing to work in the Quebec region (excluding Gatineau).",
+    id: "64H+pl",
     description: "The work region of Canada described as Quebec.",
   },
   [WorkRegion.Ontario]: {
     defaultMessage:
-      "I am willing to work in the Ontario Region (excluding Ottawa).",
-    id: "Prrttj",
+      "I am willing to work in the Ontario region (excluding Ottawa).",
+    id: "x9dfvs",
     description: "The work region of Canada described as Ontario.",
   },
   [WorkRegion.Prairie]: {
     defaultMessage:
-      "I am willing to work in the Prairie Region (Manitoba, Saskatchewan, Alberta).",
-    id: "Q17Nro",
+      "I am willing to work in the Prairie region (Manitoba, Saskatchewan, Alberta).",
+    id: "PPSXML",
     description: "The work region of Canada described as Prairie.",
   },
   [WorkRegion.BritishColumbia]: {
-    defaultMessage: "I am willing to work in the British Columbia Region.",
-    id: "BY7pT4",
+    defaultMessage: "I am willing to work in the British Columbia region.",
+    id: "wdfDZH",
     description: "The work region of Canada described as British Columbia.",
   },
   [WorkRegion.North]: {
     defaultMessage:
-      "I am willing to work in the North Region (Yukon, Northwest Territories and Nunavut).",
-    id: "QlXPG6",
+      "I am willing to work in the North region (Yukon, Northwest Territories and Nunavut).",
+    id: "D3+nw/",
     description: "The work region of Canada described as North.",
   },
 });

--- a/packages/i18n/src/messages/localizedConstants.tsx
+++ b/packages/i18n/src/messages/localizedConstants.tsx
@@ -282,45 +282,49 @@ export const getEmploymentDuration = (
 
 const workRegionsDetailed = defineMessages({
   [WorkRegion.Telework]: {
-    defaultMessage: "Virtual (work from home, anywhere in Canada)",
-    id: "x8v6Qp",
+    defaultMessage: "I am willing to work remotely.",
+    id: "8shuWS",
     description: "The work region of Canada described as Telework.",
   },
   [WorkRegion.NationalCapital]: {
     defaultMessage:
-      "National Capital Region (Ottawa, Ontario and Gatineau, Quebec)",
-    id: "dxjUnU",
+      "I am willing to work in the National Capital Region (Ottawa, Ontario and Gatineau, Quebec).",
+    id: "F9efQO",
     description: "The work region of Canada described as National Capital.",
   },
   [WorkRegion.Atlantic]: {
     defaultMessage:
-      "Atlantic Region (New Brunswick, Newfoundland and Labrador, Nova Scotia and Prince Edward Island)",
-    id: "ChFxsM",
+      "I am willing to work in the Atlantic Region (New Brunswick, Newfoundland and Labrador, Nova Scotia and Prince Edward Island).",
+    id: "S1y92B",
     description: "The work region of Canada described as Atlantic.",
   },
   [WorkRegion.Quebec]: {
-    defaultMessage: "Quebec Region (excluding Gatineau)",
-    id: "Jpq6MK",
+    defaultMessage:
+      "I am willing to work in the Quebec Region (excluding Gatineau).",
+    id: "ZSU242",
     description: "The work region of Canada described as Quebec.",
   },
   [WorkRegion.Ontario]: {
-    defaultMessage: "Ontario Region (excluding Ottawa)",
-    id: "CGNfbu",
+    defaultMessage:
+      "I am willing to work in the Ontario Region (excluding Ottawa).",
+    id: "Prrttj",
     description: "The work region of Canada described as Ontario.",
   },
   [WorkRegion.Prairie]: {
-    defaultMessage: "Prairie Region (Manitoba, Saskatchewan, Alberta)",
-    id: "oPhurq",
+    defaultMessage:
+      "I am willing to work in the Prairie Region (Manitoba, Saskatchewan, Alberta).",
+    id: "Q17Nro",
     description: "The work region of Canada described as Prairie.",
   },
   [WorkRegion.BritishColumbia]: {
-    defaultMessage: "British Columbia Region",
-    id: "qtJrUr",
+    defaultMessage: "I am willing to work in the British Columbia Region.",
+    id: "BY7pT4",
     description: "The work region of Canada described as British Columbia.",
   },
   [WorkRegion.North]: {
-    defaultMessage: "North Region (Yukon, Northwest Territories and Nunavut)",
-    id: "P9roJ7",
+    defaultMessage:
+      "I am willing to work in the North Region (Yukon, Northwest Territories and Nunavut).",
+    id: "QlXPG6",
     description: "The work region of Canada described as North.",
   },
 });


### PR DESCRIPTION
🤖 Resolves #13283.

## 👋 Introduction

This PR updates how the telework statement reads in both English and French; fixes some copy syntax; and removes unused copy and a function argument.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/applicant/personal-information#work-preferences-section
3. Check all Work location preferences checkboxes and save form
4. Verify copy in English
5. Switch to French
6. Verify copy in French

## 📸 Screenshots

### French
<img width="1155" alt="Screen Shot 2025-04-22 at 15 15 12" src="https://github.com/user-attachments/assets/1d79c924-7d76-4e6c-a156-472b2fbca85b" />

<img width="1122" alt="Screen Shot 2025-04-22 at 12 59 41" src="https://github.com/user-attachments/assets/ab777066-df88-4154-ad50-f7a887a650de" />

### English

<img width="1127" alt="Screen Shot 2025-04-22 at 15 14 56" src="https://github.com/user-attachments/assets/5aca8c52-92c0-4ec2-9c09-4dc74b6db7f8" />

<img width="1191" alt="Screen Shot 2025-04-22 at 13 00 05" src="https://github.com/user-attachments/assets/223170b8-7cc8-4198-a9ef-9beb64991a03" />
