### PR TITLE
[Bug] Handle sorting candidates to account for non-unique columns

### DIFF
--- a/api/app/Builders/PoolCandidateBuilder.php
+++ b/api/app/Builders/PoolCandidateBuilder.php
@@ -520,7 +520,10 @@ class PoolCandidateBuilder extends Builder
         extract($args);
 
         if (isset($order) && isset($locale)) {
-            return $this->withMax('pool', 'name->'.$locale)->orderBy('pool_max_name'.$locale, $order);
+            return
+            $this->withMax('pool', 'name->'.$locale)
+                ->orderBy('pool_max_name'.$locale, $order)
+                ->orderBy('submitted_at', 'ASC');
         }
 
         return $this;
@@ -538,7 +541,8 @@ class PoolCandidateBuilder extends Builder
         return $this
             ->leftJoin('users', 'pool_candidates.user_id', '=', 'users.id')
             ->leftJoin('departments', 'users.computed_department', '=', 'departments.id')
-            ->orderByRaw("departments.name->>'$locale' $order");
+            ->orderByRaw("departments.name->>'$locale' $order")
+            ->orderBy('submitted_at', 'ASC');
     }
 
     /**

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -372,7 +372,10 @@ export function getSortOrder(
       : [{ column: "is_bookmarked", order: SortOrder.Desc }]),
     // Do not apply other filters if we are sorting by process
     ...(!hasProcess
-      ? [transformSortStateToOrderByClause(sortingRules, filterState)]
+      ? [
+          transformSortStateToOrderByClause(sortingRules, filterState),
+          { column: "id", order: SortOrder.Desc }, // final sort by id to handle non-unique columns
+        ]
       : []),
   ];
 }


### PR DESCRIPTION
🤖 Resolves #14152

## 👋 Introduction

Attempt to resolve the issue with erratic candidate rows across table pages

## 🕵️ Details

The problem seems to be that if you sort by something that has a lot of equal results that it splits across pages, you don't get consistent or predictable ordering. Seems that results 1-10 of 25 and results 11-20 of 25 may follow different ordering. 

Went with Eric's suggestion to add what could be called a tiebreaker sort

## 🧪 Testing

1. Ensure you have many candidates seeded
2. Navigate to various candidates tables
3. Exhaustively test sorting

If needed, run

`make artisan CMD='db:seed --class=BigSeederPoolCandidateUser'`

