### PR TITLE
[Debt] Migrate `Separator` to tailwind

### DIFF
--- a/packages/ui/src/components/Separator/Separator.stories.tsx
+++ b/packages/ui/src/components/Separator/Separator.stories.tsx
@@ -7,32 +7,23 @@ export default {
 } as Meta<typeof Separator>;
 
 const Template: StoryFn<typeof Separator> = () => (
-  <div data-h2-width="base(100%)" data-h2-max-width="base(320px)">
+  <div className="w-full max-w-xs">
     <p>Separator for content</p>
-    <Separator
-      orientation="horizontal"
-      data-h2-margin="base(x.5, 0)"
-      data-h2-background-color="base(primary.50)"
-    />
-    <div
-      data-h2-align-items="base(center)"
-      data-h2-display="base(flex)"
-      data-h2-justify-content="base(space-between)"
-      data-h2-height="base(2rem)"
-    >
+    <Separator orientation="horizontal" className="bg-primary/50" space="xs" />
+    <div className="flex h-8 items-center justify-between">
       <p>Secondary</p>
       <Separator
         decorative
         orientation="vertical"
-        data-h2-background-color="base(secondary.50)"
-        data-h2-margin="base(0, x.5)"
+        className="bg-secondary"
+        space="xs"
       />
       <p>Red</p>
       <Separator
         decorative
         orientation="vertical"
-        data-h2-background-color="base(tertiary.50)"
-        data-h2-margin="base(0, x.5)"
+        className="bg-error"
+        space="xs"
       />
       <p>Vertical</p>
     </div>

--- a/packages/ui/src/components/Separator/Separator.tsx
+++ b/packages/ui/src/components/Separator/Separator.tsx
@@ -3,6 +3,7 @@ import { ComponentPropsWithoutRef, ElementRef, forwardRef } from "react";
 import { tv, VariantProps } from "tailwind-variants";
 
 const separator = tv({
+  base: "bg-gray",
   variants: {
     space: {
       none: "",

--- a/packages/ui/src/components/Separator/Separator.tsx
+++ b/packages/ui/src/components/Separator/Separator.tsx
@@ -1,20 +1,70 @@
 import * as SeparatorPrimitive from "@radix-ui/react-separator";
-import {
-  ComponentPropsWithoutRef,
-  DetailedHTMLProps,
-  ElementRef,
-  HTMLAttributes,
-  forwardRef,
-} from "react";
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from "react";
+import { tv, VariantProps } from "tailwind-variants";
 
-type SeparatorProps = ComponentPropsWithoutRef<
-  typeof SeparatorPrimitive.Root
-> & {
-  space?: "none" | "xs" | "sm" | "md" | "lg";
-} & Omit<
-    DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement>,
-    "ref"
-  >;
+const separator = tv({
+  variants: {
+    space: {
+      none: "",
+      xs: "",
+      sm: "",
+      md: "",
+      lg: "",
+    },
+    orientation: {
+      vertical: "h-full w-px",
+      horizontal: "h-px w-full",
+    },
+  },
+  compoundVariants: [
+    {
+      space: "xs",
+      orientation: "vertical",
+      class: "mx-3",
+    },
+    {
+      space: "xs",
+      orientation: "horizontal",
+      class: "my-3",
+    },
+    {
+      space: "sm",
+      orientation: "vertical",
+      class: "mx-6",
+    },
+    {
+      space: "sm",
+      orientation: "horizontal",
+      class: "my-6",
+    },
+    {
+      space: "md",
+      orientation: "vertical",
+      class: "mx-12",
+    },
+    {
+      space: "md",
+      orientation: "horizontal",
+      class: "my-12",
+    },
+    {
+      space: "lg",
+      orientation: "vertical",
+      class: "mx-18",
+    },
+    {
+      space: "lg",
+      orientation: "horizontal",
+      class: "my-18",
+    },
+  ],
+});
+
+type SeparatorVariants = VariantProps<typeof separator>;
+
+interface SeparatorProps
+  extends SeparatorVariants,
+    ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root> {}
 
 /**
  * @name Separator
@@ -26,49 +76,20 @@ const Separator = forwardRef<
   SeparatorProps
 >(
   (
-    { space = "md", orientation = "horizontal", decorative = true, ...rest },
+    {
+      space = "md",
+      orientation = "horizontal",
+      decorative = true,
+      className,
+      ...rest
+    },
     forwardedRef,
   ) => {
-    let spaceStyles: Record<string, string> = {};
-    if (space !== "none") {
-      if (space === "xs") {
-        spaceStyles =
-          orientation === "vertical"
-            ? { "data-h2-margin": "base(0 x.5)" }
-            : { "data-h2-margin": "base(x.5 0)" };
-      }
-
-      if (space === "sm") {
-        spaceStyles =
-          orientation === "vertical"
-            ? { "data-h2-margin": "base(0 x1)" }
-            : { "data-h2-margin": "base(x1 0)" };
-      }
-      if (space === "md") {
-        spaceStyles =
-          orientation === "vertical"
-            ? { "data-h2-margin": "base(0 x2)" }
-            : { "data-h2-margin": "base(x2 0)" };
-      }
-      if (space === "lg") {
-        spaceStyles =
-          orientation === "vertical"
-            ? { "data-h2-margin": "base(x3 0)" }
-            : { "data-h2-margin": "base(x3 0)" };
-      }
-    }
     return (
       <SeparatorPrimitive.Root
         ref={forwardedRef}
+        className={separator({ space, orientation, class: className })}
         {...{ orientation, decorative }}
-        data-h2-height="
-      base:selectors[[data-orientation='vertical']](100%)
-      base:selectors[[data-orientation='horizontal']](1px)"
-        data-h2-width="
-      base:selectors[[data-orientation='vertical']](1px)
-      base:selectors[[data-orientation='horizontal']](100%)"
-        data-h2-background-color="base(gray)"
-        {...spaceStyles}
         {...rest}
       />
     );


### PR DESCRIPTION
🤖 Resolves #13571 

## 👋 Introduction

Migrates the `Separator` component to tailwind.

## 🧪 Testing

1. No significant chromatic diff