### PR TITLE
[Copy] Updates nomination dialog subtitle, removes nomination dialog status well

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6950,10 +6950,6 @@
     "defaultMessage": "Aucune compétence trouvée.",
     "description": "Messaged displayed when no skill exists."
   },
-  "VDNYQU": {
-    "defaultMessage": "Votre mise en candidature a été soumise et est en attente d'examen. Nous vous informerons lorsque la collectivité fonctionnelle entamera le processus de révision.",
-    "description": "The description of the 'received' nomination status"
-  },
   "VDVRPt": {
     "defaultMessage": "Les possibilités d'emploi ne m'intéressent pas",
     "description": "Phrase marking lack of interest in community work opportunities"
@@ -10512,10 +10508,6 @@
   "luj0xr": {
     "defaultMessage": "Lors d’une étape ultérieure de la procédure de demande, vous aurez peut-être à fournir une preuve que vous êtes une personne autochtone. Certains moyens d’y parvenir sont inclus dans l’énoncé de définition au début de cette demande, notamment une carte de certificat de statut d’Indien, une carte de bénéficiaire inuit, une carte de citoyenneté métisse, une lettre d’un représentant autorisé d’une communauté autochtone reconnue, en plus d’un formulaire d’attestation. Aux fins d’inclusion, l’objet de ces mesures est de garantir que ce programme reste accessible aux peuples autochtones du Canada.",
     "description": "Content for the self-declaration verification dialog"
-  },
-  "lwRIsY": {
-    "defaultMessage": "Reçue",
-    "description": "The title of the 'received' nomination status"
   },
   "lwYOqk": {
     "defaultMessage": "Année d'admissibilité à la retraite",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3071,6 +3071,10 @@
     "defaultMessage": "Modifier notes",
     "description": "Button text to start editing pool candidate notes"
   },
+  "CTxxiq": {
+    "defaultMessage": "Vérifiez les détails d'une mise en candidature que vous avez soumise.",
+    "description": "Subtitle for the review talent nomination dialog"
+  },
   "CU5XqI": {
     "defaultMessage": "Formulaire d’auto-déclaration des peuples autochtones",
     "description": "Page title for the self-declaration page"
@@ -4946,10 +4950,6 @@
   "LOjdrP": {
     "defaultMessage": "Collectivité",
     "description": "Title for community"
-  },
-  "LOwBJx": {
-    "defaultMessage": "Vérifiez les détails d'une mise en candidature que vous avez soumise et suivez son évolution.",
-    "description": "Subtitle for the review talent nomination dialog"
   },
   "LQ0a0a": {
     "defaultMessage": "Participation au programme",

--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewTalentNominationDialog.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewTalentNominationDialog.tsx
@@ -3,13 +3,7 @@ import { useState } from "react";
 
 import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
 import { commonMessages } from "@gc-digital-talent/i18n";
-import {
-  Button,
-  Dialog,
-  PreviewList,
-  Separator,
-  Well,
-} from "@gc-digital-talent/ui";
+import { Button, Dialog, PreviewList, Separator } from "@gc-digital-talent/ui";
 import { formatDate, parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 import { assertUnreachable } from "@gc-digital-talent/helpers";
 
@@ -52,34 +46,6 @@ const ReviewTalentNominationDialog_Fragment = graphql(/* GraphQL */ `
     }
   }
 `);
-
-function StatusWell({ dialogVariant }: { dialogVariant: DialogVariant }) {
-  const intl = useIntl();
-  if (dialogVariant === "received") {
-    return (
-      <Well color="secondary">
-        <p data-h2-font-weight="base(bold)">
-          {intl.formatMessage({
-            defaultMessage: "Received",
-            id: "lwRIsY",
-            description: "The title of the 'received' nomination status",
-          })}
-        </p>
-        <p>
-          {intl.formatMessage({
-            defaultMessage:
-              "Your nomination has been successfully submitted and is awaiting review. We’ll notify you when the functional community begins the review process.",
-            id: "VDNYQU",
-            description: "The description of the 'received' nomination status",
-          })}
-        </p>
-      </Well>
-    );
-  }
-  // there will be other wells in the future for other variants
-  assertUnreachable(dialogVariant);
-  return null;
-}
 
 function FooterButtons({ dialogVariant }: { dialogVariant: DialogVariant }) {
   const intl = useIntl();
@@ -170,10 +136,6 @@ const ReviewTalentNominationDialog = ({
             data-h2-flex-direction="base(column)"
             data-h2-gap="base(x1)"
           >
-            <StatusWell dialogVariant={dialogVariant} />
-
-            <Separator decorative data-h2-margin="base(0)" />
-
             <div
               data-h2-display="base(grid)"
               data-h2-grid-template-columns="base(repeat(1, 1fr)) p-tablet(repeat(2, 1fr))"

--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewTalentNominationDialog.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewTalentNominationDialog.tsx
@@ -153,8 +153,8 @@ const ReviewTalentNominationDialog = ({
         <Dialog.Header
           subtitle={intl.formatMessage({
             defaultMessage:
-              "Check out the details of a nomination you’ve submitted and track its progress.",
-            id: "LOwBJx",
+              "Check out the details of a nomination you’ve submitted.",
+            id: "CTxxiq",
             description: "Subtitle for the review talent nomination dialog",
           })}
         >


### PR DESCRIPTION
🤖 Resolves #13416.

## 👋 Introduction

This PR removes "and track its progress" from the subtitle of the dialog and removes the status well from the dialog.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/applicant
3. Select and open the dialog for a talent nomination
4. Verify the status well is no longer rendered
5. Verify the subtitle has been updated

## 📸 Screenshots
<img width="897" alt="Screen Shot 2025-05-07 at 12 50 03" src="https://github.com/user-attachments/assets/b4ba0c59-2ad3-498e-8b2d-665dafb5b016" />
<img width="903" alt="Screen Shot 2025-05-07 at 12 50 22" src="https://github.com/user-attachments/assets/37cfd8f5-7f6d-4572-b45b-33eaf09efe1b" />
