### PR TITLE
[Debt] Removes `fragmentIdentifier` from `profileAndApplications`

### DIFF
--- a/apps/web/src/hooks/useNotificationInfo.ts
+++ b/apps/web/src/hooks/useNotificationInfo.ts
@@ -113,9 +113,7 @@ const applicationStatusChangedNotificationToInfo = (
         poolName: poolNameLocalized,
       },
     ),
-    href: paths.profileAndApplications({
-      fragmentIdentifier: "track-applications-section",
-    }),
+    href: paths.profileAndApplications(),
     label: intl.formatMessage(
       {
         defaultMessage:

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -17,9 +17,6 @@ const createSearchQuery = (parameters: Map<string, string>): string => {
   return `?${keyValuePairStrings.join("&")}`;
 };
 
-const createFragment = (identifier: string | null | undefined): string =>
-  identifier ? `#${identifier}` : "";
-
 const getRoutes = (lang: Locales) => {
   const baseUrl = `/${lang}`;
   const adminUrl = [baseUrl, "admin"].join("/");
@@ -261,18 +258,13 @@ const getRoutes = (lang: Locales) => {
     profileAndApplications: (opts?: {
       fromIapDraft?: boolean;
       fromIapSuccess?: boolean;
-      fragmentIdentifier?: "track-applications-section";
     }) => {
       const searchParams = new Map<string, string>();
       if (opts?.fromIapDraft) searchParams.set(FromIapDraftQueryKey, "true");
       if (opts?.fromIapSuccess)
         searchParams.set(FromIapSuccessQueryKey, "true");
 
-      return (
-        applicantUrl +
-        createSearchQuery(searchParams) +
-        createFragment(opts?.fragmentIdentifier)
-      );
+      return applicantUrl + createSearchQuery(searchParams);
     },
 
     // Employee profile


### PR DESCRIPTION
🤖 Resolves #13692.

## 👋 Introduction

This PR removes the `fragmentIdentifier` argument from `profileAndApplications` path.

## 🧪 Testing

1. Search for `fragmentIdentifier` in codebase
2. Verify there are no instances of `fragmentIdentifier` in codebase