### PR TITLE
[Debt] Removes Support form success paragraph three

### DIFF
--- a/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
+++ b/apps/web/src/pages/SupportPage/components/SupportForm/SupportForm.tsx
@@ -75,14 +75,6 @@ const SupportFormSuccess = ({ onFormToggle }: SupportFormSuccessProps) => {
           description: "Support form success paragraph two",
         })}
       </p>
-      {/* <p className="my-6">
-        {intl.formatMessage({
-          defaultMessage:
-            "In the meantime, feel free to check out our FAQs for further information.",
-          id: "QX1l/C",
-          description: "Support form success paragraph three",
-        })}
-      </p> */}
       <Button
         color="primary"
         onClick={() => {


### PR DESCRIPTION
🤖 Resolves #13973.

## 👋 Introduction

This PR removes some unused copy.

> [!NOTE]
> No French translation of the string was present in codebase.

## 🧪 Testing

1. Verify no instances of `QX1l/C` in codebase
2. Verify no instances of `Support form success paragraph three` in codebase