### PR TITLE
[Fix] Dropdown menu z-index

### DIFF
--- a/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
@@ -160,7 +160,7 @@ const AssessmentStepTracker = ({
                 />
                 {fetching ? (
                   <Well fontSize="caption" className="m-3">
-                    <div className="flex items-center">
+                    <div className="flex items-center gap-1.5">
                       <SpinnerIcon className="w-3" />
                       <span>{intl.formatMessage(commonMessages.loading)}</span>
                     </div>

--- a/packages/ui/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/ui/src/components/DropdownMenu/DropdownMenu.tsx
@@ -25,7 +25,7 @@ const StyledContent = forwardRef<
   ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
 >(({ className, ...rest }, forwardedRef) => (
   <DropdownMenuPrimitive.Content
-    className={content({ class: ["z-[9999]", className] })}
+    className={content({ class: ["z-10", className] })}
     ref={forwardedRef}
     {...rest}
   />


### PR DESCRIPTION
🤖 Resolves #13982 

## 👋 Introduction

Fixes the dropdown menu from overlaying content by reducing its absurdly high `z-index`

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as admin
3. Navigate to a communities "Manage access" tab
4. Open the actions dropdown
5. Click on an option
6. Confirm the dropdown menu shows below the dialog

## 📸 Screenshot

![swappy-20250702_152303](https://github.com/user-attachments/assets/13629137-7d75-4187-8b9a-2264edc0026a)
