### PR TITLE
[Debt] Migrate `CommunityInterest` to tailwind

### DIFF
--- a/apps/web/src/components/BoolCheckIcon/BoolCheckIcon.tsx
+++ b/apps/web/src/components/BoolCheckIcon/BoolCheckIcon.tsx
@@ -1,8 +1,22 @@
 import XCircleIcon from "@heroicons/react/20/solid/XCircleIcon";
 import CheckCircleIcon from "@heroicons/react/20/solid/CheckCircleIcon";
 import { ReactNode } from "react";
+import { tv } from "tailwind-variants";
 
 import { Maybe } from "@gc-digital-talent/graphql";
+
+const boolCheck = tv({
+  slots: {
+    base: "flex items-start gap-1.5",
+    icon: "mt-1 size-4.5 shrink-0",
+  },
+  variants: {
+    checked: {
+      true: { icon: "text-success dark:text-success-200" },
+      false: { icon: "text-gray-300 dark:text-gray" },
+    },
+  },
+});
 
 type DivProps = React.ComponentPropsWithoutRef<"div">;
 
@@ -18,32 +32,15 @@ const BoolCheckIcon = ({
   trueLabel,
   falseLabel,
   children,
+  className,
   ...rest
 }: BoolCheckIconProps) => {
   const Icon = value ? CheckCircleIcon : XCircleIcon;
+  const { base, icon } = boolCheck({ checked: value ?? false });
 
   return (
-    <div
-      data-h2-display="base(flex)"
-      data-h2-align-items="base(flex-start)"
-      data-h2-gap="base(x.25)"
-      {...rest}
-    >
-      <Icon
-        data-h2-width="base(x.75)"
-        data-h2-height="base(x.75)"
-        data-h2-margin-top="base(x.15)"
-        data-h2-flex-shrink="base(0)"
-        {...(value
-          ? {
-              "aria-label": trueLabel,
-              "data-h2-color": "base(success) base:dark(success.lighter)",
-            }
-          : {
-              "aria-label": falseLabel,
-              "data-h2-color": "base(black.lighter) base:dark(black.5)",
-            })}
-      />
+    <div className={base({ class: className })} {...rest}>
+      <Icon className={icon()} aria-label={value ? trueLabel : falseLabel} />
       <span>{children}</span>
     </div>
   );

--- a/apps/web/src/components/CommunityInterest/CommunityInterest.tsx
+++ b/apps/web/src/components/CommunityInterest/CommunityInterest.tsx
@@ -114,7 +114,7 @@ const CommunityInterest = ({
       : null;
   return (
     <>
-      <p data-h2-font-weight="base(700)" data-h2-margin-bottom="base(x.25)">
+      <p className="mb-1.5 font-bold">
         {intl.formatMessage({
           defaultMessage: "Interest in job opportunities",
           id: "dYsXAU",
@@ -122,10 +122,7 @@ const CommunityInterest = ({
             "Label for users interest in job opportunities for a community",
         })}
       </p>
-      <BoolCheckIcon
-        value={communityInterest.jobInterest}
-        data-h2-margin-bottom="base(x1)"
-      >
+      <BoolCheckIcon value={communityInterest.jobInterest} className="mb-6">
         {communityInterest.jobInterest ? (
           <span>
             {intl.formatMessage({
@@ -145,7 +142,7 @@ const CommunityInterest = ({
           })
         )}
       </BoolCheckIcon>
-      <p data-h2-font-weight="base(700)" data-h2-margin-bottom="base(x.25)">
+      <p className="mb-1.5 font-bold">
         {intl.formatMessage({
           defaultMessage: "Interest in training and development",
           id: "WfX9z1",
@@ -155,7 +152,7 @@ const CommunityInterest = ({
       </p>
       <BoolCheckIcon
         value={communityInterest.trainingInterest}
-        data-h2-margin-bottom="base(x1)"
+        className="mb-6"
       >
         {communityInterest.trainingInterest ? (
           <span>
@@ -177,11 +174,7 @@ const CommunityInterest = ({
         )}
       </BoolCheckIcon>
       {context === "applicant" && (
-        <p
-          data-h2-color="base(black.light)"
-          data-h2-font-size="base(caption)"
-          data-h2-margin-bottom="base(x1)"
-        >
+        <p className="mb-6 text-sm font-normal text-gray-600 dark:text-gray-100">
           {intl.formatMessage({
             defaultMessage:
               "* Note that by indicating you’re interested in jobs or training opportunities, you agree to share your profile information with Government of Canada HR and recruitment staff within this community.",
@@ -193,7 +186,7 @@ const CommunityInterest = ({
       )}
       {communityWorkStreams.length > 0 && (
         <>
-          <p data-h2-font-weight="base(700)" data-h2-margin-bottom="base(x.25)">
+          <p className="mb-1.5 font-bold">
             {intl.formatMessage({
               defaultMessage:
                 "Preferred work streams for job and training opportunities",
@@ -230,7 +223,7 @@ const CommunityInterest = ({
       {communityDevelopmentPrograms.length > 0 && (
         <>
           <Separator orientation="horizontal" decorative space="sm" />
-          <p data-h2-font-weight="base(700)" data-h2-margin-bottom="base(x.25)">
+          <p className="mb-1.5 font-bold">
             {intl.formatMessage({
               defaultMessage: "Leadership and professional development options",
               id: "UfwS5s",
@@ -271,10 +264,7 @@ const CommunityInterest = ({
           {/* Some fields only appear for the finance community */}
           {communityInterest.community.key === "finance" ? (
             <>
-              <p
-                data-h2-font-weight="base(700)"
-                data-h2-margin-bottom="base(x.25)"
-              >
+              <p className="mb-1.5 font-bold">
                 {intl.formatMessage({
                   defaultMessage: "CFO status",
                   id: "2KQdGz",
@@ -284,7 +274,7 @@ const CommunityInterest = ({
               </p>
               <BoolCheckIcon
                 value={communityInterest.financeIsChief}
-                data-h2-margin-bottom="base(x1)"
+                className="mb-6"
               >
                 {communityInterest.financeIsChief
                   ? intl.formatMessage({
@@ -301,10 +291,7 @@ const CommunityInterest = ({
               </BoolCheckIcon>
               {communityInterest.financeIsChief ? (
                 <>
-                  <p
-                    data-h2-font-weight="base(700)"
-                    data-h2-margin-bottom="base(x.25)"
-                  >
+                  <p className="mb-1.5 font-bold">
                     {intl.formatMessage({
                       defaultMessage: "Additional duties",
                       id: "E32ToC",
@@ -327,10 +314,7 @@ const CommunityInterest = ({
                       ),
                     )}
                   </Ul>
-                  <p
-                    data-h2-font-weight="base(700)"
-                    data-h2-margin-bottom="base(x.25)"
-                  >
+                  <p className="mb-1.5 font-bold">
                     {intl.formatMessage({
                       defaultMessage: "Other roles",
                       id: "z20NMR",
@@ -354,10 +338,7 @@ const CommunityInterest = ({
                   </Ul>
                   {communityInterest.financeOtherRolesOther ? (
                     <>
-                      <p
-                        data-h2-font-weight="base(700)"
-                        data-h2-margin-bottom="base(x.25)"
-                      >
+                      <p className="mb-1.5 font-bold">
                         {intl.formatMessage({
                           defaultMessage:
                             "Other senior delegated official (SDO) position",
@@ -365,7 +346,7 @@ const CommunityInterest = ({
                           description: "Label for the 'Other role' input",
                         })}
                       </p>
-                      <p data-h2-margin-bottom="base(x1)">
+                      <p className="mb-6">
                         {communityInterest.financeOtherRolesOther}
                       </p>
                     </>
@@ -374,7 +355,7 @@ const CommunityInterest = ({
               ) : null}
             </>
           ) : null}
-          <p data-h2-font-weight="base(700)" data-h2-margin-bottom="base(x.25)">
+          <p className="mb-1.5 font-bold">
             {intl.formatMessage({
               defaultMessage: "Additional information",
               id: "NCMG9w",

--- a/apps/web/src/components/CommunityInterest/DevelopmentProgramInterestItem.tsx
+++ b/apps/web/src/components/CommunityInterest/DevelopmentProgramInterestItem.tsx
@@ -4,6 +4,7 @@ import ExclamationCircleIcon from "@heroicons/react/20/solid/ExclamationCircleIc
 import XCircleIcon from "@heroicons/react/20/solid/XCircleIcon";
 import QuestionMarkCircleIcon from "@heroicons/react/20/solid/QuestionMarkCircleIcon";
 import BuildingLibraryIcon from "@heroicons/react/20/solid/BuildingLibraryIcon";
+import { tv } from "tailwind-variants";
 
 import {
   DevelopmentProgramParticipationStatus,
@@ -18,7 +19,6 @@ import { formatDate, parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
 
 interface StatusInfo {
   Icon: IconType;
-  iconStyles: Record<string, string>;
   message: string;
 }
 
@@ -30,9 +30,6 @@ const useStatusInfo = (
 
   const defaultStatusInfo = {
     Icon: ExclamationCircleIcon,
-    iconStyles: {
-      "data-h2-color": "base(error) base:dark(error.lighter)",
-    },
     message: intl.formatMessage(commonMessages.missingInformation),
   };
 
@@ -57,9 +54,6 @@ const useStatusInfo = (
       DevelopmentProgramParticipationStatus.Interested,
       {
         Icon: QuestionMarkCircleIcon,
-        iconStyles: {
-          "data-h2-color": "base(primary) base:dark(primary.light)",
-        },
         message: intl.formatMessage({
           defaultMessage: "Interested in this program",
           id: "ytcZ7A",
@@ -72,9 +66,6 @@ const useStatusInfo = (
       DevelopmentProgramParticipationStatus.NotInterested,
       {
         Icon: XCircleIcon,
-        iconStyles: {
-          "data-h2-color": "base(black.lighter) base:dark(black.5)",
-        },
         message: intl.formatMessage({
           defaultMessage: "Not interested",
           id: "9TIkDp",
@@ -87,9 +78,6 @@ const useStatusInfo = (
       DevelopmentProgramParticipationStatus.Enrolled,
       {
         Icon: BuildingLibraryIcon,
-        iconStyles: {
-          "data-h2-color": "base(primary) base:dark(primary.light)",
-        },
         message: date
           ? intl.formatMessage(
               {
@@ -113,9 +101,6 @@ const useStatusInfo = (
       DevelopmentProgramParticipationStatus.Completed,
       {
         Icon: CheckCircleIcon,
-        iconStyles: {
-          "data-h2-color": "base(success) base:dark(success.lighter)",
-        },
         message: intl.formatMessage(
           {
             defaultMessage: "Completed in {date}",
@@ -133,6 +118,38 @@ const useStatusInfo = (
 
   return infoMap.get(status) ?? defaultStatusInfo;
 };
+
+const devProgram = tv({
+  slots: {
+    base: "mb-1.5 flex items-start gap-1.5",
+    icon: "mt-1 size-4.5 text-error dark:text-error-200",
+    caption: "text-sm",
+  },
+  variants: {
+    status: {
+      [DevelopmentProgramParticipationStatus.Interested]: {
+        icon: "text-secondary dark:text-secondary-300",
+      },
+      [DevelopmentProgramParticipationStatus.NotInterested]: {
+        icon: "text-gray-300 dark:text-gray",
+      },
+      [DevelopmentProgramParticipationStatus.Enrolled]: {
+        icon: "text-secondary dark:text-secondary-300",
+      },
+      [DevelopmentProgramParticipationStatus.Completed]: {
+        icon: "text-success dark:text-success-200",
+      },
+    },
+    hasError: {
+      true: {
+        caption: "text-error dark:text-error-100",
+      },
+      false: {
+        caption: "text-gray- dark:text-gray-100",
+      },
+    },
+  },
+});
 
 const CommunityInterestDevelopmentProgram_Fragment = graphql(/* GraphQL */ `
   fragment CommunityInterestDevelopmentProgramInterest on DevelopmentProgramInterest {
@@ -156,41 +173,30 @@ const DevelopmentProgramInterestItem = ({
     CommunityInterestDevelopmentProgram_Fragment,
     developmentProgramInterestQuery,
   );
-  const { Icon, iconStyles, message } = useStatusInfo(
+  const { Icon, message } = useStatusInfo(
     developmentProgramInterest?.participationStatus,
     developmentProgramInterest?.completionDate,
   );
 
+  const {
+    base,
+    icon: iconStyles,
+    caption,
+  } = devProgram({
+    status: developmentProgramInterest?.participationStatus ?? undefined,
+    hasError:
+      !developmentProgramInterest?.participationStatus ||
+      (developmentProgramInterest?.participationStatus ===
+        DevelopmentProgramParticipationStatus.Completed &&
+        !developmentProgramInterest?.completionDate),
+  });
+
   return (
-    <li
-      data-h2-display="base(flex)"
-      data-h2-gap="base(x.25)"
-      data-h2-align-items="base(flex-start)"
-      data-h2-margin-bottom="base(x.25)"
-    >
-      <Icon
-        data-h2-width="base(x.75)"
-        data-h2-height="base(x.75)"
-        data-h2-margin-top="base(x.15)"
-        {...iconStyles}
-      />
-      <span data-h2-display="base(flex)" data-h2-flex-direction="base(column)">
+    <li className={base()}>
+      <Icon className={iconStyles()} />
+      <span className="flex flex-col">
         <span>{label}</span>
-        <span
-          data-h2-font-size="base(caption)"
-          {...(!developmentProgramInterest?.participationStatus ||
-          (developmentProgramInterest?.participationStatus ===
-            DevelopmentProgramParticipationStatus.Completed &&
-            !developmentProgramInterest?.completionDate)
-            ? {
-                "data-h2-color": "base(error) base:dark(error.lightest)",
-              }
-            : {
-                "data-h2-color": "base(black.light)",
-              })}
-        >
-          {message}
-        </span>
+        <span className={caption()}>{message}</span>
       </span>
     </li>
   );


### PR DESCRIPTION
🤖 Resolves #13715 

## 👋 Introduction

Migrates the `CommunityInterest` component to tailwindcss.

> [!NOTE]
> I migrated the `BoolCheck` icon as well to match the styles of the custom icons here. Otherwise, it looked odd. 

## 🧪 Testing

1. No significant chromatic diff