### PR TITLE
[Feat] User found, not verified error message

### DIFF
--- a/api/app/GraphQL/Validators/Query/GovEmployeeProfileValidator.php
+++ b/api/app/GraphQL/Validators/Query/GovEmployeeProfileValidator.php
@@ -3,6 +3,7 @@
 namespace App\GraphQL\Validators\Query;
 
 use App\Rules\GovernmentEmailRegex;
+use App\Rules\IsVerifiedGovEmployee;
 use Nuwave\Lighthouse\Validation\Validator;
 
 final class GovEmployeeProfileValidator extends Validator
@@ -15,7 +16,7 @@ final class GovEmployeeProfileValidator extends Validator
     public function rules(): array
     {
         return [
-            'workEmail' => [new GovernmentEmailRegex],
+            'workEmail' => [new GovernmentEmailRegex, new IsVerifiedGovEmployee],
         ];
     }
 }

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -99,6 +99,7 @@ use Staudenmeir\EloquentHasManyDeep\HasRelationships;
  * @property \App\Models\Notification $unreadNotifications
  * @property \Illuminate\Support\Collection<\App\Models\Notification> $notifications
  * @property ?string $off_platform_recruitment_processes
+ * @property ?bool $is_verified_gov_employee
  *
  * @method Builder|static authorizedToView()
  * @method static Builder|static query()

--- a/api/app/Rules/IsVerifiedGovEmployee.php
+++ b/api/app/Rules/IsVerifiedGovEmployee.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Rules;
+
+use App\Models\User;
+use Closure;
+use Database\Helpers\ApiErrorEnums;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class IsVerifiedGovEmployee implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+
+        $user = User::exactWorkEmail($value)->first();
+
+        if ($user && ! $user->is_verified_gov_employee) {
+            $fail(ApiErrorEnums::NOT_VERIFIED_GOVERNMENT_EMPLOYEE);
+        }
+
+    }
+}

--- a/api/database/helpers/ApiErrorEnums.php
+++ b/api/database/helpers/ApiErrorEnums.php
@@ -69,6 +69,8 @@ class ApiErrorEnums
     // Government Employee Details
     const NOT_GOVERNMENT_EMAIL = 'NotGovernmentEmail';
 
+    const NOT_VERIFIED_GOVERNMENT_EMPLOYEE = 'NotVerifiedGovEmployee';
+
     // Localized Enums
     const ENUM_NOT_FOUND = 'EnumNotFound';
 

--- a/api/tests/Feature/GovEmployeeProfileTest.php
+++ b/api/tests/Feature/GovEmployeeProfileTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\User;
+use Database\Helpers\ApiErrorEnums;
 use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
@@ -87,6 +88,6 @@ class GovEmployeeProfileTest extends TestCase
                 'data' => [
                     'govEmployeeProfile' => null,
                 ],
-            ]);
+            ])->assertGraphQLValidationError('workEmail', ApiErrorEnums::NOT_VERIFIED_GOVERNMENT_EMPLOYEE);
     }
 }

--- a/apps/web/src/components/EmployeeSearchInput/Error.tsx
+++ b/apps/web/src/components/EmployeeSearchInput/Error.tsx
@@ -90,6 +90,20 @@ const useDefaultMessages = (email: string | undefined): ErrorMessages => {
           "Description of default message when an email is not a government of Canada email",
       }),
     },
+    NOT_VERIFIED_GOVERNMENT_EMPLOYEE: {
+      title: intl.formatMessage({
+        defaultMessage: "This user hasn't verified their employee status",
+        id: "zVGK45",
+        description: "Label for when an employee was found but not verified",
+      }),
+      body: intl.formatMessage({
+        defaultMessage:
+          "We found a user with the email address provided, but they haven’t confirmed their status as an employee. Only verified employees can be nominated at this time. The user can verify their status as an employee by logging into the platform and verifying their work email.",
+        id: "hYuDZ2",
+        description:
+          "Descrioption of default message when user was found but not a verified employee",
+      }),
+    },
   };
 };
 
@@ -133,6 +147,16 @@ const Error = ({
           {...sharedProps}
           severity={severities?.NOT_GOVERNMENT_EMAIL}
           message={errorMessages.NOT_GOVERNMENT_EMAIL}
+        />
+      );
+    }
+
+    if (errorCodes?.includes("NotVerifiedGovEmployee")) {
+      return (
+        <ErrorMessage
+          {...sharedProps}
+          severity={severities?.NOT_VERIFIED_GOVERNMENT_EMPLOYEE}
+          message={errorMessages.NOT_VERIFIED_GOVERNMENT_EMPLOYEE}
         />
       );
     }

--- a/apps/web/src/components/EmployeeSearchInput/Error.tsx
+++ b/apps/web/src/components/EmployeeSearchInput/Error.tsx
@@ -99,9 +99,9 @@ const useDefaultMessages = (email: string | undefined): ErrorMessages => {
       body: intl.formatMessage({
         defaultMessage:
           "We found a user with the email address provided, but they haven’t confirmed their status as an employee. Only verified employees can be nominated at this time. The user can verify their status as an employee by logging into the platform and verifying their work email.",
-        id: "hYuDZ2",
+        id: "Ney+Il",
         description:
-          "Descrioption of default message when user was found but not a verified employee",
+          "Description of default message when user was found but not a verified employee",
       }),
     },
   };

--- a/apps/web/src/components/EmployeeSearchInput/types.ts
+++ b/apps/web/src/components/EmployeeSearchInput/types.ts
@@ -2,7 +2,10 @@ import { ReactNode } from "react";
 
 import { Maybe } from "@gc-digital-talent/graphql";
 
-type ErrorMessageKey = "NO_PROFILE" | "NOT_GOVERNMENT_EMAIL";
+type ErrorMessageKey =
+  | "NO_PROFILE"
+  | "NOT_GOVERNMENT_EMAIL"
+  | "NOT_VERIFIED_GOVERNMENT_EMPLOYEE";
 export type ErrorSeverity = "warning" | "error";
 
 export interface ErrorMessage {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5307,6 +5307,10 @@
     "defaultMessage": "<strong>Contributeur individuel</strong> : Les conseillers principaux en <abbreviation>TI</abbreviation> (<abbreviation>IT-04</abbreviation>) fournissent des conseils techniques et une orientation stratégique d'experts dans leur domaine d'expertise en matière de fourniture de solutions et de services à des clients internes ou externes et à des intervenants.",
     "description": "IT-04 senior advisor description precursor to work stream list"
   },
+  "Ney+Il": {
+    "defaultMessage": "Nous avons trouvé un utilisateur dont l'adresse courriel est fournie, mais qui n'a pas confirmé son statut d'employée ou d'employé. À l'heure actuelle, seuls les membres du personnel vérifiés peuvent être nommés. L'utilisateur peut vérifier son statut d'employée ou d'employé en ouvrant une session dans la plateforme et en vérifiant son adresse courriel professionnelle.",
+    "description": "Description of default message when user was found but not a verified employee"
+  },
   "NfRLs/": {
     "defaultMessage": "Anglais - Votre impact",
     "description": "Label for the English - Your Impact textarea in the edit pool page."
@@ -13005,6 +13009,10 @@
   "zRw5Fs": {
     "defaultMessage": "Retirez {userName} de {poolName}.",
     "description": "Label for the dialog trigger to remove a user from a process/pool"
+  },
+  "zVGK45": {
+    "defaultMessage": "Cet utilisateur n'a pas vérifié son statut d'employé(e)",
+    "description": "Label for when an employee was found but not verified"
   },
   "zVGzWa": {
     "defaultMessage": "Visitez la page du gestionnaire du Programme d'apprentissage en TI pour les personnes autochtones",

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1263,6 +1263,10 @@
     "defaultMessage": "Août",
     "description": "Name of the eighth month"
   },
+  "m/VZ/H": {
+    "defaultMessage": "Cet utilisateur n'a pas vérifié son statut d'employé(e)",
+    "description": "Error message for when a user is not verified"
+  },
   "m0iNdp": {
     "defaultMessage": "Choisir une collectivité",
     "description": "Null selection for community select input."

--- a/packages/i18n/src/messages/apiMessages.ts
+++ b/packages/i18n/src/messages/apiMessages.ts
@@ -474,6 +474,11 @@ export const apiMessages: Record<string, MessageDescriptor> = defineMessages({
     description:
       "Error message for when an error occurs during role assignment",
   },
+  NotVerifiedGovEmployee: {
+    defaultMessage: "This user hasn't verified their employee status",
+    id: "m/VZ/H",
+    description: "Error message for when a user is not verified",
+  },
 });
 
 export const tryFindMessageDescriptor = (


### PR DESCRIPTION
🤖 Resolves #12831

## 👋 Introduction

Adds the error message for when search a government employee that they exist but have yet to verify themselves.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as a verified gov employee `applicant-employee@test.com`
3. Find a user in the DB that has a work emial but null verification
4. Start a nomination
5. Using one of the employee search inputs in the nomination, search for the user from step 3
6. Confirm the error message indicating someone was found but has yet to verify themsevles

## 📸 Screenshot

![2025-04-30_09-58](https://github.com/user-attachments/assets/f2709375-b3be-4e66-bd69-0321a8f199a6)
