### PR TITLE
[Copy] Updates Subtitle for nomination rationale step

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1255,10 +1255,6 @@
     "defaultMessage": "Croissance",
     "description": "Talent portal strategy item 2 heading"
   },
-  "43Tiyp": {
-    "defaultMessage": "La dernière étape du processus de nomination consiste à expliquer pourquoi la personne candidate est nommée. Si vous avez proposé la candidature d'un cadre ou d'un membre du personnel de niveau équivalent, veuillez également indiquer les trois principales compétences en matière de leadership dont la personne a fait preuve.",
-    "description": "Subtitle for nomination rationale step"
-  },
   "43VEQA": {
     "defaultMessage": "Le profil linguistique a été mis à jour avec succès!",
     "description": "Message displayed when a user successfully updates their language profile."
@@ -8297,6 +8293,10 @@
   "d1FYv4": {
     "defaultMessage": "Classification",
     "description": "Label displayed on Work Experience card for classification"
+  },
+  "d1gdaZ": {
+    "defaultMessage": "La dernière étape du processus de nomination consiste à expliquer pourquoi la personne candidate est nommée. Veuillez également indiquer les trois principales compétences en matière de leadership dont la personne a fait preuve.",
+    "description": "Subtitle for nomination rationale step"
   },
   "d3HIMV": {
     "defaultMessage": "Renseignez-vous sur CléGC et trouvez des liens vers des renseignements sur les comptes.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2555,6 +2555,10 @@
     "defaultMessage": "Votre objectif de carrière",
     "description": "Title for a users career objective"
   },
+  "AJ9XL4": {
+    "defaultMessage": "La dernière étape du processus de nomination consiste à expliquer pourquoi la personne candidate est nommée. Veuillez également indiquer les trois principales compétences en matière de leadership dont la personne a fait preuve.",
+    "description": "Subtitle for nomination rationale step with leadership competencies"
+  },
   "AJXRC6": {
     "defaultMessage": "Les données que vous fournissez ici seront vérifiées. Vous pouvez ajouter tous les processus et bassins dans lesquels vous êtes qualifiée ou qualifié. Dans la mesure du possible, fournissez les renseignements suivants :",
     "description": "Explanation of dialog"
@@ -8294,10 +8298,6 @@
     "defaultMessage": "Classification",
     "description": "Label displayed on Work Experience card for classification"
   },
-  "d1gdaZ": {
-    "defaultMessage": "La dernière étape du processus de nomination consiste à expliquer pourquoi la personne candidate est nommée. Veuillez également indiquer les trois principales compétences en matière de leadership dont la personne a fait preuve.",
-    "description": "Subtitle for nomination rationale step"
-  },
   "d3HIMV": {
     "defaultMessage": "Renseignez-vous sur CléGC et trouvez des liens vers des renseignements sur les comptes.",
     "description": "Introductory text displayed in login and authentication accordion."
@@ -9985,6 +9985,10 @@
   "kY05h1": {
     "defaultMessage": "L'annonce à l’échelle du site a été mise à jour avec succès!",
     "description": "Message displayed when a user successfully updates sitewide announcement information"
+  },
+  "kYuVEA": {
+    "defaultMessage": "La dernière étape du processus de nomination consiste à expliquer pourquoi la personne candidate est nommée.",
+    "description": "Subtitle for nomination rationale step without leadership competencies"
   },
   "kbMB6R": {
     "defaultMessage": "Lieu de travail et terminologie",

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Rationale.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Rationale.tsx
@@ -104,8 +104,8 @@ const Rationale = ({ rationaleQuery, skillsQuery }: RationaleProps) => {
       <p data-h2-margin="base(x1 0)">
         {intl.formatMessage({
           defaultMessage:
-            "The final step in the nomination process is to explain why this candidate is being nominated. If you've nominated an executive or equivalent level employee, please also provide the top 3 key leadership competencies demonstrated by the nominee.",
-          id: "43Tiyp",
+            "The final step in the nomination process is to explain why this candidate is being nominated. Please also provide the top 3 key leadership competencies demonstrated by the nominee.",
+          id: "d1gdaZ",
           description: "Subtitle for nomination rationale step",
         })}
       </p>

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Rationale.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Rationale.tsx
@@ -102,12 +102,21 @@ const Rationale = ({ rationaleQuery, skillsQuery }: RationaleProps) => {
         {intl.formatMessage(messages.rationale)}
       </SubHeading>
       <p data-h2-margin="base(x1 0)">
-        {intl.formatMessage({
-          defaultMessage:
-            "The final step in the nomination process is to explain why this candidate is being nominated. Please also provide the top 3 key leadership competencies demonstrated by the nominee.",
-          id: "d1gdaZ",
-          description: "Subtitle for nomination rationale step",
-        })}
+        {talentNomination?.talentNominationEvent.includeLeadershipCompetencies
+          ? intl.formatMessage({
+              defaultMessage:
+                "The final step in the nomination process is to explain why this candidate is being nominated. Please also provide the top 3 key leadership competencies demonstrated by the nominee.",
+              id: "AJ9XL4",
+              description:
+                "Subtitle for nomination rationale step with leadership competencies",
+            })
+          : intl.formatMessage({
+              defaultMessage:
+                "The final step in the nomination process is to explain why this candidate is being nominated.",
+              id: "kYuVEA",
+              description:
+                "Subtitle for nomination rationale step without leadership competencies",
+            })}
       </p>
       <div
         data-h2-display="base(flex)"


### PR DESCRIPTION
🤖 Resolves #13304.

## 👋 Introduction

This PR updates the English and French subtitle for nomination rationale step copy for each of the cases where the talent event is `includeLeadershipCompetencies` is `true` and `false`.

## 🧪 Testing

> [!TIP]
> Toggle the `includeLeadershipCompetencies` boolean value in the `talent_nomination_events` table to see both cases 

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/communities/talent-events
3. Create a nomination
4. Navigate to Step 6
5. Verify copy is updated as per linked issue
6. Switch to French
7. Verify copy is updated as per linked issue

## 📸 Screenshots

### includeLeadershipCompetencies = `false`
<img width="1275" alt="Screen Shot 2025-04-24 at 10 20 54" src="https://github.com/user-attachments/assets/b3e071dd-553a-4f42-9d4b-2df07f7b6b23" />

<img width="1278" alt="Screen Shot 2025-04-24 at 10 21 09" src="https://github.com/user-attachments/assets/c8d58fdc-e734-4a25-8018-70d12078b60e" />


### includeLeadershipCompetencies = `true`
<img width="1272" alt="Screen Shot 2025-04-24 at 10 15 00" src="https://github.com/user-attachments/assets/0c36cc3a-b008-405c-8e27-3ce9e9cc53f7" />

<img width="1265" alt="Screen Shot 2025-04-24 at 10 15 17" src="https://github.com/user-attachments/assets/184c49d8-81a6-4b7e-a60f-f27823b3fb6d" />
