### PR TITLE
[Fix] `ExperienceCard` work stream list styles

### DIFF
--- a/apps/web/src/components/ExperienceCard/WorkContent/WorkStreamsContent.tsx
+++ b/apps/web/src/components/ExperienceCard/WorkContent/WorkStreamsContent.tsx
@@ -68,7 +68,7 @@ const WorkStreamContent = ({
           {workStreamsByCommunity.map((item) => (
             <li key={item.community.id} className="font-bold">
               {item.community.name?.localized ?? na}
-              <Ul unStyled className="mb-3 font-normal" space="md">
+              <Ul unStyled className="mb-3 list-none! font-normal" space="md">
                 {item.workStreams.map((workStream) => (
                   <li key={workStream.id}>
                     <BoolCheckIcon value={true}>


### PR DESCRIPTION
🤖 Resolves #14028 

## 👋 Introduction

Forces the list to have no bullets.

## 🕵️ Details

This was due to our list compnent trying to be smart and adding a circle rather than disc for nested lists. So, we had to add imprtant to override that.

## 🧪 Testing

1. Login as an applicant
2. Add a work experience with one or more work stream
3. Go to the card for that experience
4. Confirm no bullets on the nested work stream list on an experience card

## 📸 Screenshot

![swappy-20250702_145622](https://github.com/user-attachments/assets/5f066eec-fe28-4b62-872c-843e990d5152)
