### PR TITLE
[Fix] Add missing name/id to column toggle checkboxes

### DIFF
--- a/apps/web/src/components/Table/ResponsiveTable/ColumnDialog.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ColumnDialog.tsx
@@ -70,10 +70,13 @@ const ColumnDialog = <T extends object>({ table }: ColumnDialogProps<T>) => {
                 .filter((c) => c.getCanHide())
                 .map((column) => {
                   const header = getColumnHeader(column, "columnDialogHeader");
+                  const id = `toggle-${column.id}`;
                   return (
                     <div key={column.id} className="my-0.75">
                       <Field.Label className="flex items-center gap-x-1.5 text-base">
                         <input
+                          id={id}
+                          name={id}
                           {...{
                             type: "checkbox",
                             checked: column.getIsVisible(),


### PR DESCRIPTION
🤖 Resolves #13981 

## 👋 Introduction

Adds the `name` and `id` attribute to the table column dialog for a11y.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as `admin@test.com`
3. Navigate to any table `/admin/users`
4. Open the "Show/hide columns" dialog
5. Confirm the checkboxes had IDs and names