### PR TITLE
[Feature] Area of selection limitation - Canadian citizens

### DIFF
--- a/api/app/Enums/PoolSelectionLimitation.php
+++ b/api/app/Enums/PoolSelectionLimitation.php
@@ -10,9 +10,31 @@ enum PoolSelectionLimitation
 
     case AT_LEVEL_ONLY;
     case DEPARTMENTAL_PREFERENCE;
+    case CANADIAN_CITIZENS;
 
     public static function getLangFilename(): string
     {
         return 'pool_selection_limitation';
+    }
+
+    /**
+     * @return array<int, PoolSelectionLimitation>
+     */
+    public static function limitationsForEmployees(): array
+    {
+        return [
+            PoolSelectionLimitation::AT_LEVEL_ONLY,
+            PoolSelectionLimitation::DEPARTMENTAL_PREFERENCE,
+        ];
+    }
+
+    /**
+     * @return array<int, PoolSelectionLimitation>
+     */
+    public static function limitationsForPublic(): array
+    {
+        return [
+            PoolSelectionLimitation::CANADIAN_CITIZENS,
+        ];
     }
 }

--- a/api/app/GraphQL/Validators/PoolIsCompleteValidator.php
+++ b/api/app/GraphQL/Validators/PoolIsCompleteValidator.php
@@ -73,8 +73,16 @@ final class PoolIsCompleteValidator extends Validator
             'what_to_expect_admission.fr' => ['required_with:what_to_expect_admission.en', 'string', 'nullable'],
             'publishing_group' => ['required', Rule::in(array_column(PublishingGroup::cases(), 'name'))],
             'area_of_selection' => ['required', Rule::in(array_column(PoolAreaOfSelection::cases(), 'name'))],
-            'selection_limitations' => ['prohibited_unless:area_of_selection,'.PoolAreaOfSelection::EMPLOYEES->name],
-            'selection_limitations.*' => [Rule::in(array_column(PoolSelectionLimitation::cases(), 'name'))],
+            'selection_limitations' => ['nullable', 'array', 'distinct'],
+            'selection_limitations.*' => [
+                Rule::in(array_column(PoolSelectionLimitation::cases(), 'name')),
+                Rule::when(fn ($attributes) => $attributes->area_of_selection == PoolAreaOfSelection::EMPLOYEES->name,
+                    [Rule::in(array_column(PoolSelectionLimitation::limitationsForEmployees(), 'name'))]
+                ),
+                Rule::when(fn ($attributes) => $attributes->area_of_selection == PoolAreaOfSelection::PUBLIC->name,
+                    [Rule::in(array_column(PoolSelectionLimitation::limitationsForPublic(), 'name'))]
+                ),
+            ],
         ];
     }
 

--- a/api/database/factories/PoolFactory.php
+++ b/api/database/factories/PoolFactory.php
@@ -200,12 +200,16 @@ class PoolFactory extends Factory
                 'opportunity_length' => $this->faker->randomElement(array_column(PoolOpportunityLength::cases(), 'name')),
                 'area_of_selection' => $this->faker->optional()->randomElement(array_column(PoolAreaOfSelection::cases(), 'name')),
                 'selection_limitations' => function (array $attributes) {
-                    return $attributes['area_of_selection'] == PoolAreaOfSelection::EMPLOYEES->name
-                        ? $this->faker->randomElements(
-                            array_column(PoolSelectionLimitation::cases(), 'name'),
-                            $this->faker->numberBetween(0, count(PoolSelectionLimitation::cases()))
-                        )
-                        : [];
+                    $possibleLimitations = match ($attributes['area_of_selection']) {
+                        PoolAreaOfSelection::EMPLOYEES->name => PoolSelectionLimitation::limitationsForEmployees(),
+                        PoolAreaOfSelection::PUBLIC->name => PoolSelectionLimitation::limitationsForPublic(),
+                        default => []
+                    };
+
+                    return $this->faker->randomElements(
+                        array_column($possibleLimitations, 'name'),
+                        $this->faker->numberBetween(0, count($possibleLimitations))
+                    );
                 },
             ];
         });
@@ -248,12 +252,16 @@ class PoolFactory extends Factory
                 'change_justification' => $this->faker->boolean(50) ? $this->faker->paragraph() : null,
                 'area_of_selection' => $this->faker->randomElement(array_column(PoolAreaOfSelection::cases(), 'name')),
                 'selection_limitations' => function (array $attributes) {
-                    return $attributes['area_of_selection'] == PoolAreaOfSelection::EMPLOYEES->name
-                        ? $this->faker->randomElements(
-                            array_column(PoolSelectionLimitation::cases(), 'name'),
-                            $this->faker->numberBetween(0, count(PoolSelectionLimitation::cases()))
-                        )
-                        : [];
+                    $possibleLimitations = match ($attributes['area_of_selection']) {
+                        PoolAreaOfSelection::EMPLOYEES->name => PoolSelectionLimitation::limitationsForEmployees(),
+                        PoolAreaOfSelection::PUBLIC->name => PoolSelectionLimitation::limitationsForPublic(),
+                        default => []
+                    };
+
+                    return $this->faker->randomElements(
+                        array_column($possibleLimitations, 'name'),
+                        $this->faker->numberBetween(0, count($possibleLimitations))
+                    );
                 },
             ];
         });

--- a/api/lang/en/pool_selection_limitation.php
+++ b/api/lang/en/pool_selection_limitation.php
@@ -3,4 +3,5 @@
 return [
     'at_level_only' => 'At-level only',
     'departmental_preference' => 'Departmental preference',
+    'canadian_citizens' => 'Only Canadian citizens can apply',
 ];

--- a/api/lang/fr/pool_selection_limitation.php
+++ b/api/lang/fr/pool_selection_limitation.php
@@ -3,4 +3,5 @@
 return [
     'at_level_only' => 'À niveau seulement',
     'departmental_preference' => 'Préférence ministérielle',
+    'canadian_citizens' => 'Seules les personnes ayant la citoyenneté canadienne peuvent postuler',
 ];

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -3453,6 +3453,7 @@ enum PoolOpportunityLength {
 enum PoolSelectionLimitation {
   AT_LEVEL_ONLY
   DEPARTMENTAL_PREFERENCE
+  CANADIAN_CITIZENS
 }
 
 enum PoolSkillType {

--- a/apps/web/src/components/PoolCard/PoolCard.tsx
+++ b/apps/web/src/components/PoolCard/PoolCard.tsx
@@ -105,6 +105,17 @@ const deriveWhoCanApplyString = (
   intl: IntlShape,
 ): string | null => {
   if (areaOfSelection == PoolAreaOfSelection.Public) {
+    if (
+      selectionLimitations?.includes(PoolSelectionLimitation.CanadianCitizens)
+    ) {
+      return intl.formatMessage({
+        defaultMessage: "Canadian citizens",
+        id: "VotRI3",
+        description: "Canadian citizen only application criteria",
+      });
+    }
+
+    // fall-through for public
     return intl.formatMessage({
       defaultMessage: "Open to the public",
       id: "L0eho2",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1435,6 +1435,10 @@
     "defaultMessage": "Pour la raison suivante",
     "description": "Lead in text for a decisions reason"
   },
+  "4f81Y1": {
+    "defaultMessage": "En sélectionnant « Seules les personnes ayant la citoyenneté canadienne peuvent postuler », vous confirmez que cette offre d’emploi est offerte par un ministère ou un organisme qui n’est pas assujetti à la <a><italic>Loi sur l’emploi dans la fonction publique</italic></a>.",
+    "description": "Warning message when selecting the only-canadian-citizens limitation option"
+  },
   "4f9Xsc": {
     "defaultMessage": "Les renseignements que vous fournissez peuvent également être utilisés à des fins statistiques et de recherche, et ils peuvent être communiqués à la<publicServiceLink>Direction des enquêtes de la Commission de la fonction publique</publicServiceLink> au besoin.",
     "description": "Paragraph for privacy policy page"
@@ -1714,6 +1718,10 @@
   "5pf2qR": {
     "defaultMessage": "Modifier une possibilité de formation",
     "description": "Page title for the training opportunity edit page"
+  },
+  "5qjarn": {
+    "defaultMessage": "Préférence ministérielle",
+    "description": "Admin interface label for the departmental-preference selection limitation"
   },
   "5qopVO": {
     "defaultMessage": "Nomination pour l'avancement",
@@ -2718,6 +2726,10 @@
   "AlOrGy": {
     "defaultMessage": "Consentement au partage d'information",
     "description": "Label for the input for the consent check"
+  },
+  "AlhZFb": {
+    "defaultMessage": "* Il s’agit d’une offre d’emploi au sein d’un ministère ou d’un organisme qui n’est pas assujetti à la <a><italic>Loi sur l’emploi dans la fonction publique</italic></a>. Par conséquent, le processus d’embauche et la terminologie employée peuvent différer de ceux habituellement utilisés dans la fonction publique fédérale.",
+    "description": "Body p2 of a note describing that a pool is only open to canadian citizens"
   },
   "Ao/+Ba": {
     "defaultMessage": "Ce numéro de processus est obtenu auprès de votre atelier RH",
@@ -3994,6 +4006,10 @@
   "GndGRz": {
     "defaultMessage": "La mise à jour des informations sur votre prochain type de poste a échoué.",
     "description": "Message displayed when a user fails to updates employee profile information"
+  },
+  "Gnlt31": {
+    "defaultMessage": "À niveau seulement",
+    "description": "Admin interface label for the at-level-only selection limitation"
   },
   "GrHEFV": {
     "defaultMessage": "Aucune",
@@ -5910,10 +5926,6 @@
   "QAo1Vy": {
     "defaultMessage": "La possibilité de formation {trainingOpportunityId} n'a pas été trouvée.",
     "description": "Message displayed for training opportunity not found."
-  },
-  "4f81Y1": {
-    "defaultMessage": "En sélectionnant « Seules les personnes ayant la citoyenneté canadienne peuvent postuler », vous confirmez que cette offre d’emploi est offerte par un ministère ou un organisme qui n’est pas assujetti à la <a><italic>Loi sur l’emploi dans la fonction publique</italic></a>.",
-    "description": "Warning message when selecting the only-canadian-citizens limitation option"
   },
   "QCesvO": {
     "defaultMessage": "Ajouter un rôle individue",
@@ -8882,6 +8894,10 @@
     "defaultMessage": "Configuration de votre application d’authentification à deux facteurs",
     "description": "Subtitle for a section explaining setting up mfa"
   },
+  "ee4C6L": {
+    "defaultMessage": "Seules les personnes ayant la citoyenneté canadienne peuvent postuler",
+    "description": "Admin interface label for the canadian-citizen-only selection limitation"
+  },
   "eePQun": {
     "defaultMessage": "Mettez à jour les volets de travail",
     "description": "Link text to add work streams for an experience"
@@ -9673,10 +9689,6 @@
     "defaultMessage": "Tâches principales",
     "description": "Short title of the 'key tasks' section of the job poster template page"
   },
-  "AlhZFb": {
-    "defaultMessage": "* Il s’agit d’une offre d’emploi au sein d’un ministère ou d’un organisme qui n’est pas assujetti à la <a><italic>Loi sur l’emploi dans la fonction publique</italic></a>. Par conséquent, le processus d’embauche et la terminologie employée peuvent différer de ceux habituellement utilisés dans la fonction publique fédérale.",
-    "description": "Body p2 of a note describing that a pool is only open to canadian citizens"
-  },
   "hmacO5": {
     "defaultMessage": "La demande ne comprend pas de filtre!",
     "description": "Null state for a request not including a filter."
@@ -10120,6 +10132,10 @@
   "jrt4zY": {
     "defaultMessage": "Modifier les renseignements sur les processus hors plateforme.",
     "description": "Dialog header informing of purpose"
+  },
+  "js5ZcB": {
+    "defaultMessage": "Cela indiquera aux candidats que les personnes employées par les ministères liés à cette possibilité seront accordées la préférence lors de la sélection.",
+    "description": "Caption for the departmental-preference selection limitation"
   },
   "jtEouE": {
     "defaultMessage": "Ajouter l'utilisateur au bassin",
@@ -11192,6 +11208,10 @@
   "p+YRN1": {
     "defaultMessage": "Vous êtes sur le point de modifier le statut de cet utilisateur :",
     "description": "Première section du texte de la boîte de dialogue Modifier le statut du candidat"
+  },
+  "p+rROQ": {
+    "defaultMessage": "Cela indiquera aux candidats que seuls les employés à niveau ou de niveau équivalent seront pris en considération pour cette possibilité.",
+    "description": "Caption for the at-level-only selection limitation"
   },
   "p19YJ2": {
     "defaultMessage": "Présentez une demande dès aujourd’hui pour entreprendre une carrière en technologie de l’information.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3247,10 +3247,6 @@
     "defaultMessage": "Agrandir toutes les sections<hidden> de l’information sur la demande</hidden>",
     "description": "Button text to open all application information accordions"
   },
-  "DF+cgq": {
-    "defaultMessage": "Toute personne ayant la citoyenneté canadienne.",
-    "description": "Canadian citizen only application criteria"
-  },
   "DG4c6M": {
     "defaultMessage": "{status}<hidden> changer le statut pour {poolName}</hidden>",
     "description": "Button to change a users status in a pool - located in the table on view-user page"
@@ -7081,6 +7077,10 @@
   "Vnh3iD": {
     "defaultMessage": "Je soumets la candidature au nom de l'auteur ou l'autrice de la mise en candidature",
     "description": "Label for the option when the submitter is submitting a nomination on behalf of someone else"
+  },
+  "VotRI3": {
+    "defaultMessage": "Toute personne ayant la citoyenneté canadienne",
+    "description": "Canadian citizen only application criteria"
   },
   "VrLfLw": {
     "defaultMessage": "Courriel du (de la) conseiller(-ère) en RH",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1627,10 +1627,6 @@
     "defaultMessage": "Sélectionnez un type",
     "description": "Default selection for the experience type field"
   },
-  "5S5zo0": {
-    "defaultMessage": "Limites de la sélection des employés",
-    "description": "Label for a process' selection limitations"
-  },
   "5SKmte": {
     "defaultMessage": "Modifier<hidden> le regroupement des compétences</hidden>",
     "description": "Breadcrumb title for the edit skill family page link."
@@ -3238,6 +3234,10 @@
   "DC2A59": {
     "defaultMessage": "Agrandir toutes les sections<hidden> de l’information sur la demande</hidden>",
     "description": "Button text to open all application information accordions"
+  },
+  "DF+cgq": {
+    "defaultMessage": "Toute personne ayant la citoyenneté canadienne.",
+    "description": "Canadian citizen only application criteria"
   },
   "DG4c6M": {
     "defaultMessage": "{status}<hidden> changer le statut pour {poolName}</hidden>",
@@ -4887,6 +4887,10 @@
     "defaultMessage": "Découvrez-en davantage sur le Programme d’apprentissage en TI pour les personnes autochtones du gouvernement du Canada",
     "description": "Heading for the Learn more dialog"
   },
+  "LA+7mQ": {
+    "defaultMessage": "Cette possibilité d'emploi s’adresse uniquement aux personnes ayant la citoyenneté canadienne",
+    "description": "Title of a note describing that a pool is only open to canadian citizens"
+  },
   "LA0AM1": {
     "defaultMessage": "Justification et commentaires supplémentaires",
     "description": "Heading for rationale step of a talent nomination"
@@ -5906,6 +5910,10 @@
   "QAo1Vy": {
     "defaultMessage": "La possibilité de formation {trainingOpportunityId} n'a pas été trouvée.",
     "description": "Message displayed for training opportunity not found."
+  },
+  "QC0+kO": {
+    "defaultMessage": "En sélectionnant « Seules les personnes ayant la citoyenneté canadienne peuvent postuler », vous confirmez que cette offre d’emploi est offerte par un ministère ou un organisme qui n’est pas assujetti à la <a>Loi sur l’emploi dans la fonction publique</a>.",
+    "description": "Warning message when selecting the only-canadian-citizens limitation option"
   },
   "QCesvO": {
     "defaultMessage": "Ajouter un rôle individue",
@@ -7666,6 +7674,10 @@
     "defaultMessage": "Annulez et revenez aux groupes de compétences",
     "description": "Link text to return to skill family table"
   },
+  "YjKKrR": {
+    "defaultMessage": "Citoyenneté canadienne requise",
+    "description": "Label for a process' selection limitations when area of selection is for the public"
+  },
   "Yln61n": {
     "defaultMessage": "<strong>Télécopieur :</strong> 613-996-9661",
     "description": "Fax contact info"
@@ -7837,6 +7849,10 @@
   "Zd02bf": {
     "defaultMessage": "Bienvenue à la première étape de votre demande. Nous sommes ravis de vous rencontrer!",
     "description": "Subtitle for the application welcome page"
+  },
+  "ZeDdxG": {
+    "defaultMessage": "La présente offre s’adresse uniquement aux personnes ayant la citoyenneté canadienne. *",
+    "description": "Body p1 of a note describing that a pool is only open to canadian citizens"
   },
   "Zewopw": {
     "defaultMessage": "Trois types de possibilités d’apprentissage",
@@ -9657,6 +9673,10 @@
     "defaultMessage": "Tâches principales",
     "description": "Short title of the 'key tasks' section of the job poster template page"
   },
+  "hmTot0": {
+    "defaultMessage": "* Il s’agit d’une offre d’emploi au sein d’un ministère ou d’un organisme qui n’est pas assujetti à la <a>Loi sur l’emploi dans la fonction publique</a>. Par conséquent, le processus d’embauche et la terminologie employée peuvent différer de ceux habituellement utilisés dans la fonction publique fédérale.",
+    "description": "Body p2 of a note describing that a pool is only open to canadian citizens"
+  },
   "hmacO5": {
     "defaultMessage": "La demande ne comprend pas de filtre!",
     "description": "Null state for a request not including a filter."
@@ -10100,10 +10120,6 @@
   "jrt4zY": {
     "defaultMessage": "Modifier les renseignements sur les processus hors plateforme.",
     "description": "Dialog header informing of purpose"
-  },
-  "js5ZcB": {
-    "defaultMessage": "Cela indiquera aux candidats que les personnes employées par les ministères liés à cette possibilité seront accordées la préférence lors de la sélection.",
-    "description": "Caption for the departmental-preference selection limitation"
   },
   "jtEouE": {
     "defaultMessage": "Ajouter l'utilisateur au bassin",
@@ -11176,10 +11192,6 @@
   "p+YRN1": {
     "defaultMessage": "Vous êtes sur le point de modifier le statut de cet utilisateur :",
     "description": "Première section du texte de la boîte de dialogue Modifier le statut du candidat"
-  },
-  "p+rROQ": {
-    "defaultMessage": "Cela indiquera aux candidats que seuls les employés à niveau ou de niveau équivalent seront pris en considération pour cette possibilité.",
-    "description": "Caption for the at-level-only selection limitation"
   },
   "p19YJ2": {
     "defaultMessage": "Présentez une demande dès aujourd’hui pour entreprendre une carrière en technologie de l’information.",
@@ -12348,6 +12360,10 @@
   "vKzPT0": {
     "defaultMessage": "La mise à jour des informations sur votre objectif de carrière a échoué",
     "description": "Message displayed when a user fails to updates employee profile information"
+  },
+  "vLOt3K": {
+    "defaultMessage": "Limites de la sélection des employés",
+    "description": "Label for a process' selection limitations when area of selection is for employees"
   },
   "vMBiMV": {
     "defaultMessage": "Mise à jour réussie de la compétence",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5911,8 +5911,8 @@
     "defaultMessage": "La possibilité de formation {trainingOpportunityId} n'a pas été trouvée.",
     "description": "Message displayed for training opportunity not found."
   },
-  "QC0+kO": {
-    "defaultMessage": "En sélectionnant « Seules les personnes ayant la citoyenneté canadienne peuvent postuler », vous confirmez que cette offre d’emploi est offerte par un ministère ou un organisme qui n’est pas assujetti à la <a>Loi sur l’emploi dans la fonction publique</a>.",
+  "4f81Y1": {
+    "defaultMessage": "En sélectionnant « Seules les personnes ayant la citoyenneté canadienne peuvent postuler », vous confirmez que cette offre d’emploi est offerte par un ministère ou un organisme qui n’est pas assujetti à la <a><italic>Loi sur l’emploi dans la fonction publique</italic></a>.",
     "description": "Warning message when selecting the only-canadian-citizens limitation option"
   },
   "QCesvO": {
@@ -9673,8 +9673,8 @@
     "defaultMessage": "Tâches principales",
     "description": "Short title of the 'key tasks' section of the job poster template page"
   },
-  "hmTot0": {
-    "defaultMessage": "* Il s’agit d’une offre d’emploi au sein d’un ministère ou d’un organisme qui n’est pas assujetti à la <a>Loi sur l’emploi dans la fonction publique</a>. Par conséquent, le processus d’embauche et la terminologie employée peuvent différer de ceux habituellement utilisés dans la fonction publique fédérale.",
+  "AlhZFb": {
+    "defaultMessage": "* Il s’agit d’une offre d’emploi au sein d’un ministère ou d’un organisme qui n’est pas assujetti à la <a><italic>Loi sur l’emploi dans la fonction publique</italic></a>. Par conséquent, le processus d’embauche et la terminologie employée peuvent différer de ceux habituellement utilisés dans la fonction publique fédérale.",
     "description": "Body p2 of a note describing that a pool is only open to canadian citizens"
   },
   "hmacO5": {

--- a/apps/web/src/messages/processMessages.ts
+++ b/apps/web/src/messages/processMessages.ts
@@ -167,10 +167,17 @@ const messages = defineMessages({
     id: "zNgDex",
     description: "Label for a process' area of selection",
   },
-  selectionLimitations: {
+  selectionLimitationsEmployee: {
     defaultMessage: "Employee selection limitations",
-    id: "5S5zo0",
-    description: "Label for a process' selection limitations",
+    id: "vLOt3K",
+    description:
+      "Label for a process' selection limitations when area of selection is for employees",
+  },
+  selectionLimitationsPublic: {
+    defaultMessage: "Canadian citizenship limitation",
+    id: "YjKKrR",
+    description:
+      "Label for a process' selection limitations when area of selection is for the public",
   },
 });
 

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
@@ -1,12 +1,20 @@
 import { MessageDescriptor, useIntl } from "react-intl";
 import CheckCircleIcon from "@heroicons/react/20/solid/CheckCircleIcon";
 import XCircleIcon from "@heroicons/react/20/solid/XCircleIcon";
+import { ReactNode } from "react";
 
-import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
+import {
+  commonMessages,
+  getLocale,
+  getLocalizedName,
+  Locales,
+} from "@gc-digital-talent/i18n";
 import {
   EditPoolNameFragment,
   PoolAreaOfSelection,
+  PoolSelectionLimitation,
 } from "@gc-digital-talent/graphql";
+import { Link, Well } from "@gc-digital-talent/ui";
 
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
 import { getClassificationName } from "~/utils/poolUtils";
@@ -22,6 +30,7 @@ const Display = ({
   possibleEmployeeLimitations: SelectionLimitationDefinition[];
 }) => {
   const intl = useIntl();
+  const locale = getLocale(intl);
   const notProvided = intl.formatMessage(commonMessages.notProvided);
   const {
     areaOfSelection,
@@ -47,6 +56,9 @@ const Display = ({
         processMessages.selectionLimitationsPublic;
       break;
   }
+
+  const poolSelectionLimitationValues =
+    poolSelectionLimitations?.map((l) => l.value) ?? [];
 
   return (
     <>
@@ -81,9 +93,9 @@ const Display = ({
                   data-h2-gap="base(x0.25)"
                   data-h2-align-items="base(center)"
                 >
-                  {poolSelectionLimitations
-                    ?.map((l) => l.value)
-                    .includes(singleSelectionLimitation.value) ? (
+                  {poolSelectionLimitationValues.includes(
+                    singleSelectionLimitation.value,
+                  ) ? (
                     <CheckCircleIcon
                       data-h2-height="base(x0.75)"
                       data-h2-color="base(success) base:dark(success.lighter)"
@@ -106,6 +118,34 @@ const Display = ({
             })}
           </div>
         </ToggleForm.FieldDisplay>
+        {poolSelectionLimitationValues.includes(
+          PoolSelectionLimitation.CanadianCitizens,
+        ) ? (
+          <Well color="warning" data-h2-grid-column="p-tablet(1 / span 2)">
+            {intl.formatMessage(
+              {
+                defaultMessage:
+                  "By selecting “Only Canadian citizens can apply”, you’re confirming that this job opportunity is with a department or agency that is not subject to the <a>Public Service Employment Act (PSEA)</a>.",
+                id: "QC0+kO",
+                description:
+                  "Warning message when selecting the only-canadian-citizens limitation option",
+              },
+              {
+                a: (chunks: ReactNode) => {
+                  const pseaUrl: Record<Locales, string> = {
+                    en: "https://laws-lois.justice.gc.ca/eng/acts/p-33.01/",
+                    fr: "https://laws-lois.justice.gc.ca/fra/lois/p-33.01/",
+                  } as const;
+                  return (
+                    <Link href={pseaUrl[locale]} color="black" newTab external>
+                      {chunks}
+                    </Link>
+                  );
+                },
+              },
+            )}
+          </Well>
+        ) : null}
         <ToggleForm.FieldDisplay
           hasError={!classification}
           label={intl.formatMessage(processMessages.classification)}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
@@ -23,6 +23,11 @@ import processMessages from "~/messages/processMessages";
 import { DisplayProps } from "../../types";
 import { SelectionLimitationDefinition } from "./PoolNameSection";
 
+const pseaUrl: Record<Locales, string> = {
+  en: "https://laws-lois.justice.gc.ca/eng/acts/p-33.01/",
+  fr: "https://laws-lois.justice.gc.ca/fra/lois/p-33.01/",
+} as const;
+
 const Display = ({
   pool,
   possibleEmployeeLimitations,
@@ -133,22 +138,11 @@ const Display = ({
                   "Warning message when selecting the only-canadian-citizens limitation option",
               },
               {
-                a: (chunks: ReactNode) => {
-                  const pseaUrl: Record<Locales, string> = {
-                    en: "https://laws-lois.justice.gc.ca/eng/acts/p-33.01/",
-                    fr: "https://laws-lois.justice.gc.ca/fra/lois/p-33.01/",
-                  } as const;
-                  return (
-                    <Link
-                      href={pseaUrl[locale]}
-                      color="warning"
-                      newTab
-                      external
-                    >
-                      {chunks}
-                    </Link>
-                  );
-                },
+                a: (chunks: ReactNode) => (
+                  <Link href={pseaUrl[locale]} color="warning" newTab external>
+                    {chunks}
+                  </Link>
+                ),
               },
             )}
           </Well>

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
@@ -137,7 +137,12 @@ const Display = ({
                     fr: "https://laws-lois.justice.gc.ca/fra/lois/p-33.01/",
                   } as const;
                   return (
-                    <Link href={pseaUrl[locale]} color="black" newTab external>
+                    <Link
+                      href={pseaUrl[locale]}
+                      color="warning"
+                      newTab
+                      external
+                    >
                       {chunks}
                     </Link>
                   );

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
@@ -125,8 +125,8 @@ const Display = ({
             {intl.formatMessage(
               {
                 defaultMessage:
-                  "By selecting “Only Canadian citizens can apply”, you’re confirming that this job opportunity is with a department or agency that is not subject to the <a>Public Service Employment Act (PSEA)</a>.",
-                id: "QC0+kO",
+                  "By selecting “Only Canadian citizens can apply”, you’re confirming that this job opportunity is with a department or agency that is not subject to the <a><italic>Public Service Employment Act</italic></a>.",
+                id: "4f81Y1",
                 description:
                   "Warning message when selecting the only-canadian-citizens limitation option",
               },

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
@@ -75,49 +75,51 @@ const Display = ({
         >
           {getLocalizedName(areaOfSelection?.label, intl) || notProvided}
         </ToggleForm.FieldDisplay>
-        <ToggleForm.FieldDisplay
-          data-h2-grid-column="p-tablet(1 / span 2)"
-          label={intl.formatMessage(selectionLimitationLabelMessage)}
-        >
-          <div
-            data-h2-display="base(flex)"
-            data-h2-flex-direction="base(column)"
-            data-h2-gap="base(x0.25)"
-            data-h2-margin-top="base(x0.25)"
+        {areaOfSelection ? (
+          <ToggleForm.FieldDisplay
+            data-h2-grid-column="p-tablet(1 / span 2)"
+            label={intl.formatMessage(selectionLimitationLabelMessage)}
           >
-            {possibleEmployeeLimitations?.map((singleSelectionLimitation) => {
-              return (
-                <div
-                  key={singleSelectionLimitation.value}
-                  data-h2-display="base(flex)"
-                  data-h2-gap="base(x0.25)"
-                  data-h2-align-items="base(center)"
-                >
-                  {poolSelectionLimitationValues.includes(
-                    singleSelectionLimitation.value,
-                  ) ? (
-                    <CheckCircleIcon
-                      data-h2-height="base(x0.75)"
-                      data-h2-color="base(success) base:dark(success.lighter)"
-                      aria-hidden="false"
-                      aria-label={intl.formatMessage(commonMessages.selected)}
-                    />
-                  ) : (
-                    <XCircleIcon
-                      data-h2-height="base(x0.75)"
-                      data-h2-color="base(background.darker)"
-                      aria-hidden="false"
-                      aria-label={intl.formatMessage(
-                        commonMessages.notSelected,
-                      )}
-                    />
-                  )}
-                  {intl.formatMessage(singleSelectionLimitation.label)}
-                </div>
-              );
-            })}
-          </div>
-        </ToggleForm.FieldDisplay>
+            <div
+              data-h2-display="base(flex)"
+              data-h2-flex-direction="base(column)"
+              data-h2-gap="base(x0.25)"
+              data-h2-margin-top="base(x0.25)"
+            >
+              {possibleEmployeeLimitations?.map((singleSelectionLimitation) => {
+                return (
+                  <div
+                    key={singleSelectionLimitation.value}
+                    data-h2-display="base(flex)"
+                    data-h2-gap="base(x0.25)"
+                    data-h2-align-items="base(center)"
+                  >
+                    {poolSelectionLimitationValues.includes(
+                      singleSelectionLimitation.value,
+                    ) ? (
+                      <CheckCircleIcon
+                        data-h2-height="base(x0.75)"
+                        data-h2-color="base(success) base:dark(success.lighter)"
+                        aria-hidden="false"
+                        aria-label={intl.formatMessage(commonMessages.selected)}
+                      />
+                    ) : (
+                      <XCircleIcon
+                        data-h2-height="base(x0.75)"
+                        data-h2-color="base(background.darker)"
+                        aria-hidden="false"
+                        aria-label={intl.formatMessage(
+                          commonMessages.notSelected,
+                        )}
+                      />
+                    )}
+                    {intl.formatMessage(singleSelectionLimitation.label)}
+                  </div>
+                );
+              })}
+            </div>
+          </ToggleForm.FieldDisplay>
+        ) : null}
         {poolSelectionLimitationValues.includes(
           PoolSelectionLimitation.CanadianCitizens,
         ) ? (

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
@@ -1,13 +1,11 @@
-import { useIntl } from "react-intl";
+import { MessageDescriptor, useIntl } from "react-intl";
 import CheckCircleIcon from "@heroicons/react/20/solid/CheckCircleIcon";
 import XCircleIcon from "@heroicons/react/20/solid/XCircleIcon";
 
 import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 import {
   EditPoolNameFragment,
-  LocalizedEnumString,
   PoolAreaOfSelection,
-  PoolSelectionLimitation,
 } from "@gc-digital-talent/graphql";
 
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
@@ -15,12 +13,13 @@ import { getClassificationName } from "~/utils/poolUtils";
 import processMessages from "~/messages/processMessages";
 
 import { DisplayProps } from "../../types";
+import { SelectionLimitationDefinition } from "./PoolNameSection";
 
 const Display = ({
   pool,
-  allPoolSelectionLimitations,
+  possibleEmployeeLimitations,
 }: DisplayProps<EditPoolNameFragment> & {
-  allPoolSelectionLimitations: LocalizedEnumString[];
+  possibleEmployeeLimitations: SelectionLimitationDefinition[];
 }) => {
   const intl = useIntl();
   const notProvided = intl.formatMessage(commonMessages.notProvided);
@@ -35,6 +34,19 @@ const Display = ({
     publishingGroup,
     opportunityLength,
   } = pool;
+
+  let selectionLimitationLabelMessage: MessageDescriptor =
+    commonMessages.notProvided;
+  switch (areaOfSelection?.value) {
+    case PoolAreaOfSelection.Employees:
+      selectionLimitationLabelMessage =
+        processMessages.selectionLimitationsEmployee;
+      break;
+    case PoolAreaOfSelection.Public:
+      selectionLimitationLabelMessage =
+        processMessages.selectionLimitationsPublic;
+      break;
+  }
 
   return (
     <>
@@ -51,51 +63,49 @@ const Display = ({
         >
           {getLocalizedName(areaOfSelection?.label, intl) || notProvided}
         </ToggleForm.FieldDisplay>
-        {areaOfSelection?.value === PoolAreaOfSelection.Employees ? (
-          <ToggleForm.FieldDisplay
-            data-h2-grid-column="p-tablet(1 / span 2)"
-            label={intl.formatMessage(processMessages.selectionLimitations)}
+        <ToggleForm.FieldDisplay
+          data-h2-grid-column="p-tablet(1 / span 2)"
+          label={intl.formatMessage(selectionLimitationLabelMessage)}
+        >
+          <div
+            data-h2-display="base(flex)"
+            data-h2-flex-direction="base(column)"
+            data-h2-gap="base(x0.25)"
+            data-h2-margin-top="base(x0.25)"
           >
-            <div
-              data-h2-display="base(flex)"
-              data-h2-flex-direction="base(column)"
-              data-h2-gap="base(x0.25)"
-              data-h2-margin-top="base(x0.25)"
-            >
-              {allPoolSelectionLimitations?.map((singleSelectionLimitation) => {
-                return (
-                  <div
-                    key={singleSelectionLimitation.value}
-                    data-h2-display="base(flex)"
-                    data-h2-gap="base(x0.25)"
-                    data-h2-align-items="base(center)"
-                  >
-                    {poolSelectionLimitations
-                      ?.map((l) => l.value)
-                      .includes(
-                        singleSelectionLimitation.value as PoolSelectionLimitation,
-                      ) ? (
-                      <CheckCircleIcon
-                        data-h2-height="base(x0.75)"
-                        data-h2-color="base(success) base:dark(success.lighter)"
-                        aria-hidden="false"
-                        aria-label={intl.formatMessage(commonMessages.yes)}
-                      />
-                    ) : (
-                      <XCircleIcon
-                        data-h2-height="base(x0.75)"
-                        data-h2-color="base(background.darker)"
-                        aria-hidden="false"
-                        aria-label={intl.formatMessage(commonMessages.no)}
-                      />
-                    )}
-                    {getLocalizedName(singleSelectionLimitation.label, intl)}
-                  </div>
-                );
-              })}
-            </div>
-          </ToggleForm.FieldDisplay>
-        ) : null}
+            {possibleEmployeeLimitations?.map((singleSelectionLimitation) => {
+              return (
+                <div
+                  key={singleSelectionLimitation.value}
+                  data-h2-display="base(flex)"
+                  data-h2-gap="base(x0.25)"
+                  data-h2-align-items="base(center)"
+                >
+                  {poolSelectionLimitations
+                    ?.map((l) => l.value)
+                    .includes(singleSelectionLimitation.value) ? (
+                    <CheckCircleIcon
+                      data-h2-height="base(x0.75)"
+                      data-h2-color="base(success) base:dark(success.lighter)"
+                      aria-hidden="false"
+                      aria-label={intl.formatMessage(commonMessages.selected)}
+                    />
+                  ) : (
+                    <XCircleIcon
+                      data-h2-height="base(x0.75)"
+                      data-h2-color="base(background.darker)"
+                      aria-hidden="false"
+                      aria-label={intl.formatMessage(
+                        commonMessages.notSelected,
+                      )}
+                    />
+                  )}
+                  {intl.formatMessage(singleSelectionLimitation.label)}
+                </div>
+              );
+            })}
+          </div>
+        </ToggleForm.FieldDisplay>
         <ToggleForm.FieldDisplay
           hasError={!classification}
           label={intl.formatMessage(processMessages.classification)}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
@@ -390,23 +390,27 @@ const PoolNameSection = ({
                   />
                 </div>
 
-                <div data-h2-grid-column="l-tablet(1 / span 2)">
-                  <Checklist
-                    id="selectionLimitations"
-                    idPrefix="selectionLimitations"
-                    name="selectionLimitations"
-                    legend={intl.formatMessage(selectionLimitationLabelMessage)}
-                    items={possibleEmployeeLimitations.map<CheckboxOption>(
-                      (l) => ({
-                        label: intl.formatMessage(l.label),
-                        value: l.value,
-                        contentBelow: l.description
-                          ? intl.formatMessage(l.description)
-                          : undefined,
-                      }),
-                    )}
-                  />
-                </div>
+                {selectedAreaOfSelection ? (
+                  <div data-h2-grid-column="l-tablet(1 / span 2)">
+                    <Checklist
+                      id="selectionLimitations"
+                      idPrefix="selectionLimitations"
+                      name="selectionLimitations"
+                      legend={intl.formatMessage(
+                        selectionLimitationLabelMessage,
+                      )}
+                      items={possibleEmployeeLimitations.map<CheckboxOption>(
+                        (l) => ({
+                          label: intl.formatMessage(l.label),
+                          value: l.value,
+                          contentBelow: l.description
+                            ? intl.formatMessage(l.description)
+                            : undefined,
+                        }),
+                      )}
+                    />
+                  </div>
+                ) : null}
 
                 <Select
                   id="classification"

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
@@ -1,5 +1,5 @@
 import { JSX, useEffect } from "react";
-import { MessageDescriptor, useIntl } from "react-intl";
+import { defineMessage, MessageDescriptor, useIntl } from "react-intl";
 import { FormProvider, useForm } from "react-hook-form";
 import TagIcon from "@heroicons/react/24/outline/TagIcon";
 import { useQuery } from "urql";
@@ -190,43 +190,43 @@ const allSelectionLimitations: Record<
 > = {
   AT_LEVEL_ONLY: {
     value: PoolSelectionLimitation.AtLevelOnly,
-    label: {
+    label: defineMessage({
       defaultMessage: "At-level only",
       id: "Gnlt31",
       description:
         "Admin interface label for the at-level-only selection limitation",
-    },
-    description: {
+    }),
+    description: defineMessage({
       defaultMessage:
         "This will indicate to applicants that only at-level or equivalent level employees will be considered for this opportunity.",
       id: "p+rROQ",
       description: "Caption for the at-level-only selection limitation",
-    },
+    }),
   },
   DEPARTMENTAL_PREFERENCE: {
     value: PoolSelectionLimitation.DepartmentalPreference,
-    label: {
+    label: defineMessage({
       defaultMessage: "Departmental preference",
       id: "5qjarn",
       description:
         "Admin interface label for the departmental-preference selection limitation",
-    },
-    description: {
+    }),
+    description: defineMessage({
       defaultMessage:
         "This will indicate to applicants that people employed by the departments linked to this opportunity will be given preference during selection.",
       id: "js5ZcB",
       description:
         "Caption for the departmental-preference selection limitation",
-    },
+    }),
   },
   CANADIAN_CITIZENS: {
     value: PoolSelectionLimitation.CanadianCitizens,
-    label: {
+    label: defineMessage({
       defaultMessage: "Only Canadian citizens can apply",
       id: "ee4C6L",
       description:
         "Admin interface label for the canadian-citizen-only selection limitation",
-    },
+    }),
     description: undefined,
   },
 } as const;

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
@@ -1,5 +1,5 @@
 import { JSX, useEffect } from "react";
-import { useIntl } from "react-intl";
+import { MessageDescriptor, useIntl } from "react-intl";
 import { FormProvider, useForm } from "react-hook-form";
 import TagIcon from "@heroicons/react/24/outline/TagIcon";
 import { useQuery } from "urql";
@@ -174,17 +174,62 @@ const PoolNameOptions_Query = graphql(/* GraphQL */ `
         fr
       }
     }
-    allPoolSelectionLimitations: localizedEnumStrings(
-      enumName: "PoolSelectionLimitation"
-    ) {
-      value
-      label {
-        en
-        fr
-      }
-    }
   }
 `);
+
+export interface SelectionLimitationDefinition {
+  value: PoolSelectionLimitation;
+  label: MessageDescriptor;
+  description: MessageDescriptor | undefined;
+}
+
+// defining these here instead of using the LocalizedEnum since we need to select subsets of the entire list and attach descriptions anyway.
+const allSelectionLimitations: Record<
+  PoolSelectionLimitation,
+  SelectionLimitationDefinition
+> = {
+  AT_LEVEL_ONLY: {
+    value: PoolSelectionLimitation.AtLevelOnly,
+    label: {
+      defaultMessage: "At-level only",
+      id: "Gnlt31",
+      description:
+        "Admin interface label for the at-level-only selection limitation",
+    },
+    description: {
+      defaultMessage:
+        "This will indicate to applicants that only at-level or equivalent level employees will be considered for this opportunity.",
+      id: "p+rROQ",
+      description: "Caption for the at-level-only selection limitation",
+    },
+  },
+  DEPARTMENTAL_PREFERENCE: {
+    value: PoolSelectionLimitation.DepartmentalPreference,
+    label: {
+      defaultMessage: "Departmental preference",
+      id: "5qjarn",
+      description:
+        "Admin interface label for the departmental-preference selection limitation",
+    },
+    description: {
+      defaultMessage:
+        "This will indicate to applicants that people employed by the departments linked to this opportunity will be given preference during selection.",
+      id: "js5ZcB",
+      description:
+        "Caption for the departmental-preference selection limitation",
+    },
+  },
+  CANADIAN_CITIZENS: {
+    value: PoolSelectionLimitation.CanadianCitizens,
+    label: {
+      defaultMessage: "Only Canadian citizens can apply",
+      id: "ee4C6L",
+      description:
+        "Admin interface label for the canadian-citizen-only selection limitation",
+    },
+    description: undefined,
+  },
+} as const;
 
 type PoolNameSectionProps = SectionProps<
   PoolNameSubmitData,
@@ -225,8 +270,6 @@ const PoolNameSection = ({
 
   // hooks to watch, needed for conditional rendering
   const [selectedAreaOfSelection] = watch(["areaOfSelection"]);
-  const isAreaOfSelectionEmployeesOnly =
-    selectedAreaOfSelection === PoolAreaOfSelection.Employees;
 
   /**
    * Reset un-rendered fields
@@ -237,10 +280,10 @@ const PoolNameSection = ({
     };
 
     // Reset all optional fields
-    if (!isAreaOfSelectionEmployeesOnly) {
+    if (selectedAreaOfSelection != pool.areaOfSelection?.value) {
       resetDirtyField("selectionLimitations");
     }
-  }, [resetField, isAreaOfSelectionEmployeesOnly]);
+  }, [resetField, selectedAreaOfSelection, pool.areaOfSelection]);
 
   const handleSave = async (formValues: FormValues) => {
     return onSave(formValuesToSubmitData(formValues))
@@ -253,36 +296,29 @@ const PoolNameSection = ({
       .catch(() => methods.reset(formValues));
   };
 
-  const allPoolSelectionLimitations = unpackMaybes(
-    data?.allPoolSelectionLimitations,
-  );
+  // only some limitation selections are possible depending on area of selection
+  let possibleEmployeeLimitations: SelectionLimitationDefinition[] = [];
+  // label of limitation selection changes based on area of selection
+  let selectionLimitationLabelMessage: MessageDescriptor =
+    commonMessages.notProvided;
 
-  const poolSelectionLimitationsCaptions: Record<
-    PoolSelectionLimitation,
-    string
-  > = {
-    AT_LEVEL_ONLY: intl.formatMessage({
-      defaultMessage:
-        "This will indicate to applicants that only at-level or equivalent level employees will be considered for this opportunity.",
-      id: "p+rROQ",
-      description: "Caption for the at-level-only selection limitation",
-    }),
-    DEPARTMENTAL_PREFERENCE: intl.formatMessage({
-      defaultMessage:
-        "This will indicate to applicants that people employed by the departments linked to this opportunity will be given preference during selection.",
-      id: "js5ZcB",
-      description:
-        "Caption for the departmental-preference selection limitation",
-    }),
-  };
-
-  const allPoolSelectionLimitationItems =
-    allPoolSelectionLimitations.map<CheckboxOption>(({ value, label }) => ({
-      value: value,
-      label: getLocalizedName(label, intl),
-      contentBelow:
-        poolSelectionLimitationsCaptions[value as PoolSelectionLimitation],
-    }));
+  switch (selectedAreaOfSelection) {
+    case PoolAreaOfSelection.Employees:
+      possibleEmployeeLimitations = [
+        allSelectionLimitations.AT_LEVEL_ONLY,
+        allSelectionLimitations.DEPARTMENTAL_PREFERENCE,
+      ] as const;
+      selectionLimitationLabelMessage =
+        processMessages.selectionLimitationsEmployee;
+      break;
+    case PoolAreaOfSelection.Public:
+      possibleEmployeeLimitations = [
+        allSelectionLimitations.CANADIAN_CITIZENS,
+      ] as const;
+      selectionLimitationLabelMessage =
+        processMessages.selectionLimitationsPublic;
+      break;
+  }
 
   // disabled unless status is draft
   const formDisabled = pool.status?.value !== PoolStatus.Draft;
@@ -323,7 +359,7 @@ const PoolNameSection = ({
           ) : (
             <Display
               pool={pool}
-              allPoolSelectionLimitations={allPoolSelectionLimitations}
+              possibleEmployeeLimitations={possibleEmployeeLimitations}
             />
           )}
         </ToggleSection.InitialContent>
@@ -353,19 +389,25 @@ const PoolNameSection = ({
                     )}
                   />
                 </div>
-                {isAreaOfSelectionEmployeesOnly && (
-                  <div data-h2-grid-column="l-tablet(1 / span 2)">
-                    <Checklist
-                      id="selectionLimitations"
-                      idPrefix="selectionLimitations"
-                      name="selectionLimitations"
-                      legend={intl.formatMessage(
-                        processMessages.selectionLimitations,
-                      )}
-                      items={allPoolSelectionLimitationItems}
-                    />
-                  </div>
-                )}
+
+                <div data-h2-grid-column="l-tablet(1 / span 2)">
+                  <Checklist
+                    id="selectionLimitations"
+                    idPrefix="selectionLimitations"
+                    name="selectionLimitations"
+                    legend={intl.formatMessage(selectionLimitationLabelMessage)}
+                    items={possibleEmployeeLimitations.map<CheckboxOption>(
+                      (l) => ({
+                        label: intl.formatMessage(l.label),
+                        value: l.value,
+                        contentBelow: l.description
+                          ? intl.formatMessage(l.description)
+                          : undefined,
+                      }),
+                    )}
+                  />
+                </div>
+
                 <Select
                   id="classification"
                   label={intl.formatMessage({

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/AreaOfSelectionWell.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/AreaOfSelectionWell.tsx
@@ -14,6 +14,11 @@ import { getLocale, getLocalizedName, Locales } from "@gc-digital-talent/i18n";
 
 import { formatClassificationString } from "~/utils/poolUtils";
 
+const pseaUrl: Record<Locales, string> = {
+  en: "https://laws-lois.justice.gc.ca/eng/acts/p-33.01/",
+  fr: "https://laws-lois.justice.gc.ca/fra/lois/p-33.01/",
+} as const;
+
 const PoolAreaOfSelectionNote_Fragment = graphql(/* GraphQL */ `
   fragment AreaOfSelectionNote on Pool {
     classification {
@@ -211,22 +216,11 @@ const deriveAreaOfSelectionMessages = (
                     "Body p2 of a note describing that a pool is only open to canadian citizens",
                 },
                 {
-                  a: (chunks: ReactNode) => {
-                    const pseaUrl: Record<Locales, string> = {
-                      en: "https://laws-lois.justice.gc.ca/eng/acts/p-33.01/",
-                      fr: "https://laws-lois.justice.gc.ca/fra/lois/p-33.01/",
-                    } as const;
-                    return (
-                      <Link
-                        href={pseaUrl[locale]}
-                        color="black"
-                        newTab
-                        external
-                      >
-                        {chunks}
-                      </Link>
-                    );
-                  },
+                  a: (chunks: ReactNode) => (
+                    <Link href={pseaUrl[locale]} color="black" newTab external>
+                      {chunks}
+                    </Link>
+                  ),
                 },
               )}
             </p>

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/AreaOfSelectionWell.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/AreaOfSelectionWell.tsx
@@ -205,8 +205,8 @@ const deriveAreaOfSelectionMessages = (
               {intl.formatMessage(
                 {
                   defaultMessage:
-                    "*This opportunity is with a department or agency that is not subject to the <a>Public Service Employment Act (PSEA)</a>. As a result, the hiring process and terminology might be different from those typically found in the federal public service.",
-                  id: "hmTot0",
+                    "*This opportunity is with a department or agency that is not subject to the <a><italic>Public Service Employment Act</italic></a>. As a result, the hiring process and terminology might be different from those typically found in the federal public service.",
+                  id: "AlhZFb",
                   description:
                     "Body p2 of a note describing that a pool is only open to canadian citizens",
                 },

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/AreaOfSelectionWell.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/AreaOfSelectionWell.tsx
@@ -8,9 +8,9 @@ import {
   PoolAreaOfSelection,
   PoolSelectionLimitation,
 } from "@gc-digital-talent/graphql";
-import { Heading, Well } from "@gc-digital-talent/ui";
+import { Heading, Link, Well } from "@gc-digital-talent/ui";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
-import { getLocalizedName } from "@gc-digital-talent/i18n";
+import { getLocale, getLocalizedName, Locales } from "@gc-digital-talent/i18n";
 
 import { formatClassificationString } from "~/utils/poolUtils";
 
@@ -46,6 +46,7 @@ const deriveAreaOfSelectionMessages = (
   body: ReactNode;
   finePrint?: ReactNode;
 } | null => {
+  const locale = getLocale(intl);
   if (areaOfSelection == PoolAreaOfSelection.Employees) {
     if (
       selectionLimitations?.includes(PoolSelectionLimitation.AtLevelOnly) &&
@@ -173,6 +174,68 @@ const deriveAreaOfSelectionMessages = (
           "Body of a note describing that a pool is only open to employees",
       }),
     };
+  }
+
+  if (areaOfSelection == PoolAreaOfSelection.Public) {
+    if (
+      selectionLimitations?.includes(PoolSelectionLimitation.CanadianCitizens)
+    ) {
+      return {
+        title: intl.formatMessage({
+          defaultMessage: "This opportunity is for Canadian citizens only",
+          id: "LA+7mQ",
+          description:
+            "Title of a note describing that a pool is only open to canadian citizens",
+        }),
+        body: (
+          <>
+            <p>
+              {intl.formatMessage({
+                defaultMessage:
+                  "This opportunity is reserved for persons with Canadian citizenship*.",
+                id: "ZeDdxG",
+                description:
+                  "Body p1 of a note describing that a pool is only open to canadian citizens",
+              })}
+            </p>
+            <p
+              data-h2-margin-top="base(x0.5)"
+              data-h2-font-size="base(caption)"
+            >
+              {intl.formatMessage(
+                {
+                  defaultMessage:
+                    "*This opportunity is with a department or agency that is not subject to the <a>Public Service Employment Act (PSEA)</a>. As a result, the hiring process and terminology might be different from those typically found in the federal public service.",
+                  id: "hmTot0",
+                  description:
+                    "Body p2 of a note describing that a pool is only open to canadian citizens",
+                },
+                {
+                  a: (chunks: ReactNode) => {
+                    const pseaUrl: Record<Locales, string> = {
+                      en: "https://laws-lois.justice.gc.ca/eng/acts/p-33.01/",
+                      fr: "https://laws-lois.justice.gc.ca/fra/lois/p-33.01/",
+                    } as const;
+                    return (
+                      <Link
+                        href={pseaUrl[locale]}
+                        color="black"
+                        newTab
+                        external
+                      >
+                        {chunks}
+                      </Link>
+                    );
+                  },
+                },
+              )}
+            </p>
+          </>
+        ),
+      };
+    }
+
+    // no fall-through for public
   }
 
   return null;

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/WhoCanApplyText.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/WhoCanApplyText.tsx
@@ -87,11 +87,12 @@ const deriveWhoCanApplyMessages = (
     areaOfSelection == PoolAreaOfSelection.Public &&
     selectionLimitations?.includes(PoolSelectionLimitation.CanadianCitizens)
   ) {
-    body = intl.formatMessage({
-      defaultMessage: "Canadian citizens.",
-      id: "DF+cgq",
-      description: "Canadian citizen only application criteria",
-    });
+    body =
+      intl.formatMessage({
+        defaultMessage: "Canadian citizens",
+        id: "VotRI3",
+        description: "Canadian citizen only application criteria",
+      }) + "."; // period to make the message a sentence
     finePrint = null;
   } else {
     body = intl.formatMessage({

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/WhoCanApplyText.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/WhoCanApplyText.tsx
@@ -83,6 +83,16 @@ const deriveWhoCanApplyMessages = (
           },
         )
       : null;
+  } else if (
+    areaOfSelection == PoolAreaOfSelection.Public &&
+    selectionLimitations?.includes(PoolSelectionLimitation.CanadianCitizens)
+  ) {
+    body = intl.formatMessage({
+      defaultMessage: "Canadian citizens.",
+      id: "DF+cgq",
+      description: "Canadian citizen only application criteria",
+    });
+    finePrint = null;
   } else {
     body = intl.formatMessage({
       defaultMessage:
@@ -135,14 +145,16 @@ const WhoCanApplyText = ({ poolQuery }: WhoCanApplyTextProps) => {
 
   return (
     <>
-      <Text data-h2-margin-top="base(0)">{body}</Text>
-      <Text
-        data-h2-margin-bottom="base(0)"
-        data-h2-font-size="base(caption)"
-        data-h2-color="base(black.70)"
-      >
-        {finePrint}
-      </Text>
+      {body ? <Text data-h2-margin-top="base(0)">{body}</Text> : null}
+      {finePrint ? (
+        <Text
+          data-h2-margin-bottom="base(0)"
+          data-h2-font-size="base(caption)"
+          data-h2-color="base(black.70)"
+        >
+          {finePrint}
+        </Text>
+      ) : null}
     </>
   );
 };

--- a/packages/eslint-config-custom/react.mjs
+++ b/packages/eslint-config-custom/react.mjs
@@ -52,6 +52,7 @@ export default [
             "heavyRed",
             "heavySecondary",
             "heavyWarning",
+            "italic",
           ],
         },
       ],

--- a/packages/i18n/src/components/richTextElements.tsx
+++ b/packages/i18n/src/components/richTextElements.tsx
@@ -144,6 +144,13 @@ const softHyphen = () => <>&shy;</>;
  */
 const cite = (text: ReactNode) => <cite>{text}</cite>;
 
+/**
+ * Used to add a stylized cursive font
+ */
+const italic = (text: ReactNode) => (
+  <span data-h2-font-style="base(italic)">{text}</span>
+);
+
 export default {
   strong,
   hidden,
@@ -160,4 +167,5 @@ export default {
   emphasize,
   softHyphen,
   cite,
+  italic,
 };

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -839,6 +839,10 @@
     "defaultMessage": "Trier par",
     "description": "Label for the links to change how the list is sorted"
   },
+  "W9zlhl": {
+    "defaultMessage": "Sélectionnée",
+    "description": "Label when an item is selected"
+  },
   "WGoaKQ": {
     "defaultMessage": "Sauvegardez les modifications",
     "description": "Text for submit button on edit forms"
@@ -1390,6 +1394,10 @@
   "plwOsC": {
     "defaultMessage": "Sélectionnez",
     "description": "Default placeholder shown when Select field has nothing actively selected."
+  },
+  "pnoSK6": {
+    "defaultMessage": "Non sélectionnée",
+    "description": "Label when an item is not selected"
   },
   "qIOz/5": {
     "defaultMessage": "Demandes",

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -478,6 +478,16 @@ const commonMessages = defineMessages({
     id: "OUcSEy",
     description: "Label for level",
   },
+  selected: {
+    defaultMessage: "Selected",
+    id: "W9zlhl",
+    description: "Label when an item is selected",
+  },
+  notSelected: {
+    defaultMessage: "Not selected",
+    id: "pnoSK6",
+    description: "Label when an item is not selected",
+  },
 });
 
 export default commonMessages;


### PR DESCRIPTION
🤖 Resolves #13507 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Adds the ability to limit public pools to Canadian citizens only.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Rebuild the app
2. Log in as admin@test.com
3. Create or edit a draft pool and experiment with the area of selection controls
4. View a pool advertisement from the applicant side
5. Observe well and "who can apply" changes based on area of selection controls

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/a0b6fb4f-2bc8-4380-99a3-256f124504ef)

