### PR TITLE
[Copy] Changes `null` statement for recruitment processes in profile tab of a nomination

### DIFF
--- a/apps/web/src/components/RecruitmentProcesses/RecruitmentProcessesPreviewList.tsx
+++ b/apps/web/src/components/RecruitmentProcesses/RecruitmentProcessesPreviewList.tsx
@@ -151,10 +151,9 @@ const RecruitmentProcessPreviewList = ({
           <p className="font-bold">
             {intl.formatMessage({
               defaultMessage:
-                "You don't have any active recruitment processes at the moment.",
-              id: "vVAqzB",
-              description:
-                "Title for notice when there are no recruitment processes",
+                "This user doesn't have any active recruitment processes at the moment.",
+              id: "PKntBk",
+              description: "Notice when there are no recruitment processes",
             })}
           </p>
         </Well>

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5831,6 +5831,10 @@
     "defaultMessage": "Avancement",
     "description": "Label for the advancement nomination type"
   },
+  "PKntBk": {
+    "defaultMessage": "Cet utilisateur n'a aucun processus de recrutement actif pour I'instant.",
+    "description": "Notice when there are no recruitment processes"
+  },
   "PN3PMn": {
     "defaultMessage": "La Directive sur les talents numériques introduit des mesures visant à améliorer la coordination interministérielle sur le développement des talents et le perfectionnement, ainsi que des mesures visant à améliorer la promotion de l’équité. L’intention de la Directive est d’aborder la main-d’œuvre numérique du GC comme une communauté homogène et évolutive.",
     "description": "The directives digital talent and development component"


### PR DESCRIPTION
🤖 Resolves #13785.

## 👋 Introduction

This PR changes null statement for recruitment processes in profile tab of a nomination to third person.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to a talent nomination profile tab
3. Verify copy reflects desired change

## 📸 Screenshots

### English
![localhost_8000_en_admin_talent-events_cbd6925c-e79b-4ca3-9206-958b94c7510c_nominations_568a9859-0cc8-4325-bbc2-2edd561ac86c_profile](https://github.com/user-attachments/assets/816305e7-9173-4ec2-a1db-1962af3f3215)

### French
![localhost_8000_fr_admin_talent-events_cbd6925c-e79b-4ca3-9206-958b94c7510c_nominations_568a9859-0cc8-4325-bbc2-2edd561ac86c_profile](https://github.com/user-attachments/assets/9e06ac46-a8dc-49ac-8054-f17ca847e789)