### PR TITLE
[Bug] Update graphiql index to remove deprecated

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -32,6 +32,7 @@ FRESHDESK
 Gatineau
 GCNOTIFY
 gctalent
+graphiql
 heroicons
 ilike
 inclusivity

--- a/api/resources/views/vendor/graphiql/index.blade.php
+++ b/api/resources/views/vendor/graphiql/index.blade.php
@@ -1,80 +1,60 @@
+>{{-- See https://github.com/graphql/graphiql/blob/main/examples/graphiql-cdn/index.html. --}}
+@php
+use MLL\GraphiQL\GraphiQLAsset;
+@endphp
 <!DOCTYPE html>
 <html lang="en">
-@php use MLL\GraphiQL\DownloadAssetsCommand; @endphp
 <head>
-    <meta charset=utf-8/>
-    <meta name="viewport"
-          content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GraphiQL</title>
     <style nonce="**CSP_NONCE**">
         body {
             height: 100%;
             margin: 0;
             width: 100%;
-            overflow: hidden;
+            overflow: hidden; /* in Firefox */
         }
 
         #graphiql {
-            height: 100vh;
+            height: 100dvh;
         }
 
-        /* Make the explorer feel more integrated */
-        .docExplorerWrap {
-            overflow: auto !important;
-            width: 100% !important;
-            height: auto !important;
-        }
-
-        .doc-explorer-title-bar {
-            font-weight: var(--font-weight-medium);
-            font-size: var(--font-size-h2);
-            overflow-x: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-        }
-
-        .doc-explorer-rhs {
-            display: none;
-        }
-
-        .doc-explorer-contents {
-            margin: var(--px-16) 0 0;
-        }
-
-        .graphiql-explorer-actions select {
-            margin-left: var(--px-12);
+        #graphiql-loading {
+            height: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 4rem;
         }
     </style>
-    <script nonce="**CSP_NONCE**" src="{{ DownloadAssetsCommand::reactPath() }}"></script>
-    <script nonce="**CSP_NONCE**"src="{{ DownloadAssetsCommand::reactDOMPath() }}"></script>
-    <link nonce="**CSP_NONCE**" rel="stylesheet" href="{{ DownloadAssetsCommand::cssPath() }}"/>
-    <link nonce="**CSP_NONCE**" rel="shortcut icon" href="{{ DownloadAssetsCommand::faviconPath() }}"/>
+    <script nonce="**CSP_NONCE**" src="{{ GraphiQLAsset::reactJS() }}"></script>
+    <script nonce="**CSP_NONCE**" src="{{ GraphiQLAsset::reactDOMJS() }}"></script>
+    <link nonce="**CSP_NONCE**" rel="stylesheet" href="{{ GraphiQLAsset::graphiQLCSS() }}"/>
+    <link nonce="**CSP_NONCE**" rel="stylesheet" href="{{ GraphiQLAsset::pluginExplorerCSS() }}"/>
+    <link nonce="**CSP_NONCE**" rel="shortcut icon" href="{{ GraphiQLAsset::favicon() }}"/>
 </head>
 
 <body>
 
-<div id="graphiql">Loading...</div>
-<script nonce="**CSP_NONCE**" src="{{ DownloadAssetsCommand::jsPath() }}"></script>
-<script nonce="**CSP_NONCE**" src="{{ DownloadAssetsCommand::pluginExplorerPath() }}"></script>
+<div id="graphiql">
+    <div id="graphiql-loading">Loading…</div>
+</div>
+
+<script nonce="**CSP_NONCE**" src="{{ GraphiQLAsset::graphiQLJS() }}"></script>
+<script nonce="**CSP_NONCE**" src="{{ GraphiQLAsset::pluginExplorerJS() }}"></script>
 <script nonce="**CSP_NONCE**">
     const fetcher = GraphiQL.createFetcher({
         url: '{{ $url }}',
         subscriptionUrl: '{{ $subscriptionUrl }}',
     });
+    const explorer = GraphiQLPluginExplorer.explorerPlugin();
 
     function GraphiQLWithExplorer() {
-        const [query, setQuery] = React.useState('');
-
         return React.createElement(GraphiQL, {
             fetcher,
-            query,
-            onEditQuery: setQuery,
-            defaultEditorToolsVisibility: true,
             plugins: [
-                GraphiQLPluginExplorer.useExplorerPlugin({
-                    query,
-                    onEdit: setQuery,
-                }),
+                explorer,
             ],
             // See https://github.com/graphql/graphiql/tree/main/packages/graphiql#props for available settings
         });

--- a/api/resources/views/vendor/graphiql/index.blade.php
+++ b/api/resources/views/vendor/graphiql/index.blade.php
@@ -27,6 +27,34 @@ use MLL\GraphiQL\GraphiQLAsset;
             justify-content: center;
             font-size: 4rem;
         }
+
+        .graphiql-doc-explorer {
+            overflow: auto !important;
+            width: 100% !important;
+            height: auto !important;
+        }
+
+        .graphiql-doc-explorer-title {
+            font-weight: var(--font-weight-medium);
+            font-size: var(--font-size-h2);
+            overflow-x: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .graphiql-doc-explorer-content {
+            margin: var(--px-16) 0 0;
+        }
+
+        .graphiql-doc-explorer-content {
+            margin: var(--px-16) 0 0;
+        }
+
+        .graphiql-tab {
+            margin-right: 6px;
+            padding-right: 6px;
+        }
+
     </style>
     <script nonce="**CSP_NONCE**" src="{{ GraphiQLAsset::reactJS() }}"></script>
     <script nonce="**CSP_NONCE**" src="{{ GraphiQLAsset::reactDOMJS() }}"></script>

--- a/api/resources/views/vendor/graphiql/index.blade.php
+++ b/api/resources/views/vendor/graphiql/index.blade.php
@@ -1,4 +1,4 @@
->{{-- See https://github.com/graphql/graphiql/blob/main/examples/graphiql-cdn/index.html. --}}
+{{-- See https://github.com/graphql/graphiql/blob/main/examples/graphiql-cdn/index.html. --}}
 @php
 use MLL\GraphiQL\GraphiQLAsset;
 @endphp


### PR DESCRIPTION
🤖 Resolves #13446

## 👋 Introduction

Get the graphiql page up and running again. There were two issues at play
- Bug with `e.useInsertionEffect` resolved by updating to >= [v3.3.3](https://github.com/mll-lab/laravel-graphiql/releases/tag/v3.3.3)
- Deprecated `DownloadAssetsCommand` resolved by following instructions for [4.0.0](https://github.com/mll-lab/laravel-graphiql/releases/tag/v4.0.0)


## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->


1. Can use the graphiql tool again


## 📸 Screenshot

![image](https://github.com/user-attachments/assets/4db28e07-053e-4af4-95f1-95662d534783)

<!-- Add a screenshot (if possible). -->

