### PR TITLE
[Copy] Updates assessment decision labels for `hold` and `noDecision`

### DIFF
--- a/api/app/Generators/PoolCandidateCsvGenerator.php
+++ b/api/app/Generators/PoolCandidateCsvGenerator.php
@@ -249,7 +249,7 @@ class PoolCandidateCsvGenerator extends CsvGenerator implements FileGeneratorInt
                                 $this->RODData[$step->id]['education'][] = [
                                     'candidate' => $currentCandidate,
                                     'decision' => is_null($result->assessment_decision) ?
-                                        Lang::get('common.not_sure', [], $this->lang) :
+                                        Lang::get('common.pending_second_opinion', [], $this->lang) :
                                         $this->localizeEnum($result->assessment_decision, AssessmentDecision::class),
                                     'details' => $this->localizeEnumArray($result->justifications, AssessmentResultJustification::class),
                                     'notes' => is_null($result->skill_decision_notes) ? null : $this->sanitizeString($result->skill_decision_notes),
@@ -268,7 +268,7 @@ class PoolCandidateCsvGenerator extends CsvGenerator implements FileGeneratorInt
                                 $this->RODData[$step->id][$poolSkill->id][] = [
                                     'candidate' => $currentCandidate,
                                     'decision' => is_null($result->assessment_decision) ?
-                                        Lang::get('common.not_sure', [], $this->lang) :
+                                        Lang::get('common.pending_second_opinion', [], $this->lang) :
                                         $this->localizeEnum($result->assessment_decision, AssessmentDecision::class),
                                     'details' => is_null($result->assessment_decision_level) ?
                                         $this->localizeEnumArray($result->justifications, AssessmentResultJustification::class) :

--- a/api/lang/en/assessment_decision.php
+++ b/api/lang/en/assessment_decision.php
@@ -2,6 +2,6 @@
 
 return [
     'successful' => 'Demonstrated',
-    'hold' => 'Not demonstrated (Hold for further assessment)',
+    'hold' => 'Not demonstrated (candidate advances to next step)',
     'unsuccessful' => 'Not demonstrated',
 ];

--- a/api/lang/en/common.php
+++ b/api/lang/en/common.php
@@ -19,7 +19,7 @@ return [
     'at' => 'at',
     'with' => 'with',
     'not_provided' => 'Not provided',
-    'not_sure' => 'Not sure',
+    'pending_second_opinion' => 'Pending second opinion',
     'expected_end_date' => '(Expected end date)',
     'not_found' => 'Not found',
     'step' => 'Step',

--- a/api/lang/fr/assessment_decision.php
+++ b/api/lang/fr/assessment_decision.php
@@ -2,6 +2,6 @@
 
 return [
     'successful' => 'Démontrée',
-    'hold' => 'Non démontrée (en attente d’une évaluation plus poussée)',
+    'hold' => 'Non démontrée (candidat(e) avance à l’étape suivante)',
     'unsuccessful' => 'Non démontrée',
 ];

--- a/api/lang/fr/common.php
+++ b/api/lang/fr/common.php
@@ -19,7 +19,7 @@ return [
     'at' => 'à',
     'with' => 'à',
     'not_provided' => 'Renseignements manquants',
-    'not_sure' => 'Pas certain',
+    'pending_second_opinion' => 'Second avis en attente',
     'expected_end_date' => '(Date de fin prévue)',
     'not_found' => 'Introuvable',
     'step' => 'Étape',

--- a/apps/playwright/tests/admin/candidate-assessment.spec.ts
+++ b/apps/playwright/tests/admin/candidate-assessment.spec.ts
@@ -146,14 +146,16 @@ test.describe("Pool candidates", () => {
     await expect(
       appPage.page.getByText(`Test skill ${technicalSkill?.name?.en}`),
     ).toBeVisible();
-    await appPage.page.getByText("Not demonstrated (Hold for").click();
+    await appPage.page
+      .getByText("Not demonstrated (candidate advances to next step)")
+      .click();
     await appPage.page
       .getByRole("textbox", { name: "decision notes" })
       .fill("Reason");
     await appPage.page.getByRole("button", { name: "Save decision" }).click();
     await expect(
       appPage.page.getByRole("button", {
-        name: "Not demonstrated (Hold for",
+        name: "Not demonstrated (candidate advances to next step)",
       }),
     ).toBeVisible();
 
@@ -162,7 +164,9 @@ test.describe("Pool candidates", () => {
       appPage.page.getByLabel("Hold for assessment").locator("path"),
     ).toBeVisible();
     await appPage.page
-      .getByRole("button", { name: "Not demonstrated (Hold for" })
+      .getByRole("button", {
+        name: "Not demonstrated (candidate advances to next step)",
+      })
       .click();
     await appPage.page
       .getByLabel("Application screening -")

--- a/apps/playwright/tests/admin/pool-candidate-actions.spec.ts
+++ b/apps/playwright/tests/admin/pool-candidate-actions.spec.ts
@@ -196,14 +196,16 @@ test.describe("Pool candidates", () => {
     await expect(
       appPage.page.getByText(`Test skill ${technicalSkill?.name?.en}`),
     ).toBeVisible();
-    await appPage.page.getByText("Not demonstrated (Hold for").click();
+    await appPage.page
+      .getByText("Not demonstrated (candidate advances to next step)")
+      .click();
     await appPage.page
       .getByRole("textbox", { name: "decision notes" })
       .fill("Reason");
     await appPage.page.getByRole("button", { name: "Save decision" }).click();
     await expect(
       appPage.page.getByRole("button", {
-        name: "Not demonstrated (Hold for",
+        name: "Not demonstrated (candidate advances to next step)",
       }),
     ).toBeVisible();
 
@@ -212,7 +214,9 @@ test.describe("Pool candidates", () => {
       appPage.page.getByLabel("Hold for assessment").locator("path"),
     ).toBeVisible();
     await appPage.page
-      .getByRole("button", { name: "Not demonstrated (Hold for" })
+      .getByRole("button", {
+        name: "Not demonstrated (candidate advances to next step)",
+      })
       .click();
     await appPage.page
       .getByLabel("Application screening -")

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -445,7 +445,7 @@ export const ScreeningDecisionDialog = ({
           {hasBeenAssessed ? (
             <span>
               {initialValues?.assessmentDecision === "noDecision" ? (
-                <>{intl.formatMessage(commonMessages.notSure)}</>
+                <>{intl.formatMessage(commonMessages.pendingSecondOpinion)}</>
               ) : (
                 <>
                   <>

--- a/apps/web/src/components/ScreeningDecisions/useOptions.ts
+++ b/apps/web/src/components/ScreeningDecisions/useOptions.ts
@@ -82,7 +82,7 @@ const useOptions = (
 
   const assessmentDecisionItems: CardOption[] = [
     {
-      label: intl.formatMessage(commonMessages.notSure),
+      label: intl.formatMessage(commonMessages.pendingSecondOpinion),
       selectedIcon: SolidExclamationTriangleIcon,
       selectedIconColor: "warning",
       unselectedIcon: OutlineExclamationTriangleIcon,

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -419,10 +419,6 @@
     "defaultMessage": "Renseignements gouvernementaux",
     "description": "Name of Government information page"
   },
-  "GLRLYT": {
-    "defaultMessage": "Pas certain",
-    "description": "A decision has not been made"
-  },
   "Gc9PeN": {
     "defaultMessage": "Être disponible, disposé(e) et apte à travailler par quarts.",
     "description": "The operational requirement described as shift work."
@@ -734,6 +730,10 @@
   "Ro+gP0": {
     "defaultMessage": "Accueil",
     "description": "Name of Home page"
+  },
+  "Rp+NHA": {
+    "defaultMessage": "Second avis en attente",
+    "description": "Pending second opinion"
   },
   "S0w3o5": {
     "defaultMessage": "Complet",

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -189,10 +189,10 @@ const commonMessages = defineMessages({
     id: "2wKf2U",
     description: "Text to trigger edit action",
   },
-  notSure: {
-    defaultMessage: "Not sure",
-    id: "GLRLYT",
-    description: "A decision has not been made",
+  pendingSecondOpinion: {
+    defaultMessage: "Pending second opinion",
+    id: "Rp+NHA",
+    description: "Pending second opinion",
   },
   anyLanguage: {
     defaultMessage: "Any language",


### PR DESCRIPTION
🤖 Resolves #13875.

## 👋 Introduction

This PR updates assessment decision labels for `hold` and `noDecision`.

## 🧪 Testing

1. `make refresh-api; pnpm build:fresh`
2. Navigate to Screening and assessment page for a pool candidate
3. Verify `hold` and `noDecision` options in table and dialog reflect requested updates in English and French

## 🎥 Screen recording

https://github.com/user-attachments/assets/b16e4c0d-2634-498c-8131-2dbe4d3fc605
