### PR TITLE
[Accessibility] Functional community button label in dashboard

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4927,6 +4927,10 @@
     "defaultMessage": "Aidez les gestionnaires à comprendre quelles sont les compétences comportementales que vous aimeriez améliorer. Vous pouvez les modifier à tout moment et vous êtes libre de mettre les compétences dans l’ordre qui vous convient. Les compétences que vous ajoutez ici qui ne sont pas déjà dans votre portfolio seront ajoutées automatiquement.",
     "description": "Page blurb for the improve behavioural skills page"
   },
+  "LNXpTl": {
+    "defaultMessage": "Voir vos intérêts pour la {communityName}",
+    "description": "Button label for community interest dialog trigger"
+  },
   "LOVZi6": {
     "defaultMessage": "Détails sur l’évaluation",
     "description": "Title for Assessment details dialog"

--- a/apps/web/src/pages/ApplicantDashboardPage/components/FunctionalCommunityListItem.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/FunctionalCommunityListItem.tsx
@@ -91,6 +91,17 @@ const FunctionalCommunityListItem = ({
   const title =
     functionalCommunityListItemFragment?.community?.name?.localized ??
     intl.formatMessage(commonMessages.notAvailable);
+  const buttonLabel = intl.formatMessage(
+    {
+      defaultMessage: "View your {communityName} interests",
+      id: "LNXpTl",
+      description: "Button label for community interest dialog trigger",
+    },
+    {
+      communityName: title,
+    },
+  );
+
   return (
     <>
       <PreviewList.Item
@@ -102,7 +113,7 @@ const FunctionalCommunityListItem = ({
             communityInterestOptionsQuery={
               functionalCommunityListItemOptionsFragment
             }
-            trigger={<PreviewList.Button label={title} />}
+            trigger={<PreviewList.Button label={buttonLabel} />}
           />
         }
         headingAs={headingAs}


### PR DESCRIPTION
🤖 Resolves #13342 

## 👋 Introduction

Adjust the button label to be more informative as to what happens on click

## 🧪 Testing

1. Go to applicant dashboard
2. Have a functional community interest
3. Observe accessible label on button for that interest

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/12441176-9040-4e18-9bca-834f4736ac78)


<!-- Add a screenshot (if possible). -->


<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the PR if deployment steps are needed

 -->
