### PR TITLE
[Fix] Flaky gov employee pool candidate search test

### DIFF
--- a/api/database/factories/PoolCandidateFactory.php
+++ b/api/database/factories/PoolCandidateFactory.php
@@ -8,6 +8,7 @@ use App\Enums\AssessmentResultType;
 use App\Enums\CandidateRemovalReason;
 use App\Enums\ClaimVerificationResult;
 use App\Enums\EducationRequirementOption;
+use App\Enums\EmploymentCategory;
 use App\Enums\PoolCandidateStatus;
 use App\Models\AssessmentResult;
 use App\Models\AssessmentStep;
@@ -174,6 +175,7 @@ class PoolCandidateFactory extends Factory
                 // Ensure user has at least one work experience
                 $experience = WorkExperience::factory()->create([
                     'user_id' => $poolCandidate->user_id,
+                    'employment_category' => EmploymentCategory::EXTERNAL_ORGANIZATION->name,
                 ]);
                 $poolCandidate->educationRequirementWorkExperiences()->sync([$experience->id]);
             }

--- a/api/tests/Feature/PoolCandidateSearchTest.php
+++ b/api/tests/Feature/PoolCandidateSearchTest.php
@@ -439,9 +439,7 @@ class PoolCandidateSearchTest extends TestCase
             'expiry_date' => config('constants.far_future_date'),
             'pool_candidate_status' => PoolCandidateStatus::PLACED_CASUAL->name,
             'suspended_at' => null,
-            'user_id' => User::factory([
-                'computed_is_gov_employee' => false,
-            ]),
+            'user_id' => User::factory()->asGovEmployee(false),
         ]);
 
         $query =


### PR DESCRIPTION
🤖 Resolves #13016 

## 👋 Introduction

Fixes an issue where some expected non-gov employees were being seeded as gov employees in the pool candidate search test.

## 🕵️ Details

When creating a pool candidate sometimes it creates a work experience that is a government experience causing the user to be updated to be a government employee.

This forces the experience to be external avoiding this issue.

## 🧪 Testing

> [!TIP]
> `while make artisan CMD="test tests/Feature/PoolCandidateSearchTest.php --filter=testPoolCandidatesSearchGovEmployee --stop-on-failure"; do echo; done`

1. Run command provided
2. Confirm it passes 20+ times in a row