### PR TITLE
Revert "Bump storybook-react-intl from 3.2.3 to 4.0.1 in the storybook group"

### DIFF
--- a/packages/storybook-helpers/package.json
+++ b/packages/storybook-helpers/package.json
@@ -40,7 +40,7 @@
     "jest": "^29.7.0",
     "react": "^18.3.1",
     "storybook": "^8.6.12",
-    "storybook-react-intl": "^4.0.1",
+    "storybook-react-intl": "^3.2.3",
     "tsconfig": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -989,8 +989,8 @@ importers:
         specifier: ^8.6.12
         version: 8.6.12(prettier@3.5.3)
       storybook-react-intl:
-        specifier: ^4.0.1
-        version: 4.0.1(react-intl@7.1.11(react@18.3.1)(typescript@5.8.3))(storybook@8.6.12(prettier@3.5.3))
+        specifier: ^3.2.3
+        version: 3.2.3(react-intl@7.1.11(react@18.3.1)(typescript@5.8.3))
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -7353,16 +7353,13 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
-  storybook-i18n@4.0.2:
-    resolution: {integrity: sha512-yjdnebNcuu+QxExe9kiqQwXuS850dKAmzkVRHX1/K1mVdF8q46FvaczEYgCCUTepKvx+ZB3UFkvj2I73n2AK0w==}
-    peerDependencies:
-      storybook: ^9.0.0-beta.10
+  storybook-i18n@3.1.1:
+    resolution: {integrity: sha512-k1/lS+Rx6l5mJEYAHQWEgXuwU5IyWk7kjcJtm2FDIn1UqZwbEraGlrp/fEZKK2e/7+SXEQdKeCaTz7+63WTQxw==}
 
-  storybook-react-intl@4.0.1:
-    resolution: {integrity: sha512-yv8OmUYscejj8IqaHOFxrJ7c/p186yJmr8aX33gEhcIooIf+YM77cnUxezqlTcL477stIqoFPdXzjAshJW1e+w==}
+  storybook-react-intl@3.2.3:
+    resolution: {integrity: sha512-AJLei5j7PNiiSR0MyCE6scS3nBKy9cFAig4Y+47PsWHde+QkmiedMneo95w/n4xavNktHxmJoKcLaTgCKJ/nkw==}
     peerDependencies:
       react-intl: ^5.24.0 || ^6.0.0 || ^7.0.0
-      storybook: ^9.0.0-beta.10
 
   storybook@8.6.12:
     resolution: {integrity: sha512-Z/nWYEHBTLK1ZBtAWdhxC0l5zf7ioJ7G4+zYqtTdYeb67gTnxNj80gehf8o8QY9L2zA2+eyMRGLC2V5fI7Z3Tw==}
@@ -15480,15 +15477,12 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
-  storybook-i18n@4.0.2(storybook@8.6.12(prettier@3.5.3)):
-    dependencies:
-      storybook: 8.6.12(prettier@3.5.3)
+  storybook-i18n@3.1.1: {}
 
-  storybook-react-intl@4.0.1(react-intl@7.1.11(react@18.3.1)(typescript@5.8.3))(storybook@8.6.12(prettier@3.5.3)):
+  storybook-react-intl@3.2.3(react-intl@7.1.11(react@18.3.1)(typescript@5.8.3)):
     dependencies:
       react-intl: 7.1.11(react@18.3.1)(typescript@5.8.3)
-      storybook: 8.6.12(prettier@3.5.3)
-      storybook-i18n: 4.0.2(storybook@8.6.12(prettier@3.5.3))
+      storybook-i18n: 3.1.1
 
   storybook@8.6.12(prettier@3.5.3):
     dependencies:


### PR DESCRIPTION
Reverts GCTC-NTGC/gc-digital-talent#13431

## Summary

This broke chromatic it seems so we should roll it back.