### PR TITLE
[Copy] Updates user language profile strings

### DIFF
--- a/apps/web/src/components/Profile/components/LanguageProfile/Display.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/Display.tsx
@@ -98,9 +98,8 @@ const Display = ({
             {lookingForEnglish && (
               <li>
                 {intl.formatMessage({
-                  defaultMessage:
-                    "I would like to be considered for English positions",
-                  id: "vmj/E4",
+                  defaultMessage: "English-only positions",
+                  id: "b3c+iw",
                   description: "English Positions message",
                 })}
               </li>
@@ -108,9 +107,8 @@ const Display = ({
             {lookingForFrench && (
               <li>
                 {intl.formatMessage({
-                  defaultMessage:
-                    "I would like to be considered for French positions",
-                  id: "sWBbdX",
+                  defaultMessage: "French-only positions",
+                  id: "CFIG+8",
                   description: "French Positions message",
                 })}
               </li>
@@ -118,9 +116,8 @@ const Display = ({
             {lookingForBilingual && (
               <li>
                 {intl.formatMessage({
-                  defaultMessage:
-                    "I would like to be considered for bilingual positions (English and French)",
-                  id: "jx7Sf1",
+                  defaultMessage: "Bilingual positions",
+                  id: "94Pgq+",
                   description: "Bilingual Positions message",
                 })}
               </li>

--- a/apps/web/src/components/Profile/components/LanguageProfile/utils.ts
+++ b/apps/web/src/components/Profile/components/LanguageProfile/utils.ts
@@ -168,16 +168,16 @@ export const getConsideredLangItems = (intl: IntlShape) => [
   {
     value: "lookingForEnglish",
     label: intl.formatMessage({
-      defaultMessage: "English positions",
-      id: "JBRqD9",
+      defaultMessage: "English-only positions",
+      id: "i0K4Sb",
       description: "Message for the english positions option",
     }),
   },
   {
     value: "lookingForFrench",
     label: intl.formatMessage({
-      defaultMessage: "French positions",
-      id: "5pQfyv",
+      defaultMessage: "French-only positions",
+      id: "Be4zZT",
       description: "Message for the french positions option",
     }),
   },

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2311,6 +2311,10 @@
     "defaultMessage": "Reflète la spécialisation nécessaire",
     "description": "Text for education accepted information context in screening decision dialog"
   },
+  "94Pgq+": {
+    "defaultMessage": "Postes bilingues",
+    "description": "Bilingual Positions message"
+  },
   "953EAy": {
     "defaultMessage": "Compétence {skillId} non trouvée.",
     "description": "Message displayed for skill not found."
@@ -2891,6 +2895,10 @@
     "defaultMessage": "Catégorie d'emploi",
     "description": "Label for the employment category radio group"
   },
+  "Be4zZT": {
+    "defaultMessage": "Postes en français uniquement",
+    "description": "Message for the french positions option"
+  },
   "BfrCXV": {
     "defaultMessage": "Attendez-vous à passer environ 20 minutes à configurer la CléGC et l’application d’authentification.",
     "description": "A _what to expect_ point on the sign up page"
@@ -3014,6 +3022,10 @@
   "CDV1Cw": {
     "defaultMessage": "Modifier {experienceName}",
     "description": "Link text to edit a specific experience"
+  },
+  "CFIG+8": {
+    "defaultMessage": "Postes en français uniquement",
+    "description": "French Positions message"
   },
   "CKsQyK": {
     "defaultMessage": "Accessibilité et mesures d’adaptation",
@@ -8078,6 +8090,10 @@
     "defaultMessage": "Classification {classificationId} introuvable.",
     "description": "Message displayed for classification not found."
   },
+  "b3c+iw": {
+    "defaultMessage": "Postes en anglais uniquement",
+    "description": "English Positions message"
+  },
   "b44Vd5": {
     "defaultMessage": "Classification de l'auteur(trice) de la mise en candidature",
     "description": "Label for the nominator's classification"
@@ -9676,6 +9692,10 @@
   "i+C29d": {
     "defaultMessage": "Cacher les options d'équité offertes ({optionCount})",
     "description": "Heading for closing the accordion with available employment equity options."
+  },
+  "i0K4Sb": {
+    "defaultMessage": "Postes en anglais uniquement",
+    "description": "Message for the english positions option"
   },
   "i0N7DM": {
     "defaultMessage": "Télécharger les renseignements complets",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1715,10 +1715,6 @@
     "defaultMessage": "Quelle application d'authentification devrais-je installer?",
     "description": "GCKey question for which authenticator app to use"
   },
-  "5pQfyv": {
-    "defaultMessage": "Postes en français",
-    "description": "Message for the french positions option"
-  },
   "5pf2qR": {
     "defaultMessage": "Modifier une possibilité de formation",
     "description": "Page title for the training opportunity edit page"
@@ -4454,10 +4450,6 @@
   "J9l5Vd": {
     "defaultMessage": "P. ex., conception de sites Web",
     "description": "Placeholder for keyword search input"
-  },
-  "JBRqD9": {
-    "defaultMessage": "Postes en anglais",
-    "description": "Message for the english positions option"
   },
   "JBavNE": {
     "defaultMessage": "Confirmation du besoin d’une note spéciale",
@@ -10113,10 +10105,6 @@
     "defaultMessage": "Veuillez sélectionner un type d’expérience",
     "description": "Heading for the experience type section fo the experience form"
   },
-  "jx7Sf1": {
-    "defaultMessage": "J’aimerais être pris en considération pour des postes bilingues (anglais et français)",
-    "description": "Bilingual Positions message"
-  },
   "jyQi0m": {
     "defaultMessage": "Si vous êtes membre d’une Première Nation, Inuk ou Métis, et que vous vivez au Canada, vous pouvez demander à devenir un apprentis dans le cadre de ce programme.",
     "description": "Learn more dialog question on paragraph one"
@@ -11817,10 +11805,6 @@
     "defaultMessage": "Je suis un membre des Premières Nations sans statut",
     "description": "Text for the option to self-declare as a non-status first nations"
   },
-  "sWBbdX": {
-    "defaultMessage": "Je souhaite être pris en considération pour des postes en français",
-    "description": "French Positions message"
-  },
   "sYdl0V": {
     "defaultMessage": "Examens écrits",
     "description": "Label for preferred lang for exams in profile details box."
@@ -12440,10 +12424,6 @@
   "vmVdJt": {
     "defaultMessage": "<strong>Inscription</strong> : les places sont limitées. Vous devez demander un bon et satisfaire aux conditions préalables.",
     "description": "An item in a list of points about cert exams"
-  },
-  "vmj/E4": {
-    "defaultMessage": "Je souhaite être pris en considération pour des postes en anglais",
-    "description": "English Positions message"
   },
   "voMSDe": {
     "defaultMessage": "Les informations sur les objectifs et le style de travail ont été mises à jour avec succès!",


### PR DESCRIPTION
🤖 Resolves #13330.

## 👋 Introduction

This PR updates the options for the language section of the user profile.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/applicant/personal-information#language-section
3. Verify values for Language of positions you would like to be considered for are updated to those in the linked issue
4. Edit the form
5. Verify checkbox labels for Language of positions you would like to be considered for are updated to those in the linked issue
6. Navigate to admin view of user profile
7. Verify values for Language of positions you would like to be considered for are updated to those in the linked issue

## 📸 Screenshots

### User profile

#### English
<img width="1146" alt="Screen Shot 2025-05-06 at 13 28 05" src="https://github.com/user-attachments/assets/aff00464-d0c7-4704-8782-61b7fd4f9dc2" />
<img width="1160" alt="Screen Shot 2025-05-06 at 13 28 15" src="https://github.com/user-attachments/assets/3ed55c69-f21b-4bf7-b34c-1a0ab1f55bd6" />

#### French
<img width="1244" alt="Screen Shot 2025-05-06 at 14 09 24" src="https://github.com/user-attachments/assets/1f055b63-9931-44d3-86a0-8c1edde49ac3" />
<img width="1259" alt="Screen Shot 2025-05-06 at 14 09 32" src="https://github.com/user-attachments/assets/f834fbea-d589-4d02-aa05-60e881caa678" />


### Admin

#### English
<img width="1074" alt="Screen Shot 2025-05-06 at 13 27 56" src="https://github.com/user-attachments/assets/b74418de-2ab3-4e3e-be86-74f8f03c5497" />

#### French
<img width="1193" alt="Screen Shot 2025-05-06 at 14 10 05" src="https://github.com/user-attachments/assets/af825cc5-26c7-4757-9688-4451dfd687dc" />