### PR TITLE
[Copy] Updates label displayed on Community Experience form for group input

### DIFF
--- a/apps/playwright/fixtures/ExperiencePage.ts
+++ b/apps/playwright/fixtures/ExperiencePage.ts
@@ -536,7 +536,7 @@ class ExperiencePage extends AppPage {
       .fill(input.title ?? "test role");
 
     await this.page
-      .getByLabel("Group / Organization / Community *", { exact: true })
+      .getByLabel("Group, organization, or community *", { exact: true })
       .fill(input?.organization ?? "test org");
 
     await this.page

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2879,10 +2879,6 @@
     "defaultMessage": "Renseignements personnels et coordonnées",
     "description": "Title for the personal and contact information section"
   },
-  "Badvbb": {
-    "defaultMessage": "Groupe/Organisation/Collectivité",
-    "description": "Label displayed on Community Experience form for organization input"
-  },
   "Bb9Pe0": {
     "defaultMessage": "Veuillez sélectionner l'évaluation de cette nomination pour continuer.",
     "description": "Prompt for the user to evaluate the nomination before continuing"
@@ -8313,6 +8309,10 @@
   "c0SFYY": {
     "defaultMessage": "Si vous ne trouvez toujours pas une compétence, il est possible qu’elle n’ait pas encore été ajoutée à notre bibliothèque. Nous enrichissons constamment notre liste de compétences et serions ravis de connaître votre avis. <a>Faites-nous part de vos suggestions</a>.",
     "description": "Help text to tell users to change their filters to find a skill"
+  },
+  "c11b35": {
+    "defaultMessage": "Groupe, organisation ou collectivité",
+    "description": "Label displayed on Community Experience form for organization input"
   },
   "c4R8FH": {
     "defaultMessage": "<link>L'Ambition numérique</link>, publiée en 2022, donne des directives sur la façon d'accroître la représentation des groupes sous-représentés en ayant recours à des programmes tels le Programme d'apprentissage en TI pour les personnes autochtones.",

--- a/apps/web/src/utils/experienceUtils.tsx
+++ b/apps/web/src/utils/experienceUtils.tsx
@@ -105,8 +105,8 @@ export const getExperienceFormLabels = (
 
   if (experienceType === "community") {
     organization = intl.formatMessage({
-      defaultMessage: "Group / Organization / Community",
-      id: "Badvbb",
+      defaultMessage: "Group, organization, or community",
+      id: "c11b35",
       description:
         "Label displayed on Community Experience form for organization input",
     });


### PR DESCRIPTION
🤖 Resolves #13483.

## 👋 Introduction

This PR updates the group label displayed on Community Experience form for group input in English and French.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/applicant/career-timeline/create
3. Select community participation from Experience type
4. Verify label for field is Group, organization, or community
5. Switch to French
6. Verify label for field is Groupe, organisation ou collectivité

## 📸 Screenshots

<img width="1131" alt="Screen Shot 2025-05-15 at 13 30 34" src="https://github.com/user-attachments/assets/bc012d50-77df-49e1-b6bb-2051d1bb417c" />

<img width="1114" alt="Screen Shot 2025-05-15 at 13 30 57" src="https://github.com/user-attachments/assets/1e646da5-b460-47f4-a253-3649db752aa2" />

