### PR TITLE
[Debt] Removes `deletePoolCandidate ` GraphQL mutation

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -2835,10 +2835,6 @@ type Mutation {
   reinstateCandidate(id: UUID!): PoolCandidate
     @guard
     @canFind(ability: "updateDecision", find: "id", injectArgs: true)
-  deletePoolCandidate(id: ID! @whereKey): PoolCandidate
-    @delete
-    @guard
-    @canFind(ability: "delete", find: "id")
   qualifyCandidate(id: UUID!, expiryDate: Date!): PoolCandidate
     @guard
     @canFind(ability: "updateDecision", find: "id", injectArgs: true)

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -508,7 +508,6 @@ type Mutation {
   updatePoolCandidateNotes(id: UUID!, notes: String): PoolCandidate
   removeCandidate(id: UUID!, removalReason: CandidateRemovalReason!, removalReasonOther: String): PoolCandidate
   reinstateCandidate(id: UUID!): PoolCandidate
-  deletePoolCandidate(id: ID!): PoolCandidate
   qualifyCandidate(id: UUID!, expiryDate: Date!): PoolCandidate
   disqualifyCandidate(id: UUID!, reason: DisqualificationReason!): PoolCandidate
   revertFinalDecision(id: UUID!): PoolCandidate


### PR DESCRIPTION
🤖 Resolves #12674.

## 👋 Introduction

This PR removes the unused `deletePoolCandidate` GraphQL mutation.

## 🧪 Testing

1. `make refresh-api; make seed-fresh; pnpm i; pnpm build:fresh;`
2. Verify there are no references to the `deletePoolCandidate` GraphQL mutation in the codebase