### PR TITLE
[Fix] Spinner icon wobble

### DIFF
--- a/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
@@ -160,7 +160,7 @@ const AssessmentStepTracker = ({
                 />
                 {fetching ? (
                   <Well fontSize="caption" className="m-3">
-                    <div className="flex items-center">
+                    <div className="flex items-center gap-1.5">
                       <SpinnerIcon className="w-3" />
                       <span>{intl.formatMessage(commonMessages.loading)}</span>
                     </div>

--- a/apps/web/src/components/SpinnerIcon/SpinnerIcon.tsx
+++ b/apps/web/src/components/SpinnerIcon/SpinnerIcon.tsx
@@ -1,19 +1,22 @@
+import { ComponentPropsWithoutRef } from "react";
 import { m, useReducedMotion } from "motion/react";
 import ArrowPathIcon from "@heroicons/react/20/solid/ArrowPathIcon";
 import { tv } from "tailwind-variants";
 
-import { IconProps } from "@gc-digital-talent/ui";
-
 const icon = tv({
-  base: "mr-0",
+  base: "mr-0 inline-flex",
 });
 
-const SpinnerIcon = ({ className, ...rest }: IconProps) => {
+const Icon = m.create(ArrowPathIcon);
+
+const SpinnerIcon = ({
+  className,
+  ...rest
+}: ComponentPropsWithoutRef<typeof Icon>) => {
   const shouldReduceMotion = useReducedMotion();
 
   return (
-    <m.span
-      className="mr-1.5 inline-flex"
+    <Icon
       {...(!shouldReduceMotion && {
         animate: {
           rotate: [0, 360],
@@ -25,9 +28,9 @@ const SpinnerIcon = ({ className, ...rest }: IconProps) => {
           repeatDelay: 0,
         },
       })}
-    >
-      <ArrowPathIcon className={icon({ class: className })} {...rest} />
-    </m.span>
+      className={icon({ class: className })}
+      {...rest}
+    />
   );
 };
 

--- a/apps/web/src/components/SpinnerIcon/SpinnerIcon.tsx
+++ b/apps/web/src/components/SpinnerIcon/SpinnerIcon.tsx
@@ -1,7 +1,9 @@
-import { ComponentPropsWithoutRef } from "react";
+import { forwardRef } from "react";
 import { m, useReducedMotion } from "motion/react";
 import ArrowPathIcon from "@heroicons/react/20/solid/ArrowPathIcon";
 import { tv } from "tailwind-variants";
+
+import { type IconProps } from "@gc-digital-talent/ui";
 
 const icon = tv({
   base: "mr-0 inline-flex",
@@ -9,29 +11,28 @@ const icon = tv({
 
 const Icon = m.create(ArrowPathIcon);
 
-const SpinnerIcon = ({
-  className,
-  ...rest
-}: ComponentPropsWithoutRef<typeof Icon>) => {
-  const shouldReduceMotion = useReducedMotion();
+const SpinnerIcon = forwardRef<SVGSVGElement, IconProps>(
+  ({ className }, forwardedRef) => {
+    const shouldReduceMotion = useReducedMotion();
 
-  return (
-    <Icon
-      {...(!shouldReduceMotion && {
-        animate: {
-          rotate: [0, 360],
-        },
-        transition: {
-          ease: "linear",
-          duration: 1,
-          repeat: Infinity,
-          repeatDelay: 0,
-        },
-      })}
-      className={icon({ class: className })}
-      {...rest}
-    />
-  );
-};
+    return (
+      <Icon
+        ref={forwardedRef}
+        {...(!shouldReduceMotion && {
+          animate: {
+            rotate: [0, 360],
+          },
+          transition: {
+            ease: "linear",
+            duration: 1,
+            repeat: Infinity,
+            repeatDelay: 0,
+          },
+        })}
+        className={icon({ class: className })}
+      />
+    );
+  },
+);
 
 export default SpinnerIcon;


### PR DESCRIPTION
🤖 Resolves #13963 

## 👋 Introduction

Fixes an issue where the spinner icon showing during file downloads was wobbling.

## 🕵️ Details

This was caused by the wrapping `span` (that was not necessary now with tailwind) having margin right which made it an irrefular shape leading to the wobble.

This removed the wrapping span and uses `taildwind-variants` to properly merge the classes and remove the added margin.

## 🧪 Testing

> [!TIP]
> Make it easier to test by removing the `isDownloading` condition for adding the spinner icon on a specific download button 

1. Build the app `pnpm run dev:fresh`
2. Login as admin
3. Navigate to a table
4. If you did not temporariyl remove the condition, trigger a download by selecting rows and clicking download
5. Observe the icon does not wobble