### PR TITLE
[Copy] Fixes incorrect French translation of Written exam language

### DIFF
--- a/api/lang/fr/headings.php
+++ b/api/lang/fr/headings.php
@@ -19,7 +19,7 @@ return [
     'phone' => 'Numéro de téléphone',
     'preferred_communication_language' => 'Langue de communication',
     'preferred_spoken_interview_language' => 'Langue de l\'entrevue de vive voix',
-    'preferred_written_exam_language' => 'Examen de langue écrit',
+    'preferred_written_exam_language' => 'Langue de l\'examen écrit',
     'armed_forces_status' => 'Membre des FAC',
     'citizenship' => 'Citoyenneté',
     'first_official_language' => 'Première langue officielle',

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8315,7 +8315,7 @@
     "description": "Text for education accepted information context in screening decision dialog"
   },
   "boPmF+": {
-    "defaultMessage": "Examen de langue écrit",
+    "defaultMessage": "Langue de l'examen écrit",
     "description": "Legend text for written exam language preference for exams"
   },
   "bok2jV": {


### PR DESCRIPTION
🤖 Resolves #13726.

## 👋 Introduction

This PR fixes incorrect French translation of Written exam language.

## 🧪 Testing

1. Search codebase for any instance of _Examen de langue écrit_
2. Verify no instances of Examen de langue écrit in codebase

## Screenshot

<img width="1159" alt="Screen Shot 2025-06-06 at 11 40 29" src="https://github.com/user-attachments/assets/fcf6c842-a950-41cf-bb16-6833753e336f" />
