### PR TITLE
[Copy] Updates label displayed on Community Experience form for project input

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -531,10 +531,6 @@
     "defaultMessage": "En vertu de cette directive, les ministères sont tenus de fournir des informations au Bureau du dirigeant principal de l’information du Canada. Ces données sont ensuite utilisées pour créer des renseignements opérationnels et des processus de recrutement accélérés au service des ministères et des organismes du gouvernement fédéral. L’objectif est de veiller à ce que la collectivité du numérique du GC ait accès aux talents dont elle a besoin pour fournir des services numériques modernes et efficaces aux Canadiens.",
     "description": "Second paragraph describing the directive on digital talent"
   },
-  "0RlNw7": {
-    "defaultMessage": "Projet/produit",
-    "description": "Label displayed on Community Experience form for project input"
-  },
   "0SEvhI": {
     "defaultMessage": "Sélectionnez une langue",
     "description": "Placeholder displayed on the user form preferred spoken interview language field."
@@ -1534,6 +1530,10 @@
   "4yXZLY": {
     "defaultMessage": "Options de nomination",
     "description": "Label for the nomination type(s)"
+  },
+  "5+J43O": {
+    "defaultMessage": "Projet ou produit",
+    "description": "Label displayed on Community Experience form for project input"
   },
   "5+jnam": {
     "defaultMessage": "Information détaillée sur l'emploi",

--- a/apps/web/src/utils/experienceUtils.tsx
+++ b/apps/web/src/utils/experienceUtils.tsx
@@ -154,8 +154,8 @@ export const getExperienceFormLabels = (
     currentRole,
     organization,
     project: intl.formatMessage({
-      defaultMessage: "Project / Product",
-      id: "0RlNw7",
+      defaultMessage: "Project or product",
+      id: "5+J43O",
       description:
         "Label displayed on Community Experience form for project input",
     }),


### PR DESCRIPTION
🤖 Resolves #13418.

## 👋 Introduction

This PR updates the label displayed on Community Experience form for project input in English and French.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/applicant/career-timeline/create
3. Select community participation from Experience type
4. Verify label for field is Project or product

## 📸 Screenshots

<img width="1165" alt="Screen Shot 2025-05-07 at 11 53 56" src="https://github.com/user-attachments/assets/d98ebc43-6fd7-478a-9c08-2784202c1557" />

<img width="1159" alt="Screen Shot 2025-05-07 at 11 56 21" src="https://github.com/user-attachments/assets/a4e9a6f3-e1bd-4731-831c-c2861046a5bc" />

<img width="1149" alt="Screen Shot 2025-05-07 at 11 55 47" src="https://github.com/user-attachments/assets/f64927a3-9fc0-43f7-9079-e567d963c78e" />

<img width="1136" alt="Screen Shot 2025-05-07 at 11 56 02" src="https://github.com/user-attachments/assets/8c23e8b4-c966-4904-8e9b-78ea67331c58" />