### PR TITLE
[Debt] More PHP-PFM workers

### DIFF
--- a/infrastructure/conf/php-fpm-www.conf
+++ b/infrastructure/conf/php-fpm-www.conf
@@ -124,12 +124,12 @@ pm = dynamic
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = 25
+pm.max_children = 50
 
 ; The number of child processes created on startup.
 ; Note: Used only when pm is set to 'dynamic'
 ; Default Value: (min_spare_servers + max_spare_servers) / 2
-pm.start_servers = 5
+pm.start_servers = 30
 
 ; The desired minimum number of idle server processes.
 ; Note: Used only when pm is set to 'dynamic'
@@ -139,7 +139,7 @@ pm.min_spare_servers = 3
 ; The desired maximum number of idle server processes.
 ; Note: Used only when pm is set to 'dynamic'
 ; Note: Mandatory when pm is set to 'dynamic'
-pm.max_spare_servers = 10
+pm.max_spare_servers = 30
 
 ; The number of rate to spawn child processes at once.
 ; Note: Used only when pm is set to 'dynamic'


### PR DESCRIPTION
🤖 Resolves #12686 

## 👋 Introduction

<!-- Describe what this PR is solving. -->
Bumps the max PHP-FPM worker count and also the starting worker count.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->
Over the last two weeks when we've been struggling with performance I have been trying some different settings for PHP-FPM.  The setting in this PR reduces the number of "your server seems busy, try upping the working count" warnings.  It also stays well within the CPU and memory available to our app service.

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Restart the web server container (or deploy into an Azure app service).
2. Shell into the web server container (or SSH into the Azure app service).
3. Run `php-fpm -t` to confirm that the settings are valid
4. Run `curl 127.0.0.1:8080/fpm-status` to confirm that at least 30 workers were started
5. Confirm that the app still runs well


## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
![image](https://github.com/user-attachments/assets/81d6f52e-915f-4ff4-a4dc-3378c4abb2c8)


## 🚚 Deployment

<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the PR if deployment steps are needed

 -->
