### PR TITLE
[Fix] Prevent unrelated notification in status changed test

### DIFF
--- a/api/tests/Feature/Notifications/TriggerApplicationStatusChangedTest.php
+++ b/api/tests/Feature/Notifications/TriggerApplicationStatusChangedTest.php
@@ -29,6 +29,11 @@ class TriggerApplicationStatusChangedTest extends TestCase
         $this->seed(RolePermissionSeeder::class);
 
         $this->user = User::factory()->create([
+            // Make computed gov employee fields null to not accidentally trigger a
+            // 'gov employee but not verified' notification
+            'work_email' => null,
+            'work_email_verified_at' => null,
+            'computed_is_gov_employee' => null,
             'enabled_email_notifications' => [NotificationFamily::APPLICATION_UPDATE->name],
             'enabled_in_app_notifications' => [NotificationFamily::APPLICATION_UPDATE->name],
         ]);


### PR DESCRIPTION
🤖 Resolves #12782 

## 👋 Introduction

Prevents a test fail due to an unrelated notification firing when none are expected.

## 🕵️ Details

This simply nulls the fields that would trigger a "gov employee but not verified" notification from being sent since we are not expecting any.

## 🧪 Testing

> [!TIP]
> `while make artisan CMD="test tests/Feature/Notifications/TriggerApplicationStatusChangedTest.php --filter=testNothingSentForNewApplications --stop-on-failure"; do echo; done`

1. Run the command provided
2. Confirm test passes 30 times in a row (or more if you want :woman_shrugging: )