### PR TITLE
[Feature] Assessment result saved updates candidate status

### DIFF
--- a/api/app/Listeners/ComputeCandidateAssessmentStatus.php
+++ b/api/app/Listeners/ComputeCandidateAssessmentStatus.php
@@ -2,6 +2,7 @@
 
 namespace App\Listeners;
 
+use App\Enums\PoolCandidateStatus;
 use App\Events\AssessmentResultSaved;
 use App\Events\CandidateStatusChanged;
 
@@ -26,11 +27,16 @@ class ComputeCandidateAssessmentStatus
             'poolCandidate.pool.assessmentSteps',
         ]);
 
+        /** @var \App\Models\PoolCandidate */
         $candidate = $result->poolCandidate;
 
         $assessmentStatus = $candidate->computeAssessmentStatus();
 
         $candidate->computed_assessment_status = $assessmentStatus;
+
+        if ($candidate->pool_candidate_status === PoolCandidateStatus::NEW_APPLICATION->name) {
+            $candidate->pool_candidate_status = PoolCandidateStatus::UNDER_ASSESSMENT->name;
+        }
 
         $candidate->save();
 


### PR DESCRIPTION
🤖 Resolves #12781

## 👋 Introduction

When creating an assessment result, if the status is new application update it to under assessment. Otherwise, do not change the status. 

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Work through a new application flow and assessing it I suppose?

