### PR TITLE
[Fix] formatjs eslint rules

### DIFF
--- a/apps/web/src/components/ExperienceWorkStreams/ExperienceWorkStreams.tsx
+++ b/apps/web/src/components/ExperienceWorkStreams/ExperienceWorkStreams.tsx
@@ -135,8 +135,8 @@ const ExperienceWorkStreams = ({
             {intl.formatMessage(
               {
                 defaultMessage:
-                  "{workStreamCount, plural, =0 {0 linked work streams} =1 {1 linked work stream} other {# linked work streams}}",
-                id: "HWjcqg",
+                  "{workStreamCount, plural, =0 {0 linked work streams} one {# linked work stream} other {# linked work streams}}",
+                id: "8ii/QN",
                 description: "Count of work streams for work experience",
               },
               {

--- a/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
@@ -332,8 +332,8 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
       intl.formatMessage(
         {
           defaultMessage:
-            "{total, plural, =0 {0 results found} =1 {1 result found} other {# results found}}",
-          id: "SLYAoc",
+            "{total, plural, =0 {0 results found} one {# result found} other {# results found}}",
+          id: "+cS81c",
           description:
             "Message announced to assistive technology when number of items in a table changes",
         },

--- a/apps/web/src/components/Table/ResponsiveTable/RowSelection.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/RowSelection.tsx
@@ -267,8 +267,8 @@ const Actions = ({
                   {intl.formatMessage(
                     {
                       defaultMessage:
-                        "{count, plural, =0 {0 items selected} =1 {1 item selected} other {# items selected}}",
-                      id: "450itb",
+                        "{count, plural, =0 {0 items selected} one {# item selected} other {# items selected}}",
+                      id: "AVlXEr",
                       description:
                         "Message displayed for the number of rows selected in a table",
                     },

--- a/apps/web/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
+++ b/apps/web/src/components/UserProfile/SkillAccordion/SkillAccordion.tsx
@@ -377,8 +377,8 @@ const SkillAccordion = ({
         context={intl.formatMessage(
           {
             defaultMessage:
-              "{experienceCount, plural, =0 {0 experiences} =1 {1 experience} other {# experiences}}",
-            id: "C6kQXh",
+              "{experienceCount, plural, =0 {0 experiences} one {# experience} other {# experiences}}",
+            id: "uuXnmb",
             description: "list a number of unknown experiences",
           },
           {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4515,6 +4515,10 @@
     "defaultMessage": "Bons pour examens de certification",
     "description": "Title for the certification exam vouchers page"
   },
+  "JL6B1D": {
+    "defaultMessage": "Demande de candidats pour le bassin : <primary>{candidateCountNumber, plural, =0 {aucun candidat} one {# candidat estimé} other {# candidats estimés}}</primary>",
+    "description": "Total estimated candidates message in summary of filters"
+  },
   "JO2yLA": {
     "defaultMessage": "Lieu de travail",
     "description": "Work Location label, followed by colon"
@@ -6178,10 +6182,6 @@
   "R8Naqm": {
     "defaultMessage": "Filtrage et évaluation",
     "description": "Heading for the information of an application"
-  },
-  "R9Yk8Y": {
-    "defaultMessage": "Demande de candidats pour le bassin : <primary>{candidateCountNumber, plural, =0 {aucun candidat} =1 {1 candidat estimé} other {# candidats estimés}}</primary>",
-    "description": "Total estimated candidates message in summary of filters"
   },
   "RA4afJ": {
     "defaultMessage": "Approbation pour les programmes de perfectionnement",
@@ -8683,7 +8683,7 @@
     "description": "Page title for the individual user page"
   },
   "dkXjDY": {
-    "defaultMessage": "{monthCount, plural, =1 {# mois} other {# mois}}",
+    "defaultMessage": "{monthCount, plural, one {# mois} other {# mois}}",
     "description": "A duration of a certain number of months"
   },
   "dkYHTv": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -111,10 +111,6 @@
     "defaultMessage": "Endroits exclus",
     "description": "Location specifics label"
   },
-  "+UTd4G": {
-    "defaultMessage": "{developmentProgramsNominationCount, plural, =0 {Perfectionnement } other {Perfectionnement ({developmentProgramsNominationCount, number})}}",
-    "description": "Development nominations, conditional rendered off count"
-  },
   "+UjXSM": {
     "defaultMessage": "le réseautage.",
     "description": "Seventh item in list of certification topics section"
@@ -1470,10 +1466,6 @@
   "4nP41q": {
     "defaultMessage": "Sauvegardez et ajoutez cette compétence",
     "description": "Button text to save a specific skill to a users profile"
-  },
-  "4ozix3": {
-    "defaultMessage": "{lateralMovementNominationCount, plural, =0 {Mutation latérale} other {Mutation latérale ({lateralMovementNominationCount, number})}}",
-    "description": "Lateral movement nominations, conditional rendered off count"
   },
   "4p0QdF": {
     "defaultMessage": "Fermer",
@@ -3995,10 +3987,6 @@
     "defaultMessage": "Poursuivre la demande<hidden> pour {poolName}</hidden>",
     "description": "Label for continue application link"
   },
-  "Gki8Ex": {
-    "defaultMessage": "{candidateCount, plural, one {<testId>{candidateCount}</testId> concordance approximative} other {<testId>{candidateCount}</testId> concordances approximatives} }",
-    "description": "Message for total estimated matching candidates in pool"
-  },
   "GndGRz": {
     "defaultMessage": "La mise à jour des informations sur votre prochain type de poste a échoué.",
     "description": "Message displayed when a user fails to updates employee profile information"
@@ -4278,6 +4266,10 @@
   "IKaWRI": {
     "defaultMessage": " Préférences en matière de gestion des talents",
     "description": "Title for talent management preferences section"
+  },
+  "IMGvOV": {
+    "defaultMessage": "{candidateCount, plural, one {<testId>#</testId> concordance approximative} other {<testId>#</testId> concordances approximatives} }",
+    "description": "Message for total estimated matching candidates in pool"
   },
   "IO+qSg": {
     "defaultMessage": "Parlez-nous du prochain type de poste que vous vous imaginez occuper. En communiquant vos préférences concernant votre prochain emploi, vous pouvez aider le personnel des RH à trouver le poste qui vous convient.",
@@ -4870,6 +4862,10 @@
   "L819mr": {
     "defaultMessage": "Mises à jour du questionnaire sur l’octroi de contrats sur les services numériques",
     "description": "fourth 2024 key change to the directive"
+  },
+  "L8iCCj": {
+    "defaultMessage": "{developmentProgramsNominationCount, plural, =0 {Perfectionnement } other {Perfectionnement (#)}}",
+    "description": "Development nominations, conditional rendered off count"
   },
   "L8iV5q": {
     "defaultMessage": "Sélectionnez un ou plusieurs volets de travail qui, selon vous, correspondent au travail effectué par rapport à cette expérience.",
@@ -5543,6 +5539,10 @@
     "defaultMessage": "Il semble que vous n'ayez pas encore répondu aux questions générales.",
     "description": "Null state message in general questions section of the application review page."
   },
+  "OQBtt9": {
+    "defaultMessage": "{candidateCount, plural, =0 {Il y a actuellement environ <strong><testId>#</testId></strong> candidats qui répondent à vos critères.} =1 {Il y a actuellement environ <strong><testId>#</testId></strong> candidat qui répond à vos critères.} other {Il y a actuellement environ <strong><testId>#</testId></strong> candidats qui répondent à vos critères.} }",
+    "description": "Message for total estimated candidates box next to search form."
+  },
   "OTI+Kb": {
     "defaultMessage": "Options du programme de perfectionnement",
     "description": "Label for the development program options checklist on the details step"
@@ -5887,10 +5887,6 @@
     "defaultMessage": "Modifier le plan d’évaluation",
     "description": "Link text to edit a specific pool assessment"
   },
-  "Q4Lc8n": {
-    "defaultMessage": "Résultats : {totalCandidateCount, plural, =0 {<testId><b>{totalCandidateCount}</b></testId> candidats correspondants} =1 {<testId><b>{totalCandidateCount}</b></testId> candidats correspondants} other {<testId><b>{totalCandidateCount}</b></testId> candidats correspondants à l'échelle } } de {numPools, plural, =0 {<b>{numPools}</b> bassins} =1 {<b>{numPools}</b> bassins} other {<b>{numPools}</b> bassins} }",
-    "description": "Heading for total matching candidates across a certain number of pools in results section of search page."
-  },
   "Q6jULV": {
     "defaultMessage": "Sélectionnez votre niveau actuel de compétences",
     "description": "Label for required skill level select"
@@ -6174,6 +6170,10 @@
   "R8Naqm": {
     "defaultMessage": "Filtrage et évaluation",
     "description": "Heading for the information of an application"
+  },
+  "R9Yk8Y": {
+    "defaultMessage": "Demande de candidats pour le bassin : <primary>{candidateCountNumber, plural, =0 {aucun candidat} =1 {1 candidat estimé} other {# candidats estimés}</primary>",
+    "description": "Total estimated candidates message in summary of filters"
   },
   "RA4afJ": {
     "defaultMessage": "Approbation pour les programmes de perfectionnement",
@@ -7926,6 +7926,10 @@
     "defaultMessage": "Mettez en valeur jusqu’à cinq compétences comportementales qui mettent en valeur vos points forts.",
     "description": "Page description for the top behavioural skills page"
   },
+  "ZzkqoI": {
+    "defaultMessage": "{advancementNominationCount, plural, =0 {Avancement} other {Avancement (#)}}",
+    "description": "Advancement nominations, conditional rendered off count"
+  },
   "a+bWz1": {
     "defaultMessage": "Description (français)",
     "description": "Label displayed on the create a skill form description (French) field."
@@ -9086,10 +9090,6 @@
     "defaultMessage": "La réussite de deux années d'études secondaires.",
     "description": "Descriptive text explaining education requirement for CR group"
   },
-  "fOilMx": {
-    "defaultMessage": "{advancementNominationCount, plural, =0 {Avancement} other {Avancement ({advancementNominationCount, number})}}",
-    "description": "Advancement nominations, conditional rendered off count"
-  },
   "fOl4Ez": {
     "defaultMessage": "Mots-clés (français)",
     "description": "Label displayed on the skill form keywords field in French."
@@ -9393,6 +9393,10 @@
   "gSyRKu": {
     "defaultMessage": "Programme de perfectionnement",
     "description": "Label for the development program nomination option on the details step"
+  },
+  "gTZG/i": {
+    "defaultMessage": "Résultats : {totalCandidateCount, plural, =0 {<testId><b>#</b></testId> candidats correspondants} =1 {<testId><b>#</b></testId> candidats correspondants} other {<testId><b>#</b></testId> candidats correspondants à l'échelle } } de {numPools, plural, =0 {<b>#</b> bassins} =1 {<b>#</b> bassins} other {<b>#</b> bassins} }",
+    "description": "Heading for total matching candidates across a certain number of pools in results section of search page."
   },
   "gU/nxf": {
     "defaultMessage": "Ajoutez une expérience à votre parcours professionnel",
@@ -11133,10 +11137,6 @@
     "defaultMessage": "organisations",
     "description": "label for organization metadata"
   },
-  "og5vUB": {
-    "defaultMessage": "Demande de candidats pour le bassin : <primary>{candidateCountNumber, plural, =0 {aucun candidat} =1 {1 candidat estimé} other {{candidateCountNumber} candidats estimés}}</primary>",
-    "description": "Total estimated candidates message in summary of filters"
-  },
   "ogWY8Q": {
     "defaultMessage": "Le membre du personnel fait preuve des comportements attendus en matière de compétences et de mérite et a maximisé son développement professionnel dans son poste actuel. Les occasions latérales lui permettraient d'acquérir une expérience élargie, d'améliorer ses compétences, de satisfaire ses aspirations actuelles et de maintenir son engagement. Un membre du personnel doit avoir obtenu des résultats valides à l'évaluation de langue seconde (ELS) pour être jugé prêt pour une mutation latérale.",
     "description": "Description for the lateral movement nomination option on the details step"
@@ -11456,6 +11456,10 @@
   "q+bkac": {
     "defaultMessage": "Davantage de renseignements sur l’équité en matière d’emploi",
     "description": "Heading for opening the accordion with information on employment equity"
+  },
+  "q0kxlX": {
+    "defaultMessage": "{lateralMovementNominationCount, plural, =0 {Mutation latérale} other {Mutation latérale (#)}}",
+    "description": "Lateral movement nominations, conditional rendered off count"
   },
   "q0oPjr": {
     "defaultMessage": "Fait l’objet d’une évaluation complète en fonction de l’énoncé des critères de mérite du programme d’apprentissage en TI pour les personnes autochtones et avoir été jugé qualifié pour le rôle d’apprenti IT-01 (ou équivalent)",
@@ -12892,10 +12896,6 @@
   "xvULuR": {
     "defaultMessage": "En savoir plus sur les lieux de travail et la terminologie.",
     "description": "Info button label for pool application work location details."
-  },
-  "xwBt36": {
-    "defaultMessage": "{candidateCount, plural, =0 {Il y a actuellement environ <strong><testId>{candidateCount}</testId></strong> candidats qui répondent à vos critères.} =1 {Il y a actuellement environ <strong><testId>{candidateCount}</testId></strong> candidat qui répond à vos critères.} other {Il y a actuellement environ <strong><testId>{candidateCount}</testId></strong> candidats qui répondent à vos critères.} }",
-    "description": "Message for total estimated candidates box next to search form."
   },
   "xzSXz9": {
     "defaultMessage": "Type d'emploi",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2911,10 +2911,6 @@
     "defaultMessage": "Attendez-vous à passer environ 20 minutes à configurer la CléGC et l’application d’authentification.",
     "description": "A _what to expect_ point on the sign up page"
   },
-  "Bg1Pga": {
-    "defaultMessage": "Cela permettra de rendre ce bassin au public. Tous les utilisateurs associés à ce bassin pourront le voir dans les informations de leur profil.",
-    "description": "Second paragraph for un-archive pool dialog"
-  },
   "BhWVby": {
     "defaultMessage": "Proposez-vous pour passer quelques heures à participer à une équipe interministérielle qui évaluera des candidats et exécutera des processus d’emploi sur la plateforme Talents numériques du GC.",
     "description": "Paragraph two, summary on getting hiring experience"
@@ -5891,6 +5887,10 @@
     "defaultMessage": "Modifier le plan d’évaluation",
     "description": "Link text to edit a specific pool assessment"
   },
+  "Q4Lc8n": {
+    "defaultMessage": "Résultats : {totalCandidateCount, plural, =0 {<testId><b>{totalCandidateCount}</b></testId> candidats correspondants} =1 {<testId><b>{totalCandidateCount}</b></testId> candidats correspondants} other {<testId><b>{totalCandidateCount}</b></testId> candidats correspondants à l'échelle } } de {numPools, plural, =0 {<b>{numPools}</b> bassins} =1 {<b>{numPools}</b> bassins} other {<b>{numPools}</b> bassins} }",
+    "description": "Heading for total matching candidates across a certain number of pools in results section of search page."
+  },
   "Q6jULV": {
     "defaultMessage": "Sélectionnez votre niveau actuel de compétences",
     "description": "Label for required skill level select"
@@ -7625,6 +7625,10 @@
   "YYbOQz": {
     "defaultMessage": "Il semble que {name} ait déjà un compte chez nous. Nous avons rempli automatiquement ses renseignements sur la base de son profil.",
     "description": "Message that the employee was found for a search"
+  },
+  "YZRjdG": {
+    "defaultMessage": "Cela permettra de rendre ce bassin au public. Tous les utilisateurs associés à ce bassin pourront le voir dans les informations de leur profil.",
+    "description": "Second paragraph for un-archive pool dialog"
   },
   "YZtE49": {
     "defaultMessage": "Obtenez une attestation de vos compétences liées à des domaines clés des TI.",
@@ -9849,6 +9853,10 @@
     "defaultMessage": "Directement lié à l’avancement de la réconciliation, le programme a été conçu par, pour et avec les Premières Nations, les Inuit et les Métis.",
     "description": "Paragraph 2 of the 'About the program' section"
   },
+  "iVAPnW": {
+    "defaultMessage": "À partir d’ici, vous pouvez modifier cette expérience. N’oubliez pas, les expériences de travail devraient miser sur une description d’expériences vécues dans le cadre de postes à temps partiel, à plein temps, d’emplois autonomes, de bourses, de postes bénévoles, et de stages.",
+    "description": "Description for editing an experience."
+  },
   "iWD2Pz": {
     "defaultMessage": "Expériences communautaires",
     "description": "Heading for community experiences in experience by type listing"
@@ -9948,10 +9956,6 @@
   "j+jnML": {
     "defaultMessage": "<strong>Ma situation correspond à l’option de deux années d’études postsecondaires.</strong>",
     "description": "Radio group option for education requirement filter in application education form."
-  },
-  "j2qiFb": {
-    "defaultMessage": "Résultats: { totalCandidateCount, plural, =0 {<testId><b>{totalCandidateCount}</b></testId> candidats correspondants} =1 {<testId><b>{totalCandidateCount}</b></testId> candidats correspondants} other {<testId><b>{totalCandidateCount}</b></testId> candidats correspondants à l'échelle } } de { numPools, plural, =0 {<b>{numPools}</b> bassins} =1 {<b>{numPools}</b> bassins} other {<b>{numPools}</b> bassins} }",
-    "description": "Heading for total matching candidates across a certain number of pools in results section of search page."
   },
   "j3OROA": {
     "defaultMessage": "Les techniciens (<abbreviation>IT-01</abbreviation>) fournissent un soutien technique pour l'élaboration, la mise en œuvre, l'intégration et la maintenance de la prestation de services aux clients et aux intervenants",
@@ -10513,10 +10517,6 @@
     "defaultMessage": "À propos du Portail des talents autochtones",
     "description": "Talent Portal information heading"
   },
-  "lr6PWk": {
-    "defaultMessage": "Si vous n’avez pas encore d’application d’authentification, vous devrez en télécharger une. Des fournisseurs numériques comme Google Authenticator et Microsoft Authenticator offrent des applications d’authentification. Quelle que soit l’application que vous choisissez, veillez à ce qu’elle provienne d’un fournisseur réputé.",
-    "description": "Copy explaining mfa apps"
-  },
   "ltzA7w": {
     "defaultMessage": "Si vous avez des questions concernant cette étape, ou si vous ne savez pas trop comment procéder, veuillez communiquer avec notre équipe de soutien, à <a>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</a>.",
     "description": "How to get help from the support team - IAP variant"
@@ -10592,6 +10592,10 @@
   "mEh+iY": {
     "defaultMessage": "Membres de la collectivité",
     "description": "Page title for the view community members page"
+  },
+  "mF1IpF": {
+    "defaultMessage": "Si vous n’avez pas encore d’application d’authentification, vous devrez en télécharger une. Des fournisseurs numériques comme Google Authenticator et Microsoft Authenticator offrent des applications d’authentification. Quelle que soit l’application que vous choisissez, veillez à ce qu’elle provienne d’un fournisseur réputé.",
+    "description": "Copy explaining mfa apps"
   },
   "mF1SAO": {
     "defaultMessage": "Plusieurs postes devraient être dotés dans le cadre de ce processus. Vous pouvez vous inscrire à ce processus si vous répondez à l’un des profils linguistiques précédents.",
@@ -13240,10 +13244,6 @@
   "zLuuVe": {
     "defaultMessage": "Ces informations aident les candidates et candidats à comprendre ce que signifie être admis dans un processus de recrutement et ce à quoi ils pourraient s'attendre en tant que candidates et candidats qualifiés.",
     "description": "Describes the 'what to expect after admission' section of a process' advertisement."
-  },
-  "zMZQLY": {
-    "defaultMessage": "À partir d’ici, vous pouvez modifier cette expérience. N’oubliez pas, les expériences de travail devraient miser sur une description d’expériences vécues dans le cadre de postes à temps partiel, à plein temps, d’emplois autonomes, de bourses, de postes bénévoles, et de stages.",
-    "description": "Description for editing an experience."
   },
   "zMa59V": {
     "defaultMessage": "Veuillez ne pas fournir des renseignements personnels supplémentaires qui ne sont pas requis à cette fin.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6172,7 +6172,7 @@
     "description": "Heading for the information of an application"
   },
   "R9Yk8Y": {
-    "defaultMessage": "Demande de candidats pour le bassin : <primary>{candidateCountNumber, plural, =0 {aucun candidat} =1 {1 candidat estimé} other {# candidats estimés}</primary>",
+    "defaultMessage": "Demande de candidats pour le bassin : <primary>{candidateCountNumber, plural, =0 {aucun candidat} =1 {1 candidat estimé} other {# candidats estimés}}</primary>",
     "description": "Total estimated candidates message in summary of filters"
   },
   "RA4afJ": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -123,6 +123,10 @@
     "defaultMessage": "Emplois dans le gouvernement numérique",
     "description": "Heading for the digital government job opportunities"
   },
+  "+cS81c": {
+    "defaultMessage": "{total, plural, =0 {0 résultats trouvés} one {# résultat trouvé} other { # résultats trouvés}}",
+    "description": "Message announced to assistive technology when number of items in a table changes"
+  },
   "+cn9MN": {
     "defaultMessage": "Les personnes qui se voient offrir des postes avec la possibilité de travailler à domicile doivent avoir un accès Internet adéquat pour le travail à distance.",
     "description": "IAP Requirement list item six"
@@ -146,10 +150,6 @@
   "+fSWpK": {
     "defaultMessage": "Dans la pratique, la plupart des postes bilingues sont soit de niveau intermédiaire (B B B), soit avancé (C B C).",
     "description": "Description for second language proficiency on language requirement dialog"
-  },
-  "+fYyID": {
-    "defaultMessage": "{monthCount, plural, =1 {# mois} other {# mois}}",
-    "description": "A duration of a certain number of months"
   },
   "+gnEgg": {
     "defaultMessage": "Trouvez une compétence et ajoutez-la à votre portfolio",
@@ -375,10 +375,6 @@
     "defaultMessage": "Voir toutes les notifications",
     "description": "Link text for the notifications page"
   },
-  "/ldR5A": {
-    "defaultMessage": "{count, plural, =0 {0 expériences} =1 {1 expérience} other {# expériences}}",
-    "description": "Number of experiences linked to a skill"
-  },
   "/mFrpj": {
     "defaultMessage": "Diplôme d’études postsecondaires exigé",
     "description": "Education level message when candidate has a diploma found on the request page."
@@ -515,6 +511,10 @@
     "defaultMessage": "De la même manière que vous avez sélectionné des éléments de votre parcours professionnel pour confirmer les exigences en matière d’expérience et d’études, nous vous demanderons de décrire une ou plusieurs expériences de votre parcours professionnel au cours desquelles vous avez activement utilisé la compétence requise.",
     "description": "Application step for skill requirements, introduction, description, paragraph two"
   },
+  "0NKan4": {
+    "defaultMessage": "{count, plural, =0 {0 expériences} one {# expérience} other {# expériences}}",
+    "description": "Number of experiences linked to a skill"
+  },
   "0NbdGD": {
     "defaultMessage": "Erreur : Échec de la suppression de la compétence",
     "description": "Message displayed to user after skill fails to be deleted."
@@ -582,10 +582,6 @@
   "0dQ62G": {
     "defaultMessage": "Nombre de compétences appariées",
     "description": "Title displayed on the candidate skill count column."
-  },
-  "0fexP+": {
-    "defaultMessage": "{experienceCount, plural, =0 {0 expérience en matière d’éducation et de certificats} =1 {1 expérience en matière d’éducation et de certificats} other {# expériences en matière d’éducation et de certificats}}",
-    "description": "list a number of education experiences"
   },
   "0jV7Rn": {
     "defaultMessage": "Complet",
@@ -1290,10 +1286,6 @@
   "4438xW": {
     "defaultMessage": "Expérience mise à jour avec succès!",
     "description": "Success message displayed after updating an experience"
-  },
-  "450itb": {
-    "defaultMessage": "{count, plural, =0 {0 éléments sélectionnés} =1 {1 élément sélectionné} other {# éléments sélectionnés}}",
-    "description": "Message displayed for the number of rows selected in a table"
   },
   "45ber4": {
     "defaultMessage": "À qui s'adresse cette page?",
@@ -2251,6 +2243,10 @@
     "defaultMessage": "Nous publions constamment de nouvelles offres. En tenant votre profil à jour, vous pourrez soumettre des demandes à la vitesse de l’éclair le moment venu.",
     "description": "Text describing upcoming opportunities instructing users to update a profile when signed in"
   },
+  "8ii/QN": {
+    "defaultMessage": "{workStreamCount, plural, =0 {0 volet de travail lié} one {# volet de travail lié} other {# volets de travail liés}}",
+    "description": "Count of work streams for work experience"
+  },
   "8ioBIZ": {
     "defaultMessage": "Éditeur de compétence",
     "description": "Title for skills editor"
@@ -2667,6 +2663,10 @@
     "defaultMessage": "Foire aux questions (FAQ)",
     "description": "Heading for Frequently Asked Questions section on sign in page"
   },
+  "AVlXEr": {
+    "defaultMessage": "{count, plural, =0 {0 éléments sélectionnés} one {# élément sélectionné} other {# éléments sélectionnés}}",
+    "description": "Message displayed for the number of rows selected in a table"
+  },
   "AWk4BX": {
     "defaultMessage": "Nom du propriétaire",
     "description": "Title displayed for the Pool table Owner Name column"
@@ -2987,10 +2987,6 @@
     "defaultMessage": "La plupart des offres d’emploi ne nécessiteront pas de note spéciale. Cette section est réservée à des circonstances particulières. Cette note spéciale peut notamment servir à indiquer si un processus peut être utilisé pour embaucher dans plusieurs classifications ou non et si le processus est limité aux candidatures d’un groupe visé par l’équité en matière d’emploi spécifique.",
     "description": "Describes the 'special note' section of a process' advertisement."
   },
-  "C6kQXh": {
-    "defaultMessage": "{experienceCount, plural, =0 {0 expérience} =1 {1 expérience} other {# expériences}}",
-    "description": "list a number of unknown experiences"
-  },
   "C780XI": {
     "defaultMessage": "L’étape suivante consiste à s’assurer que votre parcours professionnel est aussi à jour que possible.",
     "description": "Application step to begin working on career timeline, paragraph one"
@@ -3235,6 +3231,10 @@
     "defaultMessage": "Agrandir toutes les sections<hidden> de l’information sur la demande</hidden>",
     "description": "Button text to open all application information accordions"
   },
+  "DEdQkH": {
+    "defaultMessage": "{count, plural, one {# évaluation} other {# évaluations}}",
+    "description": "Number of assessments for a skill"
+  },
   "DG4c6M": {
     "defaultMessage": "{status}<hidden> changer le statut pour {poolName}</hidden>",
     "description": "Button to change a users status in a pool - located in the table on view-user page"
@@ -3446,6 +3446,10 @@
   "E32ToC": {
     "defaultMessage": "Tâches supplémentaires",
     "description": "Label for additional duties of a finance chief"
+  },
+  "E4AMEH": {
+    "defaultMessage": "{experienceCount, plural, =0 {0 expérience professionnelle} one {# expérience professionnelle} other {# expériences professionnelles}}",
+    "description": "list a number of work experiences"
   },
   "E9I34y": {
     "defaultMessage": "Titre de la thèse",
@@ -3887,6 +3891,10 @@
     "defaultMessage": "Objectifs et style de travail",
     "description": "Title for goals and work style section"
   },
+  "GEULvE": {
+    "defaultMessage": "{experienceCount, plural, =0 {0 expérience d’apprentissage personnel} one {# expérience d’apprentissage personnel} other {# expériences d’apprentissage personnel}}",
+    "description": "list a number of personal experiences"
+  },
   "GF8FPy": {
     "defaultMessage": "Autres commentaires",
     "description": "Title for the additional comments block for a search request"
@@ -4095,10 +4103,6 @@
     "defaultMessage": "Bien que les Procédures obligatoires soient également efficaces, il est possible d’en améliorer la clarté, de réduire la charge de travail des ministères en matière de rapports et de mieux les aligner sur les nouvelles <link>procédures obligatoires pour les propriétaires fonctionnels lors de l’approvisionnement en services professionnels</link> menées par le Bureau du contrôleur général du Canada (BCG).",
     "description": "third paragraph describing the 2024 changes to the directive on digital talent"
   },
-  "HWjcqg": {
-    "defaultMessage": "{workStreamCount, plural, =0 {0 volet de travail lié} =1 {1 volet de travail lié} other {# volets de travail liés}}",
-    "description": "Count of work streams for work experience"
-  },
   "HXF9GA": {
     "defaultMessage": "Bassin demandé",
     "description": "Title for the pool block in the manager info section of the single search request view."
@@ -4106,6 +4110,10 @@
   "HY0vjz": {
     "defaultMessage": "Supprimer le (la) candidat(e)",
     "description": "Title for action to remove a candidate infinitive"
+  },
+  "HYUyl0": {
+    "defaultMessage": "{count, plural, =0 {0 demandes} one {# demande} other {# demandes}}",
+    "description": "The number of applicants to a specific process"
   },
   "HYeViW": {
     "defaultMessage": "Comprendre les dates limites pour présenter une demande",
@@ -4134,10 +4142,6 @@
   "Hi7hnj": {
     "defaultMessage": "Anishinaabemowin (Ojibwé de l’Ouest)",
     "description": "Name of Western Ojibwe language"
-  },
-  "HkFHt6": {
-    "defaultMessage": "{nominationCount, plural, =0 {0 personne candidate} =1 {1 personne candidate} other {# personnes candidates}}",
-    "description": "Count of nominees"
   },
   "HqtjhD": {
     "defaultMessage": "Je suis intéressé(e) à offrir un stage",
@@ -4279,6 +4283,10 @@
     "defaultMessage": "Pour cette possibilité, les demandes doivent être soumises au plus tard, le :",
     "description": "Second paragraph for pool deadlines dialog"
   },
+  "IOwsKt": {
+    "defaultMessage": "{experienceCount, plural, =0 {0 expérience de participation au sein de la collectivité} one {# expérience de participation au sein de la collectivité} other {# expériences de participation au sein de la collectivité}}",
+    "description": "list a number of community experiences"
+  },
   "IQiTZd": {
     "defaultMessage": "Intérêt pour les possibilités de mentorat",
     "description": "Label for an employee profile career development preference field"
@@ -4354,10 +4362,6 @@
   "ImTMRk": {
     "defaultMessage": "Mettez à jour et passez en revue vos renseignements personnels, vos coordonnées et vos préférences.",
     "description": "Subtitle for the application profile  page"
-  },
-  "ImwOeT": {
-    "defaultMessage": "{experienceCount, plural, =0 {0 expérience professionnelle} =1 {1 expérience professionnelle} other {# expériences professionnelles}}",
-    "description": "list a number of work experiences"
   },
   "Iodi0/": {
     "defaultMessage": "Nos concepteurs prêtent une attention particulière aux éléments suivants : ",
@@ -5003,6 +5007,10 @@
     "defaultMessage": "Date à laquelle le recrutement cessera d'accepter les candidatures. <dialog>En apprendre davantage sur le fonctionnement des heures de clôture.</dialog>",
     "description": "Describes what the selecting a closing date for a process."
   },
+  "Lj0csm": {
+    "defaultMessage": "{nominationCount, plural, =0 {0 personne candidate} one {# personne candidate} other {# personnes candidates}}",
+    "description": "Count of nominees"
+  },
   "LjYzkS": {
     "defaultMessage": "Postulez le ou avant le {closingDate}",
     "description": "Message to apply to the pool before deadline"
@@ -5219,6 +5227,10 @@
     "defaultMessage": "Cette section vous permet de présenter des informations sur vous-même et sur votre façon de travailler, y compris sur vos objectifs pour l'avenir et sur les environnements qui vous permettent de donner le meilleur de vous-même.",
     "description": "Describes the goals and work style section of employee profile"
   },
+  "MrfPJb": {
+    "defaultMessage": "{yearCount, plural, one {# an} other {# ans}}, {monthCount, plural, one {# mois} other {# mois}}",
+    "description": "A duration of a certain number of years and months"
+  },
   "MsLKAj": {
     "defaultMessage": "Voir l’expérience pour {experienceName}",
     "description": "Assistive technology link text to view a specific experience"
@@ -5379,10 +5391,6 @@
     "defaultMessage": "Supprimez le (la) candidat(e)",
     "description": "Title for action to remove a candidate imperative"
   },
-  "NWbotz": {
-    "defaultMessage": "{yearCount, plural, =1 {# an} other {# ans}}, {monthCount, plural, =1 {# mois} other {# mois}}",
-    "description": "A duration of a certain number of years and months"
-  },
   "NZ3laJ": {
     "defaultMessage": "Pour vous reconnecter, vous devrez utiliser votre nom d’utilisateur et votre mot de passe CléGC. Nous espérons vous voir bientôt!",
     "description": "Message displayed to a user after signing out"
@@ -5538,10 +5546,6 @@
   "OPbfwn": {
     "defaultMessage": "Il semble que vous n'ayez pas encore répondu aux questions générales.",
     "description": "Null state message in general questions section of the application review page."
-  },
-  "OQBtt9": {
-    "defaultMessage": "{candidateCount, plural, =0 {Il y a actuellement environ <strong><testId>#</testId></strong> candidats qui répondent à vos critères.} =1 {Il y a actuellement environ <strong><testId>#</testId></strong> candidat qui répond à vos critères.} other {Il y a actuellement environ <strong><testId>#</testId></strong> candidats qui répondent à vos critères.} }",
-    "description": "Message for total estimated candidates box next to search form."
   },
   "OTI+Kb": {
     "defaultMessage": "Options du programme de perfectionnement",
@@ -5778,6 +5782,10 @@
   "PYMFoh": {
     "defaultMessage": "Recherche par mot-clé",
     "description": "Label for the keyword search input"
+  },
+  "PYeS11": {
+    "defaultMessage": "{experienceCount, plural, =0 {0 expérience en matière de prix et de reconnaissance} one {# expérience en matière de prix et de reconnaissance} other {# expériences en matière de prix et de reconnaissance}}",
+    "description": "list a number of award experiences"
   },
   "PZEAt8": {
     "defaultMessage": "Options du programme de perfectionnement",
@@ -6395,10 +6403,6 @@
     "defaultMessage": "femme.",
     "description": "Statement for when someone indicates they are a woman"
   },
-  "SLYAoc": {
-    "defaultMessage": "{total, plural, =0 {0 résultats trouvés} =1 {1 résultat trouvé} other { # résultats trouvés}}",
-    "description": "Message announced to assistive technology when number of items in a table changes"
-  },
   "SLedtO": {
     "defaultMessage": "Profil de l’utilisateur",
     "description": "Title for the user profile page"
@@ -6934,10 +6938,6 @@
     "defaultMessage": "Réduire toutes les sections d'informations complémentaires",
     "description": "Accessible link text to collapse all accordions for more information"
   },
-  "V6wB0a": {
-    "defaultMessage": "{experienceCount, plural, =0 {0 expérience de participation au sein de la collectivité} =1 {1 expérience de participation au sein de la collectivité} other {# expériences de participation au sein de la collectivité}}",
-    "description": "list a number of community experiences"
-  },
   "V8sPIH": {
     "defaultMessage": "Expérience professionnelle",
     "description": "Link text for the experience of a nominee"
@@ -7393,10 +7393,6 @@
   "XKpHTN": {
     "defaultMessage": "La possibilité de formation a été créée avec succès!",
     "description": "Message displayed to user after a training opportunity is created successfully."
-  },
-  "XOFVsC": {
-    "defaultMessage": "{count, plural, =1 {# évaluation} other {# évaluations}}",
-    "description": "Number of assessments for a skill"
   },
   "XOeFdu": {
     "defaultMessage": "À quoi s’attendre (français)",
@@ -8686,6 +8682,10 @@
     "defaultMessage": "Détails sur le candidat",
     "description": "Page title for the individual user page"
   },
+  "dkXjDY": {
+    "defaultMessage": "{monthCount, plural, =1 {# mois} other {# mois}}",
+    "description": "A duration of a certain number of months"
+  },
   "dkYHTv": {
     "defaultMessage": "Choisissez l’expérience que vous souhaitez ajouter",
     "description": "Heading for the experience selection"
@@ -8797,6 +8797,10 @@
   "e5BoL+": {
     "defaultMessage": "Cette bibliothèque contient une série de modèles pour des emplois courants dans les collectivités soutenues par Talents numériques du GC. Les modèles comprennent des informations suggérées et des recommandations pour des éléments tels que le titre du poste, les tâches courantes, les compétences essentielles et les compétences optionnelles. Parcourez la liste complète ou utilisez la barre de recherche et les filtres pour trouver des modèles qui correspondent aux spécificités du poste.",
     "description": "Description of how to use the form to filter job poster templates"
+  },
+  "e5N39X": {
+    "defaultMessage": "Résultats : {totalCandidateCount, plural, =0 {<testId><b>#</b></testId> candidats correspondants} one {<testId><b>#</b></testId> candidats correspondants} other {<testId><b>#</b></testId> candidats correspondants à l'échelle } } de {numPools, plural, =0 {<b>#</b> bassins} one {<b>#</b> bassins} other {<b>#</b> bassins} }",
+    "description": "Heading for total matching candidates across a certain number of pools in results section of search page."
   },
   "e5xrSy": {
     "defaultMessage": "Embauché à titre d’employé pour une période déterminée",
@@ -9394,10 +9398,6 @@
     "defaultMessage": "Programme de perfectionnement",
     "description": "Label for the development program nomination option on the details step"
   },
-  "gTZG/i": {
-    "defaultMessage": "Résultats : {totalCandidateCount, plural, =0 {<testId><b>#</b></testId> candidats correspondants} =1 {<testId><b>#</b></testId> candidats correspondants} other {<testId><b>#</b></testId> candidats correspondants à l'échelle } } de {numPools, plural, =0 {<b>#</b> bassins} =1 {<b>#</b> bassins} other {<b>#</b> bassins} }",
-    "description": "Heading for total matching candidates across a certain number of pools in results section of search page."
-  },
   "gU/nxf": {
     "defaultMessage": "Ajoutez une expérience à votre parcours professionnel",
     "description": "Title for application career timeline add experience"
@@ -9909,10 +9909,6 @@
     "defaultMessage": "Obtention d’un diplôme",
     "description": "Title for the EX graduation with degree requirement."
   },
-  "ilZlfH": {
-    "defaultMessage": "{count, plural, =0 {0 demandes} =1 {1 demande} other {# demandes}}",
-    "description": "The number of applicants to a specific process"
-  },
   "imNqyO": {
     "defaultMessage": "Rédaction (ou expression écrite))",
     "description": "Proficiency level related skill on language requirements dialog"
@@ -9920,10 +9916,6 @@
   "inxVq8": {
     "defaultMessage": "Vous êtes sur le point de supprimer le nom d'utilisateur suivant de la plateforme :",
     "description": "Lead in text for the delete user form."
-  },
-  "inyUex": {
-    "defaultMessage": "{experienceCount, plural, =0 {0 expérience en matière de prix et de reconnaissance} =1 {1 expérience en matière de prix et de reconnaissance} other {# expériences en matière de prix et de reconnaissance}}",
-    "description": "list a number of award experiences"
   },
   "ipDTrs": {
     "defaultMessage": "Historique des notifications",
@@ -11449,10 +11441,6 @@
     "defaultMessage": "Il n'y a pas d'options d'équité en matière d'emploi.",
     "description": "Message displayed when there are no employment equity categories available to be added."
   },
-  "q++unL": {
-    "defaultMessage": "{experienceCount, plural, =0 {0 expérience d’apprentissage personnel} =1 {1 expérience d’apprentissage personnel} other {# expériences d’apprentissage personnel}}",
-    "description": "list a number of personal experiences"
-  },
   "q+bkac": {
     "defaultMessage": "Davantage de renseignements sur l’équité en matière d’emploi",
     "description": "Heading for opening the accordion with information on employment equity"
@@ -12101,6 +12089,10 @@
     "defaultMessage": "2. Cours et camps d’entrainement dirigés par un instructeur ou une instructrice",
     "description": "Title for instructor-led classes card"
   },
+  "tj90+D": {
+    "defaultMessage": "{experienceCount, plural, =0 {0 expérience en matière d’éducation et de certificats} one {# expérience en matière d’éducation et de certificats} other {# expériences en matière d’éducation et de certificats}}",
+    "description": "list a number of education experiences"
+  },
   "tj9Dz3": {
     "defaultMessage": "Adresse courriel professionnelle",
     "description": "Work email label"
@@ -12324,6 +12316,10 @@
   "utlf9l": {
     "defaultMessage": "À quoi devrais-je m’attendre si je réussis ce processus?",
     "description": "Button text to toggle the accordion for what to expect after admission"
+  },
+  "uuXnmb": {
+    "defaultMessage": "{experienceCount, plural, =0 {0 expérience} one {# expérience} other {# expériences}}",
+    "description": "list a number of unknown experiences"
   },
   "uup5F2": {
     "defaultMessage": "Sélectionnez une langue",
@@ -12656,6 +12652,10 @@
   "wYohzF": {
     "defaultMessage": "Membres du processus",
     "description": "Page title for the manage process members page"
+  },
+  "wZKKk1": {
+    "defaultMessage": "{candidateCount, plural, =0 {Il y a actuellement environ <strong><testId>#</testId></strong> candidats qui répondent à vos critères.} one {Il y a actuellement environ <strong><testId>#</testId></strong> candidat qui répond à vos critères.} other {Il y a actuellement environ <strong><testId>#</testId></strong> candidats qui répondent à vos critères.} }",
+    "description": "Message for total estimated candidates box next to search form."
   },
   "wdFBSc": {
     "defaultMessage": "Merci d'avoir proposé la candidature de {name}! L'équipe de gestion des talents de {community} examinera bientôt votre mise en candidature. En attendant, vous pouvez consulter votre demande et son état d'avancement à partir de votre tableau de bord.",

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/ApplicationCareerTimelineEditPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/ApplicationCareerTimelineEditPage.tsx
@@ -105,8 +105,8 @@ const ApplicationCareerTimelineEdit = ({
       <p data-h2-margin="base(x1, 0, 0, 0)">
         {intl.formatMessage({
           defaultMessage:
-            "From here you can edit this experience. Don't forget, work experiences should focus on describing  your part-time, full-time, self-employment, fellowship, non-profit, or internship experiences.",
-          id: "zMZQLY",
+            "From here you can edit this experience. Don't forget, work experiences should focus on describing your part-time, full-time, self-employment, fellowship, non-profit, or internship experiences.",
+          id: "iVAPnW",
           description: "Description for editing an experience.",
         })}
       </p>

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
@@ -91,8 +91,8 @@ function formatExperienceCount(
       return intl.formatMessage(
         {
           defaultMessage:
-            "{experienceCount, plural, =0 {0 work experiences} =1 {1 work experience} other {# work experiences}}",
-          id: "ImwOeT",
+            "{experienceCount, plural, =0 {0 work experiences} one {# work experience} other {# work experiences}}",
+          id: "E4AMEH",
           description: "list a number of work experiences",
         },
         {
@@ -103,8 +103,8 @@ function formatExperienceCount(
       return intl.formatMessage(
         {
           defaultMessage:
-            "{experienceCount, plural, =0 {0 personal learning experiences} =1 {1 personal learning experience} other {# personal learning experiences}}",
-          id: "q++unL",
+            "{experienceCount, plural, =0 {0 personal learning experiences} one {# personal learning experience} other {# personal learning experiences}}",
+          id: "GEULvE",
           description: "list a number of personal experiences",
         },
         {
@@ -115,8 +115,8 @@ function formatExperienceCount(
       return intl.formatMessage(
         {
           defaultMessage:
-            "{experienceCount, plural, =0 {0 community participation experiences} =1 {1 community participation experience} other {# community participation experiences}}",
-          id: "V6wB0a",
+            "{experienceCount, plural, =0 {0 community participation experiences} one {# community participation experience} other {# community participation experiences}}",
+          id: "IOwsKt",
           description: "list a number of community experiences",
         },
         {
@@ -127,8 +127,8 @@ function formatExperienceCount(
       return intl.formatMessage(
         {
           defaultMessage:
-            "{experienceCount, plural, =0 {0 education and certificate experiences} =1 {1 education and certificate experience} other {# education and certificate experiences}}",
-          id: "0fexP+",
+            "{experienceCount, plural, =0 {0 education and certificate experiences} one {# education and certificate experience} other {# education and certificate experiences}}",
+          id: "tj90+D",
           description: "list a number of education experiences",
         },
         {
@@ -139,8 +139,8 @@ function formatExperienceCount(
       return intl.formatMessage(
         {
           defaultMessage:
-            "{experienceCount, plural, =0 {0 award and recognition experiences} =1 {1 award and recognition experience} other {# award and recognition experiences}}",
-          id: "inyUex",
+            "{experienceCount, plural, =0 {0 award and recognition experiences} one {# award and recognition experience} other {# award and recognition experiences}}",
+          id: "PYeS11",
           description: "list a number of award experiences",
         },
         {
@@ -152,8 +152,8 @@ function formatExperienceCount(
       return intl.formatMessage(
         {
           defaultMessage:
-            "{experienceCount, plural, =0 {0 experiences} =1 {1 experience} other {# experiences}}",
-          id: "C6kQXh",
+            "{experienceCount, plural, =0 {0 experiences} one {# experience} other {# experiences}}",
+          id: "uuXnmb",
           description: "list a number of unknown experiences",
         },
         {

--- a/apps/web/src/pages/Auth/SignUpPage/SignUpPage.tsx
+++ b/apps/web/src/pages/Auth/SignUpPage/SignUpPage.tsx
@@ -273,8 +273,8 @@ export const Component = () => {
               <p>
                 {intl.formatMessage({
                   defaultMessage:
-                    "If you don’t already have an authenticator app you will need to download one. Digital vendors, like Google Authenticator and Microsoft Authenticator,  provide authenticator apps. Whichever app you choose, ensure that it comes from a reputable vendor.",
-                  id: "lr6PWk",
+                    "If you don’t already have an authenticator app you will need to download one. Digital vendors, like Google Authenticator and Microsoft Authenticator, provide authenticator apps. Whichever app you choose, ensure that it comes from a reputable vendor.",
+                  id: "mF1IpF",
                   description: "Copy explaining mfa apps",
                 })}
               </p>

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/SkillSummaryTable.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/SkillSummaryTable.tsx
@@ -134,8 +134,8 @@ const plannedAssessmentCell = (
         ? intl.formatMessage(
             {
               defaultMessage:
-                "{count, plural, =1 {# assessment} other {# assessments}}",
-              id: "XOFVsC",
+                "{count, plural, one {# assessment} other {# assessments}}",
+              id: "DEdQkH",
               description: "Number of assessments for a skill",
             },
             {

--- a/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
@@ -423,8 +423,8 @@ export const ViewPool = ({
                 {intl.formatMessage(
                   {
                     defaultMessage:
-                      "{count, plural, =0 {0 total applicants} =1 {1 total applicant} other {# total applicants}}",
-                    id: "ilZlfH",
+                      "{count, plural, =0 {0 total applicants} one {# total applicant} other {# total applicants}}",
+                    id: "HYUyl0",
                     description:
                       "The number of applicants to a specific process",
                   },

--- a/apps/web/src/pages/Pools/ViewPoolPage/components/UnArchiveProcessDialog.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/components/UnArchiveProcessDialog.tsx
@@ -57,8 +57,8 @@ const UnarchiveProcessDialog = ({
           <p data-h2-margin="base(x1, 0)">
             {intl.formatMessage({
               defaultMessage:
-                "This will show this pool back to the public.  All users associated with this pool will be able to see it in their profile information.",
-              id: "Bg1Pga",
+                "This will show this pool back to the public. All users associated with this pool will be able to see it in their profile information.",
+              id: "YZRjdG",
               description: "Second paragraph for un-archive pool dialog",
             })}
           </p>

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -671,8 +671,8 @@ export const RequestForm = ({
             {intl.formatMessage(
               {
                 defaultMessage:
-                  "Request for pool candidates: <primary>{candidateCountNumber, plural, =0 {no candidates} =1 {1 estimated candidate} other {# estimated candidates}}</primary>",
-                id: "R9Yk8Y",
+                  "Request for pool candidates: <primary>{candidateCountNumber, plural, =0 {no candidates} one {# estimated candidate} other {# estimated candidates}}</primary>",
+                id: "JL6B1D",
                 description:
                   "Total estimated candidates message in summary of filters",
               },

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -671,8 +671,8 @@ export const RequestForm = ({
             {intl.formatMessage(
               {
                 defaultMessage:
-                  "Request for pool candidates: <primary>{candidateCountNumber, plural, =0 {no candidates} =1 {1 estimated candidate} other {{candidateCountNumber} estimated candidates}}</primary>",
-                id: "og5vUB",
+                  "Request for pool candidates: <primary>{candidateCountNumber, plural, =0 {no candidates} =1 {1 estimated candidate} other {# estimated candidates}}</primary>",
+                id: "R9Yk8Y",
                 description:
                   "Total estimated candidates message in summary of filters",
               },

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/EstimatedCandidates.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/EstimatedCandidates.tsx
@@ -19,11 +19,11 @@ const CandidateMessage = ({ candidateCount }: CandidateMessageProps) => {
       {intl.formatMessage(
         {
           defaultMessage: `{candidateCount, plural,
-          =0 {There are approximately <strong><testId>{candidateCount}</testId></strong> candidates right now who meet your criteria.}
-          =1 {There is approximately <strong><testId>{candidateCount}</testId></strong> candidate right now who meets your criteria.}
-          other {There are approximately <strong><testId>{candidateCount}</testId></strong> candidates right now who meet your criteria.}
+          =0 {There are approximately <strong><testId>#</testId></strong> candidates right now who meet your criteria.}
+          =1 {There is approximately <strong><testId>#</testId></strong> candidate right now who meets your criteria.}
+          other {There are approximately <strong><testId>#</testId></strong> candidates right now who meet your criteria.}
         }`,
-          id: "xwBt36",
+          id: "OQBtt9",
           description:
             "Message for total estimated candidates box next to search form.",
         },

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/EstimatedCandidates.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/EstimatedCandidates.tsx
@@ -20,10 +20,10 @@ const CandidateMessage = ({ candidateCount }: CandidateMessageProps) => {
         {
           defaultMessage: `{candidateCount, plural,
           =0 {There are approximately <strong><testId>#</testId></strong> candidates right now who meet your criteria.}
-          =1 {There is approximately <strong><testId>#</testId></strong> candidate right now who meets your criteria.}
+          one {There is approximately <strong><testId>#</testId></strong> candidate right now who meets your criteria.}
           other {There are approximately <strong><testId>#</testId></strong> candidates right now who meet your criteria.}
         }`,
-          id: "OQBtt9",
+          id: "wZKKk1",
           description:
             "Message for total estimated candidates box next to search form.",
         },

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -233,17 +233,14 @@ export const SearchForm = ({
               <Heading level="h3" size="h4" id="results">
                 {intl.formatMessage(
                   {
-                    defaultMessage: `Results:
-                    { totalCandidateCount, plural,
+                    defaultMessage: `Results: {totalCandidateCount, plural,
                       =0 {<testId><b>{totalCandidateCount}</b></testId> matching candidates}
                       =1 {<testId><b>{totalCandidateCount}</b></testId> matching candidate}
-                      other {<testId><b>{totalCandidateCount}</b></testId> matching candidates} }
-                    across
-                    { numPools, plural,
+                      other {<testId><b>{totalCandidateCount}</b></testId> matching candidates} } across {numPools, plural,
                       =0 {<b>{numPools}</b> pools}
                       =1 {<b>{numPools}</b> pool}
                       other {<b>{numPools}</b> pools} }`,
-                    id: "j2qiFb",
+                    id: "Q4Lc8n",
                     description:
                       "Heading for total matching candidates across a certain number of pools in results section of search page.",
                   },

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -235,12 +235,12 @@ export const SearchForm = ({
                   {
                     defaultMessage: `Results: {totalCandidateCount, plural,
                       =0 {<testId><b>#</b></testId> matching candidates}
-                      =1 {<testId><b>#</b></testId> matching candidate}
+                      one {<testId><b>#</b></testId> matching candidate}
                       other {<testId><b>#</b></testId> matching candidates} } across {numPools, plural,
                       =0 {<b>#</b> pools}
-                      =1 {<b>#</b> pool}
+                      one {<b>#</b> pool}
                       other {<b>#</b> pools} }`,
-                    id: "gTZG/i",
+                    id: "e5N39X",
                     description:
                       "Heading for total matching candidates across a certain number of pools in results section of search page.",
                   },

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -234,13 +234,13 @@ export const SearchForm = ({
                 {intl.formatMessage(
                   {
                     defaultMessage: `Results: {totalCandidateCount, plural,
-                      =0 {<testId><b>{totalCandidateCount}</b></testId> matching candidates}
-                      =1 {<testId><b>{totalCandidateCount}</b></testId> matching candidate}
-                      other {<testId><b>{totalCandidateCount}</b></testId> matching candidates} } across {numPools, plural,
-                      =0 {<b>{numPools}</b> pools}
-                      =1 {<b>{numPools}</b> pool}
-                      other {<b>{numPools}</b> pools} }`,
-                    id: "Q4Lc8n",
+                      =0 {<testId><b>#</b></testId> matching candidates}
+                      =1 {<testId><b>#</b></testId> matching candidate}
+                      other {<testId><b>#</b></testId> matching candidates} } across {numPools, plural,
+                      =0 {<b>#</b> pools}
+                      =1 {<b>#</b> pool}
+                      other {<b>#</b> pools} }`,
+                    id: "gTZG/i",
                     description:
                       "Heading for total matching candidates across a certain number of pools in results section of search page.",
                   },

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
@@ -167,7 +167,7 @@ const SearchResultCard = ({ candidateCount, pool }: SearchResultCardProps) => {
                 one {<testId>#</testId> approximate match}
                 other {<testId>#</testId> approximate matches}
               }`,
-              id: "IMGvOV",
+              id: 'IMGvOV',
               description:
                 "Message for total estimated matching candidates in pool",
             },

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
@@ -167,7 +167,7 @@ const SearchResultCard = ({ candidateCount, pool }: SearchResultCardProps) => {
                 one {<testId>#</testId> approximate match}
                 other {<testId>#</testId> approximate matches}
               }`,
-              id: 'IMGvOV',
+              id: "IMGvOV",
               description:
                 "Message for total estimated matching candidates in pool",
             },

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
@@ -164,10 +164,10 @@ const SearchResultCard = ({ candidateCount, pool }: SearchResultCardProps) => {
           {intl.formatMessage(
             {
               defaultMessage: `{candidateCount, plural,
-                one {<testId>{candidateCount}</testId> approximate match}
-                other {<testId>{candidateCount}</testId> approximate matches}
+                one {<testId>#</testId> approximate match}
+                other {<testId>#</testId> approximate matches}
               }`,
-              id: "Gki8Ex",
+              id: "IMGvOV",
               description:
                 "Message for total estimated matching candidates in pool",
             },

--- a/apps/web/src/pages/Skills/components/SkillPortfolioTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillPortfolioTable.tsx
@@ -191,8 +191,8 @@ const SkillPortfolioTable = ({
         intl.formatMessage(
           {
             defaultMessage:
-              "{count, plural, =0 {0 experiences} =1 {1 experience} other {# experiences}}",
-            id: "/ldR5A",
+              "{count, plural, =0 {0 experiences} one {# experience} other {# experiences}}",
+            id: "0NKan4",
             description: "Number of experiences linked to a skill",
           },
           {

--- a/apps/web/src/pages/TalentEvents/components/helpers.tsx
+++ b/apps/web/src/pages/TalentEvents/components/helpers.tsx
@@ -48,8 +48,8 @@ export const nominationsCell = (
       {intl.formatMessage(
         {
           defaultMessage:
-            "{nominationCount, plural, =0 {0 nominees} =1 {1 nominee} other {# nominees}}",
-          id: "HkFHt6",
+            "{nominationCount, plural, =0 {0 nominees} one {# nominee} other {# nominees}}",
+          id: "Lj0csm",
           description: "Count of nominees",
         },
         { nominationCount: count },

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/NominatedForList.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/NominatedForList.tsx
@@ -56,8 +56,8 @@ const NominatedForList = ({
         {intl.formatMessage(
           {
             defaultMessage:
-              "{advancementNominationCount, plural, =0 {Advancement} other {Advancement ({advancementNominationCount, number})}}",
-            id: "fOilMx",
+              "{advancementNominationCount, plural, =0 {Advancement} other {Advancement (#)}}",
+            id: "ZzkqoI",
             description:
               "Advancement nominations, conditional rendered off count",
           },
@@ -74,8 +74,8 @@ const NominatedForList = ({
         {intl.formatMessage(
           {
             defaultMessage:
-              "{lateralMovementNominationCount, plural, =0 {Lateral movement} other {Lateral movement ({lateralMovementNominationCount, number})}}",
-            id: "4ozix3",
+              "{lateralMovementNominationCount, plural, =0 {Lateral movement} other {Lateral movement (#)}}",
+            id: "q0kxlX",
             description:
               "Lateral movement nominations, conditional rendered off count",
           },
@@ -92,8 +92,8 @@ const NominatedForList = ({
         {intl.formatMessage(
           {
             defaultMessage:
-              "{developmentProgramsNominationCount, plural, =0 {Development} other {Development ({developmentProgramsNominationCount, number})}}",
-            id: "+UTd4G",
+              "{developmentProgramsNominationCount, plural, =0 {Development} other {Development (#)}}",
+            id: "L8iCCj",
             description:
               "Development nominations, conditional rendered off count",
           },

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/NominatedForList.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/NominatedForList.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable formatjs/enforce-plural-rules */
+// NOTE: Not really plural, I guess?
 import { useIntl } from "react-intl";
 
 import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/fullCareerExperiencesUtils.ts
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/fullCareerExperiencesUtils.ts
@@ -31,8 +31,8 @@ function durationMonthsToSubtitle(
     return intl.formatMessage(
       {
         defaultMessage:
-          "{yearCount, plural, =1 {# year} other {# years}}, {monthCount, plural, =1 {# month} other {# months}}",
-        id: "NWbotz",
+          "{yearCount, plural,one {# year} other {# years}}, {monthCount, plural, one {# month} other {# months}}",
+        id: "MrfPJb",
         description: "A duration of a certain number of years and months",
       },
       {
@@ -44,8 +44,8 @@ function durationMonthsToSubtitle(
 
   return intl.formatMessage(
     {
-      defaultMessage: "{monthCount, plural, =1 {# month} other {# months}}",
-      id: "+fYyID",
+      defaultMessage: "{monthCount, plural, one {# month} other {# months}}",
+      id: "dkXjDY",
       description: "A duration of a certain number of months",
     },
     {

--- a/packages/eslint-config-custom/react.mjs
+++ b/packages/eslint-config-custom/react.mjs
@@ -55,9 +55,10 @@ export default [
           ],
         },
       ],
-      // TODO: Turn on and fix in in #12832
+
+      // We use this a bit and have not had issue with it...yet
       "formatjs/no-multiple-plurals": "off",
-      "formatjs/no-multiple-whitespaces": "off",
+      // TODO: Turn on and fix in in #12832
       "formatjs/prefer-pound-in-plural": "off",
       "formatjs/enforce-plural-rules": "off",
 

--- a/packages/eslint-config-custom/react.mjs
+++ b/packages/eslint-config-custom/react.mjs
@@ -29,6 +29,8 @@ export default [
       "react/jsx-uses-react": "off",
       "react/react-in-jsx-scope": "off",
       "formatjs/no-id": "off",
+      // We use this a bit and have not had issue with it...yet
+      "formatjs/no-multiple-plurals": "off",
       "formatjs/enforce-id": [
         "error",
         {
@@ -56,10 +58,7 @@ export default [
         },
       ],
 
-      // We use this a bit and have not had issue with it...yet
-      "formatjs/no-multiple-plurals": "off",
       // TODO: Turn on and fix in in #12832
-      "formatjs/prefer-pound-in-plural": "off",
       "formatjs/enforce-plural-rules": "off",
 
       "react/display-name": "off",

--- a/packages/eslint-config-custom/react.mjs
+++ b/packages/eslint-config-custom/react.mjs
@@ -38,6 +38,7 @@ export default [
           idWhitelist: ["\\."],
         },
       ],
+      "formatjs/enforce-plural-rules": "off",
       "formatjs/enforce-description": ["error", "literal"],
       "formatjs/enforce-placeholders": [
         "error",
@@ -57,9 +58,6 @@ export default [
           ],
         },
       ],
-
-      // TODO: Turn on and fix in in #12832
-      "formatjs/enforce-plural-rules": "off",
 
       "react/display-name": "off",
       "react/prop-types": "off",

--- a/packages/eslint-config-custom/react.mjs
+++ b/packages/eslint-config-custom/react.mjs
@@ -38,7 +38,6 @@ export default [
           idWhitelist: ["\\."],
         },
       ],
-      "formatjs/enforce-plural-rules": "off",
       "formatjs/enforce-description": ["error", "literal"],
       "formatjs/enforce-placeholders": [
         "error",

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -411,10 +411,6 @@
     "defaultMessage": "Je consens à travailler dans la Région de la capitale nationale (Ottawa, en Ontario et Gatineau, au Québec).",
     "description": "The work region of Canada described as National Capital."
   },
-  "FYrmhH": {
-    "defaultMessage": "{total, plural, =0 {<strong>0</strong> options disponibles} =1 {<strong>1</strong> option disponible} other { <strong>#</strong> options disponibles}}",
-    "description": "Message showing number of all available options in combobox menu"
-  },
   "FqsPMv": {
     "defaultMessage": "Indéterminé",
     "description": "Duration that is permanent (short-form for limited space)"
@@ -470,6 +466,10 @@
   "Hu321P": {
     "defaultMessage": "La compétence du bassin n'existe pas pour le bassin en question.",
     "description": "Error message that a given pool skill is not valid."
+  },
+  "HxxE2u": {
+    "defaultMessage": "{count, plural, =0 {0 options sélectionnées} one {1 option sélectionnée} other {# options sélectionnées}}",
+    "description": "Message displayed telling user how many items they have selected in a multi-select combobox"
   },
   "I1jrAG": {
     "defaultMessage": "Non accepté",
@@ -527,8 +527,8 @@
     "defaultMessage": "À un stade initial de développement",
     "description": "The behavioural skill level for beginner"
   },
-  "KGX4bI": {
-    "defaultMessage": "{count, plural, =0 { <strong>0</strong> résultats équivalents} =1 {<strong>1</strong> résultats équivalents} other {<strong>#</strong> résultats équivalents}} de {total, plural, =0 {<strong>0</strong> options disponibles} =1 {<strong>1</strong> option disponible} other {<strong>#</strong> options disponibles}}",
+  "KeleaV": {
+    "defaultMessage": "{count, plural, =0 { <strong>0</strong> résultats équivalents} one {<strong>1</strong> résultats équivalents} other {<strong>#</strong> résultats équivalents}} de {total, plural, =0 {<strong>0</strong> options disponibles} one {<strong>1</strong> option disponible} other {<strong>#</strong> options disponibles}}",
     "description": "Message showing number of matching items from all available options in combobox menu"
   },
   "Ko0JX/": {
@@ -863,6 +863,10 @@
     "defaultMessage": "Veuillez entrer une date valide",
     "description": "Error message that appears when a user enters an invalid date into a date input"
   },
+  "X3wRqo": {
+    "defaultMessage": "{total, plural, =0 {<strong>0</strong> options disponibles} one {<strong>1</strong> option disponible} other { <strong>#</strong> options disponibles}}",
+    "description": "Message showing number of all available options in combobox menu"
+  },
   "XCKYVJ": {
     "defaultMessage": "Lien",
     "description": "Label for adding a link in the rich text editor"
@@ -1046,10 +1050,6 @@
   "e6YQ8t": {
     "defaultMessage": "Ouvrir le menu",
     "description": "Text label for button that opens side menu."
-  },
-  "eBNZxB": {
-    "defaultMessage": "{count, plural, =0 {0 options sélectionnées} =1 {1 option sélectionnée} other {# options sélectionnées}}",
-    "description": "Message displayed telling user how many items they have selected in a multi-select combobox"
   },
   "eQ8bTh": {
     "defaultMessage": "Expire",

--- a/packages/i18n/src/messages/formMessages.ts
+++ b/packages/i18n/src/messages/formMessages.ts
@@ -56,22 +56,22 @@ const formMessages = defineMessages({
   },
   allAvailableCombobox: {
     defaultMessage:
-      "{total, plural, =0 {<strong>0</strong> available options} =1 {<strong>1</strong> available option} other {<strong>#</strong> available options}}",
-    id: "FYrmhH",
+      "{total, plural, =0 {<strong>0</strong> available options} one {<strong>#</strong> available option} other {<strong>#</strong> available options}}",
+    id: "X3wRqo",
     description:
       "Message showing number of all available options in combobox menu",
   },
   subsetAvailableCombobox: {
     defaultMessage:
-      "{count, plural, =0 {<strong>0</strong> matching results} =1 {<strong>1</strong> matching result} other {<strong>#</strong> matching results}} out of {total, plural, =0 {<strong>0</strong> available options} =1 {<strong>1</strong> available option} other {<strong>#</strong> available options}}",
-    id: "KGX4bI",
+      "{count, plural, =0 {<strong>0</strong> matching results} one {<strong>#</strong> matching result} other {<strong>#</strong> matching results}} out of {total, plural, =0 {<strong>0</strong> available options} one {<strong>#</strong> available option} other {<strong>#</strong> available options}}",
+    id: "KeleaV",
     description:
       "Message showing number of matching items from all available options in combobox menu",
   },
   itemsSelectedCombobox: {
     defaultMessage:
-      "{count, plural, =0 {0 options selected} =1 {1 option selected} other {# options selected}}",
-    id: "eBNZxB",
+      "{count, plural, =0 {0 options selected} one {# option selected} other {# options selected}}",
+    id: "HxxE2u",
     description:
       "Message displayed telling user how many items they have selected in a multi-select combobox",
   },


### PR DESCRIPTION
🤖 Resolves #12832 

## 👋 Introduction

Re-enables some of the rules and fixes instances of them.

## 🕵️ Details

I left off some because I lack the knowledge authority to enable them :sweat_smile: 

 - [`no-multiple-plurals`](https://formatjs.github.io/docs/tooling/linter#no-multiple-plurals)
     - We have strings with multiple plurals and I'm not sure how to modify them to not use it
 - [`enforce-plural-rules`](https://formatjs.github.io/docs/tooling/linter#enforce-plural-rules)
      - This requires we supply a value of `one` but some we don't and I'm not sure if that is valid or not since `one` is the same as `other` :confused:   

I did not change any of the  [`no-literal-string-in-jsx`](https://formatjs.github.io/docs/tooling/linter#no-literal-string-in-jsx) because it is primarily punctuaion and I don't feel condfident in modifying the French to fix this.

I'm willing to attempt fixing some of these but I'll need some help from someone who has moderate French ability to assist. Or someone else can pick this up? :pray: 

> [!NOTE]
> Spoke with @mnigh and @NienkeBr and agreed the `no-multiple-plurals` isn't a huge issue for us so we can take on the added complexity and have left this rule off. 

## 🧪 Testing

1. Confirm only `no-multiple-plurals` and `no-id` are the only disabled formatjs rules
2. Confirm lint passes
3. Confirm translations are intact