### PR TITLE
 [Copy] Exam Vouchers Page Copy and Links Updated

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2495,10 +2495,6 @@
     "defaultMessage": "Créer une classification",
     "description": "Page title for the classification creation page"
   },
-  "9gU2in": {
-    "defaultMessage": "Nous répondrons à votre demande dans les sept jours ouvrables. Si votre demande est approuvée, nous vous ferons parvenir un code pour le bon que vous pourrez utiliser pour réserver une date d'examen sur la plateforme du fournisseur.",
-    "description": "First paragraph of what to expect section"
-  },
   "9gklPf": {
     "defaultMessage": "Raison de ne pas retenir cette nomination",
     "description": "label for rejection notes"
@@ -13024,6 +13020,10 @@
   "y5xvLj": {
     "defaultMessage": "La collectivité de la gestion financière",
     "description": "Section heading, expand on community aspects"
+  },
+  "y6pG9A": {
+    "defaultMessage": "Nous répondrons à votre demande dans les 14 jours. Si votre demande est approuvée, nous vous ferons parvenir un code pour le bon que vous pourrez utiliser pour réserver une date d'examen sur la plateforme du fournisseur.",
+    "description": "First paragraph of what to expect section"
   },
   "y827h2": {
     "defaultMessage": "Sélectionnez un ministère",

--- a/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
+++ b/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
@@ -295,8 +295,8 @@ export const Component = () => {
             <p data-h2-margin-bottom="base(x.5)">
               {intl.formatMessage({
                 defaultMessage:
-                  "We'll respond to your application within 7 business days. If your request is approved, we'll send you a voucher code that you can use when booking your exam on the provider's platform.",
-                id: "9gU2in",
+                  "We'll respond to your application within 14 days. If your request is approved, we'll send you a voucher code that you can use when booking your exam on the provider's platform.",
+                id: "y6pG9A",
                 description: "First paragraph of what to expect section",
               })}
             </p>

--- a/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
+++ b/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
@@ -29,8 +29,8 @@ const mailLink = (chunks: ReactNode) => (
 );
 
 const requestAVoucherUrl = {
-  en: "https://forms-formulaires.alpha.canada.ca/en/id/cm8hx7lwz000uyl693aju6upq",
-  fr: "https://forms-formulaires.alpha.canada.ca/fr/id/cm8hx7lwz000uyl693aju6upq",
+  en: "https://forms-formulaires.alpha.canada.ca/en/id/cmb13t7jr00cxx601nzt7gfpk",
+  fr: "https://forms-formulaires.alpha.canada.ca/fr/id/cmb13t7jr00cxx601nzt7gfpk",
 } as const;
 
 const pageSubtitle = defineMessage({


### PR DESCRIPTION
🤖 Resolves #13593

## 👋 Introduction

This PR updates a small copy change and button links on the Certification Exam Vouchers page in both English and French.

## 🕵️ Details

Changes include:

Updated English copy from:
- "We'll respond to your application within 7 business days."
to
- "We'll respond to your application within 14 days."

Updated French copy from:

- "Nous répondrons à votre demande dans les sept jours ouvrables."
to
- "Nous répondrons à votre demande dans les 14 jours."

Updated both English and French form buttons to link to the new form:

- EN: https://forms-formulaires.alpha.canada.ca/en/id/cmb13t7jr00cxx601nzt7gfpk
- FR: https://forms-formulaires.alpha.canada.ca/fr/id/cmb13t7jr00cxx601nzt7gfpk

## 🧪 Testing

1. Navigate to `en/it-training-fund/certification-exam-vouchers`
2. Confirm the copy now says: "We'll respond to your application within 14 days."
3. Click the button `request a voucher` — confirm it opens the new English form link.
4. Switch to the French version of the page `fr/it-training-fund/certification-exam-vouchers`
5. Confirm the copy now says: "Nous répondrons à votre demande dans les 14 jours."
6. Click the button `Demandez un bon` — confirm it opens the new French form link.


## 📸 Screenshot

![localhost_8000_en_it-training-fund_certification-exam-vouchers](https://github.com/user-attachments/assets/d7caab24-0fbb-41d7-adaf-05bd0ea6d5ec)

![localhost_8000_fr_it-training-fund_certification-exam-vouchers](https://github.com/user-attachments/assets/bb87af27-1709-4cd5-93bf-506b016ccbea)

![forms-formulaires alpha canada ca_en_id_cmb13t7jr00cxx601nzt7gfpk (1)](https://github.com/user-attachments/assets/91da2c08-12d0-4fc0-8946-bdba08b6df27)


![forms-formulaires alpha canada ca_fr_id_cmb13t7jr00cxx601nzt7gfpk](https://github.com/user-attachments/assets/7b40c4c9-af42-4bab-97a5-9c02d9f94732)

