### PR TITLE
[Bug] Nginx asset caching time

### DIFF
--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -173,10 +173,10 @@ server {
         try_files /tc-report/_site/$1 /tc-report/_site/$1/index.html =404;
     }
 
-    # serve other asset files files
+    # serve other asset files
     location ~ "\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest|webp|pptx)$" {
         # contenthashed asset files get cached for a year
-        location ~ "^/(.*\.)?[a-z0-9]{20}\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest|webp|pptx)$" {
+        location ~ "-[A-z0-9]{8}\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest|webp|pptx)$" {
             add_header Cache-Control "public, max-age=31536000"; # 1 year
             try_files /apps/web/dist/$uri =404;
         }

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -219,12 +219,12 @@ server {
         try_files /tc-report/_site/$1 /tc-report/_site/$1/index.html =404;
     }
 
-    # serve other asset files files
-    # NOTE: this is set up like this to mirror prod version, where different location blocks allow unique cach-control headers
+    # serve other asset files
+    # NOTE: this is set up like this to mirror prod version, where different location blocks allow unique cache-control headers
     # NOTE2: this excludes assets starting with /static/ since there's a redirect to static hosting for that case below
     location ~ "^(?!/static/).*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest|webp|pptx)$" {
         # contenthashed asset files get cached for a year
-        location ~ "^/(.*\.)?[a-z0-9]{20}\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest|webp|pptx)$" {
+        location ~ "-[A-z0-9]{8}\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest|webp|pptx)$" {
             # add_header Cache-Control "public, max-age=31536000"; # 1 year
             try_files /apps/web/dist/$uri =404;
         }


### PR DESCRIPTION
🤖 Resolves #14076

## 👋 Introduction

Possibly the regex match was broken by the webpack -> vite change and the pattern no longer applied.
Assets appear to follow `name-AAAAAAAA.xyz` where name represents the source file and the repeating "A" represents exactly 8 characters forming the hash. 

## 🧪 Testing

1. To test locally, make the changes below to your **_local_** file
2. Comment or uncomment the marked lines

<img width="959" height="177" alt="image" src="https://github.com/user-attachments/assets/aec35aa7-25bb-4f08-8c2a-8f5cc715268a" />

<img width="1164" height="279" alt="image" src="https://github.com/user-attachments/assets/22d38fd1-54cf-4878-add5-e07b686cf5af" />


## 📸 Screenshot

<img width="522" height="353" alt="image" src="https://github.com/user-attachments/assets/b85b2184-af4d-422f-b79b-3164bfa741b2" />


## 🚚 Deployment

<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the PR if deployment steps are needed

 -->
