### PR TITLE
[Bug] Resolve `countApplicants` and `countPoolCandidatesByPool` mismatch

### DIFF
--- a/api/app/Builders/UserBuilder.php
+++ b/api/app/Builders/UserBuilder.php
@@ -310,8 +310,8 @@ class UserBuilder extends Builder
                     $query->whereClassifications($filters['qualifiedClassifications']);
                 }
 
-                if (array_key_exists('qualifiedStreams', $filters)) {
-                    $query->whereWorkStreamsIn($filters['qualifiedStreams']);
+                if (array_key_exists('workStreams', $filters)) {
+                    $query->whereWorkStreamsIn($filters['workStreams']);
                 }
             });
 


### PR DESCRIPTION
🤖 Resolves #13465

## 👋 Introduction

Fixes the issue, it appears the key name was wrong. This appears to have been a bug present for a while 😬 

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Test the talent search


## 📸 Screenshot

Field on the filter type is called `workStreams`

![image](https://github.com/user-attachments/assets/7032c677-8caa-4e0d-8bc8-dff725108fed)

Query `CountPoolCandidatesByPool` correctly referred to it

![image](https://github.com/user-attachments/assets/f3722606-b4b8-4dad-8a04-2211e6d99248)

Scope `whereHasTalentSearchablePublishingGroups` referred to something else instead

![image](https://github.com/user-attachments/assets/a296844d-acc4-48e2-ac56-92c52f4114e1)

![image](https://github.com/user-attachments/assets/7ed4d8aa-6159-4139-906d-b479c85c17a9)


<!-- Add a screenshot (if possible). -->


