### PR TITLE
[Fix] Add missing `type` field

### DIFF
--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/FullCareerExperiences.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/FullCareerExperiences.tsx
@@ -40,6 +40,12 @@ export const FullCareerExperiencesUser_Fragment = graphql(/* GraphQL */ `
       ... on EducationExperience {
         startDate
         endDate
+        type {
+          value
+          label {
+            localized
+          }
+        }
       }
       ... on PersonalExperience {
         startDate


### PR DESCRIPTION
🤖 Resolves #13481.

## 👋 Introduction

This PR adds a missing `type` field that is used in the `ExperienceCard` title.

## 🧪 Testing

1. `pnpm build:fresh`
2. Find a nominee with an education experience
3. Navigate to the career experience tab from the Talent Management table (`http://localhost:8000/en/admin/talent-events/:event-id/nominations/:nomination-id/career-experience`)
4. Verify the experience cards for any of the education experiences when sorted by type have the correct title (should match those in the profile for the same experiences)

## 📸 Screenshot

<img width="1419" alt="Screen Shot 2025-05-15 at 15 53 35" src="https://github.com/user-attachments/assets/843bf824-c199-4c4d-9b9d-77fe2ab17e33" />