### PR TITLE
[Copy] Update "Rejected" nomination statuses to "Not supported"

### DIFF
--- a/api/lang/en/talent_nomination_group_decision.php
+++ b/api/lang/en/talent_nomination_group_decision.php
@@ -2,5 +2,5 @@
 
 return [
     'approved' => 'Approved',
-    'rejected' => 'Rejected',
+    'rejected' => 'Not supported',
 ];

--- a/api/lang/en/talent_nomination_group_status.php
+++ b/api/lang/en/talent_nomination_group_status.php
@@ -4,5 +4,5 @@ return [
     'in_progress' => 'In progress',
     'approved' => 'Approved',
     'partially_approved' => 'Partially approved',
-    'rejected' => 'Rejected',
+    'rejected' => 'Not supported',
 ];

--- a/api/lang/fr/talent_nomination_group_decision.php
+++ b/api/lang/fr/talent_nomination_group_decision.php
@@ -2,5 +2,5 @@
 
 return [
     'approved' => 'Approuvée',
-    'rejected' => 'Rejetée',
+    'rejected' => 'Non retenue',
 ];

--- a/api/lang/fr/talent_nomination_group_status.php
+++ b/api/lang/fr/talent_nomination_group_status.php
@@ -4,5 +4,5 @@ return [
     'in_progress' => 'En cours',
     'approved' => 'Approuvée',
     'partially_approved' => 'Partiellement approuvée',
-    'rejected' => 'Rejetée',
+    'rejected' => 'Non retenue',
 ];

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/ComputedIcon.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/ComputedIcon.tsx
@@ -51,7 +51,7 @@ const ComputedIcon = ({ count, decision }: ComputedIconProps) => {
       <XCircleIcon
         data-h2-color="base(error) base:dark(error.lighter)"
         aria-hidden="false"
-        aria-label={intl.formatMessage(commonMessages.rejected)}
+        aria-label={intl.formatMessage(commonMessages.notSupported)}
         {...sharedIconStyling}
       />
     );

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -195,6 +195,10 @@
     "defaultMessage": "Une erreur s’est produite au moment d’annuler la décision finale. Veuillez communiquer avec le personnel de soutien si le problème persiste.",
     "description": "Error message that reverting the final decision for a candidate failed"
   },
+  "5RMS25": {
+    "defaultMessage": "Non retenue",
+    "description": "Not supported status"
+  },
   "5RTQe6": {
     "defaultMessage": "Préparation de votre fichier pour le téléchargement. Une fois celle-ci terminée, vous recevrez une notification.",
     "description": "Message to user when they request a file for download"
@@ -554,10 +558,6 @@
   "M3c9Yo": {
     "defaultMessage": "Erreur : la suppression de la candidature a échoué",
     "description": "Message displayed to user after application fails to get deleted."
-  },
-  "M9k8b8": {
-    "defaultMessage": "Rejetée",
-    "description": "Rejected status"
   },
   "MAeNit": {
     "defaultMessage": "J'accepte d'avoir un emploi dans le cadre duquel je dois transporter, soulever et déposer de l'équipement pesant jusqu'à 20 kg.",

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -437,10 +437,10 @@ const commonMessages = defineMessages({
     id: "oCFl63",
     description: "Approved status",
   },
-  rejected: {
-    defaultMessage: "Rejected",
-    id: "M9k8b8",
-    description: "Rejected status",
+  notSupported: {
+    defaultMessage: "Not supported",
+    id: "5RMS25",
+    description: "Not supported status",
   },
   inProgress: {
     defaultMessage: "In progress",


### PR DESCRIPTION
🤖 Resolves #13414.

## 👋 Introduction

Updates "Rejected" nomination statuses to instead say "Not supported".

## 🧪 Testing

1. Navigate to view a talent nomination group: `/admin/talent-events/{eventId}/nominations/{nominationGroupId}`.
2. Assess the candidate as not supported if it isn't already.
3. Confirm the status says "Not supported".
4. Navigate to view the nomination table for the event: `/admin/talent-events/{eventId}/nominations`.
5. Confirm the status of your nomination is "Not supported".
6. Look for any other instances referring to nomination status as "Rejected".

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/fccbf4f0-2fb0-4752-a889-5e7726f4fee9)
![image](https://github.com/user-attachments/assets/59ec7499-b4b9-4f24-85b8-61f091ecdb5e)
