### PR TITLE
[Bug] Community interest development programs initial values

### DIFF
--- a/apps/web/src/pages/CommunityInterests/UpdateCommunityInterestPage/UpdateCommunityInterestPage.tsx
+++ b/apps/web/src/pages/CommunityInterests/UpdateCommunityInterestPage/UpdateCommunityInterestPage.tsx
@@ -13,7 +13,7 @@ import {
 } from "@gc-digital-talent/graphql";
 import { errorMessages, navigationMessages } from "@gc-digital-talent/i18n";
 import { toast } from "@gc-digital-talent/toast";
-import { NotFoundError } from "@gc-digital-talent/helpers";
+import { NotFoundError, unpackMaybes } from "@gc-digital-talent/helpers";
 
 import SEO from "~/components/SEO/SEO";
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
@@ -45,6 +45,9 @@ const UpdateCommunityInterestFormOptions_Fragment = graphql(/* GraphQL */ `
       id
       developmentPrograms {
         id
+        name {
+          localized
+        }
       }
     }
   }
@@ -119,14 +122,22 @@ const UpdateCommunityInterestForm = ({
     formDataQuery,
   );
 
-  const formMethods = useForm<FormValues>({
-    defaultValues: apiDataToFormValues(userId, formData),
-  });
-
-  const developmentProgramCount: number =
+  const developmentProgramsForCommunity = unpackMaybes(
     formOptions?.communities?.find(
       (community) => community?.id === formData.community.id,
-    )?.developmentPrograms?.length ?? 0;
+    )?.developmentPrograms,
+  );
+
+  const developmentProgramCount: number =
+    developmentProgramsForCommunity.length;
+
+  const formMethods = useForm<FormValues>({
+    defaultValues: apiDataToFormValues(
+      userId,
+      formData,
+      developmentProgramsForCommunity,
+    ),
+  });
 
   return (
     <>

--- a/apps/web/src/pages/CommunityInterests/form.ts
+++ b/apps/web/src/pages/CommunityInterests/form.ts
@@ -206,11 +206,11 @@ export function apiDataToFormValues(
   // the initial values for FormValues.interestInDevelopmentPrograms must have the maximum length possible, otherwise values are skewed
   // 22 possible programs but 21 interests marked means a skew of one
   // thus build the initial value off community.developmentPrograms instead of communityInterest.interestInDevelopmentPrograms
-  const sortedDevelopmentPrograms = developmentProgramsForCommunity.sort(
+  developmentProgramsForCommunity.sort(
     sortAlphaBy((devPro) => devPro.name?.localized),
   );
   const initialInterestInDevelopmentPrograms: FormValues["interestInDevelopmentPrograms"] =
-    sortedDevelopmentPrograms.map((developmentProgram) => {
+    developmentProgramsForCommunity.map((developmentProgram) => {
       const correspondingProgram = usersInterestDevelopmentPrograms.find(
         (userDevPro) =>
           userDevPro.developmentProgram.id === developmentProgram.id,

--- a/apps/web/src/pages/CommunityInterests/form.ts
+++ b/apps/web/src/pages/CommunityInterests/form.ts
@@ -2,12 +2,12 @@ import {
   CreateCommunityInterestInput,
   CreateDevelopmentProgramInterestInput,
   DevelopmentProgramParticipationStatus,
+  Maybe,
   UpdateCommunityInterestFormData_FragmentFragment,
   UpdateCommunityInterestInput,
   UpdateDevelopmentProgramInterestHasMany,
 } from "@gc-digital-talent/graphql";
 import { sortAlphaBy, unpackMaybes } from "@gc-digital-talent/helpers";
-import { strToFormDate } from "@gc-digital-talent/date-helpers";
 
 import { SubformValues as FindANewCommunitySubformValues } from "./sections/FindANewCommunity";
 import { SubformValues as TrainingAndDevelopmentOpportunitiesSubformValues } from "./sections/TrainingAndDevelopmentOpportunities";
@@ -186,13 +186,42 @@ export function formValuesToApiUpdateInput(
   };
 }
 
+interface DevelopmentProgramSlice {
+  id: string;
+  name?: Maybe<{ localized?: Maybe<string> }>;
+}
+
 export function apiDataToFormValues(
   userId: string | null | undefined,
   communityInterest:
     | UpdateCommunityInterestFormData_FragmentFragment
     | null
     | undefined,
+  developmentProgramsForCommunity: DevelopmentProgramSlice[],
 ): FormValues {
+  const usersInterestDevelopmentPrograms = unpackMaybes(
+    communityInterest?.interestInDevelopmentPrograms,
+  );
+
+  // the initial values for FormValues.interestInDevelopmentPrograms must have the maximum length possible, otherwise values are skewed
+  // 22 possible programs but 21 interests marked means a skew of one
+  // thus build the initial value off community.developmentPrograms instead of communityInterest.interestInDevelopmentPrograms
+  const sortedDevelopmentPrograms = developmentProgramsForCommunity.sort(
+    sortAlphaBy((devPro) => devPro.name?.localized),
+  );
+  const initialInterestInDevelopmentPrograms: FormValues["interestInDevelopmentPrograms"] =
+    sortedDevelopmentPrograms.map((developmentProgram) => {
+      const correspondingProgram = usersInterestDevelopmentPrograms.find(
+        (userDevPro) =>
+          userDevPro.developmentProgram.id === developmentProgram.id,
+      );
+      return {
+        developmentProgramId: developmentProgram.id,
+        participationStatus: correspondingProgram?.participationStatus ?? null,
+        completionDate: correspondingProgram?.completionDate ?? null,
+      };
+    });
+
   return {
     userId: userId ?? null,
     communityId: communityInterest?.community.id ?? null,
@@ -201,21 +230,8 @@ export function apiDataToFormValues(
     jobInterest: communityInterest?.jobInterest?.toString() ?? null,
     trainingInterest: communityInterest?.trainingInterest?.toString() ?? null,
     additionalInformation: communityInterest?.additionalInformation ?? null,
-    interestInDevelopmentPrograms:
-      communityInterest?.interestInDevelopmentPrograms
-        ?.sort(
-          sortAlphaBy(
-            (interest) => interest.developmentProgram.name?.localized,
-          ),
-        )
-        .map((interest) => ({
-          developmentProgramId: interest.developmentProgram.id,
-          participationStatus: interest.participationStatus ?? null,
-          completionDate:
-            typeof interest.completionDate === "string"
-              ? strToFormDate(interest.completionDate)
-              : null,
-        })) ?? null,
+    interestInDevelopmentPrograms: initialInterestInDevelopmentPrograms,
+
     // finance-only fields
     financeIsChief: communityInterest?.financeIsChief ?? null,
     financeAdditionalDuties: communityInterest?.financeAdditionalDuties


### PR DESCRIPTION
🤖 Resolves #13615

## 👋 Introduction

Resolve the initial values bug

## 🕵️ Details

I believe the issue lies within `FormValues`
If there are 20 possible development programs, there will be 20 radio groups. If the user has only set say 19 interests, there is a discrepancy. The interests passed in and the object `FormValues["interestInDevelopmentPrograms"]` they associate with are of varying lengths.

So I instead built the `FormValues["interestInDevelopmentPrograms"]` field starting from the community instead

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Be unable to replicate the bug from the issue
2. Use for sample instructions https://github.com/GCTC-NTGC/gc-digital-talent/issues/13615#issuecomment-2917301318


