### PR TITLE
[Fix] Improve email verification alignment

### DIFF
--- a/apps/web/src/components/Profile/components/EmailVerificationStatus.tsx
+++ b/apps/web/src/components/Profile/components/EmailVerificationStatus.tsx
@@ -1,0 +1,51 @@
+import { useIntl } from "react-intl";
+
+import { Button, Chip } from "@gc-digital-talent/ui";
+
+interface EmailVerificationStatusProps {
+  isEmailVerified?: boolean;
+  onClickVerify: () => Promise<void>;
+}
+
+const EmailVerificationStatus = ({
+  isEmailVerified,
+  onClickVerify,
+}: EmailVerificationStatusProps) => {
+  const intl = useIntl();
+
+  return isEmailVerified ? (
+    <Chip color="success" className="-mb-0.25">
+      {intl.formatMessage({
+        defaultMessage: "Verified",
+        id: "GMglI5",
+        description: "The email address has been verified to be owned by user",
+      })}
+    </Chip>
+  ) : (
+    <>
+      <Chip color="error" className="-mb-0.25">
+        {intl.formatMessage({
+          defaultMessage: "Unverified",
+          id: "tUIvbq",
+          description:
+            "The email address has not been verified to be owned by user",
+        })}
+      </Chip>
+      <Button
+        type="button"
+        mode="inline"
+        color="error"
+        className="-mt-0.25"
+        onClick={onClickVerify}
+      >
+        {intl.formatMessage({
+          defaultMessage: "Verify now",
+          id: "ADPfNp",
+          description: "Button to start the email address verification process",
+        })}
+      </Button>
+    </>
+  );
+};
+
+export default EmailVerificationStatus;

--- a/apps/web/src/components/Profile/components/GovernmentInformation/Display.tsx
+++ b/apps/web/src/components/Profile/components/GovernmentInformation/Display.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router";
 
 import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 import { empty } from "@gc-digital-talent/helpers";
-import { Button, Chip } from "@gc-digital-talent/ui";
 
 import { wrapAbbr } from "~/utils/nameUtils";
 import profileMessages from "~/messages/profileMessages";
@@ -11,6 +10,7 @@ import useRoutes from "~/hooks/useRoutes";
 import FieldDisplay from "~/components/FieldDisplay/FieldDisplay";
 
 import { PartialUser } from "./types";
+import EmailVerificationStatus from "../EmailVerificationStatus";
 
 interface DisplayProps {
   user: PartialUser;
@@ -64,39 +64,6 @@ const Display = ({
     await navigate(routes.verifyWorkEmail());
   };
 
-  const emailVerificationComponents = isWorkEmailVerified ? (
-    <Chip color="success">
-      {intl.formatMessage({
-        defaultMessage: "Verified",
-        id: "GMglI5",
-        description: "The email address has been verified to be owned by user",
-      })}
-    </Chip>
-  ) : (
-    <>
-      <Chip color="error">
-        {intl.formatMessage({
-          defaultMessage: "Unverified",
-          id: "tUIvbq",
-          description:
-            "The email address has not been verified to be owned by user",
-        })}
-      </Chip>
-      <Button
-        type="button"
-        mode="inline"
-        color="error"
-        onClick={handleVerifyNowClick}
-      >
-        {intl.formatMessage({
-          defaultMessage: "Verify now",
-          id: "ADPfNp",
-          description: "Button to start the email address verification process",
-        })}
-      </Button>
-    </>
-  );
-
   return (
     <div className="flex flex-col gap-y-6">
       <FieldDisplay
@@ -137,21 +104,24 @@ const Display = ({
                 )
               : notProvided}
           </FieldDisplay>
-          <div className="flex items-end gap-3">
-            <FieldDisplay
-              hasError={!workEmail}
-              label={intl.formatMessage({
-                defaultMessage: "Work email",
-                id: "tj9Dz3",
-                description: "Work email label",
-              })}
-            >
-              {workEmail ?? notProvided}
-            </FieldDisplay>
-            {showEmailVerification && workEmail
-              ? emailVerificationComponents
-              : null}
-          </div>
+          <FieldDisplay
+            hasError={!workEmail}
+            label={intl.formatMessage({
+              defaultMessage: "Work email",
+              id: "tj9Dz3",
+              description: "Work email label",
+            })}
+          >
+            <div className="flex items-center gap-3">
+              <span>{workEmail ?? notProvided}</span>
+              {showEmailVerification && workEmail ? (
+                <EmailVerificationStatus
+                  isEmailVerified={!!isWorkEmailVerified}
+                  onClickVerify={handleVerifyNowClick}
+                />
+              ) : null}
+            </div>
+          </FieldDisplay>
         </>
       )}
       <FieldDisplay

--- a/apps/web/src/components/Profile/components/PersonalInformation/Display.tsx
+++ b/apps/web/src/components/Profile/components/PersonalInformation/Display.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router";
 
 import { User } from "@gc-digital-talent/graphql";
 import { empty } from "@gc-digital-talent/helpers";
-import { Button, Chip, Link } from "@gc-digital-talent/ui";
+import { Link } from "@gc-digital-talent/ui";
 import {
   commonMessages,
   getArmedForcesStatusesProfile,
@@ -14,6 +14,8 @@ import {
 import profileMessages from "~/messages/profileMessages";
 import useRoutes from "~/hooks/useRoutes";
 import FieldDisplay from "~/components/FieldDisplay/FieldDisplay";
+
+import EmailVerificationStatus from "../EmailVerificationStatus";
 
 type PartialUser = Pick<
   User,
@@ -62,39 +64,6 @@ const Display = ({
     );
   };
 
-  const emailVerificationComponents = isEmailVerified ? (
-    <Chip color="success">
-      {intl.formatMessage({
-        defaultMessage: "Verified",
-        id: "GMglI5",
-        description: "The email address has been verified to be owned by user",
-      })}
-    </Chip>
-  ) : (
-    <>
-      <Chip color="error">
-        {intl.formatMessage({
-          defaultMessage: "Unverified",
-          id: "tUIvbq",
-          description:
-            "The email address has not been verified to be owned by user",
-        })}
-      </Chip>
-      <Button
-        type="button"
-        mode="inline"
-        color="error"
-        onClick={handleVerifyNowClick}
-      >
-        {intl.formatMessage({
-          defaultMessage: "Verify now",
-          id: "ADPfNp",
-          description: "Button to start the email address verification process",
-        })}
-      </Button>
-    </>
-  );
-
   return (
     <div className="grid gap-6 xs:grid-cols-2 sm:grid-cols-3">
       <FieldDisplay
@@ -117,14 +86,21 @@ const Display = ({
       >
         {lastName ?? notProvided}
       </FieldDisplay>
-      <div className="flex items-end gap-x-3 xs:col-span-2 sm:col-span-3">
+      <div className="xs:col-span-2 sm:col-span-3">
         <FieldDisplay
           hasError={!email}
           label={intl.formatMessage(commonMessages.email)}
         >
-          {email ?? notProvided}
+          <div className="flex items-center gap-3">
+            <span>{email ?? notProvided}</span>
+            {showEmailVerification ? (
+              <EmailVerificationStatus
+                isEmailVerified={!!isEmailVerified}
+                onClickVerify={handleVerifyNowClick}
+              />
+            ) : null}
+          </div>
         </FieldDisplay>
-        {showEmailVerification ? emailVerificationComponents : null}
       </div>
       <FieldDisplay
         hasError={!telephone}


### PR DESCRIPTION
🤖 Resolves #13863 

## 👋 Introduction

Adjusts the email vverification chip/link to try and better align the different elements.

## 🕵️ Details

I hope I got it, the original was only sligly off so it is hard to tell. It is really different because we haver 3 separate elements with different baselines.

 1. Regular body text
 2. Regular small text with padding
 3. Regular bold link with underline

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as an applicant employee
3. Navigate to your profile
4. Confirm the email verification chip/link align with the email text

## 📸 Screenshot

![swappy-20250704_161520](https://github.com/user-attachments/assets/72d1f1d0-d81b-4d4e-8241-01e7584c92c6)
![swappy-20250704_161548](https://github.com/user-attachments/assets/033f43b2-5b75-42f4-99ac-5261d5638644)
