### PR TITLE
[Debt] Migrate `NextRoleAndCareerObjective` to tailwind

### DIFF
--- a/apps/web/src/components/NextRoleAndCareerObjective/CareerObjective.tsx
+++ b/apps/web/src/components/NextRoleAndCareerObjective/CareerObjective.tsx
@@ -51,11 +51,7 @@ const CareerObjective = ({ careerObjectiveQuery }: CareerObjectiveProps) => {
     !careerObjectiveCommunity?.id && !!careerObjectiveCommunityOther;
 
   return (
-    <div
-      data-h2-display="base(grid)"
-      data-h2-gap="base(x1)"
-      data-h2-grid-template-columns="base(repeat(1, 1fr)) p-tablet(repeat(2, 1fr)) "
-    >
+    <div className="grid gap-6 sm:grid-cols-2">
       <FieldDisplay
         label={intl.formatMessage(
           employeeProfileMessages.targetClassificationGroup,
@@ -102,7 +98,7 @@ const CareerObjective = ({ careerObjectiveQuery }: CareerObjectiveProps) => {
       </FieldDisplay>
       <FieldDisplay
         label={intl.formatMessage(employeeProfileMessages.community)}
-        data-h2-grid-column="l-tablet(span 2)"
+        className="sm:col-span-2"
       >
         {handleCommunity(
           careerObjectiveCommunity?.name?.localized,
@@ -113,7 +109,7 @@ const CareerObjective = ({ careerObjectiveQuery }: CareerObjectiveProps) => {
       {isCommunityOther ? (
         <FieldDisplay
           label={intl.formatMessage(messages.otherCommunity)}
-          data-h2-grid-column="l-tablet(span 2)"
+          className="sm:col-span-2"
         >
           {careerObjectiveCommunityOther}
         </FieldDisplay>
@@ -123,7 +119,7 @@ const CareerObjective = ({ careerObjectiveQuery }: CareerObjectiveProps) => {
       careerObjectiveWorkStreams?.length ? (
         <FieldDisplay
           label={intl.formatMessage(employeeProfileMessages.workStreams)}
-          data-h2-grid-column="l-tablet(span 2)"
+          className="sm:col-span-2"
         >
           {careerObjectiveWorkStreams?.length ? (
             <Ul>
@@ -138,7 +134,7 @@ const CareerObjective = ({ careerObjectiveQuery }: CareerObjectiveProps) => {
       ) : null}
       <FieldDisplay
         label={intl.formatMessage(employeeProfileMessages.departments)}
-        data-h2-grid-column="l-tablet(span 2)"
+        className="sm:col-span-2"
       >
         {careerObjectiveDepartments?.length ? (
           <Ul>
@@ -154,7 +150,7 @@ const CareerObjective = ({ careerObjectiveQuery }: CareerObjectiveProps) => {
         label={intl.formatMessage(
           employeeProfileMessages.additionalInformationNextRole,
         )}
-        data-h2-grid-column="l-tablet(span 2)"
+        className="sm:col-span-2"
       >
         {careerObjectiveAdditionalInformation ?? notProvided}
       </FieldDisplay>

--- a/apps/web/src/components/NextRoleAndCareerObjective/NextRole.tsx
+++ b/apps/web/src/components/NextRoleAndCareerObjective/NextRole.tsx
@@ -47,11 +47,7 @@ const NextRole = ({ nextRoleQuery }: NextRoleProps) => {
   const isCommunityOther = !nextRoleCommunity?.id && !!nextRoleCommunityOther;
 
   return (
-    <div
-      data-h2-display="base(grid)"
-      data-h2-gap="base(x1)"
-      data-h2-grid-template-columns="base(repeat(1, 1fr)) p-tablet(repeat(2, 1fr)) "
-    >
+    <div className="grid gap-6 sm:grid-cols-2">
       <FieldDisplay
         label={intl.formatMessage(
           employeeProfileMessages.targetClassificationGroup,
@@ -98,7 +94,7 @@ const NextRole = ({ nextRoleQuery }: NextRoleProps) => {
       </FieldDisplay>
       <FieldDisplay
         label={intl.formatMessage(employeeProfileMessages.community)}
-        data-h2-grid-column="l-tablet(span 2)"
+        className="sm:col-span-2"
       >
         {handleCommunity(
           nextRoleCommunity?.name?.localized,
@@ -109,7 +105,7 @@ const NextRole = ({ nextRoleQuery }: NextRoleProps) => {
       {isCommunityOther ? (
         <FieldDisplay
           label={intl.formatMessage(messages.otherCommunity)}
-          data-h2-grid-column="l-tablet(span 2)"
+          className="sm:col-span-2"
         >
           {nextRoleCommunityOther}
         </FieldDisplay>
@@ -118,7 +114,7 @@ const NextRole = ({ nextRoleQuery }: NextRoleProps) => {
       {nextRoleCommunity?.workStreams?.length || nextRoleWorkStreams?.length ? (
         <FieldDisplay
           label={intl.formatMessage(employeeProfileMessages.workStreams)}
-          data-h2-grid-column="l-tablet(span 2)"
+          className="sm:col-span-2"
         >
           {nextRoleWorkStreams?.length ? (
             <Ul>
@@ -133,7 +129,7 @@ const NextRole = ({ nextRoleQuery }: NextRoleProps) => {
       ) : null}
       <FieldDisplay
         label={intl.formatMessage(employeeProfileMessages.departments)}
-        data-h2-grid-column="l-tablet(span 2)"
+        className="sm:col-span-2"
       >
         {nextRoleDepartments?.length ? (
           <Ul>
@@ -149,7 +145,7 @@ const NextRole = ({ nextRoleQuery }: NextRoleProps) => {
         label={intl.formatMessage(
           employeeProfileMessages.additionalInformationNextRole,
         )}
-        data-h2-grid-column="l-tablet(span 2)"
+        className="sm:col-span-2"
       >
         {nextRoleAdditionalInformation ?? notProvided}
       </FieldDisplay>

--- a/apps/web/src/components/NextRoleAndCareerObjective/NextRoleAndCareerObjective.tsx
+++ b/apps/web/src/components/NextRoleAndCareerObjective/NextRoleAndCareerObjective.tsx
@@ -60,7 +60,7 @@ const NextRoleAndCareerObjective = ({
             description: "Subtitle for next role and career objective section",
           })}
         >
-          <span data-h2-font-weight="base(400)">
+          <span className="font-normal">
             {intl.formatMessage({
               defaultMessage: "Next role and career objective",
               id: "QhFxW1",
@@ -89,7 +89,7 @@ const NextRoleAndCareerObjective = ({
               />
             )}
             {hasAllEmptyFieldsCareerObjective({ ...careerObjective }) ? (
-              <Well data-h2-padding-bottom="base(x1)">
+              <Well>
                 <p>
                   {intl.formatMessage({
                     defaultMessage:


### PR DESCRIPTION
🤖 Resolves #13731 

## 👋 Introduction

Migrates the `NextRoleAndCareerObjective` components to tailwindcss.

## 🧪 Testing

1. Navigate to nomination group
2. Confirm no diff in next role and career object section