### PR TITLE
[Fix] Display skill definitions after assessing a skill

### DIFF
--- a/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
+++ b/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
@@ -108,6 +108,33 @@ export const AssessmentResultsTable_Fragment = graphql(/* GraphQL */ `
       skillDecisionNotes
       poolSkill {
         id
+        type {
+          value
+          label {
+            en
+            fr
+          }
+        }
+        requiredLevel
+        skill {
+          id
+          category {
+            value
+            label {
+              en
+              fr
+            }
+          }
+          key
+          name {
+            en
+            fr
+          }
+          description {
+            en
+            fr
+          }
+        }
       }
     }
     pool {


### PR DESCRIPTION
🤖 Resolves #13397 

## 👋 Introduction

Fixes an issue where skill definitions were dissapearing after you assess a skill.

## 🕵️ Details

This one was a little odd and I had a hard time understanidng how this is all put together :sweat_smile: 

It seems we use a different item from the query to display skill definitions depending on if it has been assessed or not :confused: 

```ts
const poolSkill = assessmentResult?.poolSkill ?? poolSkillToAssess;
```

So, the assessment result was not querying the required info to display a definition. There is most certainly a better way to solve this but the component itself is pretty hard to understand and could probably do with some clean up so I opted for a low effort fix for now :woman_shrugging: 

## 🧪 Testing

1. Build the app `pnpm run dev:fresh`
2. Login as admin `admin@test.com`
3. Navigate to a pool candidate to start an assessment
4. If there are no assess skills, simply assess one
5. After the button flips to the assessed version, open it
6. Confirm the accordion with skill definitions diplays the definition instead of a null state

## 📸 Screenshot

![2025-05-06_15-40](https://github.com/user-attachments/assets/2e8c92f7-0ba8-40af-b1cc-848031d93efe)
