### PR TITLE
[Copy] Update breadcrumbs to "Applicant dashboard"

### DIFF
--- a/apps/web/src/pages/Auth/RegistrationPages/EmployeeInformationPage/EmployeeInformationPage.tsx
+++ b/apps/web/src/pages/Auth/RegistrationPages/EmployeeInformationPage/EmployeeInformationPage.tsx
@@ -615,7 +615,7 @@ const EmployeeInformation = () => {
           intl.formatMessage(commonMessages.accountUpdateSuccessful),
         );
         if (skipVerification) {
-          const navigationTarget = from ?? paths.profileAndApplications();
+          const navigationTarget = from ?? paths.applicantDashboard();
           await navigate(navigationTarget);
         } else {
           await navigate({

--- a/apps/web/src/pages/Auth/RegistrationPages/RegistrationWorkEmailVerificationPage.tsx
+++ b/apps/web/src/pages/Auth/RegistrationPages/RegistrationWorkEmailVerificationPage.tsx
@@ -42,12 +42,12 @@ const RegistrationWorkEmailVerificationPage = () => {
   });
 
   const handleVerificationSuccess = async (): Promise<void> => {
-    const navigationTarget = from ?? paths.profileAndApplications();
+    const navigationTarget = from ?? paths.applicantDashboard();
     await navigate(navigationTarget);
   };
 
   const handleSkip = async (): Promise<void> => {
-    const navigationTarget = from ?? paths.profileAndApplications();
+    const navigationTarget = from ?? paths.applicantDashboard();
     await navigate(navigationTarget);
   };
 

--- a/apps/web/src/pages/Auth/SignInPage/SignInPage.tsx
+++ b/apps/web/src/pages/Auth/SignInPage/SignInPage.tsx
@@ -46,7 +46,7 @@ export const Component = () => {
   const fromPath = searchParams.get("from");
   const iapMode =
     fromPath === paths.iap() || searchParams.get("personality") === "iap";
-  const fallbackPath = paths.profileAndApplications();
+  const fallbackPath = paths.applicantDashboard();
   const loginPath = apiPaths.login(fromPath ?? fallbackPath, getLocale(intl));
 
   const pageTitle = intl.formatMessage({

--- a/apps/web/src/pages/Auth/SignUpPage/SignUpPage.tsx
+++ b/apps/web/src/pages/Auth/SignUpPage/SignUpPage.tsx
@@ -53,7 +53,7 @@ export const Component = () => {
   const fromPath = searchParams.get("from");
   const iapMode =
     fromPath === paths.iap() || searchParams.get("personality") === "iap";
-  const fallbackPath = paths.profileAndApplications();
+  const fallbackPath = paths.applicantDashboard();
   const loginPath = apiPaths.login(fromPath ?? fallbackPath, getLocale(intl));
 
   const pageTitle = intl.formatMessage({

--- a/apps/web/src/pages/Auth/SignedOutPage/SignedOutPage.tsx
+++ b/apps/web/src/pages/Auth/SignedOutPage/SignedOutPage.tsx
@@ -33,7 +33,7 @@ export const Component = () => {
   const locale = getLocale(intl);
   const { loggedIn, logout } = useAuthentication();
   const paths = useRoutes();
-  const returnPath = useReturnPath(paths.profileAndApplications());
+  const returnPath = useReturnPath(paths.applicantDashboard());
 
   const logoutReason = localStorage.getItem(
     LOGOUT_REASON_KEY,

--- a/apps/web/src/pages/EmailVerificationPages/ProfileContactEmailVerificationPage.tsx
+++ b/apps/web/src/pages/EmailVerificationPages/ProfileContactEmailVerificationPage.tsx
@@ -31,8 +31,8 @@ const ProfileContactEmailVerificationPage = () => {
   const crumbs = useBreadcrumbs({
     crumbs: [
       {
-        label: intl.formatMessage(navigationMessages.profileAndApplications),
-        url: paths.profileAndApplications(),
+        label: intl.formatMessage(navigationMessages.applicantDashboard),
+        url: paths.applicantDashboard(),
       },
       {
         label: intl.formatMessage(profilePageMessages.pageTitle),

--- a/apps/web/src/pages/EmailVerificationPages/ProfileWorkEmailVerificationPage.tsx
+++ b/apps/web/src/pages/EmailVerificationPages/ProfileWorkEmailVerificationPage.tsx
@@ -40,8 +40,8 @@ const ProfileWorkEmailVerificationPage = () => {
   const crumbs = useBreadcrumbs({
     crumbs: [
       {
-        label: intl.formatMessage(navigationMessages.profileAndApplications),
-        url: paths.profileAndApplications(),
+        label: intl.formatMessage(navigationMessages.applicantDashboard),
+        url: paths.applicantDashboard(),
       },
       {
         label: intl.formatMessage(profilePageMessages.pageTitle),

--- a/apps/web/src/pages/EmployeeProfile/EmployeeProfilePage.tsx
+++ b/apps/web/src/pages/EmployeeProfile/EmployeeProfilePage.tsx
@@ -123,7 +123,7 @@ const EmployeeProfile = ({
     crumbs: [
       {
         label: intl.formatMessage(navigationMessages.applicantDashboard),
-        url: paths.profileAndApplications(),
+        url: paths.applicantDashboard(),
       },
       {
         url: paths.employeeProfile(),

--- a/apps/web/src/pages/Profile/CareerTimelinePage/components/CareerTimeline.tsx
+++ b/apps/web/src/pages/Profile/CareerTimelinePage/components/CareerTimeline.tsx
@@ -65,7 +65,7 @@ const CareerTimeline = ({ experiencesQuery, userId }: CareerTimelineProps) => {
     crumbs: [
       {
         label: intl.formatMessage(navigationMessages.applicantDashboard),
-        url: paths.profileAndApplications(),
+        url: paths.applicantDashboard(),
       },
       {
         label: intl.formatMessage(pageTitle),

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -472,8 +472,8 @@ export const ExperienceForm = ({
   const crumbs = useBreadcrumbs({
     crumbs: [
       {
-        label: intl.formatMessage(navigationMessages.profileAndApplications),
-        url: paths.profileAndApplications(),
+        label: intl.formatMessage(navigationMessages.applicantDashboard),
+        url: paths.applicantDashboard(),
       },
       {
         label: intl.formatMessage(navigationMessages.careerTimeline),

--- a/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
+++ b/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
@@ -804,7 +804,7 @@ export const ProfileForm = ({ userQuery }: ProfilePageProps) => {
     crumbs: [
       {
         label: intl.formatMessage(navigationMessages.applicantDashboard),
-        url: paths.profileAndApplications(),
+        url: paths.applicantDashboard(),
       },
       {
         label: formattedPageTitle,

--- a/apps/web/src/pages/Skills/ImproveBehaviouralSkillsPage.tsx
+++ b/apps/web/src/pages/Skills/ImproveBehaviouralSkillsPage.tsx
@@ -73,8 +73,8 @@ const ImproveBehaviouralSkills = ({
   const crumbs = useBreadcrumbs({
     crumbs: [
       {
-        label: intl.formatMessage(navigationMessages.profileAndApplications),
-        url: paths.profileAndApplications(),
+        label: intl.formatMessage(navigationMessages.applicantDashboard),
+        url: paths.applicantDashboard(),
       },
       {
         label: intl.formatMessage(navigationMessages.skillShowcase),

--- a/apps/web/src/pages/Skills/ImproveTechnicalSkillsPage.tsx
+++ b/apps/web/src/pages/Skills/ImproveTechnicalSkillsPage.tsx
@@ -71,8 +71,8 @@ const ImproveTechnicalSkills = ({
   const crumbs = useBreadcrumbs({
     crumbs: [
       {
-        label: intl.formatMessage(navigationMessages.profileAndApplications),
-        url: paths.profileAndApplications(),
+        label: intl.formatMessage(navigationMessages.applicantDashboard),
+        url: paths.applicantDashboard(),
       },
       {
         label: intl.formatMessage(navigationMessages.skillShowcase),

--- a/apps/web/src/pages/Skills/SkillPortfolioPage.tsx
+++ b/apps/web/src/pages/Skills/SkillPortfolioPage.tsx
@@ -68,7 +68,7 @@ const SkillPortfolio = ({ userSkills, skills }: SkillPortfolioProps) => {
     crumbs: [
       {
         label: intl.formatMessage(navigationMessages.applicantDashboard),
-        url: paths.profileAndApplications(),
+        url: paths.applicantDashboard(),
       },
       {
         label: intl.formatMessage(navigationMessages.skillPortfolio),

--- a/apps/web/src/pages/Skills/SkillShowcasePage.tsx
+++ b/apps/web/src/pages/Skills/SkillShowcasePage.tsx
@@ -107,7 +107,7 @@ export const SkillShowcase = ({
     crumbs: [
       {
         label: intl.formatMessage(navigationMessages.applicantDashboard),
-        url: paths.profileAndApplications(),
+        url: paths.applicantDashboard(),
       },
       {
         label: intl.formatMessage(navigationMessages.skillPortfolio),

--- a/apps/web/src/pages/Skills/SkillShowcasePage.tsx
+++ b/apps/web/src/pages/Skills/SkillShowcasePage.tsx
@@ -106,7 +106,7 @@ export const SkillShowcase = ({
   const crumbs = useBreadcrumbs({
     crumbs: [
       {
-        label: intl.formatMessage(navigationMessages.profileAndApplications),
+        label: intl.formatMessage(navigationMessages.applicantDashboard),
         url: paths.profileAndApplications(),
       },
       {

--- a/apps/web/src/pages/Skills/TopBehaviouralSkillsPage.tsx
+++ b/apps/web/src/pages/Skills/TopBehaviouralSkillsPage.tsx
@@ -71,8 +71,8 @@ const TopBehaviouralSkills = ({
   const crumbs = useBreadcrumbs({
     crumbs: [
       {
-        label: intl.formatMessage(navigationMessages.profileAndApplications),
-        url: paths.profileAndApplications(),
+        label: intl.formatMessage(navigationMessages.applicantDashboard),
+        url: paths.applicantDashboard(),
       },
       {
         label: intl.formatMessage(navigationMessages.skillShowcase),

--- a/apps/web/src/pages/Skills/TopTechnicalSkillsPage.tsx
+++ b/apps/web/src/pages/Skills/TopTechnicalSkillsPage.tsx
@@ -65,8 +65,8 @@ const TopTechnicalSkills = ({
   const crumbs = useBreadcrumbs({
     crumbs: [
       {
-        label: intl.formatMessage(navigationMessages.profileAndApplications),
-        url: paths.profileAndApplications(),
+        label: intl.formatMessage(navigationMessages.applicantDashboard),
+        url: paths.applicantDashboard(),
       },
       {
         label: intl.formatMessage(navigationMessages.skillShowcase),

--- a/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateUserSkillPage.tsx
@@ -300,8 +300,8 @@ export const UpdateUserSkillForm = ({
   const crumbs = useBreadcrumbs({
     crumbs: [
       {
-        label: intl.formatMessage(navigationMessages.profileAndApplications),
-        url: paths.profileAndApplications(),
+        label: intl.formatMessage(navigationMessages.applicantDashboard),
+        url: paths.applicantDashboard(),
       },
 
       {


### PR DESCRIPTION
🤖 Resolves #13259

## 👋 Introduction

This PR updates old breadcrumb  "Profile and applications" to "Applicant dashboard" across several pages.


## 🕵️ Details

Performed a search and updated any "Profile and applications" breadcrumbs


## 🧪 Testing

1. Build app
2. Log in as `admin@test.com` 
3. Navigate to `applicant/skills/showcase` 
4. Confirm breadcrumbs are updated to `Applicant dashboard` / `Tableau de bord du (de la) candidat(e)` 
 

## 📸 Screenshot

![Screen Shot 2025-05-30 at 10 51 18](https://github.com/user-attachments/assets/cff0ee82-0eba-4882-a292-2cfc00a6c500)

