### PR TITLE
[Copy] Fixes spelling of French translation for Contact email address

### DIFF
--- a/api/lang/fr/headings.php
+++ b/api/lang/fr/headings.php
@@ -15,7 +15,7 @@ return [
     'archival_date' => 'Date d\'archivage',
     'first_name' => 'Prénom',
     'last_name' => 'Nom de famille',
-    'email' => 'Address courriel de correspondance',
+    'email' => 'Adresse courriel de correspondance',
     'phone' => 'Numéro de téléphone',
     'preferred_communication_language' => 'Langue de communication',
     'preferred_spoken_interview_language' => 'Langue de l\'entrevue de vive voix',

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -100,7 +100,7 @@
     "description": "Title for deadline"
   },
   "1UX8RD": {
-    "defaultMessage": "Address courriel de correspondance",
+    "defaultMessage": "Adresse courriel de correspondance",
     "description": "Title for contact email address"
   },
   "1Wq7Pf": {


### PR DESCRIPTION
🤖 Resolves #13704.

## 👋 Introduction

This PR fixes the spelling of the French translation for Contact email address.

## 🕵️ Details

Did not find any other instances of "Address" in French other than the two files changed.

## 🧪 Testing

1. Search codebase for Address (`fr.json` files; `api/lang/fr/*.php`)
2. Verify only instances of Address are for English strings