### PR TITLE
[Feat] Support casts in `LocalizedEnum` types

### DIFF
--- a/api/app/GraphQL/Types/LocalizedEnumTypeRegistrar.php
+++ b/api/app/GraphQL/Types/LocalizedEnumTypeRegistrar.php
@@ -60,6 +60,13 @@ final class LocalizedEnumTypeRegistrar implements TypeRegistrarInterface
                     }
                 }
 
+                if (is_object($parent) && $parent instanceof $enum) {
+                    switch ($info->fieldName) {
+                        case 'value': return $parent->name;
+                        case 'label': return $enum::localizedString($parent->name);
+                    }
+                }
+
                 return null;
             };
 

--- a/api/app/Models/TalentNomination.php
+++ b/api/app/Models/TalentNomination.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\TalentNominationSubmitterRelationshipToNominator;
 use App\Observers\TalentNominationObserver;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -77,6 +78,7 @@ class TalentNomination extends Model
             'submitted_steps' => 'array',
             'submitted_at' => 'datetime',
             'lateral_movement_options' => 'array',
+            'submitter_relationship_to_nominator' => TalentNominationSubmitterRelationshipToNominator::class,
         ];
     }
 


### PR DESCRIPTION
🤖 Resolves #12906 

## 👋 Introduction

Adds another case to our localized enum type in graphql to support enum casting.

## 🕵️ Details

Our original graphql type expected a string or array but with casting, it is now an instance of the enum. This adds another case in the resolver to handle that case.

Added one example of this. 

## 🧪 Testing

> [!NOTE]
> You don't need to use this example and just add another easier to test cast . I just used it because it was the one referenced int he ticket. 

1. Confirm the cast works in both laravel and the graphql api