### PR TITLE
[Debt] Migrate `Field.*` to tailwind

### DIFF
--- a/packages/forms/src/components/Field/BoundingBox.tsx
+++ b/packages/forms/src/components/Field/BoundingBox.tsx
@@ -1,6 +1,18 @@
 import { DetailedHTMLProps, InputHTMLAttributes } from "react";
+import { tv } from "tailwind-variants";
 
-import { useInputStylesDeprecated } from "../../hooks/useInputStyles";
+import { inputStyles } from "../../styles";
+
+const boundingBox = tv({
+  extend: inputStyles,
+  base: "mt-1.5 flex flex-col gap-y-1.5",
+  variants: {
+    flat: {
+      true: "border-0 border-transparent p-0",
+      false: "bg-white dark:bg-gray-600",
+    },
+  },
+});
 
 type BoundingBoxProps = DetailedHTMLProps<
   InputHTMLAttributes<HTMLDivElement>,
@@ -9,28 +21,8 @@ type BoundingBoxProps = DetailedHTMLProps<
   flat?: boolean;
 };
 
-const BoundingBox = ({ flat, ...rest }: BoundingBoxProps) => {
-  const styles = useInputStylesDeprecated();
-
-  return (
-    <div
-      data-h2-display="base(flex)"
-      data-h2-flex-direction="base(column)"
-      data-h2-gap="base(x.25 0)"
-      data-h2-margin-top="base(x.25)"
-      {...styles}
-      {...(flat
-        ? {
-            "data-h2-border-color": "base(transparent)",
-            "data-h2-border-width": "base(0)",
-            "data-h2-padding": "base(0)",
-          }
-        : {
-            "data-h2-background": "base(foreground)",
-          })}
-      {...rest}
-    />
-  );
+const BoundingBox = ({ flat, className, ...rest }: BoundingBoxProps) => {
+  return <div className={boundingBox({ flat, class: className })} {...rest} />;
 };
 
 export default BoundingBox;

--- a/packages/forms/src/components/Field/BoundingBox.tsx
+++ b/packages/forms/src/components/Field/BoundingBox.tsx
@@ -14,12 +14,13 @@ const boundingBox = tv({
   },
 });
 
-type BoundingBoxProps = DetailedHTMLProps<
-  InputHTMLAttributes<HTMLDivElement>,
-  HTMLDivElement
-> & {
+interface BoundingBoxProps
+  extends DetailedHTMLProps<
+    InputHTMLAttributes<HTMLDivElement>,
+    HTMLDivElement
+  > {
   flat?: boolean;
-};
+}
 
 const BoundingBox = ({ flat, className, ...rest }: BoundingBoxProps) => {
   return <div className={boundingBox({ flat, class: className })} {...rest} />;

--- a/packages/forms/src/components/Field/BoundingBox.tsx
+++ b/packages/forms/src/components/Field/BoundingBox.tsx
@@ -8,7 +8,7 @@ const boundingBox = tv({
   base: "mt-1.5 flex flex-col gap-y-1.5",
   variants: {
     flat: {
-      true: "border-0 border-transparent p-0",
+      true: "border-0 bg-transparent p-0",
       false: "bg-white dark:bg-gray-600",
     },
   },

--- a/packages/forms/src/components/Field/BoundingBox.tsx
+++ b/packages/forms/src/components/Field/BoundingBox.tsx
@@ -8,7 +8,7 @@ const boundingBox = tv({
   base: "mt-1.5 flex flex-col gap-y-1.5",
   variants: {
     flat: {
-      true: "border-0 bg-transparent p-0",
+      true: "border-0 bg-transparent p-0 dark:bg-transparent",
       false: "bg-white dark:bg-gray-600",
     },
   },

--- a/packages/forms/src/components/Field/Fieldset.tsx
+++ b/packages/forms/src/components/Field/Fieldset.tsx
@@ -1,17 +1,18 @@
 import { forwardRef } from "react";
+import { tv } from "tailwind-variants";
 
 import { HTMLFieldsetProps } from "../../types";
 
+const fieldSet = tv({
+  base: "flex flex-col gap-y-1.5 border-none p-0",
+});
+
 const Fieldset = forwardRef<HTMLFieldSetElement, HTMLFieldsetProps>(
-  (props, forwardedRef) => (
+  ({ className, ...rest }, forwardedRef) => (
     <fieldset
       ref={forwardedRef}
-      data-h2-border="base(none)"
-      data-h2-display="base(flex)"
-      data-h2-flex-direction="base(column)"
-      data-h2-gap="base(x.25 0)"
-      data-h2-padding="base(0)"
-      {...props}
+      className={fieldSet({ class: className })}
+      {...rest}
     />
   ),
 );

--- a/packages/forms/src/components/Field/Label.tsx
+++ b/packages/forms/src/components/Field/Label.tsx
@@ -1,21 +1,22 @@
 import { DetailedHTMLProps, LabelHTMLAttributes, forwardRef } from "react";
 
 import Required from "./Required";
+import { labelStyles } from "./styles";
 
-export type LabelProps = DetailedHTMLProps<
-  LabelHTMLAttributes<HTMLLabelElement>,
-  HTMLLabelElement
-> & {
+export interface LabelProps
+  extends DetailedHTMLProps<
+    LabelHTMLAttributes<HTMLLabelElement>,
+    HTMLLabelElement
+  > {
   required?: boolean;
-};
+}
 
 const Label = forwardRef<HTMLLabelElement, LabelProps>(
-  ({ required, children, ...props }, forwardedRef) => (
+  ({ required, children, className, ...rest }, forwardedRef) => (
     <label
       ref={forwardedRef}
-      data-h2-color="base(black)"
-      data-h2-font-size="base(caption)"
-      {...props}
+      className={labelStyles({ class: className })}
+      {...rest}
     >
       {children}
       <Required required={required} />

--- a/packages/forms/src/components/Field/Legend.tsx
+++ b/packages/forms/src/components/Field/Legend.tsx
@@ -1,20 +1,18 @@
 import { DetailedHTMLProps, HTMLAttributes } from "react";
 
 import Required from "./Required";
+import { labelStyles } from "./styles";
 
-export type LegendProps = DetailedHTMLProps<
-  HTMLAttributes<HTMLLegendElement>,
-  HTMLLegendElement
-> & {
+export interface LegendProps
+  extends DetailedHTMLProps<
+    HTMLAttributes<HTMLLegendElement>,
+    HTMLLegendElement
+  > {
   required?: boolean;
-};
+}
 
-const Legend = ({ required, children, ...props }: LegendProps) => (
-  <legend
-    data-h2-color="base(black)"
-    data-h2-font-size="base(caption)"
-    {...props}
-  >
+const Legend = ({ required, children, className, ...rest }: LegendProps) => (
+  <legend className={labelStyles({ class: className })} {...rest}>
     {children}
     <Required required={required} />
   </legend>

--- a/packages/forms/src/components/Field/Required.tsx
+++ b/packages/forms/src/components/Field/Required.tsx
@@ -5,7 +5,7 @@ export interface RequiredProps {
 const Required = ({ required }: RequiredProps) =>
   required ? (
     // eslint-disable-next-line formatjs/no-literal-string-in-jsx
-    <span data-h2-color="base(error.dark) base:dark(error.lightest)"> *</span>
+    <span className="text-error-500 dark:text-error-300"> *</span>
   ) : null;
 
 export default Required;

--- a/packages/forms/src/components/Field/Wrapper.tsx
+++ b/packages/forms/src/components/Field/Wrapper.tsx
@@ -1,18 +1,17 @@
 import { DetailedHTMLProps, HtmlHTMLAttributes } from "react";
+import { tv } from "tailwind-variants";
+
+const wrapper = tv({
+  base: "flex w-full flex-col gap-y-3",
+});
 
 export type WrapperProps = DetailedHTMLProps<
   HtmlHTMLAttributes<HTMLDivElement>,
   HTMLDivElement
 >;
 
-const Wrapper = (props: WrapperProps) => (
-  <div
-    data-h2-display="base(flex)"
-    data-h2-flex-direction="base(column)"
-    data-h2-gap="base(x.25 0)"
-    data-h2-max-width="base(100%)"
-    {...props}
-  />
+const Wrapper = ({ className, ...rest }: WrapperProps) => (
+  <div className={wrapper({ class: className })} {...rest} />
 );
 
 export default Wrapper;

--- a/packages/forms/src/components/Field/Wrapper.tsx
+++ b/packages/forms/src/components/Field/Wrapper.tsx
@@ -2,7 +2,7 @@ import { DetailedHTMLProps, HtmlHTMLAttributes } from "react";
 import { tv } from "tailwind-variants";
 
 const wrapper = tv({
-  base: "flex w-full flex-col gap-y-3",
+  base: "flex w-full flex-col gap-y-1.5",
 });
 
 export type WrapperProps = DetailedHTMLProps<

--- a/packages/forms/src/components/Field/styles.ts
+++ b/packages/forms/src/components/Field/styles.ts
@@ -1,0 +1,5 @@
+import { tv } from "tailwind-variants";
+
+export const labelStyles = tv({
+  base: "text-sm text-black dark:text-white",
+});


### PR DESCRIPTION
🤖 Resolves #13664 

## 👋 Introduction

Migrates all the `Field.*` components to use tailwindcss.

## 🧪 Testing

1. No significant chromatic diff