### PR TITLE
[Fix] All elements announced as clickable

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -67,6 +67,7 @@
   <body>
     <div
       id="root"
+      role="presentation"
       data-h2-color="base(black)"
       data-h2-background="base(background)"
       data-h2-font-family="base(sans)"


### PR DESCRIPTION
🤖 Resolves #13503 

## 👋 Introduction

Updates the react root to have `role=presentation` to prevent the clickable action being added to all children.

## 🧪 Testing

1. Open the site in firefox (for the a11y tools)
2. In the accessibility inspector, select an element that sohuld not be clickable
3. Confirm that there is no click action

## :camera_flash: Screenshot

### List
![2025-06-11_13-55](https://github.com/user-attachments/assets/e7ef5568-ae9e-438f-ac7b-2eae00853222)

### This branch
![2025-06-11_13-55_1](https://github.com/user-attachments/assets/d86cbc8e-afbe-4470-ae59-32970a2621de)
