### PR TITLE
[Copy] Updates strings to be sentence case in footer

### DIFF
--- a/apps/playwright/tests/footer.spec.ts
+++ b/apps/playwright/tests/footer.spec.ts
@@ -19,7 +19,7 @@ test.describe("Footer", () => {
           .getByRole("link", { name: /terms and conditions/i }),
       ).toHaveAttribute("href", "/en/terms-and-conditions");
     });
-    test("links to Privacy Policy", async ({ page }) => {
+    test("links to Privacy policy", async ({ page }) => {
       await expect(
         page
           .getByRole("navigation", { name: /policy and feedback/i })
@@ -59,7 +59,7 @@ test.describe("Footer", () => {
           .getByRole("link", { name: /avis/i }),
       ).toHaveAttribute("href", "/fr/terms-and-conditions");
     });
-    test("links to Privacy Policy (French)", async ({ page }) => {
+    test("links to Privacy policy (French)", async ({ page }) => {
       await expect(
         page
           .getByRole("navigation", { name: /politique et rétroaction/i })

--- a/apps/playwright/tests/footer.spec.ts
+++ b/apps/playwright/tests/footer.spec.ts
@@ -12,11 +12,11 @@ test.describe("Footer", () => {
           .getByRole("link", { name: /contact us/i }),
       ).toHaveAttribute("href", "/en/support");
     });
-    test("links to Terms & Conditions", async ({ page }) => {
+    test("links to Terms and conditions", async ({ page }) => {
       await expect(
         page
           .getByRole("navigation", { name: /policy and feedback/i })
-          .getByRole("link", { name: /terms & conditions/i }),
+          .getByRole("link", { name: /terms and conditions/i }),
       ).toHaveAttribute("href", "/en/terms-and-conditions");
     });
     test("links to Privacy Policy", async ({ page }) => {
@@ -52,7 +52,7 @@ test.describe("Footer", () => {
           .getByRole("link", { name: /pour nous joindre/i }),
       ).toHaveAttribute("href", "/fr/support");
     });
-    test("links to Terms & Conditions (French)", async ({ page }) => {
+    test("links to Terms and conditions (French)", async ({ page }) => {
       await expect(
         page
           .getByRole("navigation", { name: /politique et rétroaction/i })

--- a/apps/playwright/tests/static-pages.spec.ts
+++ b/apps/playwright/tests/static-pages.spec.ts
@@ -17,7 +17,7 @@ test.describe("Static pages", () => {
       expect(accessibilityScanResults.violations).toEqual([]);
     });
   });
-  test.describe("Privacy Policy", () => {
+  test.describe("Privacy policy", () => {
     test("has heading", async ({ page }) => {
       await page.goto("/en/privacy-policy");
       await expect(

--- a/apps/playwright/tests/static-pages.spec.ts
+++ b/apps/playwright/tests/static-pages.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "~/fixtures";
 
 test.describe("Static pages", () => {
-  test.describe("Terms & Conditions", () => {
+  test.describe("Terms and conditions", () => {
     test("has heading", async ({ page }) => {
       await page.goto("/en/terms-and-conditions");
       await expect(

--- a/apps/web/src/components/Footer/Footer.tsx
+++ b/apps/web/src/components/Footer/Footer.tsx
@@ -38,8 +38,8 @@ const Footer = () => {
     {
       href: paths.privacyPolicy(),
       children: intl.formatMessage({
-        defaultMessage: "Privacy Policy",
-        id: "VcOlXA",
+        defaultMessage: "Privacy policy",
+        id: "K/01hq",
         description: "Label for the privacy link in the Footer.",
       }),
     },

--- a/apps/web/src/components/Footer/Footer.tsx
+++ b/apps/web/src/components/Footer/Footer.tsx
@@ -30,8 +30,8 @@ const Footer = () => {
     {
       href: paths.termsAndConditions(),
       children: intl.formatMessage({
-        defaultMessage: "Terms & Conditions",
-        id: "ZGpncy",
+        defaultMessage: "Terms and conditions",
+        id: "U/Ugr6",
         description: "Label for the terms and conditions link in the Footer.",
       }),
     },

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6851,6 +6851,10 @@
     "defaultMessage": "Expérience inconnue",
     "description": "Title for unknown experiences"
   },
+  "U/Ugr6": {
+    "defaultMessage": "Avis",
+    "description": "Label for the terms and conditions link in the Footer."
+  },
   "U/ji+A": {
     "defaultMessage": "Candidature créée",
     "description": "Application created successfully"
@@ -7913,10 +7917,6 @@
   "ZEmZm4": {
     "defaultMessage": "Allocation budgétaire annuelle ($CAN)",
     "description": "Label for annual budget allocation field"
-  },
-  "ZGpncy": {
-    "defaultMessage": "Avis",
-    "description": "Label for the terms and conditions link in the Footer."
   },
   "ZKss5S": {
     "defaultMessage": "Afin que nous puissions mieux vous appuyer au fil de votre parcours d'embauche d'un apprentis en TI, veuillez nous laisser savoir si vous avez",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4727,6 +4727,10 @@
     "defaultMessage": "Date de clôture",
     "description": "Closing Date field label for publish pool dialog"
   },
+  "K/01hq": {
+    "defaultMessage": "Énoncé de confidentialité",
+    "description": "Label for the privacy link in the Footer."
+  },
   "K0Zkdw": {
     "defaultMessage": "Compétences constituant un atout",
     "description": "Title for optional skills"
@@ -7165,10 +7169,6 @@
   "Vc44L9": {
     "defaultMessage": "Renseignements supplémentaires sur votre prochain type de poste",
     "description": "Additional information about your next role"
-  },
-  "VcOlXA": {
-    "defaultMessage": "Énoncé de confidentialité",
-    "description": "Label for the privacy link in the Footer."
   },
   "Vck6JW": {
     "defaultMessage": "<strong>Description</strong> : bons pour examens de certification en ligne attestant les compétences reconnues liées à des domaines clés des TI.",


### PR DESCRIPTION
🤖 Resolves #14099.

## 👋 Introduction

This PR changes all footer link strings to be sentence case.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/
3. Verify "Terms and conditions" exists in footer
4. Verify "Privacy policy" exists in footer

## 📸 Screenshot

<img width="832" alt="Screen Shot 2025-07-08 at 08 13 11" src="https://github.com/user-attachments/assets/c3348596-bf5f-4d86-a29c-e889e55ee26c" />