### PR TITLE
[Fix] Attempt to improve performance of notification polling

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1512,6 +1512,8 @@ type Query {
   ): [Notification!]
     @orderBy(column: "created_at", direction: DESC)
     @paginate(defaultCount: 10, scopes: ["authorizedToView"])
+  notificationCount(where: NotificationFilterInput): Int
+    @count(model: "App\\Models\\Notification", scopes: ["authorizedToView"])
 
   sitewideAnnouncement: SitewideAnnouncement
   talentNominationEvents(

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -399,6 +399,7 @@ type Query {
   roles: [Role]!
   workStream(id: UUID!): WorkStream
   workStreams(talentSearchable: Boolean): [WorkStream]!
+  notificationCount(where: NotificationFilterInput): Int
   sitewideAnnouncement: SitewideAnnouncement
   talentNominationEvents(where: TalentNominationEventsFilterInput): [TalentNominationEvent]!
   talentNominationEvent(id: UUID!): TalentNominationEvent

--- a/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
+++ b/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
@@ -6,7 +6,7 @@ import BellAlertIconSm from "@heroicons/react/20/solid/BellAlertIcon";
 import XMarkIcon from "@heroicons/react/20/solid/XMarkIcon";
 import { UseQueryExecute } from "urql";
 
-import { unpackMaybes, useIsSmallScreen } from "@gc-digital-talent/helpers";
+import { useIsSmallScreen } from "@gc-digital-talent/helpers";
 import { graphql } from "@gc-digital-talent/graphql";
 import {
   DialogPrimitive,
@@ -31,11 +31,7 @@ const Overlay = m.create(DialogPrimitive.Overlay);
 // This is to query to minimal amount of data to display the badge
 const NotificationCount_Query = graphql(/* GraphQL */ `
   query NotificationCount {
-    notifications(where: { onlyUnread: true }, first: 1) {
-      data {
-        id
-      }
-    }
+    notificationCount(where: { onlyUnread: true })
   }
 `);
 
@@ -179,7 +175,7 @@ const NotificationDialog = ({
     { query: NotificationCount_Query },
     60,
   );
-  const notificationCount = unpackMaybes(data?.notifications?.data).length;
+  const notificationCount: number = data?.notificationCount ?? 0;
   const buttonLabel = open
     ? intl.formatMessage({
         defaultMessage: "Close notifications",


### PR DESCRIPTION
🤖 Resolves #13869 

## 👋 Introduction

This replaces the existing paginated query for notifications with a simple `@count`.

## 🕵️ Details

I made the changes we had but, it is actually slower :cry: I think we might need to dig in a find a better approach all together.

I don't think it is the database query itself but something inbetween :thinking: This is what is being generated and it seems straightforward. We also have indexs on `notifiable_type` and `notifiable_id` so that should help :woman_shrugging: 

 - Main: `~565ms`
 - PR: `~600ms`

```sql
# Runs in 0.01s locally
count(*) as aggregate from "notifications" where "read_at" is null and "notifiable_id" = ? and "notifications"."deleted_at" is null;
```

## 🧪 Testing


1. Refresh api `make refresh-api`
2. Seed a lot of notifications `make arisan CMD="db:seed --class=BigSeederNotifications`
3. Open the homepage
4. Confirm the time it takes for the `NotificationCount` query to run
