### PR TITLE
[Fix] Add Canadian citzen note to pool basic info form

### DIFF
--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/CitizensNote.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/CitizensNote.tsx
@@ -1,0 +1,38 @@
+import { ReactNode } from "react";
+import { useIntl } from "react-intl";
+
+import { getLocale, Locales } from "@gc-digital-talent/i18n";
+import { Link, Well } from "@gc-digital-talent/ui";
+
+const pseaUrl: Record<Locales, string> = {
+  en: "https://laws-lois.justice.gc.ca/eng/acts/p-33.01/",
+  fr: "https://laws-lois.justice.gc.ca/fra/lois/p-33.01/",
+} as const;
+
+const CitizensNote = () => {
+  const intl = useIntl();
+  const locale = getLocale(intl);
+
+  return (
+    <Well color="warning" className="xs:col-span-2">
+      {intl.formatMessage(
+        {
+          defaultMessage:
+            "By selecting “Only Canadian citizens can apply”, you’re confirming that this job opportunity is with a department or agency that is not subject to the <a><italic>Public Service Employment Act</italic></a>.",
+          id: "4f81Y1",
+          description:
+            "Warning message when selecting the only-canadian-citizens limitation option",
+        },
+        {
+          a: (chunks: ReactNode) => (
+            <Link href={pseaUrl[locale]} color="warning" newTab external>
+              {chunks}
+            </Link>
+          ),
+        },
+      )}
+    </Well>
+  );
+};
+
+export default CitizensNote;

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
@@ -22,6 +22,7 @@ import processMessages from "~/messages/processMessages";
 
 import { DisplayProps } from "../../types";
 import { SelectionLimitationDefinition } from "./PoolNameSection";
+import CitizensNote from "./CitizensNote";
 
 const pseaUrl: Record<Locales, string> = {
   en: "https://laws-lois.justice.gc.ca/eng/acts/p-33.01/",
@@ -114,24 +115,7 @@ const Display = ({
         {poolSelectionLimitationValues.includes(
           PoolSelectionLimitation.CanadianCitizens,
         ) ? (
-          <Well color="warning" className="xs:col-span-2">
-            {intl.formatMessage(
-              {
-                defaultMessage:
-                  "By selecting “Only Canadian citizens can apply”, you’re confirming that this job opportunity is with a department or agency that is not subject to the <a><italic>Public Service Employment Act</italic></a>.",
-                id: "4f81Y1",
-                description:
-                  "Warning message when selecting the only-canadian-citizens limitation option",
-              },
-              {
-                a: (chunks: ReactNode) => (
-                  <Link href={pseaUrl[locale]} color="warning" newTab external>
-                    {chunks}
-                  </Link>
-                ),
-              },
-            )}
-          </Well>
+          <CitizensNote />
         ) : null}
         <ToggleForm.FieldDisplay
           hasError={!classification}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
@@ -1,20 +1,13 @@
 import { MessageDescriptor, useIntl } from "react-intl";
 import CheckCircleIcon from "@heroicons/react/20/solid/CheckCircleIcon";
 import XCircleIcon from "@heroicons/react/20/solid/XCircleIcon";
-import { ReactNode } from "react";
 
-import {
-  commonMessages,
-  getLocale,
-  getLocalizedName,
-  Locales,
-} from "@gc-digital-talent/i18n";
+import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 import {
   EditPoolNameFragment,
   PoolAreaOfSelection,
   PoolSelectionLimitation,
 } from "@gc-digital-talent/graphql";
-import { Link, Well } from "@gc-digital-talent/ui";
 
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
 import { getClassificationName } from "~/utils/poolUtils";
@@ -24,11 +17,6 @@ import { DisplayProps } from "../../types";
 import { SelectionLimitationDefinition } from "./PoolNameSection";
 import CitizensNote from "./CitizensNote";
 
-const pseaUrl: Record<Locales, string> = {
-  en: "https://laws-lois.justice.gc.ca/eng/acts/p-33.01/",
-  fr: "https://laws-lois.justice.gc.ca/fra/lois/p-33.01/",
-} as const;
-
 const Display = ({
   pool,
   possibleEmployeeLimitations,
@@ -36,7 +24,6 @@ const Display = ({
   possibleEmployeeLimitations: SelectionLimitationDefinition[];
 }) => {
   const intl = useIntl();
-  const locale = getLocale(intl);
   const notProvided = intl.formatMessage(commonMessages.notProvided);
   const {
     areaOfSelection,

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
@@ -51,6 +51,7 @@ import {
 } from "./utils";
 import { SectionProps } from "../../types";
 import ActionWrapper from "../ActionWrapper";
+import CitizensNote from "./CitizensNote";
 
 const EditPoolName_Fragment = graphql(/* GraphQL */ `
   fragment EditPoolName on Pool {
@@ -269,7 +270,10 @@ const PoolNameSection = ({
   const { handleSubmit, watch, resetField } = methods;
 
   // hooks to watch, needed for conditional rendering
-  const [selectedAreaOfSelection] = watch(["areaOfSelection"]);
+  const [selectedAreaOfSelection, selectionLimitations] = watch([
+    "areaOfSelection",
+    "selectionLimitations",
+  ]);
 
   /**
    * Reset un-rendered fields
@@ -406,6 +410,10 @@ const PoolNameSection = ({
                     />
                   </div>
                 ) : null}
+
+                {selectionLimitations?.includes(
+                  PoolSelectionLimitation.CanadianCitizens,
+                ) && <CitizensNote />}
 
                 <Select
                   id="classification"


### PR DESCRIPTION
🤖 Resolves #13934 

## 👋 Introduction

Takes existing note/warning from display and adds it to the edit form as well.

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Login as admin `admin@test.com`
3. Navigate to create a pool `/admin/pools/create`
4. Creatge the poool
5. Open the "Basic information" form
6. Select "Open to public"
7. Select "Canadian citzens only"
8. Confirm the warning appears
9. Deselect "Canadian citizens only"
10. Confirm the warning dissapears 

## 📸 Screenshot

![swappy-20250704_151109](https://github.com/user-attachments/assets/8be48274-b7b0-4456-8d7b-823b2e89a0b1)
