### PR TITLE
[Fix] Table overflow on smaller screens

### DIFF
--- a/apps/web/src/components/Table/ResponsiveTable/Table.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/Table.tsx
@@ -17,13 +17,15 @@ import SortButton from "./SortButton";
 import { AddDef } from "./types";
 import { getColumnHeader } from "./utils";
 
+const wrapper = tv({ base: "relative overflow-hidden" });
+
 type WrapperProps = DetailedHTMLProps<
   HTMLAttributes<HTMLDivElement>,
   HTMLDivElement
 >;
 
-const Wrapper = ({ children, ...rest }: WrapperProps) => (
-  <div role="region" {...rest}>
+const Wrapper = ({ children, className, ...rest }: WrapperProps) => (
+  <div role="region" className={wrapper({ class: className })} {...rest}>
     <div className="overflow-x-auto overflow-y-hidden rounded-md shadow-md">
       {children}
     </div>


### PR DESCRIPTION
🤖 Resolves #13932 

## 👋 Introduction

Fixes an issue where tables had invisible overflow on smaller screens causing side-scrollling. 

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as `admin@test.com`
3. Navigate to a page with a table
4. Reduce screen with
5. Confirm the table still side scrolls but the website itself does not