### PR TITLE
[Fix] Remove tiptap from manual chunk

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -80,12 +80,6 @@ export default defineConfig(({ command }) => ({
           graphql: ["@gc-digital-talent/graphql"],
           react: ["react", "react-dom"],
           router: ["react-router", "react-router"],
-          tiptap: [
-            "@tiptap/react",
-            "@tiptap/starter-kit",
-            "@tiptap/extension-link",
-            "@tiptap/extension-character-count",
-          ],
         },
       },
     },


### PR DESCRIPTION
🤖 Resolves #14077 

## 👋 Introduction

Removes tiptap from from manual chunks to allow it to lazy load.

## 🕵️ Details

There is currently a bug in vite that forces all manual chunks to load before the entry point bundle. Since this is about 100kb and we don't really need to manual chunk it, removing it allows it to auto lazy load the resources.

```sh
# Branch
index.js   998.11 kB │ gzip: 308.87 kB │ map: 2,174.69 kB

# Main
tiptap.js  327.82 kB │ gzip: 104.56 kB │ map: 1,494.74 kB
index.js   998.43 kB │ gzip: 308.91 kB │ map: 2,174.69 kB
```

## 🧪 Testing

> [!TIP]
> Before testing, make sure you do not have a sitewide announcement. Having one will load tiptap dependencies since it needs it. 

1. Build main and take not of the bundle size for `index.js` and `tiptap.js`
2. Checkout branch and build `pnpm dev:fresh`
3. Confirm no `tiptap.js` bundle.
4. Confirm `index.js` has not increased in size too considerably
5. Load the home page
6. Check to make sure no tiptap deps were loaded