### PR TITLE
[Feature] Filters legacy pool candidate statuses from pool status options

### DIFF
--- a/apps/web/src/components/CandidateDialog/ChangeStatusDialog.tsx
+++ b/apps/web/src/components/CandidateDialog/ChangeStatusDialog.tsx
@@ -158,6 +158,23 @@ const ChangeStatusDialogForm = ({
   const intl = useIntl();
   const options = getFragment(ChangeStatusFormOptions_Fragment, optionsQuery);
 
+  const poolCandidateLegacyStatuses = [
+    "DRAFT_EXPIRED",
+    "DRAFT",
+    "EXPIRED",
+    "NEW_APPLICATION",
+    "REMOVED",
+    "SCREENED_OUT_APPLICATION",
+    "SCREENED_OUT_ASSESSMENT",
+    "SCREENED_OUT_NOT_INTERESTED",
+    "SCREENED_OUT_NOT_RESPONSIVE",
+    "UNDER_ASSESSMENT",
+  ];
+
+  const poolCandidateStatusesFiltered = options?.poolCandidateStatuses?.filter(
+    (e) => !poolCandidateLegacyStatuses.includes(e.value),
+  );
+
   const methods = useForm<FormValues>({
     defaultValues: { status: selectedCandidate.status?.value },
   });
@@ -315,7 +332,7 @@ const ChangeStatusDialogForm = ({
               required: intl.formatMessage(errorMessages.required),
             }}
             options={localizedEnumToOptions(
-              options?.poolCandidateStatuses,
+              poolCandidateStatusesFiltered,
               intl,
             )}
           />

--- a/apps/web/src/components/CandidateDialog/ChangeStatusDialog.tsx
+++ b/apps/web/src/components/CandidateDialog/ChangeStatusDialog.tsx
@@ -158,6 +158,7 @@ const ChangeStatusDialogForm = ({
   const intl = useIntl();
   const options = getFragment(ChangeStatusFormOptions_Fragment, optionsQuery);
 
+  // we are progressively removing statuses from the manual status picker.
   const poolCandidateLegacyStatuses = [
     "DRAFT_EXPIRED",
     "DRAFT",


### PR DESCRIPTION
🤖 Resolves #13616.

## 👋 Introduction

This PR filters legacy pool candidate statuses from options so that they are no longer able to be saved.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to a pool candidate with a status that is part of the legacy list
3. In the candidate status section, click the status value to open the dialog
4. Verify the legacy status is not in the pool status `select` input field
5. Verify none of the legacy statuses appears as options in the pool status `select` input field

## 🎥  Screen recording

https://github.com/user-attachments/assets/5fd1e160-300e-4af7-a013-4651b42f643b