### PR TITLE
[Bug] Improve word counter for rich text

### DIFF
--- a/packages/forms/src/components/RichTextInput/Footer.tsx
+++ b/packages/forms/src/components/RichTextInput/Footer.tsx
@@ -1,4 +1,7 @@
+import { useWatch } from "react-hook-form";
+
 import WordCounter from "../WordCounter";
+import { countNumberOfWordsAfterReplacingHTML } from "../../utils";
 
 interface FooterProps {
   name: string;
@@ -6,11 +9,21 @@ interface FooterProps {
 }
 
 const Footer = ({ wordLimit, name }: FooterProps) => {
+  const currentValue = useWatch<Record<string, string | undefined>>({ name });
+
   if (!wordLimit) return null;
+
+  const wordCountForOverride = currentValue
+    ? countNumberOfWordsAfterReplacingHTML(currentValue)
+    : 0;
 
   return (
     <div data-h2-text-align="base(right)">
-      <WordCounter name={name} wordLimit={wordLimit} />
+      <WordCounter
+        name={name}
+        wordLimit={wordLimit}
+        currentCount={wordCountForOverride}
+      />
     </div>
   );
 };

--- a/packages/forms/src/components/RichTextInput/RichTextInput.tsx
+++ b/packages/forms/src/components/RichTextInput/RichTextInput.tsx
@@ -7,7 +7,7 @@ import { errorMessages } from "@gc-digital-talent/i18n";
 import { CommonInputProps } from "../../types";
 import Field from "../Field";
 import ControlledInput from "./ControlledInput";
-import { countNumberOfWords } from "../../utils";
+import { countNumberOfWordsAfterReplacingHTML } from "../../utils";
 import useFieldState from "../../hooks/useFieldState";
 import useInputDescribedBy from "../../hooks/useInputDescribedBy";
 
@@ -60,7 +60,7 @@ const RichTextInput = ({
   if (wordLimit) {
     wordLimitRule = {
       wordCount: (value: string) =>
-        countNumberOfWords(value) <= wordLimit ||
+        countNumberOfWordsAfterReplacingHTML(value) <= wordLimit ||
         intl.formatMessage(errorMessages.overWordLimit, {
           value: wordLimit,
         }),

--- a/packages/forms/src/formUtils.test.ts
+++ b/packages/forms/src/formUtils.test.ts
@@ -7,6 +7,7 @@ import {
   enumToOptions,
   countNumberOfWords,
   alphaSortOptions,
+  countNumberOfWordsAfterReplacingHTML,
 } from "./utils";
 
 describe("string matching tests", () => {
@@ -207,5 +208,33 @@ describe("Alphabetically sorting select and combobox options tests", () => {
 
     modifiedList = alphaSortOptions(convertToOptions(unsortedList));
     expect(modifiedList).toStrictEqual(convertToOptions(sortedList));
+  });
+});
+
+describe("Test countNumberOfWordsAfterReplacingHTML()", () => {
+  const f = countNumberOfWordsAfterReplacingHTML;
+
+  test("Empty string", () => {
+    expect(f("")).toEqual(0);
+  });
+
+  test("Regular string", () => {
+    expect(f("apples to oranges")).toEqual(3);
+  });
+
+  test("Regular string with punctuation and multi spacing", () => {
+    expect(f("apples to oranges,  then at last, to   bananas")).toEqual(8);
+  });
+
+  test("Simple HTML", () => {
+    expect(f("<p>abc</p><p>def</p><p>ghi</p>")).toEqual(3);
+  });
+
+  test("Complicated HTML", () => {
+    expect(
+      f(
+        '<p>aaa</p><ul><li><p>item one</p></li><li><p>item two</p></li><li><p>item three</p></li></ul><p>abc</p><p><a target="__self" rel="noopener noreferrer nofollow" href="http://localhost.gov">link</a></p><p><br>the end</p>',
+      ),
+    ).toEqual(11);
   });
 });

--- a/packages/forms/src/utils.ts
+++ b/packages/forms/src/utils.ts
@@ -189,7 +189,7 @@ export const countNumberOfWordsAfterReplacingHTML = (text: string): number => {
   }
 
   const replacedString = text
-    .replace(/<(?:"[^"]*"['"]*|'[^']*'['"]*|[^'">])+>/g, " ")
+    .replace(/<(?:"[^"]*"|'[^']*'|[^'">])*>/g, " ")
     .trim();
   return replacedString.replace(/\s+/g, " ").trim().split(" ").length;
 };

--- a/packages/forms/src/utils.ts
+++ b/packages/forms/src/utils.ts
@@ -177,6 +177,23 @@ export const countNumberOfWords = (text: string): number => {
   return 0;
 };
 
+// Reference https://uibakery.io/regex-library/html
+/**
+ * Returns total number of words in a string after stripping out HTML tags
+ * @param text String you want the word count for after removing HTML tags
+ * @returns number
+ */
+export const countNumberOfWordsAfterReplacingHTML = (text: string): number => {
+  if (text === "") {
+    return 0; // otherwise this sometimes returns "<empty string>"
+  }
+
+  const replacedString = text
+    .replace(/<(?:"[^"]*"['"]*|'[^']*'['"]*|[^'">])+>/g, " ")
+    .trim();
+  return replacedString.replace(/\s+/g, " ").trim().split(" ").length;
+};
+
 /**
  * Maps a list of objects to sorted options
  * @param objects An array of objects with an id and name property


### PR DESCRIPTION
🤖 Resolves #12775

## 👋 Introduction

The word counter wasn't working right for instances of `<RichTextInput />`
This was due to HTML characters not being handled at all with the word counter function we used. I added another word counter function for handling HTML, for use in rich text. I elected to avoid a one size fits all function so that each function can be tuned separately if needed


## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->


1. Test text inputs with word counters
2. Example, text fields for editing a pool


## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
![image](https://github.com/user-attachments/assets/aa589309-5cd8-47db-9fd2-555e8208b838)


