### PR TITLE
[Feat] Add `locked` variant of `TaskCard`

### DIFF
--- a/packages/ui/src/components/TaskCard/TaskCard.stories.tsx
+++ b/packages/ui/src/components/TaskCard/TaskCard.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryFn } from "@storybook/react";
 import { faker } from "@faker-js/faker/locale/en";
 import UsersIcon from "@heroicons/react/24/outline/UsersIcon";
-import { color } from "motion/react";
 
 import { allModes } from "@gc-digital-talent/storybook-helpers";
 

--- a/packages/ui/src/components/TaskCard/TaskCard.stories.tsx
+++ b/packages/ui/src/components/TaskCard/TaskCard.stories.tsx
@@ -46,7 +46,20 @@ const Template: StoryFn<typeof TaskCard.Root> = (args) => (
     ))}
     <TaskCard.Root
       headingColor="primary"
-      {...args}
+      icon={UsersIcon}
+      link={{ label: "Locked link", href: "" }}
+      title="Locked (primary + icon)"
+      locked
+    >
+      <TaskCard.Item>
+        <Well>{faker.lorem.words()}</Well>
+      </TaskCard.Item>
+      <TaskCard.Item>
+        <Well>{faker.lorem.paragraph()}</Well>
+      </TaskCard.Item>
+    </TaskCard.Root>
+    <TaskCard.Root
+      headingColor="primary"
       link={{ label: "Locked link", href: "" }}
       title="Locked (primary)"
       locked

--- a/packages/ui/src/components/TaskCard/TaskCard.stories.tsx
+++ b/packages/ui/src/components/TaskCard/TaskCard.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryFn } from "@storybook/react";
 import { faker } from "@faker-js/faker/locale/en";
 import UsersIcon from "@heroicons/react/24/outline/UsersIcon";
+import { color } from "motion/react";
 
 import { allModes } from "@gc-digital-talent/storybook-helpers";
 
@@ -44,6 +45,20 @@ const Template: StoryFn<typeof TaskCard.Root> = (args) => (
         </TaskCard.Item>
       </TaskCard.Root>
     ))}
+    <TaskCard.Root
+      headingColor="primary"
+      {...args}
+      link={{ label: "Locked link", href: "" }}
+      title="Locked (primary)"
+      locked
+    >
+      <TaskCard.Item>
+        <Well>{faker.lorem.words()}</Well>
+      </TaskCard.Item>
+      <TaskCard.Item>
+        <Well>{faker.lorem.paragraph()}</Well>
+      </TaskCard.Item>
+    </TaskCard.Root>
   </div>
 );
 export const Default = Template.bind({});

--- a/packages/ui/src/components/TaskCard/TaskCard.tsx
+++ b/packages/ui/src/components/TaskCard/TaskCard.tsx
@@ -34,15 +34,20 @@ interface TaskCardHeadingProps {
   icon?: IconType;
   headingAs?: HeadingLevel;
   children?: ReactNode;
+  locked?: boolean;
 }
 
 // a custom heading that is somewhat different from our standard heading component
 const TaskCardHeading = ({
   icon,
   headingAs = "h3",
+  locked,
   children,
 }: TaskCardHeadingProps) => {
-  const Icon = icon;
+  let Icon = icon;
+  if (icon && locked) {
+    Icon = LockClosedIcon;
+  }
   const CustomHeading = headingAs;
   const { base, icon: iconStyles } = heading({ hasIcon: !!icon });
   return (
@@ -125,10 +130,7 @@ const Root = ({
   return (
     <div className={base()}>
       <div className={header()}>
-        <TaskCardHeading
-          icon={locked ? LockClosedIcon : icon}
-          headingAs={headingAs}
-        >
+        <TaskCardHeading {...{ icon, headingAs, locked }}>
           {title}
         </TaskCardHeading>
         {link ? (

--- a/packages/ui/src/components/TaskCard/TaskCard.tsx
+++ b/packages/ui/src/components/TaskCard/TaskCard.tsx
@@ -1,5 +1,6 @@
 import { ReactElement, ReactNode } from "react";
 import { tv, VariantProps } from "tailwind-variants";
+import LockClosedIcon from "@heroicons/react/24/outline/LockClosedIcon";
 
 import { IconType } from "../../types";
 import Link, { LinkProps } from "../Link";
@@ -81,7 +82,21 @@ const root = tv({
           "border-b-error-700 bg-error-100 text-error-700 dark:border-b-error-100 dark:bg-error-700 dark:text-error-100",
       },
     },
+    locked: {
+      true: {},
+      false: {},
+    },
   },
+  compoundVariants: [
+    {
+      locked: true,
+      headingColor: ["primary", "secondary", "success", "warning", "error"],
+      class: {
+        header:
+          "border-b-gray-100 bg-gray-100 text-gray-700 dark:border-b-gray-100 dark:bg-gray-700 dark:text-gray-100",
+      },
+    },
+  ],
 });
 
 type RootVariants = VariantProps<typeof root>;
@@ -101,19 +116,27 @@ const Root = ({
   icon,
   title,
   headingColor = "primary",
+  locked = false,
   link,
   headingAs,
   children,
 }: RootProps) => {
-  const { base, header } = root({ headingColor });
+  const { base, header } = root({ headingColor, locked });
   return (
     <div className={base()}>
       <div className={header()}>
-        <TaskCardHeading icon={icon} headingAs={headingAs}>
+        <TaskCardHeading
+          icon={locked ? LockClosedIcon : icon}
+          headingAs={headingAs}
+        >
           {title}
         </TaskCardHeading>
         {link ? (
-          <Link color={headingColor} href={link.href} className="text-nowrap">
+          <Link
+            color={locked ? "black" : headingColor}
+            href={link.href}
+            className="text-nowrap"
+          >
             {link.label}
           </Link>
         ) : null}


### PR DESCRIPTION
🤖 Resolves #14091 

## 👋 Introduction

Adds a the `locked` variant of `TaskCard` which overrides, heading and link colour along with the icon.

## 🧪 Testing

1. Run storybook `pnpm storybook`
2. Navigate to the "TaskCard" story
3. Confirm the locked variant matchs [the mockup ](https://www.figma.com/design/oZhQe9ahidHFfaiqgREvxa/Dashboard--All-users-?node-id=4372-104068&m=dev)

## 📸 Screenshot

![swappy-20250708_131148](https://github.com/user-attachments/assets/50fa3b87-c622-4f6f-a6a2-b234956f2479)
