### PR TITLE
[Feat] Scroll to top on nomination form step transition

### DIFF
--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/SubHeading.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/SubHeading.tsx
@@ -1,13 +1,33 @@
-import { Heading, HeadingProps } from "@gc-digital-talent/ui";
+import { useEffect, useRef } from "react";
 
-const SubHeading = (props: HeadingProps) => (
-  <Heading
-    level="h2"
-    color="primary"
-    data-h2-margin-top="base(0)"
-    data-h2-font-weight="base(400)"
-    {...props}
-  />
-);
+import { Heading, HeadingProps, HeadingRef } from "@gc-digital-talent/ui";
+
+interface SubHeadingProps extends HeadingProps {
+  preventAutoFocus?: boolean;
+}
+
+const SubHeading = ({ preventAutoFocus, ...rest }: SubHeadingProps) => {
+  const headingRef = useRef<HeadingRef>(null);
+
+  useEffect(() => {
+    if (headingRef.current && !preventAutoFocus) {
+      // Focus heading and scroll to top
+      headingRef.current.focus({ preventScroll: false });
+      window.scrollTo({ top: 0, left: 0, behavior: "instant" });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <Heading
+      ref={headingRef}
+      level="h2"
+      color="primary"
+      data-h2-margin-top="base(0)"
+      data-h2-font-weight="base(400)"
+      {...rest}
+    />
+  );
+};
 
 export default SubHeading;


### PR DESCRIPTION
🤖 Resolves #13289 

## 👋 Introduction

Adds a focus and scroll to top on mount of the nomination talent step sub headings.

## 🧪 Testing

1. Build app `pnpm run dev:fresh`
2. Login as an employee `applicant-employee@test.com`
3. Start a nomination
4. Fill out a step with lots of data to force a scroll that is noticable
5. Submit the page
6. Confirm the next page subheading is focus and scroll position is reset