### PR TITLE
[Fix] Skill dialog submitting parent form

### DIFF
--- a/apps/web/src/components/SkillBrowser/SkillBrowserDialog.tsx
+++ b/apps/web/src/components/SkillBrowser/SkillBrowserDialog.tsx
@@ -153,7 +153,13 @@ const SkillBrowserDialog = ({
         <Dialog.Header subtitle={subtitle}>{title}</Dialog.Header>
         <Dialog.Body>
           <FormProvider {...methods}>
-            <form onSubmit={methods.handleSubmit(handleAddSkill)}>
+            <form
+              onSubmit={async (e) => {
+                e.preventDefault();
+                await methods.handleSubmit(handleAddSkill)(e);
+                e.stopPropagation();
+              }}
+            >
               <SkillSelection
                 {...{ skills, inLibrary }}
                 onSelectSkill={setSelectedSkill}

--- a/apps/web/src/components/SkillBrowser/SkillBrowserDialog.tsx
+++ b/apps/web/src/components/SkillBrowser/SkillBrowserDialog.tsx
@@ -156,8 +156,9 @@ const SkillBrowserDialog = ({
             <form
               onSubmit={async (e) => {
                 e.preventDefault();
-                await methods.handleSubmit(handleAddSkill)(e);
                 e.stopPropagation();
+                await methods.handleSubmit(handleAddSkill)(e);
+                return false;
               }}
             >
               <SkillSelection


### PR DESCRIPTION
🤖 Resolves #13284 

## 👋 Introduction

Prevents the skill browser form from propagating the submission up to the parent form.

## 🧪 Testing

1. Build app `pnpm run dev:fresh`
2. Login as applicant `applicant-employee@test.com`
3. Navigate to either create or edit experience
4. Scroll down to the skills section
5. Using your keyboard, select "Add a skill"
6. Select a skill and submit the form (with your keyboard)
7. Confirm the skill is selected and there is no attempt to submit the experience form
