### PR TITLE
[Debt] Migrate `NotFound` to tailwind

### DIFF
--- a/packages/ui/src/components/NotFound/NotFound.tsx
+++ b/packages/ui/src/components/NotFound/NotFound.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from "react";
 
+import Heading from "../Heading";
+
 interface NotFoundProps {
   headingMessage: string;
   children: ReactNode;
@@ -7,21 +9,11 @@ interface NotFoundProps {
 
 const NotFound = ({ headingMessage, children }: NotFoundProps) => {
   return (
-    <div data-h2-margin="base(x3, 0)">
-      <div data-h2-wrapper="base(center, large, x1) p-tablet(center, large, x2)">
-        <div data-h2-flex-grid="base(flex-start, x3)" aria-live="polite">
-          <div data-h2-flex-item="base(1of1)" data-h2-text-align="base(center)">
-            <h3
-              data-h2-font-size="base(h4, 1.3)"
-              data-h2-font-weight="base(700)"
-              data-h2-margin="base(0, 0, x1, 0)"
-            >
-              {headingMessage}
-            </h3>
-            {children}
-          </div>
-        </div>
-      </div>
+    <div className="my-18 text-center" aria-live="polite">
+      <Heading size="h4" className="mb-6 font-bold">
+        {headingMessage}
+      </Heading>
+      {children}
     </div>
   );
 };


### PR DESCRIPTION
🤖 Resolves #13567.

## 👋 Introduction

This PR migrates the `NotFound` component to tailwind.

## 🧪 Testing

1. `pnpm storybook`
2. Verify `NotFound` component is the same visually as before

## 📸 Screenshot

<img width="1383" alt="Screen Shot 2025-05-26 at 15 32 04" src="https://github.com/user-attachments/assets/f6a61447-4b45-4e7e-85a4-33865ec36fac" />