### PR TITLE
[Fix] `GoalsAndWorkStyle` section heading style

### DIFF
--- a/apps/web/src/components/GoalsAndWorkStyle/GoalsAndWorkStyle.tsx
+++ b/apps/web/src/components/GoalsAndWorkStyle/GoalsAndWorkStyle.tsx
@@ -38,7 +38,7 @@ const GoalsAndWorkStyle = ({
             description: "Subtitle for goals and work style section",
           })}
         >
-          <span className="font-bold">
+          <span className="font-normal">
             {intl.formatMessage({
               defaultMessage: "Goals and work style",
               id: "GDCKBX",


### PR DESCRIPTION
🤖 Resolves #13856.

## 👋 Introduction

This PR fixes the `GoalsAndWorkStyle` section heading style.

## 🧪 Testing

1. Navigate to nomination group
2. Navigate to Profile tab for a user
3. Observe no style difference between `GoalsAndWorkStyle` section heading and other section headings

## 📸 Screenshot

![localhost_8000_en_admin_talent-events_7d9765f4-87c7-4199-8c32-1c88ded3fba6_nominations_e71c8ea1-803d-4b34-b952-3a76aa8cf8dd_profile](https://github.com/user-attachments/assets/9fb0ca6d-9b35-4e25-8121-ad7a1179976f)