### PR TITLE
[Debt] Migrate `TalentEvents/` pages to tailwind

### DIFF
--- a/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
@@ -68,7 +68,7 @@ const TalentEventDetails = ({ query }: TalentEventDetailsProps) => {
         level="h2"
         icon={CalendarIcon}
         color="secondary"
-        data-h2-margin-top="base(0)"
+        className="mt-0"
       >
         {intl.formatMessage({
           defaultMessage: "Event details",
@@ -76,7 +76,7 @@ const TalentEventDetails = ({ query }: TalentEventDetailsProps) => {
           description: "Subheading for nomination event details",
         })}
       </Heading>
-      <p data-h2-margin="base(x1 0)">
+      <p className="my-6">
         {intl.formatMessage({
           defaultMessage:
             "Review and edit the details of this talent management event.",
@@ -84,137 +84,125 @@ const TalentEventDetails = ({ query }: TalentEventDetailsProps) => {
           description: "Description for the details of a nomination event",
         })}
       </p>
-      <Card>
-        <div
-          data-h2-display="base(grid)"
-          data-h2-grid-template-columns="l-tablet(1fr 1fr)"
-          data-h2-gap="base(x1)"
+      <Card className="grid gap-6 sm:grid-cols-2">
+        <FieldDisplay
+          label={intl.formatMessage({
+            defaultMessage: "Event name (English)",
+            id: "gXF4Rj",
+            description: "Label for nomination event name in English",
+          })}
         >
-          <FieldDisplay
-            label={intl.formatMessage({
-              defaultMessage: "Event name (English)",
-              id: "gXF4Rj",
-              description: "Label for nomination event name in English",
-            })}
-          >
-            {talentEvent.name.en ??
-              intl.formatMessage(commonMessages.notProvided)}
-          </FieldDisplay>
-          <FieldDisplay
-            label={intl.formatMessage({
-              defaultMessage: "Event name (French)",
-              id: "BisYQJ",
-              description: "Label for nomination event name in French",
-            })}
-          >
-            {talentEvent.name.fr ??
-              intl.formatMessage(commonMessages.notProvided)}
-          </FieldDisplay>
-          <FieldDisplay
-            label={intl.formatMessage({
-              defaultMessage: "Event description (English)",
-              id: "axPXQ9",
-              description: "Label for nomination event description in English",
-            })}
-          >
-            {talentEvent.description?.en ??
-              intl.formatMessage(commonMessages.notProvided)}
-          </FieldDisplay>
-          <FieldDisplay
-            label={intl.formatMessage({
-              defaultMessage: "Event description (French)",
-              id: "e7vPeZ",
-              description: "Label for nomination event description in French",
-            })}
-          >
-            {talentEvent.description?.fr ??
-              intl.formatMessage(commonMessages.notProvided)}
-          </FieldDisplay>
-          <FieldDisplay
-            label={intl.formatMessage({
-              defaultMessage: "More information link (English)",
-              id: "dgQIEG",
-              description:
-                "Label for nomination event more information link in English",
-            })}
-          >
-            {talentEvent.learnMoreUrl?.en ? (
-              <Link
-                mode="text"
-                external
-                newTab
-                href={talentEvent.learnMoreUrl.en}
-                data-h2-word-break="base(break-all)"
-              >
-                {talentEvent.learnMoreUrl.en}
-              </Link>
-            ) : (
-              intl.formatMessage(commonMessages.notProvided)
-            )}
-          </FieldDisplay>
-          <FieldDisplay
-            label={intl.formatMessage({
-              defaultMessage: "More information link (French)",
-              id: "4q/R7/",
-              description:
-                "Label for nomination event more information link in French",
-            })}
-          >
-            {talentEvent.learnMoreUrl?.fr ? (
-              <Link
-                mode="text"
-                external
-                newTab
-                href={talentEvent.learnMoreUrl.fr}
-                data-h2-word-break="base(break-all)"
-              >
-                {talentEvent.learnMoreUrl.fr}
-              </Link>
-            ) : (
-              intl.formatMessage(commonMessages.notProvided)
-            )}
-          </FieldDisplay>
-        </div>
-        <CardSeparator space="sm" decorative />
-        <div
-          data-h2-display="base(grid)"
-          data-h2-grid-template-columns="l-tablet(1fr 1fr)"
-          data-h2-gap="base(x1)"
+          {talentEvent.name.en ??
+            intl.formatMessage(commonMessages.notProvided)}
+        </FieldDisplay>
+        <FieldDisplay
+          label={intl.formatMessage({
+            defaultMessage: "Event name (French)",
+            id: "BisYQJ",
+            description: "Label for nomination event name in French",
+          })}
         >
-          <FieldDisplay
-            label={intl.formatMessage({
-              defaultMessage: "Nomination opening date",
-              id: "JhEMHT",
-              description:
-                "Label for nomination event date to start accepting nominations",
-            })}
-          >
-            {talentEvent.openDate
-              ? formatDate({
-                  date: parseDateTimeUtc(talentEvent.openDate),
-                  formatString: "MMMM d, yyyy",
-                  intl,
-                })
-              : intl.formatMessage(commonMessages.notProvided)}
-          </FieldDisplay>
-          <FieldDisplay
-            label={intl.formatMessage({
-              defaultMessage: "Nomination closing date",
-              id: "pq/4js",
-              description:
-                "Label for nomination event date to stop accepting nominations",
-            })}
-          >
-            {talentEvent.closeDate
-              ? formatDate({
-                  date: parseDateTimeUtc(talentEvent.closeDate),
-                  formatString: "MMMM d, yyyy",
-                  intl,
-                })
-              : intl.formatMessage(commonMessages.notProvided)}
-          </FieldDisplay>
-        </div>
-        <CardSeparator space="sm" decorative />
+          {talentEvent.name.fr ??
+            intl.formatMessage(commonMessages.notProvided)}
+        </FieldDisplay>
+        <FieldDisplay
+          label={intl.formatMessage({
+            defaultMessage: "Event description (English)",
+            id: "axPXQ9",
+            description: "Label for nomination event description in English",
+          })}
+        >
+          {talentEvent.description?.en ??
+            intl.formatMessage(commonMessages.notProvided)}
+        </FieldDisplay>
+        <FieldDisplay
+          label={intl.formatMessage({
+            defaultMessage: "Event description (French)",
+            id: "e7vPeZ",
+            description: "Label for nomination event description in French",
+          })}
+        >
+          {talentEvent.description?.fr ??
+            intl.formatMessage(commonMessages.notProvided)}
+        </FieldDisplay>
+        <FieldDisplay
+          label={intl.formatMessage({
+            defaultMessage: "More information link (English)",
+            id: "dgQIEG",
+            description:
+              "Label for nomination event more information link in English",
+          })}
+        >
+          {talentEvent.learnMoreUrl?.en ? (
+            <Link
+              mode="text"
+              external
+              newTab
+              href={talentEvent.learnMoreUrl.en}
+              className="break-all"
+            >
+              {talentEvent.learnMoreUrl.en}
+            </Link>
+          ) : (
+            intl.formatMessage(commonMessages.notProvided)
+          )}
+        </FieldDisplay>
+        <FieldDisplay
+          label={intl.formatMessage({
+            defaultMessage: "More information link (French)",
+            id: "4q/R7/",
+            description:
+              "Label for nomination event more information link in French",
+          })}
+        >
+          {talentEvent.learnMoreUrl?.fr ? (
+            <Link
+              mode="text"
+              external
+              newTab
+              href={talentEvent.learnMoreUrl.fr}
+              className="break-all"
+            >
+              {talentEvent.learnMoreUrl.fr}
+            </Link>
+          ) : (
+            intl.formatMessage(commonMessages.notProvided)
+          )}
+        </FieldDisplay>
+        <CardSeparator space="sm" decorative className="sm:col-span-2" />
+        <FieldDisplay
+          label={intl.formatMessage({
+            defaultMessage: "Nomination opening date",
+            id: "JhEMHT",
+            description:
+              "Label for nomination event date to start accepting nominations",
+          })}
+        >
+          {talentEvent.openDate
+            ? formatDate({
+                date: parseDateTimeUtc(talentEvent.openDate),
+                formatString: "MMMM d, yyyy",
+                intl,
+              })
+            : intl.formatMessage(commonMessages.notProvided)}
+        </FieldDisplay>
+        <FieldDisplay
+          label={intl.formatMessage({
+            defaultMessage: "Nomination closing date",
+            id: "pq/4js",
+            description:
+              "Label for nomination event date to stop accepting nominations",
+          })}
+        >
+          {talentEvent.closeDate
+            ? formatDate({
+                date: parseDateTimeUtc(talentEvent.closeDate),
+                formatString: "MMMM d, yyyy",
+                intl,
+              })
+            : intl.formatMessage(commonMessages.notProvided)}
+        </FieldDisplay>
+        <CardSeparator space="sm" decorative className="sm:col-span-2" />
         <FieldDisplay
           label={intl.formatMessage({
             defaultMessage: "Relevant development programs",
@@ -222,6 +210,7 @@ const TalentEventDetails = ({ query }: TalentEventDetailsProps) => {
             description:
               "Label for development programs relevant to a nomination event",
           })}
+          className="sm:col-span-2"
         >
           {developmentPrograms.length > 0 ? (
             <Ul>

--- a/apps/web/src/pages/TalentEvents/TalentEvent/NominationsPage.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/NominationsPage.tsx
@@ -229,15 +229,10 @@ const TalentEventNominationsPage = () => {
 
   return (
     <>
-      <Heading
-        icon={EnvelopeOpenIcon}
-        color="secondary"
-        data-h2-margin-top="base(0)"
-        data-h2-margin-bottom="base(x1)"
-      >
+      <Heading icon={EnvelopeOpenIcon} color="secondary" className="mt-0 mb-6">
         {intl.formatMessage(messages.talentNominations)}
       </Heading>
-      <p data-h2-margin-bottom="base(x1.5)">
+      <p className="mb-9">
         {intl.formatMessage({
           defaultMessage:
             "View and manage all the nominations received for this talent management event.",

--- a/apps/web/src/pages/TalentManagementEventsPage/TalentManagementEventsPage.tsx
+++ b/apps/web/src/pages/TalentManagementEventsPage/TalentManagementEventsPage.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from "react";
 import { useQuery } from "urql";
 
 import {
+  Container,
   Flourish,
   Loading,
   TableOfContents,
@@ -76,8 +77,8 @@ export const Component = () => {
   return (
     <>
       <Hero title={pageTitle} subtitle={subtitle} crumbs={crumbs} />
-      <div data-h2-wrapper="base(center, large, x1) p-tablet(center, large, x2)">
-        <TableOfContents.Wrapper data-h2-margin-top="base(x3)">
+      <Container className="my-18">
+        <TableOfContents.Wrapper>
           <TableOfContents.Navigation>
             <TableOfContents.List>
               {sections.map((section) => (
@@ -95,11 +96,11 @@ export const Component = () => {
                 size="h3"
                 icon={MegaphoneOutlineIcon}
                 color="primary"
-                data-h2-margin-top="base(0)"
+                className="mt-0"
               >
                 {sections[0].title}
               </TableOfContents.Heading>
-              <p data-h2-margin="base(x1 0)">
+              <p className="my-6">
                 {intl.formatMessage({
                   defaultMessage:
                     "Events found in this section are currently accepting nominations.",
@@ -110,11 +111,7 @@ export const Component = () => {
               {fetching ? (
                 <Loading inline />
               ) : activeEvents.length > 0 ? (
-                <div
-                  data-h2-display="base(flex)"
-                  data-h2-flex-direction="base(column)"
-                  data-h2-gap="base(x.25)"
-                >
+                <div className="flex flex-col gap-1.5">
                   {activeEvents.map((item) => (
                     <TalentNominationEventCard
                       key={item.id}
@@ -123,11 +120,8 @@ export const Component = () => {
                   ))}
                 </div>
               ) : (
-                <Well data-h2-text-align="base(center)">
-                  <p
-                    data-h2-font-weight="base(700)"
-                    data-h2-margin-bottom="base(x.5)"
-                  >
+                <Well className="text-center">
+                  <p className="mb-3 font-bold">
                     {intl.formatMessage({
                       defaultMessage:
                         "There aren't any active events at the moment.",
@@ -150,7 +144,7 @@ export const Component = () => {
             </TableOfContents.Section>
           </TableOfContents.Content>
         </TableOfContents.Wrapper>
-      </div>
+      </Container>
       <Flourish />
     </>
   );


### PR DESCRIPTION
🤖 Resolves #13956 

## 👋 Introduction

Migrates the `TalentEvents/` pages to tailwindcss.

## 🧪 Testing

1. No significant diff