### PR TITLE
[Copy] Talent nomination event status strings

### DIFF
--- a/api/lang/fr/talent_nomination_event_status.php
+++ b/api/lang/fr/talent_nomination_event_status.php
@@ -2,6 +2,6 @@
 
 return [
     'active' => 'Actif',
-    'upcoming' => 'Passé',
-    'past' => 'À venir',
+    'upcoming' => 'À venir',
+    'past' => 'Passé',
 ];


### PR DESCRIPTION
🤖 Resolves #13409.

## 👋 Introduction

This PR fixes talent nomination event status strings that were mixed up in French.