### PR TITLE
[Debt] Remove form watch type casts

### DIFF
--- a/apps/web/src/components/SkillBrowser/SkillBrowser.tsx
+++ b/apps/web/src/components/SkillBrowser/SkillBrowser.tsx
@@ -33,11 +33,11 @@ const SkillBrowser = ({
     category: `${id}-${INPUT_NAME.CATEGORY}`,
     family: `${id}-${INPUT_NAME.FAMILY}`,
   };
-  const { watch, resetField, setValue } = useFormContext();
-  const [family, skillValue] = watch([inputNames.family, name]) as [
-    FormValues["family"],
-    FormValues["skill"],
-  ];
+  const { watch, resetField, setValue } = useFormContext<{
+    [inputNames.family]: FormValues["family"];
+    [name]: FormValues["skill"];
+  }>();
+  const [family, skillValue] = watch([inputNames.family, name]);
 
   const filteredFamilies = useMemo(() => {
     return getFilteredFamilies({ skills }).sort((familyA, familyB) => {

--- a/apps/web/src/pages/Pools/EditPoolPage/components/CoreRequirementsSection/CoreRequirementsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/CoreRequirementsSection/CoreRequirementsSection.tsx
@@ -122,7 +122,7 @@ const CoreRequirementsSection = ({
     defaultValues: dataToFormValues(pool),
   });
   const { handleSubmit, control, watch } = methods;
-  const locationOption: FormValues["locationOption"] = useWatch({
+  const locationOption = useWatch<FormValues>({
     control,
     name: "locationOption",
   });


### PR DESCRIPTION
🤖 Resolves #11371 

## 👋 Introduction

Updates the type casting for form watchers to prefer the use of the generic.

## 🧪 Testing

1. Confirm no more type casts around `useWatch` and `watch` form methods
2. Confirm typescript is still happy