### PR TITLE
[Fix] Mobile menu colour mismatch in safari

### DIFF
--- a/apps/web/src/components/Header/Header.tsx
+++ b/apps/web/src/components/Header/Header.tsx
@@ -32,7 +32,7 @@ const Header = () => {
   const location = useLocation();
   const changeToLang = oppositeLocale(locale);
   const languageTogglePath = localizePath(location, changeToLang);
-  const isSmallScreen = useIsSmallScreen(1080);
+  const isSmallScreen = useIsSmallScreen("sm");
 
   return (
     <header className="border-b border-black/20 bg-white py-6 xs:py-4.5 dark:border-white/20 dark:bg-gray-700">

--- a/apps/web/src/components/NavMenu/MainNavMenu.tsx
+++ b/apps/web/src/components/NavMenu/MainNavMenu.tsx
@@ -68,7 +68,7 @@ const MainNavMenu = () => {
   const intl = useIntl();
   const locale = getLocale(intl);
   const paths = useRoutes();
-  const isSmallScreen = useIsSmallScreen(1080);
+  const isSmallScreen = useIsSmallScreen("sm");
 
   const shouldReduceMotion = useReducedMotion();
 

--- a/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
+++ b/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
@@ -175,7 +175,7 @@ const NotificationDialog = ({
   color,
 }: NotificationDialog) => {
   const intl = useIntl();
-  const isSmallScreen = useIsSmallScreen(1080);
+  const isSmallScreen = useIsSmallScreen("sm");
 
   useEffect(() => {
     if (open) {

--- a/packages/helpers/src/hooks/useIsSmallScreen.ts
+++ b/packages/helpers/src/hooks/useIsSmallScreen.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-export type Breakpoint = "xs" | "sm" | "md" | "lg";
+type Breakpoint = "xs" | "sm" | "md" | "lg";
 
 const breakpoints: Record<Breakpoint, string> = {
   xs: "48rem",

--- a/packages/helpers/src/hooks/useIsSmallScreen.ts
+++ b/packages/helpers/src/hooks/useIsSmallScreen.ts
@@ -1,22 +1,39 @@
-import { useLayoutEffect, useState } from "react";
-import debounce from "lodash/debounce";
+import { useEffect, useState } from "react";
 
-const useIsSmallScreen = (threshold = 768, wait = 250) => {
-  const [isSmallScreen, setSmallScreen] = useState(
-    window.innerWidth < threshold,
+export type Breakpoint = "xs" | "sm" | "md" | "lg";
+
+const breakpoints: Record<Breakpoint, string> = {
+  xs: "48rem",
+  sm: "67.5rem",
+  md: "80rem",
+  lg: "100rem",
+};
+
+export function useIsSmallScreen(threshold: Breakpoint): boolean;
+export function useIsSmallScreen(threshold: string): boolean;
+export function useIsSmallScreen(threshold: string): boolean {
+  const value = breakpoints[threshold as Breakpoint] ?? threshold;
+  const query = `(max-width: ${value})`;
+
+  const [isSmallScreen, setIsSmallScreen] = useState(
+    typeof window !== "undefined" ? window.matchMedia(query).matches : false,
   );
 
-  useLayoutEffect(() => {
-    const updateSize = (): void => {
-      setSmallScreen(window.innerWidth < threshold);
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+
+    const mql = window.matchMedia(query);
+    const handler = () => setIsSmallScreen(mql.matches);
+
+    mql.addEventListener("change", handler);
+    setIsSmallScreen(mql.matches);
+
+    return () => {
+      mql.removeEventListener("change", handler);
     };
-
-    window.addEventListener("resize", debounce(updateSize, wait));
-
-    return (): void => window.removeEventListener("resize", updateSize);
-  }, [threshold, wait]);
+  }, [query]);
 
   return isSmallScreen;
-};
+}
 
 export default useIsSmallScreen;

--- a/packages/ui/src/components/NavMenu/NavMenu.tsx
+++ b/packages/ui/src/components/NavMenu/NavMenu.tsx
@@ -181,7 +181,7 @@ const IconLink = forwardRef<
 >(({ children, type = "link", icon, href, ...rest }, forwardedRef) => {
   const linkRef = useRef<HTMLAnchorElement>(null);
   const { isActive } = useActiveLink(href, !!icon, linkRef.current);
-  const isSmallScreen = useIsSmallScreen(1080);
+  const isSmallScreen = useIsSmallScreen("sm");
   const navContext = useNavMenuContext();
 
   return (
@@ -241,7 +241,7 @@ const Link = forwardRef<
   ) => {
     const linkRef = useRef<HTMLAnchorElement>(null);
     const { isActive } = useActiveLink(href, !!icon, linkRef.current);
-    const isSmallScreen = useIsSmallScreen(1080);
+    const isSmallScreen = useIsSmallScreen("sm");
     const navContext = useNavMenuContext();
 
     return (


### PR DESCRIPTION
🤖 Resolves #13233 

## 👋 Introduction

Possible fix for the colours not matching when transitioning into the `sm` breakpoint.

## 🕵️ Details

We had a hook `useIsSmallScreen` that was using a dwebounced even listener watching for screen size changes and adjusting from `innerWidth`. This could have been causing issues in safari if the inner width was not updating in sync with the css media queries.

This refactors that hook to accept our tialwind sizes and react based on media query change rather than window size which should help it sync up with the CSS :thinking: 

## 🧪 Testing

1. Build the site `pnpm build:fresh`
2. Open the site at a size larger than 1080px width in safari
3. Reduce the window size until it collapses to a mobile menu
4. Confirm the background colour is corrext as well as links

## 📸 Screenshot

