### PR TITLE
[Debt] Remove backing from language enum

### DIFF
--- a/api/app/Casts/LanguageCode.php
+++ b/api/app/Casts/LanguageCode.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Casts;
+
+use App\Enums\Language;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+
+class LanguageCode implements CastsAttributes
+{
+    /**
+     * Cast the given value.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function get(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        if (is_null($value) || $value === '' || $value === 'null') {
+            return null;
+        }
+
+        return Language::EN->localeMatches($value) ? Language::EN->name : Language::FR->name;
+    }
+
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function set(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        return strtolower($value);
+    }
+}

--- a/api/app/Discoverers/EnumDiscoverer.php
+++ b/api/app/Discoverers/EnumDiscoverer.php
@@ -20,8 +20,6 @@ class EnumDiscoverer
     {
         return Discover::in(self::path())
             ->enums()
-                // TODO: Language has a custom implementation remove in #10964
-            ->custom(fn (DiscoveredStructure $structure) => $structure->name !== 'Language')
             ->sortBy(self::$sort)
             ->get();
     }

--- a/api/app/Enums/Language.php
+++ b/api/app/Enums/Language.php
@@ -11,6 +11,16 @@ enum Language
     case EN;
     case FR;
 
+    public function localeMatches(?string $locale)
+    {
+        return strcasecmp($this->name, $locale) == 0;
+    }
+
+    public function toLower()
+    {
+        return strtolower($this->name);
+    }
+
     public static function getLangFilename(): string
     {
         return 'language';

--- a/api/app/Enums/Language.php
+++ b/api/app/Enums/Language.php
@@ -4,12 +4,12 @@ namespace App\Enums;
 
 use App\Traits\HasLocalization;
 
-enum Language: string
+enum Language
 {
     use HasLocalization;
 
-    case EN = 'en';
-    case FR = 'fr';
+    case EN;
+    case FR;
 
     public static function getLangFilename(): string
     {

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -235,7 +235,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
      */
     public function preferredLocale(): string
     {
-        return strtolower($this->preferred_lang) ?? 'en';
+        return strtolower($this->preferred_lang ?? 'en');
     }
 
     /** @return HasMany<Pool, $this> */

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Casts\LanguageCode;
 use App\Enums\CandidateExpiryFilter;
 use App\Enums\CandidateSuspendedFilter;
 use App\Enums\EmailType;
@@ -129,6 +130,10 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
         'indigenous_communities' => 'array',
         'enabled_email_notifications' => 'array',
         'enabled_in_app_notifications' => 'array',
+        'preferred_lang' => LanguageCode::class,
+        'preferred_language_for_interview' => LanguageCode::class,
+        'preferred_language_for_exam' => LanguageCode::class,
+        'first_official_language' => LanguageCode::class,
     ];
 
     protected $fillable = [

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -235,7 +235,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
      */
     public function preferredLocale(): string
     {
-        return $this->preferred_lang ?? 'en';
+        return strtolower($this->preferred_lang) ?? 'en';
     }
 
     /** @return HasMany<Pool, $this> */

--- a/api/app/Notifications/AdHocEmail.php
+++ b/api/app/Notifications/AdHocEmail.php
@@ -37,8 +37,8 @@ class AdHocEmail extends Notification implements CanBeSentViaGcNotifyEmail
     {
         $locale = $this->locale ?? $notifiable->preferredLocale();
         $templateId = match ($locale) {
-            Language::EN->value => $this->templateIdEn,
-            Language::FR->value => $this->templateIdFr,
+            strtolower(Language::EN->name) => $this->templateIdEn,
+            strtolower(Language::FR->name) => $this->templateIdFr,
             default => throw new \InvalidArgumentException("Unsupported locale: $locale"),
         };
 

--- a/api/app/Notifications/AdHocEmail.php
+++ b/api/app/Notifications/AdHocEmail.php
@@ -37,8 +37,8 @@ class AdHocEmail extends Notification implements CanBeSentViaGcNotifyEmail
     {
         $locale = $this->locale ?? $notifiable->preferredLocale();
         $templateId = match ($locale) {
-            strtolower(Language::EN->name) => $this->templateIdEn,
-            strtolower(Language::FR->name) => $this->templateIdFr,
+            Language::EN->toLower() => $this->templateIdEn,
+            Language::FR->toLower() => $this->templateIdFr,
             default => throw new \InvalidArgumentException("Unsupported locale: $locale"),
         };
 

--- a/api/app/Notifications/ApplicationDeadlineApproaching.php
+++ b/api/app/Notifications/ApplicationDeadlineApproaching.php
@@ -75,7 +75,7 @@ class ApplicationDeadlineApproaching extends Notification implements CanBeSentVi
             fn () => $this->closingDate->translatedFormat($locale === 'en' ? 'F j, Y' : 'j F Y')
         );
 
-        if ($locale == Language::EN->value) {
+        if ($locale == strtolower(Language::EN->name)) {
             // English notification
             $message = new GcNotifyEmailMessage(
                 config('notify.templates.application_deadline_approaching_en'),

--- a/api/app/Notifications/ApplicationDeadlineApproaching.php
+++ b/api/app/Notifications/ApplicationDeadlineApproaching.php
@@ -75,7 +75,7 @@ class ApplicationDeadlineApproaching extends Notification implements CanBeSentVi
             fn () => $this->closingDate->translatedFormat($locale === 'en' ? 'F j, Y' : 'j F Y')
         );
 
-        if ($locale == strtolower(Language::EN->name)) {
+        if (Language::EN->localeMatches($locale)) {
             // English notification
             $message = new GcNotifyEmailMessage(
                 config('notify.templates.application_deadline_approaching_en'),

--- a/api/app/Notifications/ApplicationStatusChanged.php
+++ b/api/app/Notifications/ApplicationStatusChanged.php
@@ -65,7 +65,7 @@ class ApplicationStatusChanged extends Notification implements CanBeSentViaGcNot
     {
         $locale = $this->locale ?? $notifiable->preferredLocale();
 
-        if ($locale == strtolower(Language::EN->name)) {
+        if (Language::EN->localeMatches($locale)) {
             // English notification
             $message = new GcNotifyEmailMessage(
                 config('notify.templates.application_status_changed_en'),

--- a/api/app/Notifications/ApplicationStatusChanged.php
+++ b/api/app/Notifications/ApplicationStatusChanged.php
@@ -65,7 +65,7 @@ class ApplicationStatusChanged extends Notification implements CanBeSentViaGcNot
     {
         $locale = $this->locale ?? $notifiable->preferredLocale();
 
-        if ($locale == Language::EN->value) {
+        if ($locale == strtolower(Language::EN->name)) {
             // English notification
             $message = new GcNotifyEmailMessage(
                 config('notify.templates.application_status_changed_en'),

--- a/api/app/Notifications/NewJobPosted.php
+++ b/api/app/Notifications/NewJobPosted.php
@@ -63,7 +63,7 @@ class NewJobPosted extends Notification implements CanBeSentViaGcNotifyEmail
     {
         $locale = $this->locale ?? $notifiable->preferredLocale();
 
-        if ($locale == strtolower(Language::EN->name)) {
+        if (Language::EN->localeMatches($locale)) {
             // English notification
             $message = new GcNotifyEmailMessage(
                 config('notify.templates.new_job_posted_en'),

--- a/api/app/Notifications/NewJobPosted.php
+++ b/api/app/Notifications/NewJobPosted.php
@@ -63,7 +63,7 @@ class NewJobPosted extends Notification implements CanBeSentViaGcNotifyEmail
     {
         $locale = $this->locale ?? $notifiable->preferredLocale();
 
-        if ($locale == Language::EN->value) {
+        if ($locale == strtolower(Language::EN->name)) {
             // English notification
             $message = new GcNotifyEmailMessage(
                 config('notify.templates.new_job_posted_en'),

--- a/api/app/Notifications/System.php
+++ b/api/app/Notifications/System.php
@@ -79,7 +79,7 @@ class System extends Notification implements CanBeSentViaGcNotifyEmail
     {
         $locale = $this->locale ?? $notifiable->preferredLocale();
 
-        if ($locale == strtolower(Language::EN->name)) {
+        if (Language::EN->localeMatches($locale)) {
             // English notification
             $message = new GcNotifyEmailMessage(
                 config('notify.templates.system_notification_en'),

--- a/api/app/Notifications/System.php
+++ b/api/app/Notifications/System.php
@@ -79,7 +79,7 @@ class System extends Notification implements CanBeSentViaGcNotifyEmail
     {
         $locale = $this->locale ?? $notifiable->preferredLocale();
 
-        if ($locale == Language::EN->value) {
+        if ($locale == strtolower(Language::EN->name)) {
             // English notification
             $message = new GcNotifyEmailMessage(
                 config('notify.templates.system_notification_en'),

--- a/api/app/Notifications/TalentNominationReceivedNominator.php
+++ b/api/app/Notifications/TalentNominationReceivedNominator.php
@@ -100,7 +100,7 @@ class TalentNominationReceivedNominator extends Notification implements CanBeSen
             $this->nominateForLateralMovement,
             $this->nominateForDevelopmentPrograms);
 
-        if ($locale == strtolower(Language::EN->name)) {
+        if (Language::EN->localeMatches($locale)) {
             // English notification
             $message = new GcNotifyEmailMessage(
                 config('notify.templates.nomination_received_nominator_en'),

--- a/api/app/Notifications/TalentNominationReceivedNominator.php
+++ b/api/app/Notifications/TalentNominationReceivedNominator.php
@@ -100,7 +100,7 @@ class TalentNominationReceivedNominator extends Notification implements CanBeSen
             $this->nominateForLateralMovement,
             $this->nominateForDevelopmentPrograms);
 
-        if ($locale == Language::EN->value) {
+        if ($locale == strtolower(Language::EN->name)) {
             // English notification
             $message = new GcNotifyEmailMessage(
                 config('notify.templates.nomination_received_nominator_en'),

--- a/api/app/Notifications/TalentNominationReceivedSubmitter.php
+++ b/api/app/Notifications/TalentNominationReceivedSubmitter.php
@@ -81,7 +81,7 @@ class TalentNominationReceivedSubmitter extends Notification implements CanBeSen
             $this->nominateForLateralMovement,
             $this->nominateForDevelopmentPrograms);
 
-        if ($locale == Language::EN->value) {
+        if ($locale == strtolower(Language::EN->name)) {
             // English notification
             $message = new GcNotifyEmailMessage(
                 config('notify.templates.nomination_received_submitter_en'),

--- a/api/app/Notifications/TalentNominationReceivedSubmitter.php
+++ b/api/app/Notifications/TalentNominationReceivedSubmitter.php
@@ -81,7 +81,7 @@ class TalentNominationReceivedSubmitter extends Notification implements CanBeSen
             $this->nominateForLateralMovement,
             $this->nominateForDevelopmentPrograms);
 
-        if ($locale == strtolower(Language::EN->name)) {
+        if (Language::EN->localeMatches($locale)) {
             // English notification
             $message = new GcNotifyEmailMessage(
                 config('notify.templates.nomination_received_submitter_en'),

--- a/api/app/Notifications/VerifyEmail.php
+++ b/api/app/Notifications/VerifyEmail.php
@@ -44,7 +44,7 @@ class VerifyEmail extends Notification implements CanBeSentViaGcNotifyEmail
     {
         if ($notifiable instanceof User) {
             $locale = $this->locale ?? $notifiable->preferredLocale();
-            if ($locale == strtolower(Language::EN->name)) {
+            if (Language::EN->localeMatches($locale)) {
                 $templateId = config('notify.templates.verify_email_en');
             } else {
                 $templateId = config('notify.templates.verify_email_fr');

--- a/api/app/Notifications/VerifyEmail.php
+++ b/api/app/Notifications/VerifyEmail.php
@@ -44,7 +44,7 @@ class VerifyEmail extends Notification implements CanBeSentViaGcNotifyEmail
     {
         if ($notifiable instanceof User) {
             $locale = $this->locale ?? $notifiable->preferredLocale();
-            if ($locale == Language::EN->value) {
+            if ($locale == strtolower(Language::EN->name)) {
                 $templateId = config('notify.templates.verify_email_en');
             } else {
                 $templateId = config('notify.templates.verify_email_fr');

--- a/api/app/Providers/GraphQLServiceProvider.php
+++ b/api/app/Providers/GraphQLServiceProvider.php
@@ -3,10 +3,8 @@
 namespace App\Providers;
 
 use App\Discoverers\EnumDiscoverer;
-use App\Enums\Language;
 use App\GraphQL\Operators\PostgreSQLOperator;
 use GraphQL\Type\Definition\EnumType;
-use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
@@ -18,28 +16,6 @@ class GraphQLServiceProvider extends ServiceProvider
 {
     public function boot(TypeRegistry $typeRegistry): void
     {
-
-        /**
-         * Note: This is strange but PHPStan is having trouble knowing that EnumType
-         * implements the interface and the function is callable.
-         *
-         * Same for the other registerLazy
-         *
-         * @var callable(): \GraphQL\Type\Definition\Type&\GraphQL\Type\Definition\NamedType $callback */
-        $callback = static function (): NamedType {
-            return new EnumType([
-                'name' => 'Language',
-                'values' => [
-                    Language::EN->name => ['value' => Language::EN->value],
-                    Language::FR->name => ['value' => Language::FR->value],
-                ],
-            ]);
-        };
-
-        $typeRegistry->registerLazy(
-            'Language',
-            $callback
-        );
 
         // Discover all enums in the App\Enum namespace to register them with GraphQL
         $enums = EnumDiscoverer::discoverEnums();

--- a/api/database/factories/UserFactory.php
+++ b/api/database/factories/UserFactory.php
@@ -82,16 +82,16 @@ class UserFactory extends Factory
             'email' => $this->faker->firstName().'_'.$this->faker->unique()->safeEmail(),
             'sub' => $this->faker->boolean(75) ? $this->faker->unique()->uuid() : null,
             'telephone' => $this->faker->e164PhoneNumber(),
-            'preferred_lang' => $this->faker->randomElement(Language::cases())->value,
-            'preferred_language_for_interview' => $this->faker->randomElement(Language::cases())->value,
-            'preferred_language_for_exam' => $this->faker->randomElement(Language::cases())->value,
+            'preferred_lang' => $this->faker->randomElement(Language::cases())->name,
+            'preferred_language_for_interview' => $this->faker->randomElement(Language::cases())->name,
+            'preferred_language_for_exam' => $this->faker->randomElement(Language::cases())->name,
             'current_province' => $this->faker->randomElement(ProvinceOrTerritory::cases())->name,
             'current_city' => $this->faker->city(),
             'looking_for_english' => $lookingEnglish,
             'looking_for_french' => $lookingFrench,
             'looking_for_bilingual' => $lookingBilingual,
             'first_official_language' => $lookingBilingual ?
-                $this->faker->randomElement(Language::cases())->value
+                $this->faker->randomElement(Language::cases())->name
                 : null,
             'estimated_language_ability' => $lookingBilingual ?
                 $this->faker->randomElement(EstimatedLanguageAbility::cases())->name

--- a/api/database/factories/UserFactory.php
+++ b/api/database/factories/UserFactory.php
@@ -82,16 +82,16 @@ class UserFactory extends Factory
             'email' => $this->faker->firstName().'_'.$this->faker->unique()->safeEmail(),
             'sub' => $this->faker->boolean(75) ? $this->faker->unique()->uuid() : null,
             'telephone' => $this->faker->e164PhoneNumber(),
-            'preferred_lang' => $this->faker->randomElement(Language::cases())->name,
-            'preferred_language_for_interview' => $this->faker->randomElement(Language::cases())->name,
-            'preferred_language_for_exam' => $this->faker->randomElement(Language::cases())->name,
+            'preferred_lang' => $this->faker->randomElement(Language::cases())->toLower(),
+            'preferred_language_for_interview' => $this->faker->randomElement(Language::cases())->toLower(),
+            'preferred_language_for_exam' => $this->faker->randomElement(Language::cases())->toLower(),
             'current_province' => $this->faker->randomElement(ProvinceOrTerritory::cases())->name,
             'current_city' => $this->faker->city(),
             'looking_for_english' => $lookingEnglish,
             'looking_for_french' => $lookingFrench,
             'looking_for_bilingual' => $lookingBilingual,
             'first_official_language' => $lookingBilingual ?
-                $this->faker->randomElement(Language::cases())->name
+                $this->faker->randomElement(Language::cases())->toLower()
                 : null,
             'estimated_language_ability' => $lookingBilingual ?
                 $this->faker->randomElement(EstimatedLanguageAbility::cases())->name

--- a/api/phpstan-baseline.neon
+++ b/api/phpstan-baseline.neon
@@ -3,7 +3,7 @@ parameters:
 		-
 			message: '#^PHPDoc tag @var with type callable\(\)\: GraphQL\\Type\\Definition\\Type&GraphQL\\Type\\Definition\\NamedType is not subtype of native type Closure\(\)\: GraphQL\\Type\\Definition\\EnumType\.$#'
 			identifier: varTag.nativeType
-			count: 2
+			count: 1
 			path: app/Providers/GraphQLServiceProvider.php
 
 		-

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -2985,11 +2985,6 @@ dealing with really large numbers to be on the safe side.
 """
 scalar Mixed
 
-enum Language {
-  EN
-  FR
-}
-
 enum ApplicationStep {
   WELCOME
   SELF_DECLARATION
@@ -3314,6 +3309,11 @@ enum IndigenousCommunity {
   METIS
   OTHER
   LEGACY_IS_INDIGENOUS
+}
+
+enum Language {
+  EN
+  FR
 }
 
 enum LanguageAbility {

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -199,7 +199,7 @@ class SnapshotTest extends TestCase
             'pool_id' => $pool->id,
             'profile_snapshot' => [
                 // Single enum
-                'preferredLang' => Language::EN->name,
+                'preferredLang' => strtolower(Language::EN->name),
                 // Array based enum
                 'acceptedOperationalRequirements' => [
                     OperationalRequirement::DRIVERS_LICENSE->name,
@@ -227,7 +227,7 @@ class SnapshotTest extends TestCase
         assertSame([
             // Single enum
             'preferredLang' => [
-                'value' => Language::EN->name,
+                'value' => strtolower(Language::EN->name),
                 'label' => Language::localizedString(Language::EN->name),
             ],
             // Array based enum

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -45,7 +45,7 @@ class SnapshotTest extends TestCase
      *
      * @return void
      */
-    public function test_create_snapshot()
+    public function testCreateSnapshot()
     {
         $snapshotQuery = file_get_contents(base_path('app/GraphQL/Mutations/PoolCandidateSnapshot.graphql'), true);
         $user = User::factory()
@@ -106,7 +106,7 @@ class SnapshotTest extends TestCase
         assertEquals($expectedSnapshot, $decodedActual);
     }
 
-    public function test_snapshot_skill_filtering()
+    public function testSnapshotSkillFiltering()
     {
         Skill::factory(20)->create();
 
@@ -165,7 +165,7 @@ class SnapshotTest extends TestCase
         assertEquals($intersectedArrayLength, 0);
     }
 
-    public function test_set_application_snapshot_does_not_overwrite()
+    public function testSetApplicationSnapshotDoesNotOverwrite()
     {
         // non-null snapshot value set
         $user = User::factory()
@@ -187,7 +187,7 @@ class SnapshotTest extends TestCase
         assertSame(['snapshot' => 'set'], $snapshot);
     }
 
-    public function test_localizing_legacy_enums()
+    public function testLocalizingLegacyEnums()
     {
         // non-null snapshot value set
         $user = User::factory()

--- a/api/tests/Feature/SnapshotTest.php
+++ b/api/tests/Feature/SnapshotTest.php
@@ -45,7 +45,7 @@ class SnapshotTest extends TestCase
      *
      * @return void
      */
-    public function testCreateSnapshot()
+    public function test_create_snapshot()
     {
         $snapshotQuery = file_get_contents(base_path('app/GraphQL/Mutations/PoolCandidateSnapshot.graphql'), true);
         $user = User::factory()
@@ -106,7 +106,7 @@ class SnapshotTest extends TestCase
         assertEquals($expectedSnapshot, $decodedActual);
     }
 
-    public function testSnapshotSkillFiltering()
+    public function test_snapshot_skill_filtering()
     {
         Skill::factory(20)->create();
 
@@ -165,7 +165,7 @@ class SnapshotTest extends TestCase
         assertEquals($intersectedArrayLength, 0);
     }
 
-    public function testSetApplicationSnapshotDoesNotOverwrite()
+    public function test_set_application_snapshot_does_not_overwrite()
     {
         // non-null snapshot value set
         $user = User::factory()
@@ -187,7 +187,7 @@ class SnapshotTest extends TestCase
         assertSame(['snapshot' => 'set'], $snapshot);
     }
 
-    public function testLocalizingLegacyEnums()
+    public function test_localizing_legacy_enums()
     {
         // non-null snapshot value set
         $user = User::factory()
@@ -199,7 +199,7 @@ class SnapshotTest extends TestCase
             'pool_id' => $pool->id,
             'profile_snapshot' => [
                 // Single enum
-                'preferredLang' => strtolower(Language::EN->name),
+                'preferredLang' => Language::EN->toLower(),
                 // Array based enum
                 'acceptedOperationalRequirements' => [
                     OperationalRequirement::DRIVERS_LICENSE->name,
@@ -227,7 +227,7 @@ class SnapshotTest extends TestCase
         assertSame([
             // Single enum
             'preferredLang' => [
-                'value' => strtolower(Language::EN->name),
+                'value' => Language::EN->toLower(),
                 'label' => Language::localizedString(Language::EN->name),
             ],
             // Array based enum


### PR DESCRIPTION
🤖 Resolves #10964 

## 👋 Introduction

Removes the backing of the `Language` enum to make it consistent with the other enums.

## 🕵️ Details

This was backed so we could have case sensitive comparisons with the app locale. So, instead of backing, it just uses `strtolower` in the comparisons. 

## 🧪 Testing

> [!IMPORTANT]
> It would be nice if someone could test creating a new user and triggering an email notification in each language to confirm that works. That is probably the most brittle version

1. Refresh api `make refresh-api` 
2. Build the app `pnpm run dev:fresh`
3. Login as any user
4. Change your prefered language a few times
5. Confirm that still works
6. Preferably trigger an email and confirm you get the correct language