### PR TITLE
[Fix] Toast dark mode dismiss colour

### DIFF
--- a/packages/toast/src/components/Toast/Toast.stories.tsx
+++ b/packages/toast/src/components/Toast/Toast.stories.tsx
@@ -58,6 +58,7 @@ const Template = () => {
       );
       toast.success("Toast success text", { autoClose: false });
       toast.warning("Toast warning text", { autoClose: false });
+      toast.error("Toast error text", { autoClose: false });
     }, 100);
   }, []);
   return <Toast />;

--- a/packages/toast/src/components/Toast/styles.ts
+++ b/packages/toast/src/components/Toast/styles.ts
@@ -5,31 +5,31 @@ const closeButtonStyles: Record<TypeOptions, Record<string, string>> = {
     "data-h2-background-color":
       "base(transparent) base:hover(black.lightest) base:focus-visible(focus.light)",
     "data-h2-color":
-      "base:(inherit) base:hover(black.darker)  base:focus-visible(black)",
+      "base(inherit) base:dark(black.darkest) base:hover(black.darker) base:focus-visible(black) p-tablet:dark(inherit)",
   },
   success: {
     "data-h2-background-color":
       "base(transparent) base:hover(success.lightest) base:focus-visible(focus.light)",
     "data-h2-color":
-      "base:(inherit) base:hover(success.darker)  base:focus-visible(black)",
+      "base(inherit) base:dark(success.darkest) base:hover(success.darker) base:focus-visible(black) p-tablet:dark(inherit)",
   },
   warning: {
     "data-h2-background-color":
       "base(transparent) base:hover(warning.lightest) base:focus-visible(focus.light)",
     "data-h2-color":
-      "base:(inherit) base:hover(warning.darker)  base:focus-visible(black)",
+      "base(inherit) base:dark(warning.darkest) base:hover(warning.darker) base:focus-visible(black) p-tablet:dark(inherit)",
   },
   info: {
     "data-h2-background-color":
       "base(transparent) base:hover(secondary.lightest) base:focus-visible(focus.light)",
     "data-h2-color":
-      "base:(inherit) base:hover(secondary.darker)  base:focus-visible(black)",
+      "base(inherit) base:dark(secondary.darkest) base:hover(secondary.darker) base:focus-visible(black) p-tablet:dark(inherit)",
   },
   error: {
     "data-h2-background-color":
       "base(transparent) base:hover(tertiary.lightest) base:focus-visible(focus.light)",
     "data-h2-color":
-      "base:(inherit) base:hover(tertiary.darker)  base:focus-visible(black)",
+      "base:(inherit) base:dark(tertiary.darkest) base:hover(tertiary.darker) base:focus-visible(black) p-tablet:dark(inherit)",
   },
 };
 


### PR DESCRIPTION
🤖 Resolves #13334.

## 👋 Introduction

This PR updates the Toast component dismiss icon colour on smaller width screens to improve colour contrast. It also adds a toast.error to the Toast storybook story.

## 🧪 Testing

1. `pnpm storybook`
2. Verify Toast component dismiss icon colour meets minimum colour contrast standards

## 📸 Screenshot

<img width="853" alt="Screen Shot 2025-04-25 at 09 52 05" src="https://github.com/user-attachments/assets/d33c087a-84a0-453f-bbf9-29d987229e75" />