### PR TITLE
[Debt] Add depth and complexity limits to API

### DIFF
--- a/api/app/GraphQL/Handlers/LoggingErrorHandler.php
+++ b/api/app/GraphQL/Handlers/LoggingErrorHandler.php
@@ -17,7 +17,13 @@ class LoggingErrorHandler implements ErrorHandler
         }
 
         // Log the error
-        Log::info('GraphQL Error: '.$error->getMessage());
+        $errorMessage = $error->getMessage();
+        if (str_contains($errorMessage, 'query depth')) {
+            // some errors need a higher logging level
+            Log::error('GraphQL Error: '.$errorMessage);
+        } else {
+            Log::info('GraphQL Error: '.$errorMessage);
+        }
 
         // Keep the pipeline going, last step formats the error into an array
         return $next($error);

--- a/api/config/lighthouse.php
+++ b/api/config/lighthouse.php
@@ -136,7 +136,7 @@ return [
     */
 
     'security' => [
-        'max_query_complexity' => GraphQL\Validator\Rules\QueryComplexity::DISABLED,
+        'max_query_complexity' => 50000, // examples: applicant dashboard - 508, candidate search - 2491, AvailablePoolsToAddTo - 27001, ScreeningAndEvaluation_Candidates - 4201, PoolsInFilter - 20001
         'max_query_depth' => GraphQL\Validator\Rules\QueryDepth::DISABLED,
         'disable_introspection' => (bool) env('LIGHTHOUSE_SECURITY_DISABLE_INTROSPECTION', false)
             ? GraphQL\Validator\Rules\DisableIntrospection::ENABLED

--- a/api/config/lighthouse.php
+++ b/api/config/lighthouse.php
@@ -137,7 +137,7 @@ return [
 
     'security' => [
         'max_query_complexity' => 50000, // examples: applicant dashboard - 508, candidate search - 2491, AvailablePoolsToAddTo - 27001, ScreeningAndEvaluation_Candidates - 4201, PoolsInFilter - 20001
-        'max_query_depth' => GraphQL\Validator\Rules\QueryDepth::DISABLED,
+        'max_query_depth' => 20, // examples: applicant dashboard - 6
         'disable_introspection' => (bool) env('LIGHTHOUSE_SECURITY_DISABLE_INTROSPECTION', false)
             ? GraphQL\Validator\Rules\DisableIntrospection::ENABLED
             : GraphQL\Validator\Rules\DisableIntrospection::DISABLED,

--- a/api/config/lighthouse.php
+++ b/api/config/lighthouse.php
@@ -136,7 +136,7 @@ return [
     */
 
     'security' => [
-        'max_query_complexity' => 50000, // examples: applicant dashboard - 508, candidate search - 2491, AvailablePoolsToAddTo - 27001, ScreeningAndEvaluation_Candidates - 4201, PoolsInFilter - 20001
+        'max_query_complexity' => GraphQL\Validator\Rules\QueryComplexity::DISABLED,
         'max_query_depth' => 20, // examples: applicant dashboard - 6
         'disable_introspection' => (bool) env('LIGHTHOUSE_SECURITY_DISABLE_INTROSPECTION', false)
             ? GraphQL\Validator\Rules\DisableIntrospection::ENABLED


### PR DESCRIPTION
🤖 Resolves #12843 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Adds depth and complexity limits to the API.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->
Unfortunately, I wasn't able to find a deterministic way to measure the depth and complexity of our various queries.  I wasn't able to even find a good way to log them.  So I did trial-and-error and just clicked around the site bumping up the limits as I hit them.  :clown_face:   As a result, I roughly doubled the highest values I found to give a generous safety margin.  We can try bringing these down in the future if we want.

There were two queries that resulted in suspiciously high complexity values: AvailablePoolsToAddTo and PoolsInFilter.  I'm going to start a ticket to investigate those.

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Click around the site
2. Confirm you didn't hit any limits.


## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
![image](https://github.com/user-attachments/assets/2f2339eb-50fa-49cc-9b42-276a21c05207)
