### PR TITLE
[Debt] Removes `genericJobTitle` GraphQL query

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1397,9 +1397,6 @@ type Query {
   skills(families: [String!] @scope): [Skill]!
     @all
     @canModel(ability: "viewAny")
-  genericJobTitle(id: UUID! @eq): GenericJobTitle
-    @find
-    @canModel(ability: "view")
   genericJobTitles: [GenericJobTitle]! @all @canModel(ability: "viewAny")
 
   community(id: UUID! @eq): Community @find @canQuery(ability: "view")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -380,7 +380,6 @@ type Query {
   skillFamilies: [SkillFamily]!
   skill(id: UUID!): Skill
   skills(families: [String!]): [Skill]!
-  genericJobTitle(id: UUID!): GenericJobTitle
   genericJobTitles: [GenericJobTitle]!
   community(id: UUID!): Community
   communities: [Community]!

--- a/api/tests/Feature/GenericJobTitleTest.php
+++ b/api/tests/Feature/GenericJobTitleTest.php
@@ -69,29 +69,4 @@ class GenericJobTitleTest extends TestCase
             ->graphQL('query { genericJobTitles { id } }')
             ->assertJsonFragment(['id' => $this->genericJobTitle->id]);
     }
-
-    /**
-     * Test base user can view any
-     *
-     * @return void
-     */
-    public function testViewGenericJobTitle()
-    {
-
-        $variables = ['id' => $this->genericJobTitle->id];
-
-        $query =
-            /** @lang GraphQL */
-            '
-            query Get($id: UUID!) {
-                genericJobTitle(id: $id) {
-                    id
-                }
-            }
-        ';
-
-        $this->actingAs($this->baseUser, 'api')
-            ->graphQL($query, $variables)
-            ->assertJsonFragment($variables);
-    }
 }


### PR DESCRIPTION
🤖 Resolves #12671.

## 👋 Introduction

This PR removes the (nearly and now) unused `genericJobTitle` GraphQL query.

## 🧪 Testing

1. `make refresh-api; make seed-fresh; pnpm i; pnpm build:fresh;`
2. Verify there are no references to the `genericJobTitle` GraphQL query in the codebase
3. Verify there are no references to the `testViewGenericJobTitle` function in the codebase