### PR TITLE
[Fix] Mobile menu layout

### DIFF
--- a/apps/web/src/components/Footer/Footer.tsx
+++ b/apps/web/src/components/Footer/Footer.tsx
@@ -63,7 +63,7 @@ const Footer = () => {
   ];
 
   return (
-    <footer className="relative z-50 mt-auto border-t border-black/20 bg-white py-12 dark:bg-gray-700">
+    <footer className="mt-auto border-t border-black/20 bg-white py-12 dark:bg-gray-700">
       <Container center size="lg">
         <div className="grid items-center gap-6 xs:grid-cols-2 xs:gap-12 md:grid-cols-3">
           <div className="text-center xs:text-left md:col-start-1 md:col-end-3">

--- a/apps/web/src/components/NavMenu/MainNavMenu.tsx
+++ b/apps/web/src/components/NavMenu/MainNavMenu.tsx
@@ -26,6 +26,7 @@ import {
   Button,
   NavMenu,
   Separator,
+  SeparatorProps,
   NavMenuProvider,
   Container,
 } from "@gc-digital-talent/ui";
@@ -43,24 +44,25 @@ import useMainNavLinks from "./useMainNavLinks";
 import ThemeSwitcher from "../ThemeSwitcher/ThemeSwitcher";
 import navMenuMessages from "./messages";
 
-const borderItem = tv({
-  base: "sm:border-x sm:border-white/20 sm:px-4.5",
-});
-
-const homeItem = tv({
-  base: "hidden sm:flex",
+const separator = tv({
+  base: "bg-black/20 dark:bg-white/20",
   variants: {
-    hidden: {
-      true: "sm:border-r sm:border-white/20 sm:pr-4.5",
+    vertical: {
+      true: "hidden h-6 sm:block",
+      false: "sm:hidden",
     },
   },
 });
 
-const MenuSeparator = () => (
+const MenuSeparator = ({ className, orientation }: SeparatorProps) => (
   <Separator
     decorative
-    space="none"
-    className="my-6 bg-black/20 sm:hidden dark:bg-black/50"
+    space="xs"
+    orientation={orientation}
+    className={separator({
+      class: className,
+      vertical: orientation === "vertical",
+    })}
   />
 );
 
@@ -133,11 +135,6 @@ const MainNavMenu = () => {
     usefulRoleAssignments.length === 1 &&
     usefulRoleAssignments[0].role?.name !== ROLE_NAME.Applicant;
 
-  const onlyHasApplicantRole =
-    navRole !== null &&
-    usefulRoleAssignments.length === 1 &&
-    usefulRoleAssignments[0].role?.name === ROLE_NAME.Applicant;
-
   const showRoleSwitcher = onlyHasOneRoleNotApplicant || hasMoreThanOneRole;
 
   const showMenu = !isSmallScreen || isMenuOpen;
@@ -167,14 +164,14 @@ const MainNavMenu = () => {
                   description: "Label for the main navigation",
                 })}
                 data-state={isMenuOpen ? "open" : "closed"}
-                className="rounded-md bg-white py-6 sm:rounded-none sm:bg-gray-700/90 sm:py-6 dark:bg-gray-600/90 sm:dark:bg-gray-700/90"
+                className="rounded-md bg-white pt-3 pb-1.5 sm:rounded-none sm:bg-gray-700/90 sm:py-0 dark:bg-gray-600 sm:dark:bg-gray-700/90"
               >
                 <Container
                   center
                   size={{ sm: "lg" }}
                   className="items-center px-0 sm:flex sm:justify-between sm:px-6"
                 >
-                  <div className="mx-6 flex items-center justify-between sm:m-0 sm:hidden">
+                  <div className="flex items-center justify-center gap-x-6 sm:m-0 sm:hidden">
                     <NavMenu.IconLink
                       ref={homeLinkRef}
                       href={paths.home()}
@@ -200,23 +197,17 @@ const MainNavMenu = () => {
                     </a>
                   </div>
 
-                  <MenuSeparator />
+                  <MenuSeparator orientation="horizontal" />
 
-                  <div className="flex flex-col sm:flex-row sm:items-center sm:gap-x-4.5">
-                    <NavMenu.List className="flex flex-col sm:flex-row sm:items-center sm:gap-x-4.5">
-                      <NavMenu.Item
-                        className={homeItem({
-                          hidden:
-                            !loggedIn ||
-                            onlyHasApplicantRole ||
-                            usefulRoleAssignments.length === 0,
-                        })}
-                      >
+                  <div className="flex flex-col sm:flex-row sm:items-center">
+                    <NavMenu.List type="main">
+                      <NavMenu.Item className="mr-1 -ml-1 hidden sm:flex sm:items-center">
                         {homeLink}
                       </NavMenu.Item>
+                      <MenuSeparator orientation="vertical" />
                       {showRoleSwitcher ? (
                         <>
-                          <NavMenu.Item className={borderItem()}>
+                          <NavMenu.Item>
                             <NavMenu.Trigger
                               color={isSmallScreen ? "black" : "white"}
                               fixedColor={!isSmallScreen}
@@ -244,9 +235,11 @@ const MainNavMenu = () => {
                       ) : null}
                     </NavMenu.List>
 
-                    {showRoleSwitcher && <MenuSeparator />}
+                    {showRoleSwitcher && (
+                      <MenuSeparator orientation="horizontal" />
+                    )}
 
-                    <NavMenu.List className="flex flex-col sm:flex-row">
+                    <NavMenu.List type="main">
                       {mainLinks}
                       {systemSettings && (
                         <NavMenu.Item>
@@ -288,32 +281,36 @@ const MainNavMenu = () => {
                     </NavMenu.List>
                   </div>
 
-                  <MenuSeparator />
+                  <MenuSeparator orientation="horizontal" />
 
-                  <NavMenu.List className="flex flex-col sm:flex-row sm:gap-x-4.5">
+                  <NavMenu.List type="main">
                     {accountLinks && (
-                      <NavMenu.Item className={borderItem()}>
-                        <NavMenu.Trigger
-                          color={isSmallScreen ? "black" : "white"}
-                          fixedColor={!isSmallScreen}
-                          block={false}
-                        >
-                          {intl.formatMessage({
-                            defaultMessage: "Your account",
-                            id: "CBedVL",
-                            description:
-                              "Nav menu trigger for account links sub menu",
-                          })}
-                        </NavMenu.Trigger>
-                        <NavMenu.Content>
-                          <NavMenu.List>{accountLinks}</NavMenu.List>
-                        </NavMenu.Content>
-                      </NavMenu.Item>
+                      <>
+                        <MenuSeparator orientation="vertical" />
+                        <NavMenu.Item>
+                          <NavMenu.Trigger
+                            color={isSmallScreen ? "black" : "white"}
+                            fixedColor={!isSmallScreen}
+                            block={false}
+                          >
+                            {intl.formatMessage({
+                              defaultMessage: "Your account",
+                              id: "CBedVL",
+                              description:
+                                "Nav menu trigger for account links sub menu",
+                            })}
+                          </NavMenu.Trigger>
+                          <NavMenu.Content>
+                            <NavMenu.List>{accountLinks}</NavMenu.List>
+                          </NavMenu.Content>
+                        </NavMenu.Item>
+                      </>
                     )}
 
                     {loggedIn && (
                       <>
-                        <NavMenu.Item className="hidden sm:inline-flex">
+                        <MenuSeparator orientation="vertical" />
+                        <NavMenu.Item className="ml-1 hidden sm:inline-flex">
                           <NotificationDialog
                             open={isNotificationDialogOpen}
                             onOpenChange={setNotificationDialogOpen}

--- a/apps/web/src/components/NavMenu/MainNavMenu.tsx
+++ b/apps/web/src/components/NavMenu/MainNavMenu.tsx
@@ -44,6 +44,18 @@ import useMainNavLinks from "./useMainNavLinks";
 import ThemeSwitcher from "../ThemeSwitcher/ThemeSwitcher";
 import navMenuMessages from "./messages";
 
+const borderItem = tv({
+  base: "sm:flex",
+  variants: {
+    borderLeft: {
+      true: "before:hidden before:h-6 before:w-px before:self-center before:bg-black/20 sm:before:block before:sm:bg-white/20 before:dark:bg-white/20",
+    },
+    borderRight: {
+      true: "after:hidden after:h-6 after:w-px after:self-center after:bg-black/20 sm:after:block after:sm:bg-white/20 after:dark:bg-white/20",
+    },
+  },
+});
+
 const separator = tv({
   base: "bg-black/20 dark:bg-white/20",
   variants: {
@@ -201,13 +213,20 @@ const MainNavMenu = () => {
 
                   <div className="flex flex-col sm:flex-row sm:items-center">
                     <NavMenu.List type="main">
-                      <NavMenu.Item className="mr-1 -ml-1 hidden sm:flex sm:items-center">
+                      <NavMenu.Item
+                        className={borderItem({
+                          borderRight: true,
+                          class:
+                            "mr-1 -ml-1 hidden after:ml-3 sm:flex sm:items-center",
+                        })}
+                      >
                         {homeLink}
                       </NavMenu.Item>
-                      <MenuSeparator orientation="vertical" />
                       {showRoleSwitcher ? (
                         <>
-                          <NavMenu.Item>
+                          <NavMenu.Item
+                            className={borderItem({ borderRight: true })}
+                          >
                             <NavMenu.Trigger
                               color={isSmallScreen ? "black" : "white"}
                               fixedColor={!isSmallScreen}
@@ -286,7 +305,6 @@ const MainNavMenu = () => {
                   <NavMenu.List type="main">
                     {accountLinks && (
                       <>
-                        <MenuSeparator orientation="vertical" />
                         <NavMenu.Item>
                           <NavMenu.Trigger
                             color={isSmallScreen ? "black" : "white"}
@@ -309,8 +327,12 @@ const MainNavMenu = () => {
 
                     {loggedIn && (
                       <>
-                        <MenuSeparator orientation="vertical" />
-                        <NavMenu.Item className="ml-1 hidden sm:inline-flex">
+                        <NavMenu.Item
+                          className={borderItem({
+                            borderLeft: true,
+                            class: "hidden before:mr-3 sm:inline-flex",
+                          })}
+                        >
                           <NotificationDialog
                             open={isNotificationDialogOpen}
                             onOpenChange={setNotificationDialogOpen}

--- a/apps/web/src/components/NavMenu/MainNavMenu.tsx
+++ b/apps/web/src/components/NavMenu/MainNavMenu.tsx
@@ -360,7 +360,7 @@ const MainNavMenu = () => {
           </AnimatePresence>
         </NavMenuProvider>
         {isSmallScreen && (
-          <div className="fixed right-4.5 bottom-4.5 z-10 flex gap-3">
+          <div className="fixed right-4.5 bottom-4.5 z-30 flex gap-3">
             <Button
               color="black"
               mode="solid"

--- a/apps/web/src/components/NavMenu/useMainNavLinks.tsx
+++ b/apps/web/src/components/NavMenu/useMainNavLinks.tsx
@@ -66,7 +66,6 @@ const useMainNavLinks = () => {
       href={paths.home()}
       icon={HomeIcon}
       label={intl.formatMessage(navigationMessages.home)}
-      className="-ml-1"
     />
   );
 

--- a/packages/ui/src/components/NavMenu/NavMenu.tsx
+++ b/packages/ui/src/components/NavMenu/NavMenu.tsx
@@ -55,7 +55,7 @@ const Trigger = forwardRef<
 ));
 
 const content = tv({
-  base: "sm:bg-whitesm:p-1.5 top-full sm:absolute sm:left-1/2 sm:z-20 sm:min-w-3xs sm:-translate-x-1/2 sm:rounded sm:shadow-lg dark:sm:bg-gray-600",
+  base: "top-full sm:absolute sm:left-1/2 sm:z-20 sm:min-w-3xs sm:-translate-x-1/2 sm:rounded sm:bg-white sm:p-1.5 sm:shadow-lg dark:sm:bg-gray-600",
 });
 
 const Content = forwardRef<

--- a/packages/ui/src/components/NavMenu/NavMenu.tsx
+++ b/packages/ui/src/components/NavMenu/NavMenu.tsx
@@ -55,7 +55,7 @@ const Trigger = forwardRef<
 ));
 
 const content = tv({
-  base: "sm:absolute sm:left-1/2 sm:min-w-3xs sm:-translate-x-1/2 sm:rounded sm:bg-white sm:px-3 sm:py-1.5 sm:shadow-lg dark:sm:bg-gray-600",
+  base: "sm:bg-whitesm:p-1.5 top-full sm:absolute sm:left-1/2 sm:z-20 sm:min-w-3xs sm:-translate-x-1/2 sm:rounded sm:shadow-lg dark:sm:bg-gray-600",
 });
 
 const Content = forwardRef<

--- a/packages/ui/src/components/NavMenu/NavMenu.tsx
+++ b/packages/ui/src/components/NavMenu/NavMenu.tsx
@@ -44,30 +44,23 @@ const Trigger = forwardRef<
     { children, mode = "inline", color, block = false, ...rest },
     forwardedRef,
   ) => (
-    <div className="text-center sm:text-left">
-      <NavigationMenuPrimitive.Trigger
-        ref={forwardedRef}
-        asChild
-        onPointerMove={(event) => event.preventDefault()}
-        onPointerLeave={(event) => event.preventDefault()}
-        className="font-normal hover:text-primary-600 sm:hover:text-primary-200 dark:hover:text-primary-100 [&_svg]:mt-0! [&_svg]:size-4.5! [&_svg]:transform [&_svg]:transition-transform [&_svg]:duration-200 data-[state=closed]:[&_svg]:rotate-0 data-[state=open]:[&_svg]:rotate-180"
-        {...rest}
-      >
-        <Button
-          utilityIcon={ChevronDownIcon}
-          mode={mode}
-          color={color}
-          block={block}
-        >
-          {children}
-        </Button>
-      </NavigationMenuPrimitive.Trigger>
-    </div>
+    <NavigationMenuPrimitive.Trigger
+      ref={forwardedRef}
+      asChild
+      onPointerMove={(event) => event.preventDefault()}
+      onPointerLeave={(event) => event.preventDefault()}
+      className="w-full px-3 py-2 text-left font-normal hover:text-primary-600 sm:py-4.5 sm:hover:text-primary-200 dark:hover:text-primary-100 [&_svg]:mt-0! [&_svg]:size-4.5! [&_svg]:transform [&_svg]:transition-transform [&_svg]:duration-200 data-[state=closed]:[&_svg]:rotate-0 data-[state=open]:[&_svg]:rotate-180"
+      {...rest}
+    >
+      <Button utilityIcon={ChevronDownIcon} mode={mode} color={color}>
+        {children}
+      </Button>
+    </NavigationMenuPrimitive.Trigger>
   ),
 );
 
 const content = tv({
-  base: "mt-6 sm:absolute sm:left-1/2 sm:mt-0 sm:min-w-3xs sm:-translate-x-1/2 sm:rounded sm:bg-white sm:px-3 sm:py-1.5 sm:shadow dark:sm:bg-gray-600",
+  base: "sm:absolute sm:left-1/2 sm:min-w-3xs sm:-translate-x-1/2 sm:rounded sm:bg-white sm:px-3 sm:py-1.5 sm:shadow-lg dark:sm:bg-gray-600",
 });
 
 const Content = forwardRef<
@@ -93,16 +86,27 @@ const Viewport = forwardRef<
 ));
 
 const list = tv({
-  base: "m-0 flex list-none flex-col items-center gap-4.5 p-0 sm:items-start",
+  base: "m-0 flex list-none flex-col p-0",
+  variants: {
+    type: {
+      main: "sm:flex-row sm:items-center",
+    },
+  },
 });
+
+type ListVariants = VariantProps<typeof list>;
+
+interface ListProps
+  extends ListVariants,
+    ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.List> {}
 
 const List = forwardRef<
   ElementRef<typeof NavigationMenuPrimitive.List>,
-  ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.List>
->(({ children, className, ...rest }, forwardedRef) => (
+  ListProps
+>(({ children, className, type, ...rest }, forwardedRef) => (
   <NavigationMenuPrimitive.List
     ref={forwardedRef}
-    className={list({ class: className })}
+    className={list({ type, class: className })}
     {...rest}
   >
     {children}
@@ -115,7 +119,7 @@ const Item = forwardRef<
 >((props, forwardedRef) => (
   <NavigationMenuPrimitive.Item
     ref={forwardedRef}
-    className="sm:relative data-[state=active]:[&_span]:font-bold! data-[state=active]:[&_span]:no-underline!"
+    className="w-full sm:relative sm:w-auto data-[state=active]:[&_span]:font-bold! data-[state=active]:[&_span]:no-underline!"
     {...props}
   />
 ));
@@ -144,23 +148,35 @@ const useActiveLink = (
 };
 
 const navMenuLink = tv({
-  base: "font-normal text-black hover:text-primary-600 focus-visible:text-black data-active:font-bold data-active:text-primary-600 data-active:hover:text-primary-600 hover:data-[icon=true]:text-primary-700 dark:text-white dark:hover:text-primary-100 dark:data-active:text-primary-200 dark:data-active:hover:text-primary-200 dark:hover:data-[icon=true]:text-primary-700 data-active:[&_span]:no-underline",
+  base: "items-center font-normal text-black hover:text-primary-600 focus-visible:text-black data-active:font-bold data-active:text-primary-600 data-active:hover:text-primary-600 data-active:focus-visible:text-black hover:data-icon:text-primary-700 dark:text-white dark:hover:text-primary-100 dark:data-active:text-primary-200 dark:data-active:hover:text-primary-200 dark:hover:data-icon:text-primary-700 data-active:[&_span]:no-underline",
   variants: {
     isSmallScreen: {
       true: "",
       false: "",
+    },
+    isIcon: {
+      true: "",
+      false: "flex px-3 py-2 sm:py-4.5",
     },
     type: {
       link: "",
       subMenuLink: "",
     },
   },
+  defaultVariants: {
+    isIcon: false,
+  },
   compoundVariants: [
     {
       isSmallScreen: false,
       type: "link",
       class:
-        "text-white hover:text-primary-200 data-active:text-primary-200 hover:data-[icon=true]:text-primary-200 dark:data-active:text-primary-100 dark:hover:data-[icon=true]:text-primary-700",
+        "text-white hover:text-primary-200 data-active:text-primary-200 hover:data-icon:text-primary-200 dark:data-active:text-primary-100 dark:hover:data-icon:text-primary-700",
+    },
+    {
+      type: "subMenuLink",
+      isIcon: false,
+      class: "py-1.5 pr-1.5 pl-6 sm:px-3 sm:py-3",
     },
   ],
 });
@@ -202,6 +218,7 @@ const IconLink = forwardRef<
         href={href}
         icon={icon}
         className={navMenuLink({
+          isIcon: true,
           isSmallScreen,
           type,
         })}
@@ -267,6 +284,7 @@ const Link = forwardRef<
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           state={state}
           className={navMenuLink({
+            isIcon: false,
             isSmallScreen,
             type,
           })}

--- a/packages/ui/src/components/NavMenu/NavMenu.tsx
+++ b/packages/ui/src/components/NavMenu/NavMenu.tsx
@@ -48,7 +48,7 @@ const Trigger = forwardRef<
     className="w-full px-3 py-2 text-left font-normal hover:text-primary-600 sm:py-4.5 sm:hover:text-primary-200 dark:hover:text-primary-100 [&_svg]:mt-0! [&_svg]:size-4.5! [&_svg]:transform [&_svg]:transition-transform [&_svg]:duration-200 data-[state=closed]:[&_svg]:rotate-0 data-[state=open]:[&_svg]:rotate-180"
     {...rest}
   >
-    <Button utilityIcon={ChevronDownIcon} mode={mode} color={color}>
+    <Button utilityIcon={ChevronDownIcon} mode={mode} color={color} noUnderline>
       {children}
     </Button>
   </NavigationMenuPrimitive.Trigger>

--- a/packages/ui/src/components/NavMenu/NavMenu.tsx
+++ b/packages/ui/src/components/NavMenu/NavMenu.tsx
@@ -39,25 +39,20 @@ type TriggerProps = ComponentPropsWithoutRef<
 const Trigger = forwardRef<
   ElementRef<typeof NavigationMenuPrimitive.Trigger>,
   TriggerProps
->(
-  (
-    { children, mode = "inline", color, block = false, ...rest },
-    forwardedRef,
-  ) => (
-    <NavigationMenuPrimitive.Trigger
-      ref={forwardedRef}
-      asChild
-      onPointerMove={(event) => event.preventDefault()}
-      onPointerLeave={(event) => event.preventDefault()}
-      className="w-full px-3 py-2 text-left font-normal hover:text-primary-600 sm:py-4.5 sm:hover:text-primary-200 dark:hover:text-primary-100 [&_svg]:mt-0! [&_svg]:size-4.5! [&_svg]:transform [&_svg]:transition-transform [&_svg]:duration-200 data-[state=closed]:[&_svg]:rotate-0 data-[state=open]:[&_svg]:rotate-180"
-      {...rest}
-    >
-      <Button utilityIcon={ChevronDownIcon} mode={mode} color={color}>
-        {children}
-      </Button>
-    </NavigationMenuPrimitive.Trigger>
-  ),
-);
+>(({ children, mode = "inline", color, ...rest }, forwardedRef) => (
+  <NavigationMenuPrimitive.Trigger
+    ref={forwardedRef}
+    asChild
+    onPointerMove={(event) => event.preventDefault()}
+    onPointerLeave={(event) => event.preventDefault()}
+    className="w-full px-3 py-2 text-left font-normal hover:text-primary-600 sm:py-4.5 sm:hover:text-primary-200 dark:hover:text-primary-100 [&_svg]:mt-0! [&_svg]:size-4.5! [&_svg]:transform [&_svg]:transition-transform [&_svg]:duration-200 data-[state=closed]:[&_svg]:rotate-0 data-[state=open]:[&_svg]:rotate-180"
+    {...rest}
+  >
+    <Button utilityIcon={ChevronDownIcon} mode={mode} color={color}>
+      {children}
+    </Button>
+  </NavigationMenuPrimitive.Trigger>
+));
 
 const content = tv({
   base: "sm:absolute sm:left-1/2 sm:min-w-3xs sm:-translate-x-1/2 sm:rounded sm:bg-white sm:px-3 sm:py-1.5 sm:shadow-lg dark:sm:bg-gray-600",

--- a/packages/ui/src/components/Separator/Separator.tsx
+++ b/packages/ui/src/components/Separator/Separator.tsx
@@ -63,7 +63,7 @@ const separator = tv({
 
 type SeparatorVariants = VariantProps<typeof separator>;
 
-interface SeparatorProps
+export interface SeparatorProps
   extends SeparatorVariants,
     ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root> {}
 

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -65,7 +65,9 @@ import PreviewList, {
   type MetaDataProps as PreviewMetaData,
 } from "./components/PreviewList/PreviewList";
 import ResourceBlock from "./components/ResourceBlock";
-import Separator from "./components/Separator";
+import Separator, {
+  type SeparatorProps,
+} from "./components/Separator/Separator";
 import Sidebar, { SidebarProps } from "./components/Sidebar";
 import Spoiler, { SpoilerProps } from "./components/Spoiler/Spoiler";
 import Stepper, { StepperProps } from "./components/Stepper/Stepper";
@@ -120,6 +122,7 @@ export type {
   PendingProps,
   PreviewMetaData,
   ChipProps,
+  SeparatorProps,
   SidebarProps,
   SpoilerProps,
   StepperProps,


### PR DESCRIPTION
🤖 Resolves #12228 

## 👋 Introduction

Adjusts the mobile menu layout to increase activate target size.

## 🕵️ Details

Unfortunatlety, since the same links are used across both, I had to make some minor adjusts to the desktop as well. I hope the diff isnt too bad :sweat_smile: 

## 🧪 Testing

1. Build `pnpm run dev:fresh`
2. Confirm menu matches mock up in both anonymous and asuthenticated states

## 📸 Screenshot

<img width="1598" height="640" alt="swappy-20250710_171745" src="https://github.com/user-attachments/assets/ba169b49-4965-4ee9-ab86-c6e8ce12082b" />
<img width="333" height="437" alt="swappy-20250710_171754" src="https://github.com/user-attachments/assets/9918b095-08ba-4894-8eca-81810476792a" />
