### PR TITLE
[Bug] Fix duplicate submit for multiple submissions - assessment decision dialog

### DIFF
--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -361,6 +361,8 @@ export const ScreeningDecisionDialog = ({
     skill: poolSkill?.skill,
   });
 
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
   const parsedSnapshot = JSON.parse(
     String(poolCandidate.profileSnapshot),
   ) as Maybe<User>;
@@ -511,7 +513,15 @@ export const ScreeningDecisionDialog = ({
             <SupportingEvidence experiences={experiences} skill={skill} />
           )}
           <BasicForm
-            onSubmit={onSubmit}
+            onSubmit={async (values) => {
+              if (isSubmitting) return; // Prevent double submission
+              setIsSubmitting(true);
+              try {
+                await onSubmit(values);
+              } finally {
+                setIsSubmitting(false);
+              }
+            }}
             labels={labels}
             options={{
               defaultValues: initialValues ?? defaultValues,


### PR DESCRIPTION
🤖 Resolves #13298

👋 Introduction

This fix ensures that only one submission can happen at a time. It prevents users from submitting the screening decision form multiple times while a create or update mutation is in progress.  Previously user's could click the `Save decision` button multiple times which resulted in multiple submissions to the database.

🧪 Testing

1. Log in as `admin@test.com`
2. Navigate to a pool candidate
3. Click on an assessment
4. Rapidly click `Save decision`
5. Observe that multiple submissions are no longer occurring

