### PR TITLE
[Fix] Allow uppercase letters for work stream key

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -11538,6 +11538,10 @@
     "defaultMessage": "Créer<hidden> une collectivité</hidden>",
     "description": "Breadcrumb title for the create community page link."
   },
+  "r4sAvp": {
+    "defaultMessage": "Veuillez utiliser uniquement des lettres et des caractères de soulignement.",
+    "description": "Description for rule pattern on key field"
+  },
   "r5n5qA": {
     "defaultMessage": "Volets de travail",
     "description": "Label for work streams"

--- a/apps/web/src/pages/WorkStreams/CreateWorkStreamPage.tsx
+++ b/apps/web/src/pages/WorkStreams/CreateWorkStreamPage.tsx
@@ -250,11 +250,11 @@ export const CreateWorkStreamForm = ({
                   rules={{
                     required: intl.formatMessage(errorMessages.required),
                     pattern: {
-                      value: /^[a-z]+(_[a-z]+)*$/,
+                      value: /^[a-z]+(_[a-z]+)*$/i,
                       message: intl.formatMessage({
                         defaultMessage:
-                          "Please use only lowercase letters and underscores.",
-                        id: "3owqTQ",
+                          "Please use only letters and underscores.",
+                        id: "r4sAvp",
                         description:
                           "Description for rule pattern on key field",
                       }),


### PR DESCRIPTION
🤖 Resolves #12920

## 👋 Introduction

Updates the validation for a work stream key to allow any case of letter.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as admin `admin@test.com`
3. Navigate to create a work stream `/admin/settings/work-streams/create`
4. Confirm the validation allows only letters (of any case) and underscores