### PR TITLE
[Copy] rod dialogue edits

### DIFF
--- a/api/lang/en/assessment_decision.php
+++ b/api/lang/en/assessment_decision.php
@@ -3,5 +3,5 @@
 return [
     'successful' => 'Demonstrated',
     'hold' => 'Not demonstrated (Hold for further assessment)',
-    'unsuccessful' => 'Not demonstrated (Remove from process)',
+    'unsuccessful' => 'Not demonstrated',
 ];

--- a/api/lang/fr/assessment_decision.php
+++ b/api/lang/fr/assessment_decision.php
@@ -3,5 +3,5 @@
 return [
     'successful' => 'Démontré',
     'hold' => 'Non démontrée (en attente d’une évaluation plus poussée)',
-    'unsuccessful' => 'Non démontrée (supprimée du processus)',
+    'unsuccessful' => 'Non démontrée',
 ];

--- a/api/lang/fr/assessment_decision.php
+++ b/api/lang/fr/assessment_decision.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'successful' => 'Démontré',
+    'successful' => 'Démontrée',
     'hold' => 'Non démontrée (en attente d’une évaluation plus poussée)',
     'unsuccessful' => 'Non démontrée',
 ];

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -9190,6 +9190,10 @@
     "defaultMessage": "Catégorie (anglais)",
     "description": "Title for category in English"
   },
+  "fcSR2I": {
+    "defaultMessage": "Non démontrée",
+    "description": "Option for assessment decision when candidate has unsuccessful assessment and been removed from the process."
+  },
   "fdKtYm": {
     "defaultMessage": "Description (anglais)",
     "description": "Label displayed on the update a skill form description (English) field."
@@ -13336,10 +13340,6 @@
   "zXWJ/5": {
     "defaultMessage": "Intérêt pour la promotion et l'avancement",
     "description": "Label for an employee profile career development preference field"
-  },
-  "fcSR2I": {
-    "defaultMessage": "Non démontrée",
-    "description": "Option for assessment decision when candidate has unsuccessful assessment and been removed from the process."
   },
   "zYKPdV": {
     "defaultMessage": "Nom de l'auteur(trice) de la mise en candidature",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1748,7 +1748,7 @@
     "description": "Title for Goals and work style section of user employee information page"
   },
   "5wKh/o": {
-    "defaultMessage": "Démontré",
+    "defaultMessage": "Démontrée",
     "description": "Option for assessment decision when candidate has successful assessment."
   },
   "5zJ+/1": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3292,7 +3292,7 @@
     "description": "Display text for the current location field on users"
   },
   "DOmsNQ": {
-    "defaultMessage": "Non démontré suffisamment dans le cadre de la présente méthode d’évaluation – faire passer à de plus amples mises à l’essai. (Ne s’applique qu’aux occasions où les points sont cumulatifs à l’échelle des méthodes d’évaluation. Ne s’applique pas dans les cas où les candidats doivent répondre à certains critères essentiels à chaque étape).",
+    "defaultMessage": "Non démontrée suffisamment dans le cadre de la présente méthode d’évaluation – faire passer à de plus amples mises à l’essai. (Ne s’applique qu’aux occasions où les points sont cumulatifs à l’échelle des méthodes d’évaluation. Ne s’applique pas dans les cas où les candidats doivent répondre à certains critères essentiels à chaque étape).",
     "description": "Note for when an assessment was unsuccessful but put on hold"
   },
   "DOn3Hm": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -13337,8 +13337,8 @@
     "defaultMessage": "Intérêt pour la promotion et l'avancement",
     "description": "Label for an employee profile career development preference field"
   },
-  "zXkLL2": {
-    "defaultMessage": "Non démontrée (supprimée du processus)",
+  "fcSR2I": {
+    "defaultMessage": "Non démontrée",
     "description": "Option for assessment decision when candidate has unsuccessful assessment and been removed from the process."
   },
   "zYKPdV": {

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/components/AssessmentSummary.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/components/AssessmentSummary.tsx
@@ -69,8 +69,8 @@ const TableHeader = ({ tableTitle }: { tableTitle: string }): JSX.Element => {
           data-h2-color="base(error)"
           aria-hidden="false"
           aria-label={intl.formatMessage({
-            defaultMessage: "Not demonstrated (Remove from process)",
-            id: "zXkLL2",
+            defaultMessage: "Not demonstrated",
+            id: "fcSR2I",
             description:
               "Option for assessment decision when candidate has unsuccessful assessment and been removed from the process.",
           })}


### PR DESCRIPTION
🤖 Resolves #13584

👋 Introduction

This PR updates the Record of Decision (ROD) skill assessment. It removes the text "(Remove from process)" from the "Not demonstrated" option and fixes a small grammar issue in the French version.

🕵️ Details

- Removed "(Remove from process)" from the English "not demonstrated" translation in api/lang/en.
- Removed "(supprimée du processus)" from the French "not demonstrated" translation in api/lang/fr.
- Updated French label and description for "Démontrée" to correct grammar (added missing "e").
- Updated frontend strings to match revised translations.

🧪 Testing

1. Build app
2. Login as admin
3. Navigate to `admin/pool-candidates` and select a candidate
4. Select a requirement to assess
5. Verify copy `(Remove from process)` was removed from "not demonstrated" option
6. Verify French spelling for `Démontrée` was updated in the option as well as the description


## 📸 Screenshot
![Screen Shot 2025-05-23 at 10 27 53](https://github.com/user-attachments/assets/058cd1a7-18ff-466b-bdd7-6bdaac39d30d)

![Screen Shot 2025-05-23 at 10 29 19](https://github.com/user-attachments/assets/64ca12f4-61e1-48ae-b925-39fc1527f2ef)


