### PR TITLE
[Copy] Updates `SupportForm` subject label and options

### DIFF
--- a/apps/playwright/tests/support-page.spec.ts
+++ b/apps/playwright/tests/support-page.spec.ts
@@ -19,7 +19,7 @@ test.describe("Support page", () => {
     test("populates from search param", async ({ page }) => {
       await page.goto("/en/support?subject=bug&description=test");
       await expect(
-        page.getByRole("combobox", { name: /looking to/i }),
+        page.getByRole("combobox", { name: /reason for contact/i }),
       ).toHaveValue("bug");
       await expect(page.getByRole("textbox", { name: /details/i })).toHaveValue(
         "test",
@@ -28,7 +28,7 @@ test.describe("Support page", () => {
     test("does not populate invalid subject param", async ({ page }) => {
       await page.goto("/en/support?subject=invalid");
       await expect(
-        page.getByRole("combobox", { name: /looking to/i }),
+        page.getByRole("combobox", { name: /reason for contact/i }),
       ).toHaveValue("");
     });
   });

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5131,6 +5131,10 @@
     "defaultMessage": "Une fois l’apprentissage terminé avec succès, les diplômés reçoivent un certificat numérique ainsi qu’un certificat vérifiable portable. Il est approuvé par le, la dirigeant·e principal·e de l’information du Canada et officiellement reconnu comme répondant à <link>l‘alternative aux exigences d’études de la norme de qualification minimale du GC pour le groupe professionnel IT</link>.",
     "description": "Paragraph 1 of the 'Digital certificate credential' subsection"
   },
+  "M/phlO": {
+    "defaultMessage": "Question",
+    "description": "Support form subject field question option label"
+  },
   "M051tF": {
     "defaultMessage": "Retirer une compétence",
     "description": "Message in skills in details section to remove skill from the experience."
@@ -6286,6 +6290,10 @@
   "RJtGM5": {
     "defaultMessage": "PM-02 : Analyste subalterne",
     "description": "PM-02 classification label including titles"
+  },
+  "RKUtAJ": {
+    "defaultMessage": "Signalement de bogue",
+    "description": "Support form subject field bug option label"
   },
   "RNI+IH": {
     "defaultMessage": "Compétences sélectionnées ({skillCount})",
@@ -9206,10 +9214,6 @@
     "defaultMessage": "Connaissance de l’autre langue officielle",
     "description": "Sub-heading for language requirements dialog"
   },
-  "fVAMSw": {
-    "defaultMessage": "Soumettez des commentaires",
-    "description": "Support form subject field feedback option label"
-  },
   "fXl3Cm": {
     "defaultMessage": "Talents numériques du GC offre plusieurs ressources utiles pour faciliter l’exécution de vos responsabilités en vertu de la Directive sur les talents numériques. Il s’agit notamment d’un formulaire en ligne, de conseils de mise en œuvre et de liens vers la Directive.",
     "description": "Summary of the directive on digital talent"
@@ -10008,6 +10012,10 @@
   "issrI6": {
     "defaultMessage": "Avis concernant l’image de marque",
     "description": "Title for the trademark notice section."
+  },
+  "iuKEt+": {
+    "defaultMessage": "Commentaires",
+    "description": "Support form subject field feedback option label"
   },
   "iuve97": {
     "defaultMessage": "Modifier le statut",
@@ -10852,10 +10860,6 @@
   "mrMxsI": {
     "defaultMessage": "Oui, il s'agit d'un poste de supervision",
     "description": "Checkbox selection that confirms a job opportunity will have supervising duties. "
-  },
-  "msn4mz": {
-    "defaultMessage": "Posez une question",
-    "description": "Support form subject field question option label"
   },
   "mt4AkL": {
     "defaultMessage": "Candidat(e) precedent(e)",
@@ -12680,10 +12684,6 @@
   "wHWE3M": {
     "defaultMessage": "Il s’agit d’une plateforme conçue pour offrir des possibilités d’emploi aux Autochtones d’une manière qui reconnaît et met en valeur leurs talents, leurs idées, leurs compétences et leur passion uniques.",
     "description": "Talent portal information sentence 2"
-  },
-  "wIccbA": {
-    "defaultMessage": "Signaler un bogue",
-    "description": "Support form subject field bug option label"
   },
   "wJ5KIL": {
     "defaultMessage": "Intérêt pour le coaching des cadres",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8042,10 +8042,6 @@
     "defaultMessage": "Passez en revue votre profil",
     "description": "Page title for the application profile page"
   },
-  "aHpCQS": {
-    "defaultMessage": "Je cherche à…",
-    "description": "Support form subject field label"
-  },
   "aIEKtJ": {
     "defaultMessage": "Informations sur la compétence",
     "description": "Heading for the 'edit a skill' form"
@@ -10220,6 +10216,10 @@
   "js5ZcB": {
     "defaultMessage": "Cela indiquera aux candidats que les personnes employées par les ministères liés à cette possibilité seront accordées la préférence lors de la sélection.",
     "description": "Caption for the departmental-preference selection limitation"
+  },
+  "jt5BWQ": {
+    "defaultMessage": "Motif du contact",
+    "description": "Support form subject field label"
   },
   "jtEouE": {
     "defaultMessage": "Ajouter l'utilisateur au bassin",

--- a/apps/web/src/lang/whitelist.yml
+++ b/apps/web/src/lang/whitelist.yml
@@ -35,3 +35,4 @@
 - KxsYhl # Nominations
 - tgPKAn # Nominations
 - trerKD # Type
+- M/phlO # Question

--- a/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
+++ b/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
@@ -200,8 +200,8 @@ const SupportForm = ({
                 required: intl.formatMessage(errorMessages.required),
               }}
               label={intl.formatMessage({
-                defaultMessage: "I'm looking to…",
-                id: "aHpCQS",
+                defaultMessage: "Reason for contact",
+                id: "jt5BWQ",
                 description: "Support form subject field label",
               })}
               options={[

--- a/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
+++ b/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
@@ -206,6 +206,15 @@ const SupportForm = ({
               })}
               options={[
                 {
+                  value: "question",
+                  label: intl.formatMessage({
+                    defaultMessage: "Question",
+                    id: "M/phlO",
+                    description:
+                      "Support form subject field question option label",
+                  }),
+                },
+                {
                   value: "bug",
                   label: intl.formatMessage({
                     defaultMessage: "Bug report",
@@ -222,16 +231,8 @@ const SupportForm = ({
                       "Support form subject field feedback option label",
                   }),
                 },
-                {
-                  value: "question",
-                  label: intl.formatMessage({
-                    defaultMessage: "Question",
-                    id: "M/phlO",
-                    description:
-                      "Support form subject field question option label",
-                  }),
-                },
               ]}
+              doNotSort
               trackUnsaved={false}
             />
             <TextArea

--- a/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
+++ b/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
@@ -208,16 +208,16 @@ const SupportForm = ({
                 {
                   value: "bug",
                   label: intl.formatMessage({
-                    defaultMessage: "Submit a bug",
-                    id: "wIccbA",
+                    defaultMessage: "Bug report",
+                    id: "RKUtAJ",
                     description: "Support form subject field bug option label",
                   }),
                 },
                 {
                   value: "feedback",
                   label: intl.formatMessage({
-                    defaultMessage: "Submit feedback",
-                    id: "fVAMSw",
+                    defaultMessage: "Feedback",
+                    id: "iuKEt+",
                     description:
                       "Support form subject field feedback option label",
                   }),
@@ -225,8 +225,8 @@ const SupportForm = ({
                 {
                   value: "question",
                   label: intl.formatMessage({
-                    defaultMessage: "Ask a question",
-                    id: "msn4mz",
+                    defaultMessage: "Question",
+                    id: "M/phlO",
                     description:
                       "Support form subject field question option label",
                   }),


### PR DESCRIPTION
🤖 Resolves #4805.

## 👋 Introduction

This PR updates the `SupportForm` subject label and options.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/support
3. Verify `subject` field label is Reason for contact
4. Verify `subject` field options are, in this order: Question, Bug report, Feedback
5. Switch to French
6. Verify `subject` field label is Motif du contact
7. Verify `subject` field options are, in this order: Question, Signalement de bogue, Commentaires

## 📸 Screenshots

<img width="799" alt="Screen Shot 2025-06-03 at 16 58 44" src="https://github.com/user-attachments/assets/7757c1c1-22f8-4318-b6bb-aef2570ff1d2" />

<img width="795" alt="Screen Shot 2025-06-03 at 16 59 25" src="https://github.com/user-attachments/assets/946801af-535f-4941-9a4a-2966f14e2612" />