### PR TITLE
[Fix] Profile details text color

### DIFF
--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ProfileDetails/ProfileDetails.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/ProfileDetails/ProfileDetails.tsx
@@ -53,13 +53,7 @@ const ProfileDetails = ({ userQuery }: ProfileDetailsProps) => {
   return (
     <Well
       fontSize="caption"
-      data-h2-display="base(flex)"
-      data-h2-flex-wrap="base(wrap)"
-      data-h2-align-items="base(center)"
-      data-h2-gap="base(0, x.5)"
-      data-h2-color="base(black)"
-      data-h2-background="base(linear-gradient(92deg, rgba(175, 103, 255, 0.10) 1.42%, rgba(0, 195, 183, 0.10) 98.58%))"
-      data-h2-margin-top="base(x1)"
+      className="mt-6 flex flex-wrap items-center gap-3 bg-transparent bg-linear-90 from-secondary/10 to-primary/10 text-white dark:bg-transparent"
     >
       <p>
         <span data-h2-font-size="base(caption)">


### PR DESCRIPTION
🤖 Resolves #13705 

## 👋 Introduction

Fixes an issue with the text rendering of the `ProfileDetails` component by migrating it to tailwind.

## 🕵️ Details

Looks like in this instance, the tailwind stlyes were overriding the hydrogen styles and since this is always on a dakr background, the swap of the colours was not expected. I fixed this by just migrating to tialwind so we don't have competting libs.

## 🧪 Testing

1. Build `pnpm run dev`
2. Login as `admin@test.com`
3. Navigate to t a pool candidate
4. Confirm text in profile detials is legible in both light and dark mode
 -->

## 📸 Screenshot

![2025-06-05_12-08](https://github.com/user-attachments/assets/3909ad2f-bdb2-4421-a673-9d2d704e4e92)
![2025-06-05_12-08_1](https://github.com/user-attachments/assets/76e57c1e-c30f-479d-9ca2-d2998a19424f)
