### PR TITLE
[Bug] Adjust `UserPolicy.view()` team logic

### DIFF
--- a/api/app/Policies/UserPolicy.php
+++ b/api/app/Policies/UserPolicy.php
@@ -30,12 +30,17 @@ class UserPolicy
      */
     public function view(User $user, User $model)
     {
+        $roleTeams = $user->rolesTeams()->get();
+        $teamIds = $roleTeams->filter(function ($team) use ($user) {
+            return $user->isAbleTo('view-team-applicantProfile', $team);
+        })->pluck('id');
+
         return $user->isAbleTo('view-any-user') ||
             ($user->isAbleTo('view-own-user') && $user->id === $model->id) ||
             ($user->isAbleTo('view-team-applicantProfile')
                 && $this->applicantHasAppliedToPoolInTeams(
                     $model,
-                    $user->rolesTeams()->get()->pluck('id')
+                    $teamIds,
                 )
             ) ||
             count(


### PR DESCRIPTION
🤖 Resolves #13135

## 👋 Introduction

The method has been worked on a bit since issue creation so the issue is a bit outdated. Blocks 1, 2, and 4 look right to me. Block 3 seems to not assert the correct team pairing so I adjusted that. 

Tried to go for light as possible touch

## 🕵️ Details

What needed changing
If you pass in `rolesTeams` as is, you get a bunch of teams that could all have different roles. If you are X in Team A, and a Y in Team B. You need to assert attempting to be Y in A fails

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Exercise viewing users while possessing different roles/teams


