### PR TITLE
[Debt] Migrate `Well` to tailwind

### DIFF
--- a/apps/web/src/pages/ApplicantDashboardPage/components/StatusSummary.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/StatusSummary.tsx
@@ -1,9 +1,9 @@
-import { Well, Color } from "@gc-digital-talent/ui";
+import { Well, WellProps } from "@gc-digital-talent/ui";
 
 interface StatusSummaryProps {
   label: React.ReactNode;
   description: React.ReactNode;
-  color: Color;
+  color: WellProps["color"];
 }
 
 const StatusSummary = ({

--- a/packages/ui/src/components/TaskCard/TaskCard.stories.tsx
+++ b/packages/ui/src/components/TaskCard/TaskCard.stories.tsx
@@ -5,7 +5,7 @@ import UsersIcon from "@heroicons/react/24/outline/UsersIcon";
 import { allModes } from "@gc-digital-talent/storybook-helpers";
 
 import TaskCard, { colorOptions } from "./TaskCard";
-import Well from "../Well";
+import Well from "../Well/Well";
 
 faker.seed(0);
 

--- a/packages/ui/src/components/TaskCard/TaskCard.test.tsx
+++ b/packages/ui/src/components/TaskCard/TaskCard.test.tsx
@@ -8,7 +8,7 @@ import UsersIcon from "@heroicons/react/24/outline/UsersIcon";
 import { renderWithProviders, axeTest } from "@gc-digital-talent/jest-helpers";
 
 import TaskCard from "./TaskCard";
-import Well from "../Well";
+import Well from "../Well/Well";
 
 function renderComponent() {
   return renderWithProviders(

--- a/packages/ui/src/components/Well/Well.stories.tsx
+++ b/packages/ui/src/components/Well/Well.stories.tsx
@@ -31,9 +31,12 @@ const Template: StoryFn<typeof Well> = (args) => {
       data-h2-gap="base(x1 0)"
     >
       <Well>Default: {content}</Well>
+      <Well color="primary">Primary: {content}</Well>
+      <Well color="secondary">Secondary: {content}</Well>
       <Well color="success">Success: {content}</Well>
       <Well color="warning">Warning: {content}</Well>
       <Well color="error">Error: {content}</Well>
+      <Well fontSize="caption">Caption: {content}</Well>
     </div>
   );
 };

--- a/packages/ui/src/components/Well/Well.tsx
+++ b/packages/ui/src/components/Well/Well.tsx
@@ -1,86 +1,50 @@
 import { DetailedHTMLProps, HTMLAttributes, ReactNode } from "react";
+import { tv, type VariantProps } from "tailwind-variants";
 
-import { Color } from "../../types";
+const well = tv({
+  base: "rounded border",
+  variants: {
+    color: {
+      primary:
+        "border-primary-700 bg-primary-100 text-primary-700 dark:border-primary-100 dark:bg-primary-700 dark:text-primary-100",
+      secondary:
+        "border-secondary-700 bg-secondary-100 text-secondary-700 dark:border-secondary-100 dark:bg-secondary-700 dark:text-secondary-100",
+      success:
+        "border-success-700 bg-success-100 text-success-700 dark:border-success-100 dark:bg-success-700 dark:text-success-100",
+      warning:
+        "border-warning-700 bg-warning-100 text-warning-700 dark:border-warning-100 dark:bg-warning-700 dark:text-warning-100",
+      error:
+        "border-error-700 bg-error-100 text-error-700 dark:border-error-100 dark:bg-error-700 dark:text-error-100",
+      black:
+        "border-gray-700 bg-gray-100 text-gray-700 dark:border-gray-100 dark:bg-gray-700 dark:text-gray-100",
+    },
+    fontSize: {
+      body: "p-6",
+      caption: "p-3 text-sm",
+    },
+  },
+});
 
-const colorMap = new Map<Color, Record<string, string>>([
-  [
-    "primary",
-    {
-      "data-h2-background-color": "base(primary.lightest)",
-      "data-h2-border": "base(1px solid primary.darker)",
-      "data-h2-color": "base(primary.darkest)",
-    },
-  ],
-  [
-    "success",
-    {
-      "data-h2-background-color": "base(success.lightest)",
-      "data-h2-border": "base(1px solid success.darker)",
-      "data-h2-color": "base(success.darkest)",
-    },
-  ],
-  [
-    "warning",
-    {
-      "data-h2-background-color": "base(warning.lightest)",
-      "data-h2-border": "base(1px solid warning.darker)",
-      "data-h2-color": "base(warning.darkest)",
-    },
-  ],
-  [
-    "error",
-    {
-      "data-h2-background-color": "base(error.lightest)",
-      "data-h2-border": "base(1px solid error.darker)",
-      "data-h2-color": "base(error.darkest)",
-    },
-  ],
-  [
-    "black",
-    {
-      "data-h2-background-color": "base(black.lightest)",
-      "data-h2-border": "base(1px solid black.darker)",
-      "data-h2-color": "base(black.darkest)",
-    },
-  ],
-  [
-    "secondary",
-    {
-      "data-h2-background-color": "base(secondary.lightest)",
-      "data-h2-border": "base(1px solid secondary.darker)",
-      "data-h2-color": "base(secondary.darkest)",
-    },
-  ],
-]);
+type WellVariants = VariantProps<typeof well>;
 
 export interface WellProps
-  extends DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+  extends WellVariants,
+    Omit<
+      DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>,
+      "color"
+    > {
   children: ReactNode;
-  color?: Color;
-  fontSize?: "caption" | "body";
 }
 
-const Well = ({ children, color, fontSize = "body", ...rest }: WellProps) => {
-  const colorStyles = color
-    ? colorMap.get(color)
-    : {
-        "data-h2-background-color": "base(background.light)",
-        "data-h2-border": "base(1px solid background.darker)",
-        "data-h2-color": "base(background.darkest)",
-      };
-
-  let size = {
-    "data-h2-font-size": "base(body)",
-    "data-h2-padding": "base(x1)",
-  };
-  if (fontSize === "caption") {
-    size = {
-      "data-h2-font-size": "base(caption)",
-      "data-h2-padding": "base(x.5)",
-    };
-  }
+const Well = ({
+  children,
+  color = "black",
+  fontSize = "body",
+  className,
+  ...rest
+}: WellProps) => {
   return (
-    <div data-h2-radius="base(s)" {...colorStyles} {...size} {...rest}>
+    <div className={well({ color, fontSize, class: className })} {...rest}>
       {children}
     </div>
   );

--- a/packages/ui/src/components/Well/index.ts
+++ b/packages/ui/src/components/Well/index.ts
@@ -1,4 +1,0 @@
-import Well, { type WellProps } from "./Well";
-
-export default Well;
-export type { WellProps };

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -87,7 +87,7 @@ import Tabs from "./components/Tabs";
 import ToggleGroup from "./components/ToggleGroup";
 import ToggleSection from "./components/ToggleSection/ToggleSection";
 import TreeView from "./components/TreeView";
-import Well, { WellProps } from "./components/Well";
+import Well, { WellProps } from "./components/Well/Well";
 import {
   incrementHeadingRank,
   decrementHeadingRank,


### PR DESCRIPTION
🤖 Resolves #13582 

## 👋 Introduction

Migrates the `Well` component to use tailwind.

## 🧪 Testing

> [!IMPORTANT]
> Our colour pallette has changed so expect some minor colour adjustments in the diff. Refer to  [the config PR](https://github.com/GCTC-NTGC/gc-digital-talent/pull/13479) for more detail.

1. Confirm not significant diff in chromatic

## 📸 Screenshot

![2025-05-26_08-57](https://github.com/user-attachments/assets/fa25ce0a-fa74-4112-83d8-5a89221a43f5)
![2025-05-26_08-57_1](https://github.com/user-attachments/assets/dcb9e7b3-160a-4001-a0a6-faf91dc3f22e)
