### PR TITLE
[Copy] Updates French Lead-in text for application information

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3732,7 +3732,7 @@
     "description": "Form header for filling in job opportunity information section."
   },
   "FNvBxZ": {
-    "defaultMessage": "Voici l’information qui a été soumise le {submittedAt}. Vous trouverez l’historique de la carrière du candidat/de la candidate dans la section sur l’échéancier.",
+    "defaultMessage": "Voici l’information qui a été soumise le {submittedAt}. Vous trouverez l’historique complet de la carrière du candidat ou de la candidate dans la section du parcours professionnel.",
     "description": "Lead-in text for application information"
   },
   "FO0HTu": {


### PR DESCRIPTION
🤖 Resolves #13736.

## 👋 Introduction

This PR updates the French copy for lead-in text for application information.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/fr/admin/candidates/:candidate-id/application
3. Verify paragraph after _Information sur la demande_ heading is up to date

## 📸 Screenshot

<img width="1394" alt="Screen Shot 2025-06-06 at 11 54 09" src="https://github.com/user-attachments/assets/317a9929-e4f1-46c8-87f5-f3feb0ca3e12" />

