### PR TITLE
[Bug] Fix template DOR link

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -57,7 +57,7 @@ body:
     id: definition-of-ready
     attributes:
       label: 🚢 Definition of Ready
-      description: Does this meet issue meet the criteria in our [Definition of Ready](documentation/definition-of-ready.md)?
+      description: Does this meet issue meet the criteria in our [Definition of Ready](../blob/main/documentation/definition-of-ready.md)?
       options:
         - label: This issue has met the criteria in our Definition of Ready
           required: true

--- a/.github/ISSUE_TEMPLATE/spike.yml
+++ b/.github/ISSUE_TEMPLATE/spike.yml
@@ -16,13 +16,6 @@ body:
     validations:
       required: true
   - type: textarea
-    id: details
-    attributes:
-      label: 🕵️ Details
-      description: More details, background context, or ideas for how to approach this.
-    validations:
-      required: true
-  - type: textarea
     id: questions-to-answer
     attributes:
       label: ❓ Questions to answer
@@ -34,5 +27,3 @@ body:
     attributes:
       label: 🕙 Timebox
       description: How many days are we expected to spend on this?
-    validations:
-      required: true


### PR DESCRIPTION
🤖 Resolves #13257 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Fixes the "definition of ready" link on the feature template (I think!).
Also, I took the opportunity to trim the spike template down a bit.
