### PR TITLE
[Test] Increase application timeout

### DIFF
--- a/apps/playwright/tests/applicant/application-iap.spec.ts
+++ b/apps/playwright/tests/applicant/application-iap.spec.ts
@@ -74,7 +74,8 @@ test.describe("IAP Application", () => {
     pool = createdPool;
   });
 
-  test("Can submit application", async ({ appPage }) => {
+  test("Can submit application", async ({ appPage }, testInfo) => {
+    testInfo.slow();
     const application = new ApplicationPage(appPage.page, pool.id);
     await loginBySub(application.page, sub, false);
 

--- a/apps/playwright/tests/applicant/application.spec.ts
+++ b/apps/playwright/tests/applicant/application.spec.ts
@@ -228,7 +228,8 @@ test.describe("Application", () => {
     await expectOnStep(application.page, 6);
   });
 
-  test("Can submit application", async ({ appPage }) => {
+  test("Can submit application", async ({ appPage }, testInfo) => {
+    testInfo.slow();
     const adminCtx = await graphql.newContext();
     const poolName = `application test pool for submit application ${uniqueTestId}`;
     const pool = await createAndPublishPool(adminCtx, {


### PR DESCRIPTION
🤖 Resolves #13928 

## 👋 Introduction

Mark the application tests as slow to give them some more time to run in CI.

## 🧪 Testing

1. Confirm that it at least doesnt time out now
