### PR TITLE
[Bug] Fix home link alignment on main nav menu

### DIFF
--- a/apps/web/src/components/NavMenu/MainNavMenu.tsx
+++ b/apps/web/src/components/NavMenu/MainNavMenu.tsx
@@ -51,7 +51,7 @@ const homeItem = tv({
   base: "hidden sm:flex",
   variants: {
     hidden: {
-      true: "sm:border-r sm:border-white/20 sm:px-4.5",
+      true: "sm:border-r sm:border-white/20 sm:pr-4.5",
     },
   },
 });

--- a/apps/web/src/components/NavMenu/useMainNavLinks.tsx
+++ b/apps/web/src/components/NavMenu/useMainNavLinks.tsx
@@ -66,6 +66,7 @@ const useMainNavLinks = () => {
       href={paths.home()}
       icon={HomeIcon}
       label={intl.formatMessage(navigationMessages.home)}
+      className="sm:pl-0"
     />
   );
 


### PR DESCRIPTION
🤖 Resolves #13802 

## 👋 Introduction

- Fixes the alignment of the home link, with the header (goc icon line) above.

## 🧪 Testing

1. Build app `pnpm run dev`
2. Ensure home link lines up with container edge
3. Ensure everything else remains aligned

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/179d2cbd-b80b-459c-b19a-7eb4f101053e)
![image](https://github.com/user-attachments/assets/db55d07f-6aaa-438e-b211-d26036976575)

