### PR TITLE
[Debt] Migrate `CardOptionGroup` to tailwind

### DIFF
--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -35,7 +35,8 @@
     "date-fns": "^3.6.0",
     "downshift": "^9.0.9",
     "lodash": "^4.17.21",
-    "motion": "^12.12.1"
+    "motion": "^12.12.1",
+    "tailwind-variants": "^1.0.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^9.8.0",

--- a/packages/forms/src/components/CardOptionGroup/CardOptionGroup.stories.tsx
+++ b/packages/forms/src/components/CardOptionGroup/CardOptionGroup.stories.tsx
@@ -24,13 +24,9 @@ export default {
 const colors: CardOption["selectedIconColor"][] = [
   "primary",
   "secondary",
-  "tertiary",
-  "quaternary",
-  "quinary",
   "success",
   "warning",
   "error",
-  "black",
 ];
 
 const TemplateCardOptionGroup: StoryFn<typeof CardOptionGroup> = (args) => {

--- a/packages/forms/src/components/CardOptionGroup/CardOptionGroup.tsx
+++ b/packages/forms/src/components/CardOptionGroup/CardOptionGroup.tsx
@@ -1,15 +1,42 @@
 import { useFormContext } from "react-hook-form";
-import { Fragment, ReactNode } from "react";
+import { ReactNode } from "react";
+import { tv, VariantProps } from "tailwind-variants";
 
-import { Color, IconType } from "@gc-digital-talent/ui";
+import { IconType } from "@gc-digital-talent/ui";
 
 import Field from "../Field";
 import type { CommonInputProps, HTMLFieldsetProps } from "../../types";
 import useFieldState from "../../hooks/useFieldState";
 import useInputDescribedBy from "../../hooks/useInputDescribedBy";
 
-// some colors are inappropriate for icons
-type IconColor = Exclude<Color, "blackFixed" | "white" | "whiteFixed">;
+const cardOption = tv({
+  slots: {
+    label:
+      "flex cursor-pointer items-center gap-3 rounded border-2 border-transparent bg-white p-3 text-base shadow-lg peer-checked:border-black peer-checked:bg-gray-100 peer-checked:font-bold peer-focus-visible:bg-focus peer-focus-visible:text-black dark:bg-gray-600 dark:peer-checked:border-gray-100 dark:peer-checked:border-white dark:peer-checked:bg-gray-700 peer-focus-visible:[&_svg]:text-black",
+    icon: "size-6 text-black dark:text-white",
+  },
+  variants: {
+    selectedIconColor: {
+      primary: {
+        label: "peer-checked:[&_svg]:text-primary",
+      },
+      secondary: {
+        label: "peer-checked:[&_svg]:text-secondary",
+      },
+      success: {
+        label: "peer-checked:[&_svg]:text-success",
+      },
+      warning: {
+        label: "peer-checked:[&_svg]:text-warning",
+      },
+      error: {
+        label: "peer-checked:[&_svg]:text-error",
+      },
+    },
+  },
+});
+
+type CardOptionVariants = VariantProps<typeof cardOption>;
 
 export interface CardOption {
   /** form value */
@@ -21,71 +48,8 @@ export interface CardOption {
   /** icon when selected - usually the solid version of the unselected icon */
   selectedIcon: IconType;
   /** icon color when selected */
-  selectedIconColor: IconColor;
+  selectedIconColor: NonNullable<CardOptionVariants["selectedIconColor"]>;
 }
-
-const siblingIconColor: Record<IconColor, Record<string, string>> = {
-  primary: {
-    "data-h2-color": `
-          base:children[+ label>svg](black)
-          base:selectors[:checked]:children[+ label>svg](primary.dark)
-          base:focus-visible:children[+ label>svg](black)`,
-  },
-  secondary: {
-    "data-h2-color": `
-        base:children[+ label>svg](black)
-        base:selectors[:checked]:children[+ label>svg](secondary.dark)
-        base:focus-visible:children[+ label>svg](black)`,
-  },
-  secondaryDarkFixed: {
-    "data-h2-color": `
-        base:all:children[+ label>svg](white)
-        base:all:selectors[:checked]:children[+ label>svg](secondary.light)
-        base:all:focus-visible:children[+ label>svg](black)`,
-  },
-  tertiary: {
-    "data-h2-color": `
-        base:children[+ label>svg](black)
-        base:selectors[:checked]:children[+ label>svg](tertiary.dark)
-        base:focus-visible:children[+ label>svg](black)`,
-  },
-  quaternary: {
-    "data-h2-color": `
-        base:children[+ label>svg](black)
-        base:selectors[:checked]:children[+ label>svg](quaternary.dark)
-        base:focus-visible:children[+ label>svg](black)`,
-  },
-  quinary: {
-    "data-h2-color": `
-        base:children[+ label>svg](black)
-        base:selectors[:checked]:children[+ label>svg](quinary.dark)
-        base:focus-visible:children[+ label>svg](black)`,
-  },
-  success: {
-    "data-h2-color": `
-        base:children[+ label>svg](black)
-        base:selectors[:checked]:children[+ label>svg](success.dark)
-        base:focus-visible:children[+ label>svg](black)`,
-  },
-  warning: {
-    "data-h2-color": `
-        base:children[+ label>svg](black)
-        base:selectors[:checked]:children[+ label>svg](warning.dark)
-        base:focus-visible:children[+ label>svg](black)`,
-  },
-  error: {
-    "data-h2-color": `
-        base:children[+ label>svg](black)
-        base:selectors[:checked]:children[+ label>svg](error.dark)
-        base:focus-visible:children[+ label>svg](black)`,
-  },
-  black: {
-    "data-h2-color": `
-        base:children[+ label>svg](black)
-        base:selectors[:checked]:children[+ label>svg](black)
-        base:focus-visible:children[+ label>svg](black)`,
-  },
-};
 
 export type CardOptionGroupProps = Omit<CommonInputProps, "id" | "label"> &
   HTMLFieldsetProps & {
@@ -145,15 +109,12 @@ const CardOptionGroup = ({
       <Field.Fieldset
         id={idPrefix}
         aria-describedby={ariaDescribedBy}
+        className="flex flex-col gap-y-3"
         {...rest}
-        data-h2-display="base(flex)"
-        data-h2-flex-direction="base(column)"
-        data-h2-gap="base(x.25)"
       >
         <Field.Legend
           required={!!rules.required}
-          data-h2-color="base(black)"
-          data-h2-margin-bottom="base(x.25)"
+          className="mb-3 text-black dark:text-white"
         >
           {legend}
         </Field.Legend>
@@ -168,8 +129,11 @@ const CardOptionGroup = ({
             const id = `${idPrefix}-${value}`;
             const isSelected = selectedValue === value;
             const Icon = isSelected ? selectedIcon : unselectedIcon;
+            const { label: labelStyles, icon: iconStyles } = cardOption({
+              selectedIconColor,
+            });
             return (
-              <Fragment key={value}>
+              <div key={value}>
                 <input
                   id={id}
                   {...register(name, rules)}
@@ -178,33 +142,13 @@ const CardOptionGroup = ({
                   disabled={disabled}
                   defaultChecked={defaultSelected === value}
                   // hide the input - this radio group does not show the radio buttons
-                  data-h2-position="base(absolute)"
-                  data-h2-opacity="base(0)"
-                  data-h2-height="base(0)"
-                  data-h2-width="base(0)"
-                  // style the sibling label when focused and/or checked
-                  data-h2-background-color="base:children[+ label](foreground) base:selectors[:checked]:children[+ label](foreground.dark.20) base:focus-visible:children[+ label](focus)"
-                  data-h2-font-weight="base:selectors[:checked]:children[+ label](700)"
-                  data-h2-border="base:selectors[:checked]:children[+ label](2px solid black)"
-                  // color the sibling label's icon when focused and/or checked
-                  {...siblingIconColor[selectedIconColor]}
+                  className="peer sr-only"
                 />
-                <Field.Label
-                  data-h2-display="base(flex)"
-                  data-h2-padding="base(x.5)"
-                  data-h2-align-items="base(center)"
-                  data-h2-gap="base(x.5)"
-                  data-h2-shadow="base(large)"
-                  data-h2-radius="base(s)"
-                  htmlFor={id}
-                  data-h2-cursor="base(pointer)"
-                  data-h2-color="base(black)"
-                  data-h2-font-size="base(body)"
-                >
-                  <Icon data-h2-height="base(x1)" data-h2-width="base(x1)" />
+                <Field.Label htmlFor={id} className={labelStyles()}>
+                  <Icon className={iconStyles()} />
                   <span>{label}</span>
                 </Field.Label>
-              </Fragment>
+              </div>
             );
           },
         )}

--- a/packages/forms/src/components/CardOptionGroup/index.ts
+++ b/packages/forms/src/components/CardOptionGroup/index.ts
@@ -1,5 +1,0 @@
-import CardOptionGroup from "./CardOptionGroup";
-import type { CardOptionGroupProps, CardOption } from "./CardOptionGroup";
-
-export default CardOptionGroup;
-export type { CardOptionGroupProps, CardOption };

--- a/packages/forms/src/index.tsx
+++ b/packages/forms/src/index.tsx
@@ -3,7 +3,7 @@ import { ErrorMessage } from "@hookform/error-message";
 import CardOptionGroup, {
   type CardOption,
   type CardOptionGroupProps,
-} from "./components/CardOptionGroup";
+} from "./components/CardOptionGroup/CardOptionGroup";
 import Checkbox, { type CheckboxProps } from "./components/Checkbox/Checkbox";
 import CheckButton, {
   CheckButtonProps,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -618,6 +618,9 @@ importers:
       motion:
         specifier: ^12.12.1
         version: 12.12.1(react-dom@19.1.0(react@18.3.1))(react@18.3.1)
+      tailwind-variants:
+        specifier: ^1.0.0
+        version: 1.0.0(tailwindcss@4.1.8)
     devDependencies:
       '@faker-js/faker':
         specifier: ^9.8.0


### PR DESCRIPTION
🤖 Resolves #13658 

## 👋 Introduction

Migrates the `CardOptionGroup` component to tailwindcss.

## 🧪 Testing

1. No significant chromatic diff