### PR TITLE
[Fix] Spacing in Employee Profile Forms

### DIFF
--- a/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
@@ -525,8 +525,8 @@ const CareerObjectiveSection = ({
                       employeeProfileMessages.targetClassification,
                     )}
                   </p>
-                  <div className="flex flex-col xs:flex-row">
-                    <div className="mb-12 w-full">
+                  <div className="flex flex-col gap-6 xs:flex-row">
+                    <div className="w-full">
                       <Select
                         id="classificationGroup"
                         label={intl.formatMessage(commonMessages.group)}

--- a/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
@@ -521,8 +521,8 @@ const NextRoleSection = ({
                       employeeProfileMessages.targetClassification,
                     )}
                   </p>
-                  <div className="flex flex-col xs:flex-row">
-                    <div className="mb-12 w-full">
+                  <div className="flex flex-col gap-6 xs:flex-row">
+                    <div className="w-full">
                       <Select
                         id="classificationGroup"
                         label={intl.formatMessage(commonMessages.group)}


### PR DESCRIPTION
🤖 Resolves  #14034

## 👋 Introduction

This PR fixes spacing issues in the Employee Profile specifically in "Your next role" and "Your career objective". 

## 🕵️ Details

- Added spacing between inputs and removed extra margin.

## 🧪 Testing

1. Login as `Admin`
2. Navigate to `/applicant` and select `GC employee profile`
3. Scroll to the `Next role` section
4. Confirm that the horizontal and vertical spacing between the inputs looks correct
5. Scroll to the `Your career objective` section.
6. Confirm that the horizontal and vertical spacing between the inputs looks correct
7. Test on different screen widths to confirm responsiveness.

## 📸 Screenshot
![localhost_8000_en_applicant_employee-profile (1)](https://github.com/user-attachments/assets/74e7d7ac-8c7e-4bad-bfa1-f714e8203681)
![localhost_8000_en_applicant_employee-profile](https://github.com/user-attachments/assets/c1acf062-5d43-4d4b-9234-b746bbf2b577)


