### PR TITLE
[Fix] `ToggleGroup` dark mode

### DIFF
--- a/packages/ui/src/components/ToggleGroup/ToggleGroup.tsx
+++ b/packages/ui/src/components/ToggleGroup/ToggleGroup.tsx
@@ -14,7 +14,7 @@ const Item = forwardRef<
   ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item>
 >((props, forwardedRef) => (
   <ToggleGroupPrimitive.Item
-    className="hover:bg-gray-900 flex cursor-pointer items-center rounded-full bg-gray-100 p-1.5 leading-none text-black outline-none hover:bg-gray-600 hover:text-white focus-visible:bg-focus data-[state=on]:bg-warning-300 data-[state=on]:hover:bg-gray-600 data-[state=on]:focus-visible:bg-focus data-[state=on]:focus-visible:hover:bg-gray-600 [&_svg]:w-4"
+    className="hover:bg-gray-900 flex cursor-pointer items-center rounded-full bg-gray-100 p-1.5 leading-none text-black outline-none hover:bg-gray-600 hover:text-white focus-visible:bg-focus data-[state=on]:bg-warning-300 data-[state=on]:hover:bg-gray-600 data-[state=on]:focus-visible:bg-focus data-[state=on]:focus-visible:hover:bg-gray-600 dark:bg-gray-600 dark:text-white dark:hover:bg-gray-100 dark:hover:text-black data-[state=on]:dark:text-black data-[state=on]:hover:dark:bg-gray-100 [&_svg]:w-4"
     ref={forwardedRef}
     {...props}
   />


### PR DESCRIPTION
🤖 Resolves #13858.

## 👋 Introduction

This PR fixes `ToggleGroup` dark mode and therefore, the `ThemeSwitcher` component that uses the `ToggleGroup` component.

## 🧪 Testing

1. `pnpm storybook`
2. Navigate to `ToggleGroup` in dark mode
3. Verify base and hover states are correct
4. Navigate to `ThemeSwitcher` in dark mode
5. Verify base and hover states are correct