### PR TITLE
[Fix] Do not disable skill browser submit button

### DIFF
--- a/apps/web/src/components/SkillBrowser/SkillBrowserDialog.tsx
+++ b/apps/web/src/components/SkillBrowser/SkillBrowserDialog.tsx
@@ -67,6 +67,7 @@ const SkillBrowserDialog = ({
   const intl = useIntl();
   const paths = useRoutes();
   const [isOpen, setIsOpen] = useState<boolean>(defaultOpen);
+  const [adding, setAdding] = useState<boolean>(false);
   const [selectedSkill, setSelectedSkill] = useState<Skill | null>(null);
   const methods = useForm<FormValues>({
     defaultValues: initialState ?? defaultFormValues,
@@ -95,13 +96,19 @@ const SkillBrowserDialog = ({
   // Option 2: Change SkillBrowserDialog to not submit but instead run onSave function.
   const handleAddSkill = async (values: FormValues) => {
     const result = await formTrigger(["skill"]);
-    if (result)
-      await onSave(values).then(() => {
-        setIsOpen(false);
-        reset();
-        if (!noToast)
-          toast.success(selected(getLocalizedName(selectedSkill?.name, intl)));
-      });
+    if (result && !adding) {
+      setAdding(true);
+      await onSave(values)
+        .then(() => {
+          setIsOpen(false);
+          reset();
+          if (!noToast)
+            toast.success(
+              selected(getLocalizedName(selectedSkill?.name, intl)),
+            );
+        })
+        .finally(() => setAdding(false));
+    }
   };
 
   const handleOpenChange = (newIsOpen: boolean) => {

--- a/apps/web/src/components/SkillBrowser/SkillBrowserDialog.tsx
+++ b/apps/web/src/components/SkillBrowser/SkillBrowserDialog.tsx
@@ -180,12 +180,7 @@ const SkillBrowserDialog = ({
                 />
               )}
               <Dialog.Footer>
-                <Button
-                  type="button"
-                  color="secondary"
-                  disabled={isSubmitting}
-                  onClick={() => methods.handleSubmit(handleAddSkill)()}
-                >
+                <Button type="submit" color="secondary">
                   {isSubmitting
                     ? intl.formatMessage(commonMessages.saving)
                     : submit}


### PR DESCRIPTION
🤖 Resolves #13254 

## 👋 Introduction

Updates the skill browser dialog to no longer disable the submit button.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as an applicant `applicant@test.com`
3. Go to the skill library
4. Using keyboard, select a skill and submit the form
5. Confirm the button is no longer disabled and focus remains on the submit button
6. Confirm you cannot trigger the submit multiple times