### PR TITLE
[Feat] Job poster template download

### DIFF
--- a/api/app/Generators/DocGenerator.php
+++ b/api/app/Generators/DocGenerator.php
@@ -12,6 +12,8 @@ abstract class DocGenerator extends FileGenerator implements FileGeneratorInterf
 
     protected array $strong;
 
+    protected array $linkStyle;
+
     protected string $extension = 'docx';
 
     public function __construct(public string $fileName, protected ?string $dir)
@@ -46,7 +48,7 @@ abstract class DocGenerator extends FileGenerator implements FileGeneratorInterf
     protected function setup()
     {
 
-        $this->doc = new PhpWord();
+        $this->doc = new PhpWord;
 
         $this->doc->addTitleStyle(1, ['size' => 22, 'bold' => true], ['spaceBefore' => 240, 'spaceAfter' => 120]);
         $this->doc->addTitleStyle(2, ['size' => 18, 'bold' => true], ['spaceBefore' => 240, 'spaceAfter' => 120]);
@@ -55,5 +57,7 @@ abstract class DocGenerator extends FileGenerator implements FileGeneratorInterf
         $this->doc->addTitleStyle(5, ['size' => 11, 'bold' => true], ['spaceBefore' => 240, 'spaceAfter' => 120]);
 
         $this->strong = ['bold' => true];
+
+        $this->linkStyle = ['color' => '#003632', 'underline' => \PhpOffice\PhpWord\Style\Font::UNDERLINE_SINGLE];
     }
 }

--- a/api/app/Generators/JobPosterTemplateGenerator.php
+++ b/api/app/Generators/JobPosterTemplateGenerator.php
@@ -81,7 +81,9 @@ class JobPosterTemplateGenerator extends DocGenerator implements FileGeneratorIn
 
             $section->addText($this->localize('job_poster_template.'.$noteProperty));
 
-            foreach ($skills as $skill) {
+            $sorted = $skills->sortBy('name.'.$this->lang);
+
+            foreach ($sorted as $skill) {
                 $section->addTitle($skill->name[$this->lang], 3);
 
                 if ($skill->pivot->required_skill_level) {

--- a/api/app/Generators/JobPosterTemplateGenerator.php
+++ b/api/app/Generators/JobPosterTemplateGenerator.php
@@ -39,7 +39,6 @@ class JobPosterTemplateGenerator extends DocGenerator implements FileGeneratorIn
             1
         );
 
-        // Basic Details section
         $section->addTitle($this->localizeHeading('basic_details'), 2);
         $this->addLabelText($section, $this->localizeHeading('job_title'), $this->jobPoster->name[$this->lang]);
         $this->addLabelText($section, $this->localizeHeading('description'), $this->jobPoster->description[$this->lang]);
@@ -56,26 +55,25 @@ class JobPosterTemplateGenerator extends DocGenerator implements FileGeneratorIn
 
         $this->addLabelText($section, $this->localizeHeading('reference_id'), $this->jobPoster->reference_id);
 
-        // Key tasks
         $section->addTitle($this->localizeHeading('key_tasks_examples'), 2);
         $section->addText($this->localize('job_poster_template.key_tasks_note'));
         $this->addHtml($section, $this->jobPoster->tasks[$this->lang]);
 
-        $this->addSkillSection($section, $this->localizeHeading('essential_technical_skills_examples'), 'essential', 'technical');
-        $this->addSkillSection($section, $this->localizeHeading('essential_behavioural_skills_examples'), 'essential', 'behavioural');
-        $this->addSkillSection($section, $this->localizeHeading('nonessential_technical_skills_examples'), 'nonessential', 'technical');
+        $this->addSkillSection($section, 'essential', 'technical');
+        $this->addSkillSection($section, 'essential', 'behavioural');
+        $this->addSkillSection($section, 'nonessential', 'technical');
 
         return $this;
     }
 
-    private function addSkillSection(Section $section, string $title, string $type, string $category)
+    private function addSkillSection(Section $section, string $type, string $category)
     {
 
         $property = sprintf('%s_%s_skills', $type, $category);
         $relation = Str::camel($property);
         $noteProperty = sprintf('%s_notes', $property);
 
-        $section->addTitle($title, 2);
+        $section->addTitle($this->localizeHeading(sprintf('%s_examples', $property)), 2);
         if ($techNote = $this->jobPoster->$noteProperty[$this->lang]) {
             // NOTE: We are adding the footnote after the title
             // this is not ideal but it doesn't seem as though

--- a/api/app/Generators/JobPosterTemplateGenerator.php
+++ b/api/app/Generators/JobPosterTemplateGenerator.php
@@ -68,34 +68,30 @@ class JobPosterTemplateGenerator extends DocGenerator implements FileGeneratorIn
 
     private function addSkillSection(Section $section, string $type, string $category)
     {
-
         $property = sprintf('%s_%s_skills', $type, $category);
-        $relation = Str::camel($property);
         $noteProperty = sprintf('%s_notes', $property);
+        $relation = Str::camel($property);
 
-        $section->addTitle($this->localizeHeading(sprintf('%s_examples', $property)), 2);
-        if ($techNote = $this->jobPoster->$noteProperty[$this->lang]) {
-            // NOTE: We are adding the footnote after the title
-            // this is not ideal but it doesn't seem as though
-            // we cannot properly add a footnote to a title
-            $titleRun = $section->addTextRun();
-            $footnote = $titleRun->addFootnote();
-            $footnote->addText($techNote);
-        }
+        if ($skills = $this->jobPoster->$relation) {
+            $section->addTitle($this->localizeHeading(sprintf('%s_examples', $property)), 2);
 
-        $section->addText($this->localize('job_poster_template.'.$noteProperty));
-
-        $skills = $this->jobPoster->$relation;
-        foreach ($skills as $skill) {
-            $section->addTitle($skill->name[$this->lang], 3);
-
-            if ($skill->pivot->required_skill_level) {
-                $this->addLabelText($section, $this->localize('job_poster_template.level'), $this->localizeEnum($skill->pivot->required_skill_level, SkillLevel::class));
-                $definitionKey = sprintf('skill_level.definition.%s.%s', $category, strtolower($skill->pivot->required_skill_level));
-                $this->addLabelText($section, $this->localize('job_poster_template.level_definition'), $this->localize($definitionKey));
+            if ($note = $this->jobPoster->$noteProperty[$this->lang]) {
+                $this->addLabelText($section, $this->localize('job_poster_template.special_note'), $note);
             }
-            $this->addLabelText($section, $this->localize('job_poster_template.skill_definition'), $skill->description[$this->lang]);
 
+            $section->addText($this->localize('job_poster_template.'.$noteProperty));
+
+            foreach ($skills as $skill) {
+                $section->addTitle($skill->name[$this->lang], 3);
+
+                if ($skill->pivot->required_skill_level) {
+                    $this->addLabelText($section, $this->localize('job_poster_template.level'), $this->localizeEnum($skill->pivot->required_skill_level, SkillLevel::class));
+                    $definitionKey = sprintf('skill_level.definition.%s.%s', $category, strtolower($skill->pivot->required_skill_level));
+                    $this->addLabelText($section, $this->localize('job_poster_template.level_definition'), $this->localize($definitionKey));
+                }
+                $this->addLabelText($section, $this->localize('job_poster_template.skill_definition'), $skill->description[$this->lang]);
+
+            }
         }
 
     }

--- a/api/app/Generators/JobPosterTemplateGenerator.php
+++ b/api/app/Generators/JobPosterTemplateGenerator.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Generators;
+
+use App\Enums\SupervisoryStatus;
+use App\Models\JobPosterTemplate;
+use App\Traits\Generator\GeneratesDoc;
+
+class JobPosterTemplateGenerator extends DocGenerator implements FileGeneratorInterface
+{
+    use GeneratesDoc;
+
+    public function __construct(protected JobPosterTemplate $jobPoster, public ?string $dir, protected ?string $lang)
+    {
+        $fileName = sprintf(
+            '%s - %s',
+            __('filename.job_poster_template'),
+            $jobPoster->name[$lang]
+        );
+
+        parent::__construct($fileName, $dir);
+    }
+
+    public function generate(): self
+    {
+        $this->setup();
+
+        $section = $this->doc->addSection();
+
+        $section->addTitle(
+            sprintf(
+                '%s%s%s',
+                __('filename.job_poster_template'),
+                $this->colon(),
+                $this->jobPoster->name[$this->lang]),
+            1
+        );
+
+        // Basic Details section
+        $section->addTitle($this->localizeHeading('basic_details'), 2);
+        $this->addLabelText($section, $this->localizeHeading('job_title'), $this->jobPoster->name[$this->lang]);
+        $this->addLabelText($section, $this->localizeHeading('description'), $this->jobPoster->description[$this->lang]);
+        $this->addLabelText($section, $this->localizeHeading('classification'), $this->jobPoster->classification->displayName);
+        $this->addLabelText($section, $this->localizeHeading('work_stream'), $this->jobPoster->workStream->name[$this->lang]);
+        $this->addLabelText($section, $this->localizeHeading('role_type'), $this->localizeEnum($this->jobPoster->supervisory_status, SupervisoryStatus::class));
+        $this->addLabelLink($section, $this->localizeHeading('work_description'),
+            [
+                'href' => $this->jobPoster->work_description[$this->lang],
+                'text' => $this->localize('gcpedia.view'),
+            ],
+            $this->localize('gcpedia.note')
+        );
+
+        $this->addLabelText($section, $this->localizeHeading('reference_id'), $this->jobPoster->reference_id);
+
+        return $this;
+    }
+}

--- a/api/app/GraphQL/Mutations/DownloadJobPosterTemplateDoc.php
+++ b/api/app/GraphQL/Mutations/DownloadJobPosterTemplateDoc.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations;
+
+use App\Generators\JobPosterTemplateGenerator;
+use App\Models\JobPosterTemplate;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\UnauthorizedException;
+
+final readonly class DownloadJobPosterTemplateDoc
+{
+    /** @param  array{id: string|null}  $args */
+    public function __invoke(null $_, array $args)
+    {
+        $user = Auth::user();
+        throw_unless(is_string($user?->id), UnauthorizedException::class);
+
+        try {
+            $targetPoster = JobPosterTemplate::findOrFail($args['id']);
+            $generator = new JobPosterTemplateGenerator(
+                jobPoster: $targetPoster,
+                dir: $user->id,
+                lang: App::getLocale()
+            );
+
+            $generator->setUserId($user->id);
+
+            $generator->generate()->write();
+
+            return $generator->getFileNameWithExtension();
+        } catch (\Exception $e) {
+            Log::error('Error starting job poster template document generation '.$e);
+
+            return null;
+        }
+    }
+}

--- a/api/app/Models/JobPosterTemplate.php
+++ b/api/app/Models/JobPosterTemplate.php
@@ -3,6 +3,8 @@
 namespace App\Models;
 
 use App\Casts\LocalizedString;
+use App\Enums\PoolSkillType;
+use App\Enums\SkillCategory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -74,6 +76,27 @@ class JobPosterTemplate extends Model
     {
         return $this->belongsToMany(Skill::class)
             ->withPivot('type', 'required_skill_level');
+    }
+
+    public function essentialTechnicalSkills(): BelongsToMany
+    {
+        return $this->skills()
+            ->wherePivot('type', PoolSkillType::ESSENTIAL->name)
+            ->where('category', SkillCategory::TECHNICAL->name);
+    }
+
+    public function essentialBehaviouralSkills(): BelongsToMany
+    {
+        return $this->skills()
+            ->wherePivot('type', PoolSkillType::ESSENTIAL->name)
+            ->where('category', SkillCategory::BEHAVIOURAL->name);
+    }
+
+    public function nonessentialTechnicalSkills(): BelongsToMany
+    {
+        return $this->skills()
+            ->wherePivot('type', PoolSkillType::NONESSENTIAL->name)
+            ->where('category', SkillCategory::TECHNICAL->name);
     }
 
     /** @return BelongsTo<WorkStream, $this> */

--- a/api/app/Traits/Generator/GeneratesDoc.php
+++ b/api/app/Traits/Generator/GeneratesDoc.php
@@ -3,6 +3,7 @@
 namespace App\Traits\Generator;
 
 use PhpOffice\PhpWord\Element\Section;
+use PhpOffice\PhpWord\Element\TextRun;
 
 trait GeneratesDoc
 {
@@ -13,14 +14,45 @@ trait GeneratesDoc
      *
      * @param  Section  $section  The section to add it to
      * @param  string  $label  Label for the text
-     * @param  string  $text  The value
+     * @param  string|null  $text  The value
+     * @param  string|null  $footnote  Footnote text
      */
-    protected function addLabelText(Section $section, string $label, ?string $text)
+    protected function addLabelText(Section $section, string $label, ?string $text, ?string $footnote = null): void
     {
         $run = $section->addTextRun();
         $run->addText($label.$this->colon());
-        if (! is_null($text)) {
+        if ($text !== null) {
             $run->addText($text);
+        }
+        $this->appendFootnote($run, $footnote);
+    }
+
+    /**
+     * Adds link accompanied by a strong label
+     *
+     * @param  Section  $section  The section to add it to
+     * @param  string  $label  Label for the text
+     * @param  array{href: string, text: string}|null  $link
+     * @param  string|null  $footnote  Footnote text
+     */
+    protected function addLabelLink(Section $section, string $label, ?array $link, ?string $footnote = null): void
+    {
+        $run = $section->addTextRun();
+        $run->addText($label.$this->colon());
+        if ($link !== null) {
+            $run->addLink($link['href'], $link['text']);
+        }
+        $this->appendFootnote($run, $footnote);
+    }
+
+    /**
+     * Appends a footnote to the given run if text is provided.
+     */
+    private function appendFootnote(TextRun $run, ?string $text): void
+    {
+        if ($text) {
+            $footnote = $run->addFootnote();
+            $footnote->addText($text); // Fixed bug: was $footnote->addText($footnote);
         }
     }
 }

--- a/api/app/Traits/Generator/GeneratesDoc.php
+++ b/api/app/Traits/Generator/GeneratesDoc.php
@@ -41,7 +41,7 @@ trait GeneratesDoc
         $run = $section->addTextRun();
         $run->addText($label.$this->colon());
         if ($link !== null) {
-            $run->addLink($link['href'], $link['text']);
+            $run->addLink($link['href'], $link['text'], $this->linkStyle);
         }
         $this->appendFootnote($run, $footnote);
     }

--- a/api/app/Traits/Generator/GeneratesDoc.php
+++ b/api/app/Traits/Generator/GeneratesDoc.php
@@ -4,6 +4,7 @@ namespace App\Traits\Generator;
 
 use PhpOffice\PhpWord\Element\Section;
 use PhpOffice\PhpWord\Element\TextRun;
+use PhpOffice\PhpWord\Shared\Html;
 
 trait GeneratesDoc
 {
@@ -53,6 +54,13 @@ trait GeneratesDoc
         if ($text) {
             $footnote = $run->addFootnote();
             $footnote->addText($text); // Fixed bug: was $footnote->addText($footnote);
+        }
+    }
+
+    protected function addHtml(Section $section, ?string $html)
+    {
+        if ($html) {
+            Html::addHtml($section, $html, false, false);
         }
     }
 }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -3366,4 +3366,7 @@ type Mutation {
   downloadApplicationDoc(id: UUID!): String
     @guard
     @canFind(ability: "view", find: "id", model: "PoolCandidate")
+  downloadJobPosterTemplateDoc(id: UUID!): String
+    @guard
+    @canFind(ability: "view", find: "id", model: "JobPosterTemplate")
 }

--- a/api/lang/en/filename.php
+++ b/api/lang/en/filename.php
@@ -6,4 +6,5 @@ return [
     'candidate' => 'candidate',
     'users' => 'users',
     'user' => 'user',
+    'job_poster_template' => 'Job advertisement template',
 ];

--- a/api/lang/en/gcpedia.php
+++ b/api/lang/en/gcpedia.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'view' => 'View on GCPedia',
+    'note' => 'Please note that this resource is only available to Government of Canada employees on official networks.',
+];

--- a/api/lang/en/gcpedia.php
+++ b/api/lang/en/gcpedia.php
@@ -1,6 +1,0 @@
-<?php
-
-return [
-    'view' => 'View on GCPedia',
-    'note' => 'Please note that this resource is only available to Government of Canada employees on official networks.',
-];

--- a/api/lang/en/headings.php
+++ b/api/lang/en/headings.php
@@ -110,6 +110,17 @@ return [
     'skills_to_improve' => 'Skills to improve',
     'signature' => 'Signature',
     'signed' => 'Signed',
+
+    // Job poster template
+    'basic_details' => 'Basic details',
+    'job_title' => 'Job title',
+    'reference_id' => 'Reference ID',
+    'description' => 'Description',
+    'classification' => 'Classification',
+    'work_stream' => 'Workstream',
+    'role_type' => 'Type of role',
+    'work_description' => 'Generic work description',
+
     // Other
     'general_question' => 'General question',
     'screening_question' => 'Screening question',

--- a/api/lang/en/headings.php
+++ b/api/lang/en/headings.php
@@ -120,6 +120,10 @@ return [
     'work_stream' => 'Workstream',
     'role_type' => 'Type of role',
     'work_description' => 'Generic work description',
+    'key_tasks_examples' => 'Key tasks – Examples',
+    'essential_technical_skills_examples' => 'Essential technical skills – Examples',
+    'essential_behavioural_skills_examples' => 'Essential behavioural skills – Examples',
+    'nonessential_technical_skills_examples' => 'Asset technical skills - Examples',
 
     // Other
     'general_question' => 'General question',

--- a/api/lang/en/job_poster_template.php
+++ b/api/lang/en/job_poster_template.php
@@ -10,5 +10,5 @@ return [
     'level' => 'Level',
     'level_definition' => 'Level definition',
     'skill_definition' => 'Skill definition',
-
+    'special_note' => 'Special note',
 ];

--- a/api/lang/en/job_poster_template.php
+++ b/api/lang/en/job_poster_template.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    'gcpedia_view' => 'View on GCPedia',
+    'gcpedia_note' => 'Please note that this resource is only available to Government of Canada employees on official networks.',
+    'key_tasks_note' => 'The following key tasks are examples of the work that might be part of this role. When drafting your job advertisement, you\'re welcome to add, remove, or modify what is listed here to better fit your team and the job you\'re hoping to fill.',
+    'essential_technical_skills_notes' => 'Essential or required skills (also known as merit criteria) are the core skill requirements a candidate needs to perform the job. This list includes common skills that are often required for this role, but we recommend choosing only the skills that are absolutely necessary. A shorter list of required skills leads to stronger applications and simplifies the evaluation process.',
+    'essential_behavioural_skills_notes' => 'In similar fashion to the essential technical skills, this list offers recommendations for the behavioural skills commonly required for this role. We recommend keeping essential behavioural skills limited to the exact requirements for your position or team to help candidates highlight the most relevant experience.',
+    'nonessential_technical_skills_notes' => 'Asset or optional technical skills allow you to elaborate on skills that aren\'t strictly required but would benefit the role. These might address gaps on your team or be related skills that could bolster the candidate\'s work. Include any skills you think are a good fit for the position, but keep in mind that candidates aren\'t obligated to have these skills to apply or qualify.',
+    'level' => 'Level',
+    'level_definition' => 'Level definition',
+    'skill_definition' => 'Skill definition',
+
+];

--- a/api/lang/en/skill_level.php
+++ b/api/lang/en/skill_level.php
@@ -7,4 +7,20 @@ return [
     'intermediate' => Lang::get('common.intermediate', [], 'en'),
     'advanced' => Lang::get('common.advanced', [], 'en'),
     'lead' => 'Lead',
+
+    // Definitions
+    'definition' => [
+        'behavioural' => [
+            'beginner' => 'Demonstrated, but consistency varies significantly by audience and circumstance. Intermittently demonstrated in daily situations and inconsistently demonstrated with certain audiences or under conditions of stress or in moderately challenging situations. Potential is there, but there is learning to be done.',
+            'intermediate' => 'Frequently demonstrated as well-developed in most daily situations with most audiences, and intermittently demonstrated under conditions of stress and in moderately challenging situations.',
+            'advanced' => 'Consistently demonstrated as well-developed in daily conditions with all audiences, frequently demonstrated in situations of stress and in moderately challenging situations with most audiences, and intermittently demonstrated under conditions of significant stress and in challenging situations.',
+            'lead' => 'Consistently demonstrated as well-developed with all audiences, even under conditions of significant stress and in challenging situations. Behaviour is adapted and nuanced to the situation without drifting away from its core value.',
+        ],
+        'technical' => [
+            'beginner' => 'Demonstrated ability to consistently deliver on tasks of low complexity under minimal supervision and tasks of moderate complexity under strong supervision or with direct mentoring. Usually associated with junior or entry-level roles.',
+            'intermediate' => 'Demonstrated ability to consistently deliver on tasks of low to moderate complexity under minimal supervision and tasks of higher-level complexity under moderate supervision and mentoring. Usually associated with intermediate roles.',
+            'advanced' => 'Demonstrated ability to scope, undertake, and deliver on tasks of moderate to high complexity under minimal levels of supervision. Demonstrated ability to mentor others in lower levels of skill development, either through direct supervision or by setting examples and providing explanations. Usually associated with senior technical advisor or entry-level supervisory roles.',
+            'lead' => 'Demonstrated ability to identify, scope, undertake, and deliver on tasks of significant complexity with wide areas of impact, even in challenging circumstances. Demonstrated ability to lead the development of tasks, and potentially teams, for the organization in this area. Usually associated with manager or technical lead roles.',
+        ],
+    ],
 ];

--- a/api/lang/fr/filename.php
+++ b/api/lang/fr/filename.php
@@ -6,4 +6,5 @@ return [
     'candidate' => 'candidat',
     'user' => 'utilisateur',
     'users' => 'utilisateurs',
+    'job_poster_template' => 'Modèle d’offre d’emploi',
 ];

--- a/api/lang/fr/gcpedia.php
+++ b/api/lang/fr/gcpedia.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'view' => 'Voir sur GCpédia',
+    'note' => 'Veuillez noter que cette ressource n\'est disponible que pour les employées et employés du gouvernement du Canada sur les réseaux officiels',
+];

--- a/api/lang/fr/headings.php
+++ b/api/lang/fr/headings.php
@@ -112,6 +112,17 @@ return [
     'skills_to_improve' => 'Compétences à améliorer',
     'signature' => 'Signature',
     'signed' => 'Signée',
+
+    // Job poster template
+    'basic_details' => 'Détails de base',
+    'job_title' => 'Titre du poste',
+    'reference_id' => 'Identifiant de référence',
+    'description' => 'Description ',
+    'classification' => 'Classification',
+    'work_stream' => 'Flux de travail',
+    'role_type' => 'Type de poste',
+    'work_description' => 'Description générique du travail',
+
     // Other
     'general_question' => 'Question générale',
     'screening_question' => 'Question de sélection',

--- a/api/lang/fr/headings.php
+++ b/api/lang/fr/headings.php
@@ -122,6 +122,10 @@ return [
     'work_stream' => 'Flux de travail',
     'role_type' => 'Type de poste',
     'work_description' => 'Description générique du travail',
+    'key_tasks_examples' => 'Tâches principales - Exemples',
+    'essential_technical_skills_examples' => 'Compétences techniques essentielles – Exemples',
+    'essential_behavioural_skills_examples' => 'Compétences comportementales essentielles - Exemples',
+    'nonessential_technical_skills_examples' => 'Compétences techniques constituant un atout - Exemples',
 
     // Other
     'general_question' => 'Question générale',

--- a/api/lang/fr/job_poster_template.php
+++ b/api/lang/fr/job_poster_template.php
@@ -10,5 +10,5 @@ return [
     'level' => 'Niveau',
     'level_definition' => 'Définition du niveau',
     'skill_definition' => 'Définition de la compétence',
-
+    'special_note' => 'Note spéciale',
 ];

--- a/api/lang/fr/job_poster_template.php
+++ b/api/lang/fr/job_poster_template.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    'gcpedia_view' => 'Voir sur GCpédia',
+    'gcpedia_note' => 'Veuillez noter que cette ressource n\'est disponible que pour les employées et employés du gouvernement du Canada sur les réseaux officiels.',
+    'key_tasks_note' => 'Les tâches principales suivantes sont des exemples du travail qui pourrait être effectué dans le cadre de ce poste. Au moment de rédiger votre offre d’emploi, vous pouvez ajouter, supprimer ou modifier ce qui est mentionné ici afin de mieux l’adapter à votre équipe et au poste que vous souhaitez pourvoir.',
+    'essential_technical_skills_notes' => 'Les compétences essentielles ou requises (également appelées critères de mérite) sont les compétences de base dont une personne candidate a besoin pour effectuer le travail. Cette liste comprend des compétences communes qui sont souvent requises dans le cadre de ce poste, mais nous recommandons de ne choisir que les compétences qui sont absolument nécessaires. Une liste plus courte de compétences requises permet de présenter des candidatures plus solides et simplifie le processus d’évaluation.',
+    'essential_behavioural_skills_notes' => 'De la même manière que pour les compétences techniques essentielles, cette liste propose des recommandations concernant les compétences comportementales généralement requises dans le cadre de ce poste. Nous recommandons de limiter les compétences comportementales essentielles aux exigences exactes de votre poste ou de votre équipe afin d’aider les personnes candidates à mettre en évidence l’expérience la plus pertinente.',
+    'nonessential_technical_skills_notes' => 'Les compétences techniques constituant un atout ou les compétences techniques facultatives vous permettent de préciser les compétences qui ne sont pas strictement requises, mais qui seraient utiles pour le poste. Il peut s’agir de combler des lacunes au sein de votre équipe ou de posséder des compétences connexes susceptibles de renforcer le travail de la personne candidate. Mentionnez toutes les compétences que vous estimez utiles pour le poste, mais n’oubliez pas que les personnes candidates ne sont pas obligées de posséder ces compétences pour postuler ou se qualifier.',
+    'level' => 'Niveau',
+    'level_definition' => 'Définition du niveau',
+    'skill_definition' => 'Définition de la compétence',
+
+];

--- a/api/lang/fr/skill_level.php
+++ b/api/lang/fr/skill_level.php
@@ -7,4 +7,20 @@ return [
     'intermediate' => Lang::get('common.intermediate', [], 'fr'),
     'advanced' => Lang::get('common.advanced', [], 'fr'),
     'lead' => 'Lead',
+
+    // Definitions
+    'definition' => [
+        'behavioural' => [
+            'beginner' => 'Démontrée, mais la constance varie considérablement selon le public et les circonstances. Démontrée par intermittence dans des situations quotidiennes et démontrée de façon inconstante auprès de certains publics ou dans des conditions de stress ou dans des situations modérément difficiles. Le potentiel est là, mais il reste encore beaucoup à apprendre.',
+            'intermediate' => 'Souvent démontrée comme étant bien développée dans la plupart des situations quotidiennes auprès de la plupart des publics, et démontrée par intermittence dans des conditions de stress et dans des situations modérément difficiles.',
+            'advanced' => 'Constamment démontrée comme étant bien développée dans des conditions quotidiennes auprès de tous les publics, fréquemment démontrée dans des situations de stress et dans des situations modérément difficiles auprès de la plupart des publics, et démontrée par intermittence dans des conditions de stress important et dans des situations difficiles.',
+            'lead' => 'Constamment démontrée comme étant bien développée auprès de tous les publics, même dans des conditions de stress important et dans des situations difficiles. Le comportement est nuancé et adapté à la situation sans s’éloigner de sa valeur fondamentale.',
+        ],
+        'technical' => [
+            'beginner' => 'Capacité démontrée à accomplir de façon constante des tâches de faible complexité sous une supervision minimale et des tâches de complexité modérée sous une forte supervision ou un mentorat direct. Généralement associée à des postes juniors ou de niveau d’entrée.',
+            'intermediate' => 'Capacité démontrée à accomplir de façon constante des tâches de complexité faible à modérée sous une supervision minimale et des tâches de complexité plus élevée sous une supervision et un mentorat modérés. Généralement associée à des postes intermédiaires.',
+            'advanced' => 'Capacité démontrée à définir, entreprendre et exécuter des tâches de complexité modérée à élevée sous des niveaux de supervision minimaux. Capacité démontrée à encadrer d’autres personnes à des niveaux inférieurs de développement de compétences, soit par le biais d’une supervision directe, soit en donnant l’exemple et en fournissant des explications. Généralement associée à des postes de conseiller technique principal ou de supervision de niveau d’entrée.',
+            'lead' => 'Capacité démontrée à déterminer, définir, entreprendre et exécuter des tâches d’une grande complexité avec de vastes domaines de répercussions, même dans des circonstances difficiles. Capacité démontrée à diriger le développement de tâches, et potentiellement d’équipes, pour l’organisation dans ce domaine. Généralement associée à des postes de gestionnaire ou de responsable technique.',
+        ],
+    ],
 ];

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -625,6 +625,7 @@ type Mutation {
   downloadUsersZip(ids: [UUID!]!, anonymous: Boolean!): Boolean!
   downloadUserDoc(id: UUID!, anonymous: Boolean!): String
   downloadApplicationDoc(id: UUID!): String
+  downloadJobPosterTemplateDoc(id: UUID!): String
 }
 
 "A date string with format `Y-m-d`, e.g. `2011-05-23`."

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -87,10 +87,6 @@
     "defaultMessage": "Compétence",
     "description": "Label for the skill select field"
   },
-  "+Ln2X/": {
-    "defaultMessage": "Téléchargez (EN)",
-    "description": "Link to download a file in English"
-  },
   "+MCd8X": {
     "defaultMessage": "La Commission de la fonction publique (CFP) est responsable de l’ensemble des évaluations en langue seconde pour les offres d’emploi du gouvernement du Canada. Vous pouvez en savoir plus sur ce sujet sur le site Web de la CFP",
     "description": "PSC second language evaluations list for language requirements dialog"
@@ -12568,10 +12564,6 @@
   "v0EVPQ": {
     "defaultMessage": "Ce programme s’adresse aux membres de Premières nations, aux Inuits et aux Métis du Canada.",
     "description": "Disclaimer displayed when a user has indicated they are not Indigenous on the self-declaration form."
-  },
-  "v1obWV": {
-    "defaultMessage": "Téléchargez (FR)",
-    "description": "Link to download a file in French"
   },
   "v21LPW": {
     "defaultMessage": "Mises à jour de l'application",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2499,10 +2499,6 @@
     "defaultMessage": "Il s’agissait d’un rôle comme membre du personnel ou comme entrepreneur(euse) dans un ministère ou un organisme fédéral ou une société d’État.",
     "description": "Description for the goc employment category option in work experience"
   },
-  "9XgUGm": {
-    "defaultMessage": "Télécharger",
-    "description": "Button text to download an applicants application or profile"
-  },
   "9Y3w6l": {
     "defaultMessage": "Il y a actuellement des questions sans réponse dans cette section. Cliquez sur le bouton « Modifiez » pour examiner les champs obligatoires et répondre aux questions.",
     "description": "Message for unanswered questions in this section"

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatePage/JobPosterTemplatePage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatePage/JobPosterTemplatePage.tsx
@@ -1,6 +1,5 @@
 import { OperationContext, useQuery } from "urql";
 import { useIntl } from "react-intl";
-import ArrowDownOnSquareIcon from "@heroicons/react/20/solid/ArrowDownOnSquareIcon";
 
 import {
   FragmentType,
@@ -10,7 +9,6 @@ import {
 } from "@gc-digital-talent/graphql";
 import {
   Container,
-  Link,
   Pending,
   Separator,
   TableOfContents,

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatePage/JobPosterTemplatePage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatePage/JobPosterTemplatePage.tsx
@@ -32,6 +32,7 @@ import KeyTasks from "./components/KeyTasks";
 import EssentialTechnicalSkills from "./components/EssentialTechnicalSkills";
 import EssentialBehaviouralSkills from "./components/EssentialBehaviouralSkills";
 import AssetTechnicalSkills from "./components/AssetTechnicalSkills";
+import JobPosterDownloadButton from "./components/JobPosterDownloadButton";
 
 const JobPosterTemplateTopLevel_Fragment = graphql(/* GraphQL */ `
   fragment JobPosterTemplateTopLevel on JobPosterTemplate {
@@ -134,37 +135,8 @@ const JobPosterTemplate = ({
                 </TableOfContents.AnchorLink>
               </TableOfContents.ListItem>
             </TableOfContents.List>
-            {/* The download links will be added in a later issue */}
-            {/* eslint-disable-next-line no-constant-binary-expression */}
-            {false && (
-              <>
-                <Separator space="sm" />
-                <div className="flex flex-col gap-6">
-                  <Link
-                    href="#"
-                    icon={ArrowDownOnSquareIcon}
-                    className="font-bold"
-                  >
-                    {intl.formatMessage({
-                      defaultMessage: "Download (EN)",
-                      id: "+Ln2X/",
-                      description: "Link to download a file in English",
-                    })}
-                  </Link>
-                  <Link
-                    href="#"
-                    icon={ArrowDownOnSquareIcon}
-                    className="font-bold"
-                  >
-                    {intl.formatMessage({
-                      defaultMessage: "Download (FR)",
-                      id: "v1obWV",
-                      description: "Link to download a file in French",
-                    })}
-                  </Link>
-                </div>
-              </>
-            )}
+            <Separator space="sm" />
+            <JobPosterDownloadButton id={jobPosterTemplate.id} />
           </TableOfContents.Navigation>
           <TableOfContents.Content>
             <div className="flex flex-col gap-18">

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatePage/components/JobPosterDownloadButton.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatePage/components/JobPosterDownloadButton.tsx
@@ -1,0 +1,70 @@
+import { useIntl } from "react-intl";
+import { useMutation } from "urql";
+import ArrowDownTrayIcon from "@heroicons/react/20/solid/ArrowDownTrayIcon";
+
+import { graphql, Scalars } from "@gc-digital-talent/graphql";
+import { commonMessages, errorMessages } from "@gc-digital-talent/i18n";
+import { toast } from "@gc-digital-talent/toast";
+import { Button } from "@gc-digital-talent/ui";
+import { useApiRoutes } from "@gc-digital-talent/auth";
+
+import SpinnerIcon from "~/components/SpinnerIcon/SpinnerIcon";
+import useAsyncFileDownload from "~/hooks/useAsyncFileDownload";
+
+const DownloadJobPosterTemplateDoc_Mutation = graphql(/* GraphQL */ `
+  mutation DownloadJobPosterTemplateDoc($id: UUID!) {
+    downloadJobPosterTemplateDoc(id: $id)
+  }
+`);
+
+interface JobPosterDownloadButtonProps {
+  id: Scalars["UUID"]["output"];
+}
+
+const JobPosterDownloadButton = ({ id }: JobPosterDownloadButtonProps) => {
+  const intl = useIntl();
+  const paths = useApiRoutes();
+  const [{ fetching: downloadingAsyncFile }, executeAsyncDownload] =
+    useAsyncFileDownload();
+  const [{ fetching: downloadingDoc }, executeDocDownload] = useMutation(
+    DownloadJobPosterTemplateDoc_Mutation,
+  );
+
+  const handleDownloadError = () => {
+    toast.error(intl.formatMessage(errorMessages.downloadRequestFailed));
+  };
+
+  const downloadDoc = () => {
+    // Prevent duplicate downloads
+    if (downloadingAsyncFile || downloadingDoc) return;
+
+    executeDocDownload({ id })
+      .then((res) => {
+        if (res?.data?.downloadJobPosterTemplateDoc) {
+          executeAsyncDownload({
+            url: paths.userGeneratedFile(res.data.downloadJobPosterTemplateDoc),
+            fileName: res.data.downloadJobPosterTemplateDoc,
+          }).catch(handleDownloadError);
+        } else {
+          handleDownloadError();
+        }
+      })
+      .catch(handleDownloadError);
+  };
+
+  const isDownloading = downloadingDoc || downloadingAsyncFile;
+
+  return (
+    <Button
+      block
+      mode="inline"
+      onClick={downloadDoc}
+      icon={isDownloading ? SpinnerIcon : ArrowDownTrayIcon}
+      disabled={isDownloading}
+    >
+      {intl.formatMessage(commonMessages.download)}
+    </Button>
+  );
+};
+
+export default JobPosterDownloadButton;

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/DownloadButton.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/DownloadButton.tsx
@@ -4,11 +4,11 @@ import ChevronDownIcon from "@heroicons/react/20/solid/ChevronDownIcon";
 
 import { Button, DropdownMenu } from "@gc-digital-talent/ui";
 import { Scalars } from "@gc-digital-talent/graphql";
+import { commonMessages } from "@gc-digital-talent/i18n";
 
 import SpinnerIcon from "~/components/SpinnerIcon/SpinnerIcon";
 import useUserDownloads from "~/hooks/useUserDownloads";
 import useApplicationDownloads from "~/hooks/useApplicationDownloads";
-import { commonMessages } from "@gc-digital-talent/i18n";
 
 interface DownloadButtonProps {
   id: Scalars["UUID"]["output"];

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/DownloadButton.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/DownloadButton.tsx
@@ -8,6 +8,7 @@ import { Scalars } from "@gc-digital-talent/graphql";
 import SpinnerIcon from "~/components/SpinnerIcon/SpinnerIcon";
 import useUserDownloads from "~/hooks/useUserDownloads";
 import useApplicationDownloads from "~/hooks/useApplicationDownloads";
+import { commonMessages } from "@gc-digital-talent/i18n";
 
 interface DownloadButtonProps {
   id: Scalars["UUID"]["output"];
@@ -43,12 +44,7 @@ const DownloadButton = ({ id, userId }: DownloadButtonProps) => {
           utilityIcon={ChevronDownIcon}
           icon={isDownloading ? SpinnerIcon : ArrowDownTrayIcon}
         >
-          {intl.formatMessage({
-            defaultMessage: "Download",
-            id: "9XgUGm",
-            description:
-              "Button text to download an applicants application or profile",
-          })}
+          {intl.formatMessage(commonMessages.download)}
         </Button>
       </DropdownMenu.Trigger>
       <DropdownMenu.Content align="end" collisionPadding={2}>

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1,4 +1,8 @@
 {
+  "TsltMU": {
+    "defaultMessage": "Télécharger",
+    "description": "Button text to download a resource"
+  },
   "+6/qCF": {
     "defaultMessage": "Supprimer",
     "description": "Button text for a dismissible chip"

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1,8 +1,4 @@
 {
-  "TsltMU": {
-    "defaultMessage": "Télécharger",
-    "description": "Button text to download a resource"
-  },
   "+6/qCF": {
     "defaultMessage": "Supprimer",
     "description": "Button text for a dismissible chip"
@@ -810,6 +806,10 @@
   "TiIkSF": {
     "defaultMessage": "Deux années post-secondaire",
     "description": "Option for education requirement, 2-year post-secondary"
+  },
+  "TsltMU": {
+    "defaultMessage": "Télécharger",
+    "description": "Button text to download a resource"
   },
   "U/4a27": {
     "defaultMessage": "Effacer votre sélection",

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -264,6 +264,11 @@ const commonMessages = defineMessages({
     id: "jStpFw",
     description: "Name of Bilingual (English and French)",
   },
+  download: {
+    defaultMessage: "Download",
+    id: "TsltMU",
+    description: "Button text to download a resource",
+  },
   preparingDownload: {
     defaultMessage:
       "Preparing your file for download. You will receive a notification when it is ready.",


### PR DESCRIPTION
🤖 Resolves #11440 

## 👋 Introduction

Adds a download button to the job poster template page.

## 🕵️ Details

The styles of the document are not exact to the samples provided. However, none of our documents are stellar in their styling so I createdd a new ticket to scope out updating our docs to look better.

 - https://github.com/GCTC-NTGC/gc-digital-talent/issues/14114

## 🧪 Testing

> [!IMPORTANT]
> `PhpWord` does not support adding footnores to titles. @NienkeBr helped me work out a solution to this. The footnote for the different skills titles is now a paragraph just below the title with a "Special note" prefix. 
> 
> See the following image for updated example

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to the job poster templates page `/job-templates`
4. Click on a specific template
5. Confirm download button att he bottom odf the sidebar
6. Confirm the button successfully downloads the file and matches the sample

![image](https://github.com/user-attachments/assets/b8f30e4c-12ac-4d11-938c-85384d507a79)