### PR TITLE
[Fix] Column dialog styles

### DIFF
--- a/apps/web/src/components/Table/ResponsiveTable/ColumnDialog.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ColumnDialog.tsx
@@ -53,7 +53,7 @@ const ColumnDialog = <T extends object>({ table }: ColumnDialogProps<T>) => {
             </Field.Legend>
             <Field.BoundingBox>
               <div className="my-0.75">
-                <Field.Label className="flex items-start gap-x-1.5 font-normal">
+                <Field.Label className="flex items-center gap-x-1.5 text-base">
                   <input
                     ref={allColumnsRef}
                     {...{
@@ -61,8 +61,7 @@ const ColumnDialog = <T extends object>({ table }: ColumnDialogProps<T>) => {
                       checked: table.getIsAllColumnsVisible(),
                       onChange: table.getToggleAllColumnsVisibilityHandler(),
                     }}
-                    // eslint-disable-next-line formatjs/no-literal-string-in-jsx
-                  />{" "}
+                  />
                   {intl.formatMessage(adminMessages.toggleAll)}
                 </Field.Label>
               </div>
@@ -73,17 +72,16 @@ const ColumnDialog = <T extends object>({ table }: ColumnDialogProps<T>) => {
                   const header = getColumnHeader(column, "columnDialogHeader");
                   return (
                     <div key={column.id} className="my-0.75">
-                      <label>
+                      <Field.Label className="flex items-center gap-x-1.5 text-base">
                         <input
                           {...{
                             type: "checkbox",
                             checked: column.getIsVisible(),
                             onChange: column.getToggleVisibilityHandler(),
                           }}
-                          // eslint-disable-next-line formatjs/no-literal-string-in-jsx
-                        />{" "}
+                        />
                         {header}
-                      </label>
+                      </Field.Label>
                     </div>
                   );
                 })}


### PR DESCRIPTION
🤖 Resolves #13612.

## 👋 Introduction

This PR fixes the column dialog styles.

> [!NOTE]
> It would be nice to convert the HTML form inputs to the `Checkbox` component (and possibly, the fieldset to `Checklist` component if appropriate), but the scope started to creep.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to a table
3. Open a columns show/hide dialog
4. Verify font sizes of items are all the same

## 📸 Screenshot

<img width="948" alt="Screen Shot 2025-06-24 at 16 11 16" src="https://github.com/user-attachments/assets/f3fdfabe-78a4-495b-966a-418170713389" />
