### PR TITLE
[Copy] Updates description for active events section

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5699,10 +5699,6 @@
     "defaultMessage": "Ce que nous entendons",
     "description": "Heading for the quotes sections"
   },
-  "Pva73v": {
-    "defaultMessage": "Les événements présentés dans cette section acceptent actuellement des mises en candidature. Le lien « En savoir plus » figurant sur chaque carte d'événement permet d'obtenir des informations détaillées sur les exigences et les critères d'admissibilité.",
-    "description": "Description for active events section"
-  },
   "PwB71+": {
     "defaultMessage": "Veuillez sélectionner une ou plusieurs options de nomination pour continuer.",
     "description": "Null message displayed when no nomination options are selected on details step"
@@ -11165,6 +11161,10 @@
   "qD0lyZ": {
     "defaultMessage": "Le niveau « A » est le niveau le moins élevé en matière de bilinguisme et indique un niveau débutant.",
     "description": "Proficiency level on language requirements dialog"
+  },
+  "qEU5rz": {
+    "defaultMessage": "Les événements présentés dans cette section acceptent actuellement des mises en candidature.",
+    "description": "Description for active events section"
   },
   "qEvJjr": {
     "defaultMessage": "Afin de garantir que le programme reste accessible aux peuples autochtones du Canada, vous devez remplir le formulaire d’auto-déclaration des peuples autochtones et confirmer que vous êtes membre d’une ou plusieurs des communautés autochtones du Canada.",

--- a/apps/web/src/pages/TalentManagementEventsPage/TalentManagementEventsPage.tsx
+++ b/apps/web/src/pages/TalentManagementEventsPage/TalentManagementEventsPage.tsx
@@ -102,8 +102,8 @@ export const Component = () => {
               <p data-h2-margin="base(x1 0)">
                 {intl.formatMessage({
                   defaultMessage:
-                    'Events found in this section are currently accepting nominations. Use the "Learn more" link on each event card to find details outlining eligibility criteria and requirements.',
-                  id: "Pva73v",
+                    "Events found in this section are currently accepting nominations.",
+                  id: "qEU5rz",
                   description: "Description for active events section",
                 })}
               </p>


### PR DESCRIPTION
🤖 Resolves #13304.

## 👋 Introduction

This PR updates the English and French description for active events section copy.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/communities/talent-events
3. Verify copy is updated as per linked issue

## 📸 Screenshots
<img width="1285" alt="Screen Shot 2025-04-24 at 11 04 20" src="https://github.com/user-attachments/assets/aca3ebce-6627-468e-808e-d25b2e0009a2" />
<img width="1278" alt="Screen Shot 2025-04-24 at 11 04 31" src="https://github.com/user-attachments/assets/ff6cb86e-6022-44b7-ad8d-9419686a3343" />

