### PR TITLE
[Fix] Current classification spacing

### DIFF
--- a/apps/web/src/components/Profile/components/GovernmentInformation/FormFields.tsx
+++ b/apps/web/src/components/Profile/components/GovernmentInformation/FormFields.tsx
@@ -235,8 +235,8 @@ const FormFields = ({
                 "Text blurb, asking about classification and level in the government info form",
             })}
           </p>
-          <div className="flex flex-col xs:flex-row">
-            <div className="w-full sm:mb-12">
+          <div className="flex flex-col gap-6 xs:flex-row">
+            <div className="w-full">
               <Select
                 id="currentClassificationGroup"
                 label={labels.currentClassificationGroup}
@@ -251,7 +251,7 @@ const FormFields = ({
               />
             </div>
             {notEmpty(groupSelection) && (
-              <div style={{ width: "100%" }}>
+              <div className="w-full">
                 <Select
                   id="currentClassificationLevel"
                   label={labels.currentClassificationLevel}


### PR DESCRIPTION
🤖 Resolves #13975.

## 👋 Introduction

This PR fixes spacing for two inputs on the government section of a user profile.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/applicant/personal-information#government-section
3. Verify spacing between Current Classification Group and Current Classification Level inputs
4. Verify spacing on bottom of these inputs and the next input

## 📸 Screenshots

<img width="1188" alt="Screen Shot 2025-06-27 at 12 15 38" src="https://github.com/user-attachments/assets/51a30e7b-4581-4ab7-9940-4b796ba3324f" />

<img width="1180" alt="Screen Shot 2025-06-27 at 12 16 28" src="https://github.com/user-attachments/assets/f3d619c5-6208-4905-92fd-31a6e8c47ced" />

<img width="498" alt="Screen Shot 2025-06-27 at 12 16 37" src="https://github.com/user-attachments/assets/dc7c9645-e276-4905-afc0-387537140ca1" />