### PR TITLE
[Fix] Reloading employee profile on save

### DIFF
--- a/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
@@ -150,7 +150,9 @@ const UpdateEmployeeProfile_Mutation = graphql(/* GraphQL */ `
     $employeeProfile: UpdateEmployeeProfileInput!
   ) {
     updateEmployeeProfile(id: $id, employeeProfile: $employeeProfile) {
-      ...EmployeeProfileCareerObjective
+      userPublicProfile {
+        id
+      }
     }
   }
 `);

--- a/apps/web/src/pages/EmployeeProfile/components/GoalsWorkStyleSection/GoalsWorkStyleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/GoalsWorkStyleSection/GoalsWorkStyleSection.tsx
@@ -43,9 +43,9 @@ const UpdateEmployeeProfile_Mutation = graphql(/* GraphQL */ `
     $employeeProfile: UpdateEmployeeProfileInput!
   ) {
     updateEmployeeProfile(id: $id, employeeProfile: $employeeProfile) {
-      aboutYou
-      learningGoals
-      workStyle
+      userPublicProfile {
+        id
+      }
     }
   }
 `);

--- a/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
@@ -150,7 +150,9 @@ const UpdateEmployeeProfile_Mutation = graphql(/* GraphQL */ `
     $employeeProfile: UpdateEmployeeProfileInput!
   ) {
     updateEmployeeProfile(id: $id, employeeProfile: $employeeProfile) {
-      ...EmployeeProfileNextRole
+      userPublicProfile {
+        id
+      }
     }
   }
 `);


### PR DESCRIPTION
🤖 Resolves #12893 

## 👋 Introduction

Fixes an issue where some forms on the employee profile page were causing the entire page to reload, moving the users focus.

## 🕵️ Details

This was because the mutation was returning fields that were causing the currently logged in user to go stale which forced the authorisation container to re-render meaning the entire page would

## 🧪 Testing

1. Build app `pnpm run dev:fresh`
2. Login as an employee `applicant-employee@test.com`
3. Navigate to the employee profile `/applicant/employee-profile`
4. Make changes to and submit all forms on the page
5. Confirm none cause the entire page to reload