### PR TITLE
[Debt] Migrate `Sidebar` to tailwind

### DIFF
--- a/packages/ui/src/components/Sidebar/Content.tsx
+++ b/packages/ui/src/components/Sidebar/Content.tsx
@@ -1,8 +1,8 @@
 import { ReactNode } from "react";
 
 const Content = ({ children, ...rest }: { children?: ReactNode }) => (
-  <div data-h2-flex-item="base(1of1) l-tablet(3of4)" {...rest}>
-    <div>{children}</div>
+  <div className="col-span-3" {...rest}>
+    {children}
   </div>
 );
 

--- a/packages/ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar/Sidebar.tsx
@@ -1,34 +1,29 @@
 import { HTMLProps, ReactNode } from "react";
+import { tv, VariantProps } from "tailwind-variants";
 
-export interface SidebarProps extends HTMLProps<HTMLElement> {
+const scrollbarWrapper = tv({
+  base: "sticky overflow-auto",
+  variants: {
+    // Temp fix for view pool candidate page
+    scrollbar: {
+      true: "top-0 h-[calc(100vh-var(--spacing)*18)] pt-18 sm:top-18",
+      false: "top-30",
+    },
+  },
+});
+
+type ScrollbarVariants = VariantProps<typeof scrollbarWrapper>;
+
+export interface SidebarProps
+  extends ScrollbarVariants,
+    HTMLProps<HTMLElement> {
   children: ReactNode;
-  scrollbar?: boolean; // Temp fix for view pool candidate page
 }
 
 const Sidebar = ({ children, scrollbar, ...rest }: SidebarProps) => (
-  <aside data-h2-flex-item="base(1of1) l-tablet(1of4)" {...rest}>
-    <div
-      data-h2-height="base(100%)"
-      data-h2-position="base(relative)"
-      data-h2-margin-bottom="base(x1)"
-    >
-      <div
-        data-h2-position="base(sticky)"
-        data-h2-overflow="base(auto)"
-        {...(scrollbar
-          ? {
-              "data-h2-location":
-                "base(0, auto, auto, auto) l-tablet(x3, auto, auto, auto)",
-              "data-h2-height": "l-tablet(calc(100vh - x3))",
-              "data-h2-padding-top": "base(x3)",
-            }
-          : {
-              "data-h2-location": "base(x5, auto, auto, auto)",
-              "data-h2-height": "base(auto)",
-            })}
-      >
-        {children}
-      </div>
+  <aside {...rest}>
+    <div className="relative mb-6 h-full">
+      <div className={scrollbarWrapper({ scrollbar })}>{children}</div>
     </div>
   </aside>
 );

--- a/packages/ui/src/components/Sidebar/Wrapper.tsx
+++ b/packages/ui/src/components/Sidebar/Wrapper.tsx
@@ -4,7 +4,7 @@ import { tv } from "tailwind-variants";
 type WrapperProps = HTMLProps<HTMLDivElement>;
 
 const wrapper = tv({
-  base: "mb-18 grid gap-y-6 sm:grid-cols-4 sm:gap-x-18 sm:gap-y-0",
+  base: "mb-18 flex flex-col gap-y-6 sm:grid sm:grid-cols-4 sm:gap-x-18 sm:gap-y-0",
 });
 
 const Wrapper = ({ children, className, ...rest }: WrapperProps) => (

--- a/packages/ui/src/components/Sidebar/Wrapper.tsx
+++ b/packages/ui/src/components/Sidebar/Wrapper.tsx
@@ -1,14 +1,15 @@
 import { HTMLProps } from "react";
+import { tv } from "tailwind-variants";
 
 type WrapperProps = HTMLProps<HTMLDivElement>;
 
-const Wrapper = ({ children, ...rest }: WrapperProps) => (
-  <div data-h2-padding="base(0, 0, x3, 0)" {...rest}>
-    <div data-h2-wrapper="base(center, full, 0)">
-      <div data-h2-flex-grid="base(flex-start, x2, 0) l-tablet(stretch, x3)">
-        {children}
-      </div>
-    </div>
+const wrapper = tv({
+  base: "mb-18 grid gap-y-6 sm:grid-cols-4 sm:gap-x-18 sm:gap-y-0",
+});
+
+const Wrapper = ({ children, className, ...rest }: WrapperProps) => (
+  <div className={wrapper({ class: className })} {...rest}>
+    {children}
   </div>
 );
 

--- a/packages/ui/src/components/ToggleSection/ToggleSection.tsx
+++ b/packages/ui/src/components/ToggleSection/ToggleSection.tsx
@@ -122,7 +122,7 @@ const Content = forwardRef<HTMLDivElement, HTMLProps<HTMLDivElement>>(
       <div
         id={context?.contentId}
         ref={forwardedRef}
-        className="rounded-md bg-white p-6 text-black shadow-lg"
+        className="rounded-md bg-white p-6 text-black shadow-lg dark:bg-gray-600 dark:text-white"
         {...props}
       >
         {children}


### PR DESCRIPTION
🤖 Resolves #13572 

## 👋 Introduction

Migrates the `Sidebar` component to use tailwindcss.

## 🕵️ Details

Noticed a dark mode issue with `ToggleSection` and fixed in since it is semi-related :sweat_smile: 

## 🧪 Testing

1. No significant chromatic diff.
