### PR TITLE
[Bug] Filter out own draft from admin tools

### DIFF
--- a/api/app/Generators/PoolCandidateCsvGenerator.php
+++ b/api/app/Generators/PoolCandidateCsvGenerator.php
@@ -528,7 +528,7 @@ class PoolCandidateCsvGenerator extends CsvGenerator implements FileGeneratorInt
         ]);
 
         /** @var Builder<\App\Models\User> $query */
-        $query->authorizedToView(['userId' => $this->userId]);
+        $query->authorizedToView(['userId' => $this->userId])->notDraft();
 
         return $query;
     }

--- a/api/app/Generators/PoolCandidateCsvGenerator.php
+++ b/api/app/Generators/PoolCandidateCsvGenerator.php
@@ -491,6 +491,7 @@ class PoolCandidateCsvGenerator extends CsvGenerator implements FileGeneratorInt
 
     private function buildQuery()
     {
+        /** @var Builder<\App\Models\PoolCandidate> $query */
         $query = PoolCandidate::with([
             'generalQuestionResponses' => ['generalQuestion'],
             'screeningQuestionResponses' => ['screeningQuestion'],
@@ -527,7 +528,7 @@ class PoolCandidateCsvGenerator extends CsvGenerator implements FileGeneratorInt
             'community' => 'candidatesInCommunity',
         ]);
 
-        /** @var Builder<\App\Models\User> $query */
+        /** @var Builder<\App\Models\PoolCandidate> $query */
         $query->authorizedToView(['userId' => $this->userId])->notDraft();
 
         return $query;

--- a/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/UserCandidatesTable.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/UserCandidatesTable.tsx
@@ -151,7 +151,14 @@ const UserCandidatesTable = ({
   type PoolCandidateSlice = (typeof poolCandidatesUnpacked)[number];
   const columnHelper = createColumnHelper<PoolCandidateSlice>();
 
-  const candidateIds = poolCandidatesUnpacked.map((candidate) => candidate.id);
+  // an admin possessing draft applications will fetch them, fine policy wise but not useful to render
+  const candidatesFilteredForSubmitted = poolCandidatesUnpacked.filter(
+    (candidate) => !!candidate.submittedAt,
+  );
+
+  const candidateIds = candidatesFilteredForSubmitted.map(
+    (candidate) => candidate.id,
+  );
 
   const columns = [
     columnHelper.display({
@@ -293,7 +300,7 @@ const UserCandidatesTable = ({
 
   return (
     <Table<PoolCandidateSlice>
-      data={poolCandidatesUnpacked}
+      data={candidatesFilteredForSubmitted}
       columns={columns}
       caption={title}
       sort={{ internal: true }}


### PR DESCRIPTION
🤖 Resolves #12915

## 👋 Introduction

If you as an admin have a draft application, it appears in places where it isn't particularly useful. It is fine policy wise, it just isn't useful for them to be rendered/listed

## 🧪 Testing

1. Log in as an admin user
2. Create a draft application for some pool abc
3. Go to `/en/admin/users/:userId#candidate-status` for your user
4. Go to the page then download full dataset for pool abc at `/en/admin/pools/:poolId/pool-candidates`
5. Confirm your draft application does not appear


