### PR TITLE
Remove "Not provided" if no job title

### DIFF
--- a/apps/web/src/components/NextRoleAndCareerObjective/CareerObjectivePreview.tsx
+++ b/apps/web/src/components/NextRoleAndCareerObjective/CareerObjectivePreview.tsx
@@ -94,7 +94,7 @@ const CareerObjectivePreview = ({
         description: "Title for career objective dialog",
       })}
       {intl.formatMessage(commonMessages.dividingColon)} {classificationName}{" "}
-      {employeeProfile?.careerObjectiveJobTitle ?? notProvided}
+      {employeeProfile?.careerObjectiveJobTitle}
     </>
   );
   // Functional community - target role - # of desired work streams - # of desired departments

--- a/apps/web/src/components/NextRoleAndCareerObjective/NextRolePreview.tsx
+++ b/apps/web/src/components/NextRoleAndCareerObjective/NextRolePreview.tsx
@@ -89,7 +89,7 @@ const NextRolePreview = ({
         description: "Title for next role dialog",
       })}
       {intl.formatMessage(commonMessages.dividingColon)} {classificationName}{" "}
-      {employeeProfile?.nextRoleJobTitle ?? notProvided}
+      {employeeProfile?.nextRoleJobTitle}
     </>
   );
   // Functional community - target role - # of desired work streams - # of desired departments


### PR DESCRIPTION
🤖 Resolves #13784.

## 👋 Introduction

Removes fallback text for job title when viewing a nominees next role or career objective.

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Find or create a nomination for someone with both a next role and career objective saved without a job title
2. Navigate to view the nominee `admin/talent-events/{eventId}/nominations/{nominationGroupId}/profile`
3. Open the "Next role and career objective" accordion
4. Confirm neither the next role or the career objective say "Not provided" after the classification

## 📸 Screenshot
<img width="844" height="970" alt="image" src="https://github.com/user-attachments/assets/40211904-e6a9-4b14-bae4-5effd3aa36b1" />
