### PR TITLE
[Fix] Remove `storybook-react-intl` from dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,8 @@ updates:
         patterns:
           - "@storybook*"
           - "storybook*"
+        exclude-patterns:
+          - "storybook-react-intl"
         update-types:
           - "major"
           - "minor"


### PR DESCRIPTION
## 👋 Introduction

Remove a 3rd party plugin from the storybook group since it can have breaking changes (and has) that we don't want to tie to actual storybook bumps.

