### PR TITLE
[Debt] Removes `deletePoolCandidateSearchRequest ` GraphQL mutation

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -2901,12 +2901,6 @@ type Mutation {
     @update
     @guard
     @canFind(ability: "update", find: "id")
-  deletePoolCandidateSearchRequest(
-    id: ID! @whereKey
-  ): PoolCandidateSearchRequest
-    @delete
-    @guard
-    @canFind(ability: "delete", find: "id")
 
   createSkillFamily(skillFamily: CreateSkillFamilyInput! @spread): SkillFamily
     @create

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -522,7 +522,6 @@ type Mutation {
   deleteDepartment(id: ID!): Department
   createPoolCandidateSearchRequest(poolCandidateSearchRequest: CreatePoolCandidateSearchRequestInput!): PoolCandidateSearchRequest
   updatePoolCandidateSearchRequest(id: ID!, poolCandidateSearchRequest: UpdatePoolCandidateSearchRequestInput!): PoolCandidateSearchRequest
-  deletePoolCandidateSearchRequest(id: ID!): PoolCandidateSearchRequest
   createSkillFamily(skillFamily: CreateSkillFamilyInput!): SkillFamily
   updateSkillFamily(id: ID!, skillFamily: UpdateSkillFamilyInput!): SkillFamily
   createSkill(skill: CreateSkillInput!): Skill

--- a/api/tests/Feature/PoolCandidateSearchRequestTest.php
+++ b/api/tests/Feature/PoolCandidateSearchRequestTest.php
@@ -182,18 +182,8 @@ class PoolCandidateSearchRequestTest extends TestCase
                 }
             }
         ';
-        $mutationDeleteSearchRequest =
-            /** @lang GraphQL */
-            '
-            mutation deletePoolCandidateSearchRequest($id: ID!) {
-                deletePoolCandidateSearchRequest(id: $id) {
-                    id
-                }
-            }
-        ';
 
         $whereSearchRequest1 = ['id' => $searchRequest1->id];
-        $whereSearchRequest2 = ['id' => $searchRequest2->id];
         $whereUpdateSearchRequest1 = [
             'id' => $searchRequest1->id,
             'poolCandidateSearchRequest' => [
@@ -228,19 +218,6 @@ class PoolCandidateSearchRequestTest extends TestCase
             ->assertJsonFragment(['adminNotes' => 'hardcoded message here']);
         $this->actingAs($communityRecruiter, 'api')
             ->graphQL($mutationUpdateSearchRequest, $whereUpdateSearchRequest2)
-            ->assertJsonFragment(['message' => 'This action is unauthorized.']);
-
-        // test deleting a search request
-        $this->actingAs($baseUser, 'api')
-            ->graphQL($mutationDeleteSearchRequest, $whereSearchRequest1)
-            ->assertJsonFragment(['message' => 'This action is unauthorized.']);
-
-        // community recruiter can only delete searchRequest 1
-        $this->actingAs($communityRecruiter, 'api')
-            ->graphQL($mutationDeleteSearchRequest, $whereUpdateSearchRequest1)
-            ->assertJsonFragment(['id' => $searchRequest1->id]);
-        $this->actingAs($communityRecruiter, 'api')
-            ->graphQL($mutationDeleteSearchRequest, $whereUpdateSearchRequest2)
             ->assertJsonFragment(['message' => 'This action is unauthorized.']);
     }
 


### PR DESCRIPTION
🤖 Resolves #12677.

## 👋 Introduction

This PR removes the (nearly and now) unused `deletePoolCandidateSearchRequest` GraphQL mutation.

## 🧪 Testing

1. `make refresh-api; make seed-fresh; pnpm i; pnpm build:fresh;`
2. Verify there are no references to the `deletePoolCandidateSearchRequest` GraphQL mutation in the codebase