### PR TITLE
[Debt] Migrate `TextArea` to tailwind

### DIFF
--- a/packages/forms/src/components/Checklist/Checklist.tsx
+++ b/packages/forms/src/components/Checklist/Checklist.tsx
@@ -5,7 +5,7 @@ import Checkbox from "../Checkbox/Checkbox";
 import Field from "../Field";
 import type { CommonInputProps, HTMLFieldsetProps } from "../../types";
 import useFieldState from "../../hooks/useFieldState";
-import useInputStyles from "../../hooks/useInputStyles";
+import { useInputStylesDeprecated } from "../../hooks/useInputStyles";
 import useFieldStateStyles from "../../hooks/useFieldStateStyles";
 import useInputDescribedBy from "../../hooks/useInputDescribedBy";
 
@@ -46,7 +46,7 @@ const Checklist = ({
   const {
     formState: { errors },
   } = useFormContext();
-  const baseStyles = useInputStyles();
+  const baseStyles = useInputStylesDeprecated();
   const stateStyles = useFieldStateStyles(name, !trackUnsaved);
   const fieldState = useFieldState(name, !trackUnsaved);
   const isUnsaved = fieldState === "dirty" && trackUnsaved;

--- a/packages/forms/src/components/Combobox/Combobox.tsx
+++ b/packages/forms/src/components/Combobox/Combobox.tsx
@@ -8,7 +8,7 @@ import { formMessages, getLocale } from "@gc-digital-talent/i18n";
 import useFieldState from "../../hooks/useFieldState";
 import Field from "../Field";
 import useInputDescribedBy from "../../hooks/useInputDescribedBy";
-import useInputStyles from "../../hooks/useInputStyles";
+import { useInputStylesDeprecated } from "../../hooks/useInputStyles";
 import useFieldStateStyles from "../../hooks/useFieldStateStyles";
 import { CommonInputProps, HTMLInputProps } from "../../types";
 import {
@@ -69,7 +69,7 @@ const Combobox = ({
     setValue,
     formState: { errors, defaultValues },
   } = useFormContext<Record<string, ComboboxValue>>();
-  const baseStyles = useInputStyles();
+  const baseStyles = useInputStylesDeprecated();
   const stateStyles = useFieldStateStyles(name, !trackUnsaved);
   const fieldState = useFieldState(name || "", !trackUnsaved);
   const isUnsaved = fieldState === "dirty" && trackUnsaved;

--- a/packages/forms/src/components/Combobox/Menu.tsx
+++ b/packages/forms/src/components/Combobox/Menu.tsx
@@ -12,7 +12,7 @@ import {
 
 import { formMessages, uiMessages } from "@gc-digital-talent/i18n";
 
-import useInputStyles from "../../hooks/useInputStyles";
+import { useInputStylesDeprecated } from "../../hooks/useInputStyles";
 import { HTMLSpanProps } from "./types";
 
 type WrapperProps = DetailedHTMLProps<
@@ -21,7 +21,7 @@ type WrapperProps = DetailedHTMLProps<
 >;
 
 const Wrapper = (props: WrapperProps) => {
-  const baseStyles = useInputStyles();
+  const baseStyles = useInputStylesDeprecated();
   return (
     <div
       {...baseStyles}

--- a/packages/forms/src/components/Combobox/Selected.tsx
+++ b/packages/forms/src/components/Combobox/Selected.tsx
@@ -1,7 +1,7 @@
 import XMarkIcon from "@heroicons/react/20/solid/XMarkIcon";
 import { DetailedHTMLProps, HTMLAttributes, forwardRef } from "react";
 
-import useInputStyles from "../../hooks/useInputStyles";
+import { useInputStylesDeprecated } from "../../hooks/useInputStyles";
 
 type HTMLDivProps = DetailedHTMLProps<
   HTMLAttributes<HTMLDivElement>,
@@ -9,7 +9,7 @@ type HTMLDivProps = DetailedHTMLProps<
 >;
 
 const Wrapper = (props: HTMLDivProps) => {
-  const baseStyles = useInputStyles();
+  const baseStyles = useInputStylesDeprecated();
   return (
     <div
       {...baseStyles}

--- a/packages/forms/src/components/DateInput/ControlledInput.tsx
+++ b/packages/forms/src/components/DateInput/ControlledInput.tsx
@@ -10,7 +10,7 @@ import get from "lodash/get";
 
 import { dateMessages } from "@gc-digital-talent/i18n";
 
-import useInputStyles from "../../hooks/useInputStyles";
+import { useInputStylesDeprecated } from "../../hooks/useInputStyles";
 import { DateSegment, DATE_SEGMENT, RoundingMethod } from "./types";
 import {
   getMonthOptions,
@@ -38,8 +38,8 @@ const ControlledInput = ({
   stateStyles,
 }: ControlledInputProps) => {
   const intl = useIntl();
-  const inputStyles = useInputStyles();
-  const selectStyles = useInputStyles("select");
+  const inputStyles = useInputStylesDeprecated();
+  const selectStyles = useInputStylesDeprecated("select");
   const rawDefaultValue: unknown = get(defaultValues, name);
   const defaultValue =
     rawDefaultValue !== null && rawDefaultValue !== undefined

--- a/packages/forms/src/components/Field/BoundingBox.tsx
+++ b/packages/forms/src/components/Field/BoundingBox.tsx
@@ -1,6 +1,6 @@
 import { DetailedHTMLProps, InputHTMLAttributes } from "react";
 
-import useInputStyles from "../../hooks/useInputStyles";
+import { useInputStylesDeprecated } from "../../hooks/useInputStyles";
 
 type BoundingBoxProps = DetailedHTMLProps<
   InputHTMLAttributes<HTMLDivElement>,
@@ -10,7 +10,7 @@ type BoundingBoxProps = DetailedHTMLProps<
 };
 
 const BoundingBox = ({ flat, ...rest }: BoundingBoxProps) => {
-  const styles = useInputStyles();
+  const styles = useInputStylesDeprecated();
 
   return (
     <div

--- a/packages/forms/src/components/Input/Input.tsx
+++ b/packages/forms/src/components/Input/Input.tsx
@@ -9,7 +9,7 @@ import { CommonInputProps, HTMLInputProps } from "../../types";
 import useFieldState from "../../hooks/useFieldState";
 import useFieldStateStyles from "../../hooks/useFieldStateStyles";
 import useInputDescribedBy from "../../hooks/useInputDescribedBy";
-import useInputStyles from "../../hooks/useInputStyles";
+import { useInputStylesDeprecated } from "../../hooks/useInputStyles";
 
 export type InputProps = HTMLInputProps &
   CommonInputProps & {
@@ -40,7 +40,7 @@ const Input = ({
     setValue,
     formState: { errors },
   } = useFormContext();
-  const baseStyles = useInputStyles();
+  const baseStyles = useInputStylesDeprecated();
   const stateStyles = useFieldStateStyles(name, !trackUnsaved);
   const fieldState = useFieldState(id, !trackUnsaved);
   const isUnsaved = fieldState === "dirty" && trackUnsaved;

--- a/packages/forms/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/forms/src/components/RadioGroup/RadioGroup.tsx
@@ -5,7 +5,7 @@ import { ReactNode } from "react";
 import Field from "../Field";
 import type { CommonInputProps, HTMLFieldsetProps } from "../../types";
 import useFieldState from "../../hooks/useFieldState";
-import useInputStyles from "../../hooks/useInputStyles";
+import { useInputStylesDeprecated } from "../../hooks/useInputStyles";
 import useInputDescribedBy from "../../hooks/useInputDescribedBy";
 import useFieldStateStyles from "../../hooks/useFieldStateStyles";
 import getCheckboxRadioStyles from "../../utils/getCheckboxRadioStyles";
@@ -84,7 +84,7 @@ const RadioGroup = ({
     register,
     formState: { errors },
   } = useFormContext();
-  const baseStyles = useInputStyles();
+  const baseStyles = useInputStylesDeprecated();
   const shouldReduceMotion = useReducedMotion();
   const baseRadioStyles = getCheckboxRadioStyles(shouldReduceMotion);
   const stateStyles = useFieldStateStyles(name, !trackUnsaved);

--- a/packages/forms/src/components/RichTextInput/ControlledInput.tsx
+++ b/packages/forms/src/components/RichTextInput/ControlledInput.tsx
@@ -6,7 +6,7 @@ import {
   UseFormStateReturn,
 } from "react-hook-form";
 
-import useInputStyles from "../../hooks/useInputStyles";
+import { useInputStylesDeprecated } from "../../hooks/useInputStyles";
 import MenuBar from "./MenuBar";
 import Footer from "./Footer";
 import useFieldStateStyles from "../../hooks/useFieldStateStyles";
@@ -37,7 +37,7 @@ const ControlledInput = ({
   wordLimit,
   trackUnsaved,
 }: ControlledInputProps) => {
-  const inputStyles = useInputStyles();
+  const inputStyles = useInputStylesDeprecated();
   const stateStyles = useFieldStateStyles(name, !trackUnsaved);
   const content = defaultValues?.[name]
     ? String(defaultValues[name])

--- a/packages/forms/src/components/Select/Select.tsx
+++ b/packages/forms/src/components/Select/Select.tsx
@@ -8,7 +8,7 @@ import type { CommonInputProps, OptGroupOrOption } from "../../types";
 import useFieldState from "../../hooks/useFieldState";
 import useFieldStateStyles from "../../hooks/useFieldStateStyles";
 import useInputDescribedBy from "../../hooks/useInputDescribedBy";
-import useInputStyles from "../../hooks/useInputStyles";
+import { useInputStylesDeprecated } from "../../hooks/useInputStyles";
 import { alphaSortOptions } from "../../utils";
 
 export type SelectProps = CommonInputProps &
@@ -57,7 +57,7 @@ const Select = ({
     register,
     formState: { errors },
   } = useFormContext();
-  const baseStyles = useInputStyles("select");
+  const baseStyles = useInputStylesDeprecated("select");
   const stateStyles = useFieldStateStyles(name, !trackUnsaved);
   const fieldState = useFieldState(id, !trackUnsaved);
   const isUnsaved = fieldState === "dirty" && trackUnsaved;

--- a/packages/forms/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/forms/src/components/TextArea/TextArea.stories.tsx
@@ -20,7 +20,7 @@ const TemplateTextArea: StoryFn<TextAreaProps> = (args) => {
   return (
     <Form onSubmit={action("Submit Form")}>
       <TextArea {...args} />
-      <p data-h2-margin-top="base(x1)">
+      <p className="mt-6">
         <Submit />
       </p>
     </Form>

--- a/packages/forms/src/components/TextArea/TextArea.tsx
+++ b/packages/forms/src/components/TextArea/TextArea.tsx
@@ -1,6 +1,7 @@
 import { useFormContext } from "react-hook-form";
 import { useIntl } from "react-intl";
 import { DetailedHTMLProps, TextareaHTMLAttributes, FocusEvent } from "react";
+import { tv } from "tailwind-variants";
 
 import { errorMessages } from "@gc-digital-talent/i18n";
 
@@ -12,7 +13,6 @@ import useFieldState from "../../hooks/useFieldState";
 import useFieldStateStyles from "../../hooks/useFieldStateStyles";
 import useInputDescribedBy from "../../hooks/useInputDescribedBy";
 import useInputStyles from "../../hooks/useInputStyles";
-
 export type TextAreaProps = DetailedHTMLProps<
   TextareaHTMLAttributes<HTMLTextAreaElement>,
   HTMLTextAreaElement
@@ -23,6 +23,18 @@ export type TextAreaProps = DetailedHTMLProps<
     /** Sets a limit on how many words can be submitted with this input */
     wordLimit?: number;
   };
+
+const textArea = tv({
+  base: "w-full resize-y",
+  variants: {
+    readonly: {
+      true: "bg-gray-100",
+    },
+    wordLimit: {
+      true: "pb-12",
+    },
+  },
+});
 
 const TextArea = ({
   id,
@@ -69,7 +81,6 @@ const TextArea = ({
   };
 
   let wordLimitRule = {};
-  let wordLimitStyles = {};
   if (wordLimit) {
     wordLimitRule = {
       wordCount: (value: string) =>
@@ -78,10 +89,6 @@ const TextArea = ({
           value: wordLimit,
         }),
     };
-
-    wordLimitStyles = {
-      "data-h2-padding-bottom": "base(x2)",
-    };
   }
 
   return (
@@ -89,18 +96,16 @@ const TextArea = ({
       <Field.Label id={`${id}-label`} htmlFor={id} required={!!rules.required}>
         {label}
       </Field.Label>
-      <div data-h2-position="base(relative)" data-h2-z-index="base(1)">
+      <div className="relative z-1">
         <textarea
           id={id}
           aria-describedby={ariaDescribedBy}
           aria-required={!!rules.required}
           aria-invalid={isInvalid}
-          data-h2-width="base(100%)"
-          data-h2-resize="base(vertical)"
+          className={textArea({ readonly: readOnly, wordLimit: !!wordLimit })}
           rows={rows}
           {...baseStyles}
           {...stateStyles}
-          {...wordLimitStyles}
           {...register(name, {
             ...rules,
             validate: {
@@ -112,7 +117,6 @@ const TextArea = ({
           {...(readOnly
             ? {
                 readOnly: true,
-                "data-h2-background-color": "base(background.dark)",
               }
             : {})}
           {...(labelledBy && {
@@ -121,7 +125,7 @@ const TextArea = ({
           {...rest}
         />
         {wordLimit && (
-          <div data-h2-text-align="base(right)">
+          <div className="text-right">
             <WordCounter name={name} wordLimit={wordLimit} />
           </div>
         )}

--- a/packages/forms/src/components/TextArea/TextArea.tsx
+++ b/packages/forms/src/components/TextArea/TextArea.tsx
@@ -12,7 +12,7 @@ import { countNumberOfWords } from "../../utils";
 import useFieldState from "../../hooks/useFieldState";
 import useFieldStateStyles from "../../hooks/useFieldStateStyles";
 import useInputDescribedBy from "../../hooks/useInputDescribedBy";
-import { useInputStylesDeprecated } from "../../hooks/useInputStyles";
+import { inputStyles } from "../../styles";
 export type TextAreaProps = DetailedHTMLProps<
   TextareaHTMLAttributes<HTMLTextAreaElement>,
   HTMLTextAreaElement
@@ -34,6 +34,7 @@ const textArea = tv({
       true: "pb-12",
     },
   },
+  extend: inputStyles,
 });
 
 const TextArea = ({
@@ -57,7 +58,6 @@ const TextArea = ({
     setValue,
   } = useFormContext();
   const intl = useIntl();
-  const baseStyles = useInputStylesDeprecated();
   const stateStyles = useFieldStateStyles(name, !trackUnsaved);
   const fieldState = useFieldState(id, !trackUnsaved);
   const isUnsaved = fieldState === "dirty" && trackUnsaved;
@@ -104,7 +104,6 @@ const TextArea = ({
           aria-invalid={isInvalid}
           className={textArea({ readonly: readOnly, wordLimit: !!wordLimit })}
           rows={rows}
-          {...baseStyles}
           {...stateStyles}
           {...register(name, {
             ...rules,

--- a/packages/forms/src/components/TextArea/TextArea.tsx
+++ b/packages/forms/src/components/TextArea/TextArea.tsx
@@ -12,7 +12,7 @@ import { countNumberOfWords } from "../../utils";
 import useFieldState from "../../hooks/useFieldState";
 import useFieldStateStyles from "../../hooks/useFieldStateStyles";
 import useInputDescribedBy from "../../hooks/useInputDescribedBy";
-import useInputStyles from "../../hooks/useInputStyles";
+import { useInputStylesDeprecated } from "../../hooks/useInputStyles";
 export type TextAreaProps = DetailedHTMLProps<
   TextareaHTMLAttributes<HTMLTextAreaElement>,
   HTMLTextAreaElement
@@ -57,7 +57,7 @@ const TextArea = ({
     setValue,
   } = useFormContext();
   const intl = useIntl();
-  const baseStyles = useInputStyles();
+  const baseStyles = useInputStylesDeprecated();
   const stateStyles = useFieldStateStyles(name, !trackUnsaved);
   const fieldState = useFieldState(id, !trackUnsaved);
   const isUnsaved = fieldState === "dirty" && trackUnsaved;

--- a/packages/forms/src/hooks/useInputStyles.ts
+++ b/packages/forms/src/hooks/useInputStyles.ts
@@ -2,34 +2,6 @@ import { StyleRecord } from "../types";
 
 type UseInputStyles = (inputType?: "default" | "select") => StyleRecord;
 
-const useInputStyles: UseInputStyles = (inputType) => {
-  const defaults = {
-    "data-h2-border-style": "base(solid)",
-    "data-h2-border-width": "base(1px)",
-    "data-h2-outline": "base(none) base:focus-visible(2px solid focus)",
-    "data-h2-outline-offset": "base(2px)",
-    "data-h2-radius": "base(rounded)",
-    "data-h2-opacity": "base:selectors[::placeholder](.7)",
-    "data-h2-color": "base(black) base:selectors[::placeholder](gray.darkest)",
-  };
-  let padding = { "data-h2-padding": "base(x.5)" };
-  let selectIcon = {};
-  if (inputType === "select") {
-    padding = {
-      "data-h2-padding": "base(x.5, x1.5, x.5, x.5)",
-    };
-    selectIcon = {
-      "data-h2-appearance": "base(none)",
-      "data-h2-background-image": `base(url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='rgba(86, 86, 90, 1)'><path stroke-linecap='round' stroke-linejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5'/></svg>")) base:dark(url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='rgba(191, 191, 191, 1)'><path stroke-linecap='round' stroke-linejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5'/></svg>"))`,
-      "data-h2-background-repeat": "base(no-repeat)",
-      "data-h2-background-position-x": "base(calc(100% - .75rem))",
-      "data-h2-background-position-y": "base(x.7)",
-      "data-h2-background-size": "base(1rem)",
-    };
-  }
-  return { ...defaults, ...padding, ...selectIcon };
-};
-
 export const useInputStylesDeprecated: UseInputStyles = (inputType) => {
   const defaults = {
     "data-h2-border-style": "base(solid)",
@@ -57,5 +29,3 @@ export const useInputStylesDeprecated: UseInputStyles = (inputType) => {
   }
   return { ...defaults, ...padding, ...selectIcon };
 };
-
-export default useInputStyles;

--- a/packages/forms/src/hooks/useInputStyles.ts
+++ b/packages/forms/src/hooks/useInputStyles.ts
@@ -30,4 +30,32 @@ const useInputStyles: UseInputStyles = (inputType) => {
   return { ...defaults, ...padding, ...selectIcon };
 };
 
+export const useInputStylesDeprecated: UseInputStyles = (inputType) => {
+  const defaults = {
+    "data-h2-border-style": "base(solid)",
+    "data-h2-border-width": "base(1px)",
+    "data-h2-outline": "base(none) base:focus-visible(2px solid focus)",
+    "data-h2-outline-offset": "base(2px)",
+    "data-h2-radius": "base(rounded)",
+    "data-h2-opacity": "base:selectors[::placeholder](.7)",
+    "data-h2-color": "base(black) base:selectors[::placeholder](gray.darkest)",
+  };
+  let padding = { "data-h2-padding": "base(x.5)" };
+  let selectIcon = {};
+  if (inputType === "select") {
+    padding = {
+      "data-h2-padding": "base(x.5, x1.5, x.5, x.5)",
+    };
+    selectIcon = {
+      "data-h2-appearance": "base(none)",
+      "data-h2-background-image": `base(url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='rgba(86, 86, 90, 1)'><path stroke-linecap='round' stroke-linejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5'/></svg>")) base:dark(url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='rgba(191, 191, 191, 1)'><path stroke-linecap='round' stroke-linejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5'/></svg>"))`,
+      "data-h2-background-repeat": "base(no-repeat)",
+      "data-h2-background-position-x": "base(calc(100% - .75rem))",
+      "data-h2-background-position-y": "base(x.7)",
+      "data-h2-background-size": "base(1rem)",
+    };
+  }
+  return { ...defaults, ...padding, ...selectIcon };
+};
+
 export default useInputStyles;

--- a/packages/forms/src/index.tsx
+++ b/packages/forms/src/index.tsx
@@ -57,7 +57,7 @@ import {
   flattenErrors,
   alphaSortOptions,
 } from "./utils";
-import useInputStyles from "./hooks/useInputStyles";
+import { useInputStylesDeprecated } from "./hooks/useInputStyles";
 import useFieldState from "./hooks/useFieldState";
 import useFieldStateStyles from "./hooks/useFieldStateStyles";
 import useInputDescribedBy from "./hooks/useInputDescribedBy";
@@ -139,7 +139,7 @@ export {
   matchStringCaseDiacriticInsensitive,
   countNumberOfWords,
   objectsToSortedOptions,
-  useInputStyles as useCommonInputStyles,
+  useInputStylesDeprecated as useCommonInputStyles,
   useInputDescribedBy,
   useFieldState,
   useFieldStateStyles,

--- a/packages/forms/src/styles.ts
+++ b/packages/forms/src/styles.ts
@@ -18,7 +18,7 @@ const fieldStateStyles: Record<FieldState, Record<string, string>> = {
 };
 
 export const inputStyles = tv({
-  base: "rounded-md border-1 p-3 text-black outline-offset-2 outline-none placeholder:text-gray-600 placeholder:opacity-70 focus-visible:outline-2 focus-visible:outline-focus",
+  base: "rounded-md border-1 p-3 text-black outline-offset-2 outline-none placeholder:text-gray-600 placeholder:opacity-70 focus-visible:outline-2 focus-visible:outline-focus dark:text-white",
 });
 
 export const selectStyles = tv({

--- a/packages/forms/src/styles.ts
+++ b/packages/forms/src/styles.ts
@@ -1,3 +1,5 @@
+import { tv } from "tailwind-variants";
+
 import { FieldState } from "./types";
 
 const fieldStateStyles: Record<FieldState, Record<string, string>> = {
@@ -14,5 +16,14 @@ const fieldStateStyles: Record<FieldState, Record<string, string>> = {
     "data-h2-border-color": "base(secondary.darker) base:focus-visible(focus)",
   },
 };
+
+export const inputStyles = tv({
+  base: "rounded-md border-1 p-3 text-black outline-offset-2 outline-none placeholder:text-gray-600 placeholder:opacity-70 focus-visible:outline-2 focus-visible:outline-focus",
+});
+
+export const selectStyles = tv({
+  extend: inputStyles,
+  base: "bg-[url(data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='rgba(86, 86, 90, 1)'><path stroke-linecap='round' stroke-linejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5'/></svg>)] dark:bg-[url(data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='rgba(191, 191, 191, 1)'><path stroke-linecap='round' stroke-linejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5'/></svg>)] appearance-none bg-size-[1rem] bg-position-[var(--spacing*4.5)_calc(100%-.75rem)] bg-no-repeat p-3 pr-9",
+});
 
 export default fieldStateStyles;


### PR DESCRIPTION
🤖 Resolves #13671.

## 👋 Introduction

This PR migrates the `TextArea` component to tailwind.

> [!NOTE]
> `inputStyles` and `selectStyles` changes provides a path for other input styles and the select styles on other components. 

## 🧪 Testing

1. `pnpm storybook`
2. Verify `TextArea` story has no visual differences from original