### PR TITLE
[Fix] Education experience `type` label

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7422,6 +7422,10 @@
     "defaultMessage": "Vous avez été supprimé des résultats de la recherche pour {poolName}.",
     "description": "Alert displayed to the user when application card dialog submits successfully."
   },
+  "WyxGlF": {
+    "defaultMessage": "{areaOfStudy} de {institution}",
+    "description": "Study at institution without type"
+  },
   "X0YPib": {
     "defaultMessage": "Expériences relatives aux prix",
     "description": "Heading for award experiences in experience by type listing"
@@ -8873,6 +8877,10 @@
   "dxwgXw": {
     "defaultMessage": "communiquent des messages racistes, haineux, sexistes, homophobes ou diffamatoires, ou contiennent du matériel obscène ou pornographique ou y font allusion",
     "description": "Comments or contributions list item"
+  },
+  "dy98XL": {
+    "defaultMessage": "<strong>{areaOfStudy}</strong> de {institution}",
+    "description": "Study at institution without type, HTML"
   },
   "dycByE": {
     "defaultMessage": "« inclut les personnes dont le genre déclaré est celui de femme. Cela inclut les femmes cisgenres (cis) et les femmes transgenres (trans). »",

--- a/apps/web/src/messages/experienceMessages.ts
+++ b/apps/web/src/messages/experienceMessages.ts
@@ -67,6 +67,16 @@ const messages = defineMessages({
     id: "ymTeAQ",
     description: "Study at institution, HTML",
   },
+  educationAtWithoutType: {
+    defaultMessage: "{areaOfStudy} from {institution}",
+    id: "WyxGlF",
+    description: "Study at institution without type",
+  },
+  educationAtWithoutTypeHtml: {
+    defaultMessage: "<strong>{areaOfStudy}</strong> from {institution}",
+    id: "dy98XL",
+    description: "Study at institution without type, HTML",
+  },
   workAt: {
     defaultMessage: "{role} at {organization}",
     id: "wTAdQe",

--- a/apps/web/src/utils/experienceUtils.tsx
+++ b/apps/web/src/utils/experienceUtils.tsx
@@ -838,7 +838,7 @@ export const queryResultToDefaultValues = (
 export interface ExperienceName extends SimpleAnyExperience {
   title?: Maybe<string>;
   organization?: Maybe<string>;
-  type?: Maybe<Partial<LocalizedEducationType>>;
+  type?: Maybe<Partial<LocalizedEducationType>> | string;
   areaOfStudy?: Maybe<string>;
   institution?: Maybe<string>;
   role?: Maybe<string>;
@@ -883,25 +883,41 @@ export const getExperienceName = <T extends ExperienceName>(
 
   if (isEducationExperience(experience)) {
     const { type, areaOfStudy, institution } = experience;
-    const educationType =
-      type?.value === EducationType.Other
-        ? intl.formatMessage({
-            defaultMessage: "Other type of education",
-            id: "wrKBLf",
-            description:
-              "First part of education experience title for other type",
-          })
-        : type?.label.localized;
-    return intl.formatMessage(
-      html
-        ? experienceMessages.educationAtHtml
-        : experienceMessages.educationAt,
-      {
-        educationType,
-        areaOfStudy,
-        institution,
-      },
-    );
+
+    // shape of type changed at some point from string to object. this is a imperfect solution.
+    let educationType;
+    if (typeof type !== "string") {
+      educationType =
+        type?.value === EducationType.Other
+          ? intl.formatMessage({
+              defaultMessage: "Other type of education",
+              id: "wrKBLf",
+              description:
+                "First part of education experience title for other type",
+            })
+          : type?.label.localized;
+      return intl.formatMessage(
+        html
+          ? experienceMessages.educationAtHtml
+          : experienceMessages.educationAt,
+        {
+          educationType,
+          areaOfStudy,
+          institution,
+        },
+      );
+    } else {
+      return intl.formatMessage(
+        html
+          ? experienceMessages.educationAtWithoutTypeHtml
+          : experienceMessages.educationAtWithoutType,
+        {
+          educationType,
+          areaOfStudy,
+          institution,
+        },
+      );
+    }
   }
 
   if (isWorkExperience(experience)) {

--- a/apps/web/src/utils/experienceUtils.tsx
+++ b/apps/web/src/utils/experienceUtils.tsx
@@ -895,7 +895,7 @@ export const getExperienceName = <T extends ExperienceName>(
               description:
                 "First part of education experience title for other type",
             })
-          : type?.label.localized;
+          : getLocalizedName(type?.label, intl);
       return intl.formatMessage(
         html
           ? experienceMessages.educationAtHtml


### PR DESCRIPTION
🤖 Resolves #13894.

## 👋 Introduction

This PR accounts for legacy data within a pool candidate's `profile_snapshot` that contains education experience which had previously been a string and that is not an object.

> [!IMPORTANT]
> Bonus: [Fix type label value](https://github.com/GCTC-NTGC/gc-digital-talent/commit/0fd6208b816450be7f3966c05b8b6712324fde80) that used the `localized` value incorrectly.

## 🧪 Testing

1. `pnpm build:fresh`
2. Find a row in `pool_candidates` table with an education experience in the `profile_snapshot` column
3. Replace `type` value (that should be an object) with a string of BACHELORS_DEGREE
4. Navigate to the view pool candidate page for the row changed on the previous step
5. Verify that the card for the education does not render the type in the "title"
6. Verify that the card for non-legacy education experience does render the type in the "title"

## 📸 Screenshot

<img width="1430" alt="Screen Shot 2025-06-19 at 12 15 25" src="https://github.com/user-attachments/assets/86c8c05c-4048-4bba-bc7c-2a32988c8d55" />

<img width="1434" alt="Screen Shot 2025-06-19 at 12 17 45" src="https://github.com/user-attachments/assets/eadc4990-2f81-4e68-8c19-7cd90515da1a" />