### PR TITLE
[Bug] Fix remaining `canQuery` call that fetches all

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -431,7 +431,7 @@ type Pool implements HasRoleAssignments {
     @hasManyThrough
     @canRoot(ability: "viewTeamMembers")
   teamIdForRoleAssignment: ID @with(relation: "team")
-  department: Department @belongsTo @canQuery(ability: "view")
+  department: Department @belongsTo
   areaOfSelection: LocalizedPoolAreaOfSelection
     @rename(attribute: "area_of_selection")
   selectionLimitations: [LocalizedPoolSelectionLimitation!]


### PR DESCRIPTION
🤖 Resolves #13249

## 👋 Introduction

Investigating, and it appears the one expected instance of `canQuery` fetching all does indeed fetch all. Once a high number of departments exists, queries that touch that policy degrade significantly.
I elected to delete the policy call as neither current nor near-future requires gating department, no context where you need to hide  the department from a pool you can view. 
<!-- Describe what this PR is solving. -->

## 🕵️ Details

Lotta seeding to do testing. Tangential, some possible performance issues become noticeable with large data volume, An issue already exists for this though https://github.com/GCTC-NTGC/gc-digital-talent/issues/13269

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->


1. Not sure, at the minimum ensure nothing broke




<!-- Add a screenshot (if possible). -->



<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the PR if deployment steps are needed

 -->
