### PR TITLE
[Copy] Updates work experience employment category strings

### DIFF
--- a/api/lang/en/employment_category.php
+++ b/api/lang/en/employment_category.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'external_organization' => 'This was a role with an external organization',
-    'government_of_canada' => 'This was a role with the Government of Canada',
-    'canadian_armed_forces' => 'This was a role with the Canadian Armed Forces',
+    'external_organization' => 'External organization',
+    'government_of_canada' => 'Government of Canada',
+    'canadian_armed_forces' => 'Canadian Armed Forces',
 ];

--- a/api/lang/fr/employment_category.php
+++ b/api/lang/fr/employment_category.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'external_organization' => 'Il s\'agissait d\'un rôle au sein d\'une organisation externe',
-    'government_of_canada' => 'Il s\'agissait d\'un rôle au sein du gouvernement du Canada',
-    'canadian_armed_forces' => 'Il s\'agissait d\'un rôle au sein des Forces armées canadiennes',
+    'external_organization' => 'Organisation externe',
+    'government_of_canada' => 'Gouvernement du Canada',
+    'canadian_armed_forces' => 'Forces armées canadiennes',
 ];

--- a/apps/playwright/fixtures/ExperiencePage.ts
+++ b/apps/playwright/fixtures/ExperiencePage.ts
@@ -57,7 +57,7 @@ class ExperiencePage extends AppPage {
     await this.page
       .getByRole("group", { name: /employment category/i })
       .getByRole("radio", {
-        name: /This was a role with an external organization/i,
+        name: /external organization/i,
       })
       .click();
 
@@ -112,7 +112,7 @@ class ExperiencePage extends AppPage {
     await this.page
       .getByRole("group", { name: /employment category/i })
       .getByRole("radio", {
-        name: /this was a role with the government of canada/i,
+        name: /government of canada/i,
       })
       .click();
 
@@ -163,7 +163,7 @@ class ExperiencePage extends AppPage {
     await this.page
       .getByRole("group", { name: /employment category/i })
       .getByRole("radio", {
-        name: /this was a role with the government of canada/i,
+        name: /government of canada/i,
       })
       .click();
 
@@ -228,7 +228,7 @@ class ExperiencePage extends AppPage {
     await this.page
       .getByRole("group", { name: /employment category/i })
       .getByRole("radio", {
-        name: /this was a role with the government of canada/i,
+        name: /government of canada/i,
       })
       .click();
 
@@ -306,7 +306,7 @@ class ExperiencePage extends AppPage {
     await this.page
       .getByRole("group", { name: /employment category/i })
       .getByRole("radio", {
-        name: /this was a role with the government of canada/i,
+        name: /government of canada/i,
       })
       .click();
 
@@ -385,7 +385,7 @@ class ExperiencePage extends AppPage {
     await this.page
       .getByRole("group", { name: /employment category/i })
       .getByRole("radio", {
-        name: /this was a role with the canadian armed forces/i,
+        name: /canadian armed forces/i,
       })
       .click();
 
@@ -438,7 +438,7 @@ class ExperiencePage extends AppPage {
     await this.page
       .getByRole("group", { name: /employment category/i })
       .getByRole("radio", {
-        name: /this was a role with the government of canada/i,
+        name: /government of canada/i,
       })
       .click();
 

--- a/apps/web/src/components/ExperienceFormFields/WorkFields/WorkFields.tsx
+++ b/apps/web/src/components/ExperienceFormFields/WorkFields/WorkFields.tsx
@@ -74,22 +74,22 @@ const employmentCategoryDescriptions: Record<
 > = {
   EXTERNAL_ORGANIZATION: defineMessage({
     defaultMessage:
-      "Select this option if the employment had no affiliation with the Government of Canada.",
-    id: "0MakGC",
+      "This role had no affiliation with the Government of Canada.",
+    id: "Tf8eTw",
     description:
       "Description for the external employment category option in work experience",
   }),
   GOVERNMENT_OF_CANADA: defineMessage({
     defaultMessage:
-      "Select this option if the employment was with a Government of Canada department, agency, crown corporation, or if you were a contractor working with one of these organizations.",
-    id: "nmx1ym",
+      "This was a role as an employee or a contractor at a Government of Canada department, agency, or crown corporation.",
+    id: "9XTtxd",
     description:
       "Description for the goc employment category option in work experience",
   }),
   CANADIAN_ARMED_FORCES: defineMessage({
     defaultMessage:
-      "Select this option if the employment was with Canadian Army, the Royal Canadian Air Force, or the Royal Canadian Navy, either as regular force, or reserve force.",
-    id: "uZuEHk",
+      "This was a role in the regular or reserve force of the Canadian Army, the Royal Canadian Air Force, or the Royal Canadian Navy.",
+    id: "dPAsNx",
     description:
       "Description for the caf employment category option in work experience",
   }),

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -515,10 +515,6 @@
     "defaultMessage": "De la même manière que vous avez sélectionné des éléments de votre parcours professionnel pour confirmer les exigences en matière d’expérience et d’études, nous vous demanderons de décrire une ou plusieurs expériences de votre parcours professionnel au cours desquelles vous avez activement utilisé la compétence requise.",
     "description": "Application step for skill requirements, introduction, description, paragraph two"
   },
-  "0MakGC": {
-    "defaultMessage": "Sélectionnez cette option si l'emploi n'avait aucun lien avec le gouvernement du Canada.",
-    "description": "Description for the external employment category option in work experience"
-  },
   "0NbdGD": {
     "defaultMessage": "Erreur : Échec de la suppression de la compétence",
     "description": "Message displayed to user after skill fails to be deleted."
@@ -2438,6 +2434,10 @@
   "9Vzxgu": {
     "defaultMessage": "Services d’orientation",
     "description": "Button text to open section describing referrals services"
+  },
+  "9XTtxd": {
+    "defaultMessage": "Il s’agissait d’un rôle comme membre du personnel ou comme entrepreneur(euse) dans un ministère ou un organisme fédéral ou une société d’État.",
+    "description": "Description for the goc employment category option in work experience"
   },
   "9XgUGm": {
     "defaultMessage": "Télécharger",
@@ -6611,6 +6611,10 @@
     "defaultMessage": "Oui, je suis un(e) employé(e) du gouvernement du Canada.",
     "description": "Label displayed for is a government employee option"
   },
+  "Tf8eTw": {
+    "defaultMessage": "Ce rôle n’avait aucun lien avec le gouvernement du Canada.",
+    "description": "Description for the external employment category option in work experience"
+  },
   "TfEUPu": {
     "defaultMessage": "Préférence pour la durée de l'emploi",
     "description": "Legend Text for required work preferences options in work preferences form"
@@ -8533,6 +8537,10 @@
   "dOw5u/": {
     "defaultMessage": "Nous n'avons pas trouvé de profil correspondant pour « {email} »",
     "description": "Default error messsage when an employee could not be found"
+  },
+  "dPAsNx": {
+    "defaultMessage": "Il s’agissait d'un rôle dans la force régulière ou de réserve de l’Armée canadienne, de l'Aviation royale canadienne ou de la Marine royale canadienne.",
+    "description": "Description for the caf employment category option in work experience"
   },
   "dRJLsv": {
     "defaultMessage": "Sauvegardez votre prochain type de poste",
@@ -10917,10 +10925,6 @@
     "defaultMessage": "Gestion des talents de la fonction de contrôleur",
     "description": "Title for the comptrollership executives talent management page"
   },
-  "nmx1ym": {
-    "defaultMessage": "Sélectionnez cette option si l'emploi était dans un ministère ou un organisme fédéral ou une société d'État, ou si vous étiez un entrepreneur ou une entrepreneuse travaillant pour l'une de ces organisations.",
-    "description": "Description for the goc employment category option in work experience"
-  },
   "nn9B4R": {
     "defaultMessage": "Postulez dès aujourd’hui pour entamer votre parcours de carrière en TI.",
     "description": "Homepage subtitle for IT Apprenticeship Program for Indigenous Peoples"
@@ -12228,10 +12232,6 @@
   "uWfG0e": {
     "defaultMessage": "Exigences essentielles",
     "description": "Sub title for the pool core requirements"
-  },
-  "uZuEHk": {
-    "defaultMessage": "Sélectionnez cette option si l'emploi était dans l'Armée canadienne, dans l'Aviation royale canadienne ou dans la Marine royale canadienne, dans la Force régulière ou dans la Force de réserve.",
-    "description": "Description for the caf employment category option in work experience"
   },
   "uaEMMO": {
     "defaultMessage": "Type d'emploi",


### PR DESCRIPTION
🤖 Resolves #13301.

## 👋 Introduction

This PR updates work experience employment category strings.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/applicant/career-timeline/create
3. Select Work experience in Experience type field
4. Verify Employment category labels and descriptions match those in the linked issue 
5. Switch to French

## 📸 Screenshots

<img width="1314" alt="Screen Shot 2025-05-06 at 13 59 31" src="https://github.com/user-attachments/assets/302124a6-d5c9-40e5-b94e-9ea1874e54a9" />

<img width="1310" alt="Screen Shot 2025-05-06 at 14 00 00" src="https://github.com/user-attachments/assets/84efc972-d16c-4765-8b54-fe78a88a0046" />