### PR TITLE
[Fix] Missing error messages on assessment plan skills inputs

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -9446,6 +9446,10 @@
     "defaultMessage": "Dernière mise à jour du profil de la personne candidate : {lastUpdated}",
     "description": "Last time user's profile was updated"
   },
+  "gwpmTn": {
+    "defaultMessage": "Veuillez sélectionner au moins une compétence essentielle ou une compétence constituant un atout pour cette méthode d'évaluation.",
+    "description": "Error message for when a skill is not selected for assessment"
+  },
   "gyZV/3": {
     "defaultMessage": "Veuillez ajouter au moins une expérience.",
     "description": "Error message if there are no experiences"

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentDetailsDialog.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentDetailsDialog.tsx
@@ -498,6 +498,14 @@ const AssessmentDetailsDialog = ({
       return false;
     });
 
+  const requiredSkillsMessage = intl.formatMessage({
+    defaultMessage:
+      "Please select at least one essential or asset skill for this assessment method.",
+    id: "gwpmTn",
+    description:
+      "Error message for when a skill is not selected for assessment",
+  });
+
   return (
     <Dialog.Root open={isOpen} onOpenChange={(open) => setIsOpen(open)}>
       <Dialog.Trigger>{trigger}</Dialog.Trigger>
@@ -789,7 +797,10 @@ const AssessmentDetailsDialog = ({
                     )}
                     rules={{
                       validate: (selectedAssessedSkills: string[]) => {
-                        return selectedAssessedSkills.length > 0;
+                        return (
+                          selectedAssessedSkills.length > 0 ||
+                          requiredSkillsMessage
+                        );
                       },
                     }}
                   />
@@ -803,15 +814,16 @@ const AssessmentDetailsDialog = ({
                     items={alphaSortOptions(assessedSkillsItems.assetSkills)}
                     rules={{
                       validate: (selectedAssessedSkills: string[]) => {
-                        return selectedAssessedSkills.length > 0;
+                        return (
+                          selectedAssessedSkills.length > 0 ||
+                          requiredSkillsMessage
+                        );
                       },
                     }}
                   />
                 )}
                 {errors.assessedSkills ? (
-                  <Field.Error>
-                    {intl.formatMessage(errorMessages.required)}
-                  </Field.Error>
+                  <Field.Error>{requiredSkillsMessage}</Field.Error>
                 ) : null}
                 {!assessedSkillsItems.essentialSkillItems.length &&
                 !assessedSkillsItems.assetSkills.length ? (


### PR DESCRIPTION
🤖 Resolves #12540 

## 👋 Introduction

Fixes an issue where empty error messages were appearing for the skill selection in the assessment plan dialogs

## 🕵️ Details

This is not a great solution but maybe works for now? :woman_shrugging: 

The issue is that we have two separate inputs that are essentially collecting for a single data point so at least one of the inputs is required.

To be valid you must select at least one skill from either input. The ideal fix would be to use a single input instead of two separate ones that are combined in the validation and submission, however that will need come designer input so I went with this solution for now :confused: 

> [!NOTE]
> The new error message was provided by @NienkeBr since "required" was not specific enough and could cause confusion. 

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as an admin `admin@test.com`
3. Create a process
4. Select both essential and asset skills
5. Navigate to the assessment plan edit page
6. Add a new step
7. Do not check any skills
8. Attempt to submit the form
9. Observe the error messages appearing in the proper locations

## 📸 Screenshot

![2025-05-01_13-26](https://github.com/user-attachments/assets/b35c20df-167a-4d00-b0b1-44b5f144e2d6)
