### PR TITLE
[Feature] Adds Candidate-facing status column to pool candidates table

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -607,6 +607,9 @@ type PoolCandidateAdminView {
   finalDecision: LocalizedFinalDecision
     @rename(attribute: "computed_final_decision")
   placedDepartment: Department @belongsTo
+  closingDate: DateTime @rename(attribute: "closing_date")
+  removedAt: DateTime @rename(attribute: "removed_at")
+  finalDecisionAt: DateTime @rename(attribute: "final_decision_at")
 }
 
 type PoolCandidateAdminViewWithSkillCount {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -418,6 +418,7 @@ type Pool implements HasRoleAssignments {
   screeningQuestions: [ScreeningQuestion]
     @hasMany
     @orderBy(column: "sort_order", direction: ASC)
+  screeningQuestionsCount: Int @count(relation: "screeningQuestions")
   closingDate: DateTime @rename(attribute: "closing_date")
   closingReason: String @rename(attribute: "closing_reason")
   publishedAt: DateTime @rename(attribute: "published_at")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -936,6 +936,7 @@ type Pool implements HasRoleAssignments {
   updatedDate: DateTime
   generalQuestions: [GeneralQuestion]
   screeningQuestions: [ScreeningQuestion]
+  screeningQuestionsCount: Int
   closingDate: DateTime
   closingReason: String
   publishedAt: DateTime

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1067,6 +1067,9 @@ type PoolCandidateAdminView {
   assessmentStatus: AssessmentResultStatus
   finalDecision: LocalizedFinalDecision
   placedDepartment: Department
+  closingDate: DateTime
+  removedAt: DateTime
+  finalDecisionAt: DateTime
 }
 
 type PoolCandidateAdminViewWithSkillCount {

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -68,6 +68,7 @@ import {
   getPoolNameSort,
   getClaimVerificationSort,
   addSearchToPoolCandidateFilterInput,
+  publicFacingStatusCell,
 } from "./helpers";
 import { rowSelectCell } from "../Table/ResponsiveTable/RowSelection";
 import { normalizedText } from "../Table/sortingFns";
@@ -207,6 +208,17 @@ const CandidatesTableCandidatesPaginated_Query = graphql(/* GraphQL */ `
               fr
             }
           }
+          finalDecisionAt
+          finalDecision {
+            value
+          }
+          assessmentStatus {
+            assessmentStepStatuses {
+              step
+            }
+            overallAssessmentStatus
+            currentStep
+          }
           pool {
             id
             processNumber
@@ -232,6 +244,13 @@ const CandidatesTableCandidatesPaginated_Query = graphql(/* GraphQL */ `
                 en
                 fr
               }
+            }
+            closingDate
+            areaOfSelection {
+              value
+            }
+            screeningQuestions {
+              id
             }
           }
           finalDecision {
@@ -272,6 +291,7 @@ const CandidatesTableCandidatesPaginated_Query = graphql(/* GraphQL */ `
           }
           submittedAt
           suspendedAt
+          removedAt
         }
         skillCount
       }
@@ -774,6 +794,33 @@ const PoolCandidatesTable = ({
             },
           },
         }) => finalDecisionCell(finalDecision, assessmentStatus, intl),
+      },
+    ),
+    columnHelper.accessor(
+      ({
+        poolCandidate: {
+          submittedAt,
+          assessmentStatus,
+          removedAt,
+          finalDecisionAt,
+          finalDecision,
+          pool: { closingDate, areaOfSelection, screeningQuestions },
+        },
+      }) =>
+        publicFacingStatusCell(
+          submittedAt,
+          closingDate,
+          removedAt,
+          finalDecisionAt,
+          finalDecision?.value,
+          areaOfSelection?.value,
+          assessmentStatus,
+          screeningQuestions,
+          intl,
+        ),
+      {
+        id: "publicFacingStatus",
+        header: intl.formatMessage(tableMessages.publicFacingStatus),
       },
     ),
     columnHelper.accessor(

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -249,9 +249,7 @@ const CandidatesTableCandidatesPaginated_Query = graphql(/* GraphQL */ `
             areaOfSelection {
               value
             }
-            screeningQuestions {
-              id
-            }
+            screeningQuestionsCount
           }
           finalDecision {
             value
@@ -804,7 +802,7 @@ const PoolCandidatesTable = ({
           removedAt,
           finalDecisionAt,
           finalDecision,
-          pool: { closingDate, areaOfSelection, screeningQuestions },
+          pool: { closingDate, areaOfSelection, screeningQuestionsCount },
         },
       }) =>
         candidateFacingStatusCell(
@@ -815,7 +813,7 @@ const PoolCandidatesTable = ({
           finalDecision?.value,
           areaOfSelection?.value,
           assessmentStatus,
-          screeningQuestions,
+          screeningQuestionsCount,
           intl,
         ),
       {

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -68,7 +68,7 @@ import {
   getPoolNameSort,
   getClaimVerificationSort,
   addSearchToPoolCandidateFilterInput,
-  publicFacingStatusCell,
+  candidateFacingStatusCell,
 } from "./helpers";
 import { rowSelectCell } from "../Table/ResponsiveTable/RowSelection";
 import { normalizedText } from "../Table/sortingFns";
@@ -807,7 +807,7 @@ const PoolCandidatesTable = ({
           pool: { closingDate, areaOfSelection, screeningQuestions },
         },
       }) =>
-        publicFacingStatusCell(
+        candidateFacingStatusCell(
           submittedAt,
           closingDate,
           removedAt,
@@ -819,8 +819,8 @@ const PoolCandidatesTable = ({
           intl,
         ),
       {
-        id: "publicFacingStatus",
-        header: intl.formatMessage(tableMessages.publicFacingStatus),
+        id: "candidateFacingStatus",
+        header: intl.formatMessage(tableMessages.candidateFacingStatus),
       },
     ),
     columnHelper.accessor(

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -820,6 +820,7 @@ const PoolCandidatesTable = ({
         id: "candidateFacingStatus",
         header: intl.formatMessage(tableMessages.candidateFacingStatus),
         enableSorting: false,
+        enableColumnFilter: false,
       },
     ),
     columnHelper.accessor(

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -821,6 +821,7 @@ const PoolCandidatesTable = ({
       {
         id: "candidateFacingStatus",
         header: intl.formatMessage(tableMessages.candidateFacingStatus),
+        enableSorting: false,
       },
     ),
     columnHelper.accessor(

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -32,12 +32,18 @@ import {
   ClaimVerificationSort,
   QueryPoolCandidatesPaginatedAdminViewOrderByRelationOrderByClause,
   QueryPoolCandidatesPaginatedAdminViewOrderByPoolColumn,
+  PoolCandidate,
+  FinalDecision,
+  PoolAreaOfSelection,
 } from "@gc-digital-talent/graphql";
 import { notEmpty } from "@gc-digital-talent/helpers";
 
 import useRoutes from "~/hooks/useRoutes";
 import { getFullNameLabel } from "~/utils/nameUtils";
-import { getCandidateStatusChip } from "~/utils/poolCandidate";
+import {
+  getApplicationStatusChip,
+  getCandidateStatusChip,
+} from "~/utils/poolCandidate";
 import {
   stringToEnumCandidateExpiry,
   stringToEnumCandidateSuspended,
@@ -204,6 +210,31 @@ export const finalDecisionCell = (
     intl,
   );
   return <Chip color={color}>{label}</Chip>;
+};
+
+export const publicFacingStatusCell = (
+  submittedAt: PoolCandidate["submittedAt"],
+  closingDate: Pool["closingDate"],
+  removedAt: PoolCandidate["removedAt"],
+  finalDecisionAt: PoolCandidate["finalDecisionAt"],
+  finalDecision: Maybe<FinalDecision> | undefined,
+  areaOfSelection: Maybe<PoolAreaOfSelection> | undefined,
+  assessmentStatus: PoolCandidate["assessmentStatus"],
+  screeningQuestions: Pool["screeningQuestions"],
+  intl: IntlShape,
+) => {
+  const { label } = getApplicationStatusChip(
+    submittedAt,
+    closingDate,
+    removedAt,
+    finalDecisionAt,
+    finalDecision,
+    areaOfSelection,
+    assessmentStatus,
+    screeningQuestions,
+    intl,
+  );
+  return label;
 };
 
 export const bookmarkCell = (

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -212,7 +212,7 @@ export const finalDecisionCell = (
   return <Chip color={color}>{label}</Chip>;
 };
 
-export const publicFacingStatusCell = (
+export const candidateFacingStatusCell = (
   submittedAt: PoolCandidate["submittedAt"],
   closingDate: Pool["closingDate"],
   removedAt: PoolCandidate["removedAt"],

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -220,7 +220,7 @@ export const publicFacingStatusCell = (
   finalDecision: Maybe<FinalDecision> | undefined,
   areaOfSelection: Maybe<PoolAreaOfSelection> | undefined,
   assessmentStatus: PoolCandidate["assessmentStatus"],
-  screeningQuestions: Pool["screeningQuestions"],
+  screeningQuestions: Pool["screeningQuestionsCount"],
   intl: IntlShape,
 ) => {
   const { label } = getApplicationStatusChip(

--- a/apps/web/src/components/PoolCandidatesTable/tableMessages.ts
+++ b/apps/web/src/components/PoolCandidatesTable/tableMessages.ts
@@ -40,11 +40,11 @@ const messages = defineMessages({
     description:
       "Title displayed on the Pool Candidates table final decision column",
   },
-  publicFacingStatus: {
-    defaultMessage: "Public facing status",
-    id: "MJWt6k",
+  candidateFacingStatus: {
+    defaultMessage: "Candidate-facing status",
+    id: "1rnUt3",
     description:
-      "Title displayed on the Pool Candidates table public facing status column",
+      "Title displayed on the Pool Candidates table candidate-facing status column",
   },
   jobPlacement: {
     defaultMessage: "Job placement",

--- a/apps/web/src/components/PoolCandidatesTable/tableMessages.ts
+++ b/apps/web/src/components/PoolCandidatesTable/tableMessages.ts
@@ -40,6 +40,12 @@ const messages = defineMessages({
     description:
       "Title displayed on the Pool Candidates table final decision column",
   },
+  publicFacingStatus: {
+    defaultMessage: "Public facing status",
+    id: "MJWt6k",
+    description:
+      "Title displayed on the Pool Candidates table public facing status column",
+  },
   jobPlacement: {
     defaultMessage: "Job placement",
     id: "fQkgnT",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -839,6 +839,10 @@
     "defaultMessage": "À vous de découvrir",
     "description": "Heading for featured items on the homepage"
   },
+  "1rnUt3": {
+    "defaultMessage": "Statut visible par le (la) candidat(e)",
+    "description": "Title displayed on the Pool Candidates table candidate-facing status column"
+  },
   "1ru8HO": {
     "defaultMessage": "Appuyez le cheminement de carrière des peuples des Premières Nations, des Inuit et des Métis, qui sont passionnés par les TI, et contribuez à créer une fonction publique diversifiée, équitable et inclusive. Embauchez par le biais du Programme d'apprentissage en TI pour les personnes autochtones.",
     "description": "Description for the IT Apprenticeship Program for Indigenous Peoples"

--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationDialog.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationDialog.tsx
@@ -116,9 +116,7 @@ const ReviewApplicationDialog_Fragment = graphql(/* GraphQL */ `
           }
         }
       }
-      screeningQuestions {
-        id
-      }
+      screeningQuestionsCount
       opportunityLength {
         label {
           localized
@@ -174,7 +172,7 @@ const ReviewApplicationDialog = ({
     application.finalDecision?.value,
     pool.areaOfSelection?.value,
     application.assessmentStatus,
-    pool.screeningQuestions,
+    pool.screeningQuestionsCount,
     intl,
   );
 

--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationPreviewList.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationPreviewList.tsx
@@ -49,9 +49,7 @@ const ReviewApplicationPreviewList_Fragment = graphql(/* GraphQL */ `
       areaOfSelection {
         value
       }
-      screeningQuestions {
-        id
-      }
+      screeningQuestionsCount
     }
   }
 `);
@@ -101,7 +99,7 @@ const ReviewApplicationPreviewList = ({
                 application.finalDecision?.value,
                 application.pool.areaOfSelection?.value,
                 application.assessmentStatus,
-                application.pool.screeningQuestions,
+                application.pool.screeningQuestionsCount,
                 intl,
               );
               return { application, status };

--- a/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
@@ -63,7 +63,6 @@ export const IndexPoolCandidatePage = () => {
       />
       <Container className="my-18" size="full">
         <Pending fetching={fetching} error={error}>
-          <p className="my-6">{formattedSubTitle}</p>
           <PoolCandidatesTable
             hidePoolFilter
             initialFilterInput={{

--- a/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/helpers.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/helpers.tsx
@@ -190,12 +190,12 @@ export const notesCell = (
   ) : null;
 
 export const finalDecisionCell = (
-  finalDecsion: Maybe<LocalizedFinalDecision> | undefined,
+  finalDecision: Maybe<LocalizedFinalDecision> | undefined,
   assessmentStatus: Maybe<AssessmentResultStatus> | undefined,
   intl: IntlShape,
 ) => {
   const { color, label } = getCandidateStatusChip(
-    finalDecsion,
+    finalDecision,
     assessmentStatus,
     intl,
   );

--- a/apps/web/src/utils/poolCandidate.ts
+++ b/apps/web/src/utils/poolCandidate.ts
@@ -405,7 +405,7 @@ export const getApplicationStatusChip = (
   finalDecision: Maybe<FinalDecision> | undefined,
   areaOfSelection: Maybe<PoolAreaOfSelection> | undefined,
   assessmentStatus: PoolCandidate["assessmentStatus"],
-  screeningQuestions: Pool["screeningQuestions"],
+  screeningQuestionsCount: Pool["screeningQuestionsCount"],
   intl: IntlShape,
 ): StatusChipWithDescription => {
   // Draft applications
@@ -481,7 +481,7 @@ export const getApplicationStatusChip = (
   // Partially assessed applications
   const currentStep = assessmentStatus?.currentStep ?? 0;
   const numberOfScreeningSteps =
-    screeningQuestions && screeningQuestions?.length > 0 ? 2 : 1;
+    screeningQuestionsCount && screeningQuestionsCount > 0 ? 2 : 1;
   const numberOfStepStatuses =
     assessmentStatus?.assessmentStepStatuses?.length ?? 0;
 


### PR DESCRIPTION
🤖 Resolves #14078.

## 👋 Introduction

This PR adds the Candidate-facing status column to the pool candidates table.

## 🕵️ Details

In addition to adding the Candidate-facing status column to the pool candidates table, this PR:
- removes some superfluous copy from `IndexPoolCandidatePage.tsx`
- fixes a variable typo
- adds `screeningQuestionCount` for the `getApplicationStatusChip` function for efficiency

## 🧪 Testing

1. `make refresh-api; pnpm build:fresh`
2. Navigate to http://localhost:8000/en/admin/pool-candidates
3. Verify Candidate-facing status column value is the same as what is rendered on the related card for applicant dashboard Applications and processes > Job applications

## 📸 Screenshot

<img width="1440" alt="Screen Shot 2025-07-09 at 08 21 01" src="https://github.com/user-attachments/assets/fc421d5c-b6ca-44a4-85e9-2f35cd570396" />