### PR TITLE
[Fix] Talent management tests

### DIFF
--- a/apps/playwright/fixtures/TalentManagement.ts
+++ b/apps/playwright/fixtures/TalentManagement.ts
@@ -19,6 +19,8 @@ class TalentManagement extends AppPage {
   }
 
   async viewActiveTalentNominationEvent() {
+    await this.page.getByRole("button", { name: /show 10/i }).click();
+    await this.page.getByRole("menuitemradio", { name: /50/i }).click();
     await this.page
       .getByRole("link", { name: /test talent nomination event active en 0/i })
       .click();

--- a/apps/web/src/components/NextRoleAndCareerObjective/CareerObjectivePreview.tsx
+++ b/apps/web/src/components/NextRoleAndCareerObjective/CareerObjectivePreview.tsx
@@ -8,6 +8,7 @@ import {
   PreviewMetaData,
 } from "@gc-digital-talent/ui";
 import { commonMessages } from "@gc-digital-talent/i18n";
+import { nodeToString } from "@gc-digital-talent/helpers";
 
 import { formatClassificationString } from "~/utils/poolUtils";
 import { wrapAbbr } from "~/utils/nameUtils";
@@ -145,7 +146,7 @@ const CareerObjectivePreview = ({
         action={
           <CareerObjectiveDialog
             careerObjectiveDialogQuery={careerObjectivePreviewFragment}
-            trigger={<PreviewList.Button>{title}</PreviewList.Button>}
+            trigger={<PreviewList.Button label={nodeToString(title)} />}
           />
         }
         headingAs={headingAs}

--- a/apps/web/src/components/RecruitmentProcesses/RecruitmentProcessDialog.tsx
+++ b/apps/web/src/components/RecruitmentProcesses/RecruitmentProcessDialog.tsx
@@ -95,22 +95,24 @@ const RecruitmentProcessDialog = ({
   return (
     <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
       <Dialog.Trigger asChild>
-        <PreviewList.Button>
-          {pool.name?.localized
-            ? intl.formatMessage(
-                {
-                  defaultMessage:
-                    "{poolName}<hidden> recruitment process</hidden>",
-                  id: "wrg4fw",
-                  description:
-                    "Text before recruitment process pool name in recruitment process preview list.",
-                },
-                {
-                  poolName: pool.name.localized,
-                },
-              )
-            : nullMessage}
-        </PreviewList.Button>
+        <PreviewList.Button
+          label={
+            pool.name?.localized
+              ? intl.formatMessage(
+                  {
+                    defaultMessage:
+                      "{poolName}<hidden> recruitment process</hidden>",
+                    id: "wrg4fw",
+                    description:
+                      "Text before recruitment process pool name in recruitment process preview list.",
+                  },
+                  {
+                    poolName: pool.name.localized,
+                  },
+                )
+              : nullMessage
+          }
+        />
       </Dialog.Trigger>
       <Dialog.Content>
         <Dialog.Header>

--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationDialog.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationDialog.tsx
@@ -181,21 +181,24 @@ const ReviewApplicationDialog = ({
   return (
     <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
       <Dialog.Trigger asChild>
-        <PreviewList.Button>
-          {pool.name?.localized
-            ? intl.formatMessage(
-                {
-                  defaultMessage: "<hidden>Application for </hidden>{poolName}",
-                  id: "LC1Rsg",
-                  description:
-                    "Text before application pool name in application preview list.",
-                },
-                {
-                  poolName: pool.name.localized,
-                },
-              )
-            : nullMessage}
-        </PreviewList.Button>
+        <PreviewList.Button
+          label={
+            pool.name?.localized
+              ? intl.formatMessage(
+                  {
+                    defaultMessage:
+                      "<hidden>Application for </hidden>{poolName}",
+                    id: "LC1Rsg",
+                    description:
+                      "Text before application pool name in application preview list.",
+                  },
+                  {
+                    poolName: pool.name.localized,
+                  },
+                )
+              : nullMessage
+          }
+        />
       </Dialog.Trigger>
       <Dialog.Content>
         <Dialog.Header

--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewRecruitmentProcessDialog.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewRecruitmentProcessDialog.tsx
@@ -199,22 +199,24 @@ const ReviewRecruitmentProcessDialog = ({
   return (
     <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
       <Dialog.Trigger asChild>
-        <PreviewList.Button>
-          {pool.name?.localized
-            ? intl.formatMessage(
-                {
-                  defaultMessage:
-                    "{poolName}<hidden> recruitment process</hidden>",
-                  id: "wrg4fw",
-                  description:
-                    "Text before recruitment process pool name in recruitment process preview list.",
-                },
-                {
-                  poolName: pool.name.localized,
-                },
-              )
-            : nullMessage}
-        </PreviewList.Button>
+        <PreviewList.Button
+          label={
+            pool.name?.localized
+              ? intl.formatMessage(
+                  {
+                    defaultMessage:
+                      "{poolName}<hidden> recruitment process</hidden>",
+                    id: "wrg4fw",
+                    description:
+                      "Text before recruitment process pool name in recruitment process preview list.",
+                  },
+                  {
+                    poolName: pool.name.localized,
+                  },
+                )
+              : nullMessage
+          }
+        />
       </Dialog.Trigger>
       <Dialog.Content>
         <Dialog.Header

--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewTalentNominationDialog.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewTalentNominationDialog.tsx
@@ -154,21 +154,23 @@ const ReviewTalentNominationDialog = ({
   return (
     <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
       <Dialog.Trigger asChild>
-        <PreviewList.Button>
-          {talentNomination.nominee
-            ? intl.formatMessage(
-                {
-                  defaultMessage: "{name}<hidden> talent nomination</hidden>",
-                  id: "uaVogJ",
-                  description:
-                    "Label for talent nomination review dialog button",
-                },
-                {
-                  name: `${talentNomination.nominee.firstName} ${talentNomination.nominee.lastName}`,
-                },
-              )
-            : nullMessage}
-        </PreviewList.Button>
+        <PreviewList.Button
+          label={
+            talentNomination.nominee
+              ? intl.formatMessage(
+                  {
+                    defaultMessage: "{name}<hidden> talent nomination</hidden>",
+                    id: "uaVogJ",
+                    description:
+                      "Label for talent nomination review dialog button",
+                  },
+                  {
+                    name: `${talentNomination.nominee.firstName} ${talentNomination.nominee.lastName}`,
+                  },
+                )
+              : nullMessage
+          }
+        />
       </Dialog.Trigger>
       <Dialog.Content>
         <Dialog.Header

--- a/packages/ui/src/components/PreviewList/PreviewList.tsx
+++ b/packages/ui/src/components/PreviewList/PreviewList.tsx
@@ -50,7 +50,8 @@ const MetaData = (props: MetaDataProps) => {
 const actionProps = {
   color: "black",
   icon: MagnifyingGlassPlusIcon,
-  className: "after:absolute inset-0 justify-self-end mr-6 xs:mr-9",
+  className:
+    "after:content-[''] after:absolute after:inset-0 justify-self-end mr-6 xs:mr-9",
 } satisfies IconButtonProps;
 
 interface ButtonProps extends Omit<BaseButtonProps, "icon"> {
@@ -94,11 +95,11 @@ const Item = ({
   children,
 }: ItemProps) => {
   return (
-    <li className="group relative flex items-start justify-between gap-3 not-last:border-b not-last:border-b-gray-100 not-last:pb-6 first:border-t first:border-t-gray-100 first:pt-6 xs:items-center">
+    <li className="group/item relative flex items-start justify-between gap-3 not-last:border-b not-last:border-b-gray-100 not-last:pb-6 first:border-t first:border-t-gray-100 first:pt-6 xs:items-center">
       <div className="flex flex-col">
         <Heading
           level={headingAs}
-          className="m-0 mb-0.5 inline-block text-base font-bold underline group-has-[a:focus-visible,button:focus-visible]:bg-focus group-has-[a:focus-visible,button:focus-visible]:text-black group-has-[a:hover,button:hover]:text-primary-600 lg:text-base dark:group-has-[a:hover,button:hover]:text-primary-200"
+          className="m-0 mb-0.5 inline-block text-base font-bold underline group-has-[a:focus-visible,button:focus-visible]/item:bg-focus group-has-[a:focus-visible,button:focus-visible]/item:text-black group-has-[a:hover,button:hover]/item:text-primary-600 lg:text-base dark:group-has-[a:hover,button:hover]/item:text-primary-200"
         >
           {title}
         </Heading>


### PR DESCRIPTION
🤖 Resolves #13793 

## 👋 Introduction

Fixes the talent managment tests, including the `PreviewList` component.

## 🕵️ Details

This fixes the talent management tests that broke in different ways. One of those ways was the `PreviewList` component props and another was a link not being on the initial table.

## 🧪 Testing

1. Confirm talent management tests pass consistently
2. Confirm `PreviewList` component works as expected
