### PR TITLE
Bump Playwright expect timeout

### DIFF
--- a/apps/playwright/playwright.config.ts
+++ b/apps/playwright/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     ? "blob"
     : [["line"], ["html", { open: "on-failure" }]],
   timeout: Number(process.env.TEST_TIMEOUT ?? 60 * 1000), // 1 minute
-  expect: { timeout: Number(process.env.EXPECT_TIMEOUT ?? 10000) }, // 10 seconds
+  expect: { timeout: Number(process.env.EXPECT_TIMEOUT ?? 15000) }, // 15 seconds
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
## 👋 Introduction

Bump up the expect time to try and reduce test flakiness. For reference, currently shards 2 and 3 are being troublesome
Appears to get shard 2 to at least be capable of passing. Good enough for now

![image](https://github.com/user-attachments/assets/7b4c0e83-fd4c-4490-8d1e-ae814ff1a369)



