### PR TITLE
[Fix] User download showing incorrect language info

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -765,7 +765,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
             'second_language_exam_completed' => 'secondLanguageExamCompleted',
             'second_language_exam_validity' => 'secondLanguageExamValidity',
             'comprehension_level' => 'comprehensionLevel',
-            'written_level' => 'comprehensionLevel',
+            'written_level' => 'writtenLevel',
             'verbal_level' => 'verbalLevel',
             'estimated_language_ability' => 'estimatedLanguageAbility',
             'computed_is_gov_employee' => 'isGovEmployee',

--- a/api/app/Traits/Generator/GeneratesUserDoc.php
+++ b/api/app/Traits/Generator/GeneratesUserDoc.php
@@ -152,7 +152,7 @@ trait GeneratesUserDoc
             $listRun = $section->addListItemRun();
             $listRun->addText($this->localizeHeading('oral_interaction_level'), $this->strong);
             if ($user->comprehension_level) {
-                $listRun->addText($this->colon().$user->written_level);
+                $listRun->addText($this->colon().$user->oral_interaction_level);
             }
 
         } elseif ($user->estimated_language_ability) {

--- a/api/app/Traits/Generator/GeneratesUserDoc.php
+++ b/api/app/Traits/Generator/GeneratesUserDoc.php
@@ -145,14 +145,14 @@ trait GeneratesUserDoc
 
             $listRun = $section->addListItemRun();
             $listRun->addText($this->localizeHeading('writing_level'), $this->strong);
-            if ($user->comprehension_level) {
+            if ($user->written_level) {
                 $listRun->addText($this->colon().$user->written_level);
             }
 
             $listRun = $section->addListItemRun();
             $listRun->addText($this->localizeHeading('oral_interaction_level'), $this->strong);
-            if ($user->comprehension_level) {
-                $listRun->addText($this->colon().$user->oral_interaction_level);
+            if ($user->verbal_level) {
+                $listRun->addText($this->colon().$user->verbal_level);
             }
 
         } elseif ($user->estimated_language_ability) {


### PR DESCRIPTION
🤖 Resolves #14103 

## 👋 Introduction

Fixes an issue where downloading a document with user information in it was showing the incorrect language information.

## 🕵️ Details

Looks like there were more issues than the one repored :cry: 

 - We were wrapping the display in incorrect condition checks
 - We were accessing the incorrect properties from the user
 - Unrelated but also noticed we had an incorrect mapping in the snapshot

## 🧪 Testing

1. Login as `admin@test.com`
2. Set your language info to have different levels for each category (comprehension, written, verbal)
3. Apply to any Process
4. Download the application submitted in step 3
5. Confirm the language info matches what was set in step 2 

## 📸 Screenshot

![swappy-20250708_121338](https://github.com/user-attachments/assets/1be0ea6b-ad4c-4c07-9a31-fa645f63b9f9)
![swappy-20250708_121354](https://github.com/user-attachments/assets/efe18ed2-3c70-4f4a-8c73-ddbe8ccee386)
