### PR TITLE
[Feat] Highlight Selection process number on advertisement

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4123,6 +4123,10 @@
     "defaultMessage": "Inscription",
     "description": "Breadcrumb for the registration pages"
   },
+  "H6seW1": {
+    "defaultMessage": "Numéro du processus de sélection",
+    "description": "Label for pool advertisement selection process number"
+  },
   "HBljcn": {
     "defaultMessage": "Nom (anglais)",
     "description": "Title for name in English"

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -807,6 +807,19 @@ export const PoolPoster = ({
                   value={securityClearance}
                   suffix={<SecurityClearanceDialog />}
                 />
+                {pool.processNumber && (
+                  <DataRow
+                    label={
+                      intl.formatMessage({
+                        defaultMessage: "Selection process number",
+                        id: "H6seW1",
+                        description:
+                          "Label for pool advertisement selection process number",
+                      }) + intl.formatMessage(commonMessages.dividingColon)
+                    }
+                    value={pool.processNumber}
+                  />
+                )}
               </Card>
             </TableOfContents.Section>
             <TableOfContents.Section id={sections.minEducation.id}>


### PR DESCRIPTION
🤖 Resolves  #13926

## 👋 Introduction

This PR adds the "Selection process number" to the bottom of the Employment Details card while keeping the existing placement at the bottom of the page, it appears in both places.

## 🕵️ Details

Added "Selection process number" to Employment Details Card
   - New DataRow for "Selection process number" placed at the bottom of the employment details card.
   - Uses the label "Selection process number".

## 🧪 Testing

1. Build app, login as `Admin`
2. Navigate to `/browse/pools`
3. Verify "Selection process number" appears:
    - In the Employment Details card (at the bottom of the employment details card).
    - At the bottom of the page (unchanged).


## 📸 Screenshot

![Screen Shot 2025-06-30 at 10 29 07](https://github.com/user-attachments/assets/6b5aa2bf-a7f1-4f27-841e-cb453e9c8345)
![localhost_8000_en_browse_pools_ef4f9555-5b7d-4efc-a57a-d570f0897753 (2)](https://github.com/user-attachments/assets/64e7737f-ded4-4196-ad9a-a777bbbdf69f)

