### PR TITLE
[Debt] Removes `pools` GraphQL query

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1301,10 +1301,6 @@ type Query {
   ): [Pool!]!
     @all(scopes: ["wherePublished", "whereNotArchived"])
     @canModel(ability: "viewAnyPublished", model: "Pool")
-  pools: [Pool]!
-    @all(scopes: ["authorizedToView", "whereNotArchived"])
-    @canResolved(ability: "view")
-    @deprecated(reason: "pools is deprecated. Use poolsPaginated instead.")
   poolsPaginated(
     includeIds: [UUID!] @in(key: "id")
     excludeIds: [UUID!] @notIn(key: "id")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -366,7 +366,6 @@ type Query {
   countApplicants(where: ApplicantFilterInput): Int!
   pool(id: UUID!): Pool
   publishedPools(closingAfter: DateTime, publishingGroup: PublishingGroup): [Pool!]!
-  pools: [Pool]! @deprecated(reason: "pools is deprecated. Use poolsPaginated instead.")
   poolCandidate(id: UUID!): PoolCandidate
   countPoolCandidatesByPool(where: ApplicantFilterInput): [CandidateSearchPoolResult!]!
   classification(id: UUID!): Classification


### PR DESCRIPTION
🤖 Resolves #12669.

## 👋 Introduction

This PR removes the deprecated and unused `pools` GraphQL query.

## 🧪 Testing

1. `make refresh-api; make seed-fresh; pnpm i; pnpm build:fresh;`
2. Verify there are no references to the `pools` GraphQL query in the codebase