### PR TITLE
[Debt] Extract scroll to on mount into reusable hook

### DIFF
--- a/apps/web/src/hooks/useScrollToOnMount.ts
+++ b/apps/web/src/hooks/useScrollToOnMount.ts
@@ -1,27 +1,31 @@
-import { useEffect } from "react";
+import { RefObject, useEffect, useRef } from "react";
 
 interface UseScrollToOnMountOptions extends ScrollToOptions {
   preventAutoFocus?: boolean;
 }
 
-function useScrollToOnMount(
-  el: HTMLElement | null | undefined,
-  {
-    behavior = "instant",
-    top = 0,
-    left = 0,
-    preventAutoFocus,
-  }: UseScrollToOnMountOptions,
-) {
+function useScrollToOnMount<TRef extends HTMLElement>(
+  opts?: UseScrollToOnMountOptions,
+): RefObject<TRef> {
+  const el = useRef<TRef>(null);
   useEffect(() => {
-    if (el && !preventAutoFocus && typeof window !== "undefined") {
+    const { preventAutoFocus, ...restOpts }: UseScrollToOnMountOptions = {
+      preventAutoFocus: false,
+      top: 0,
+      left: 0,
+      behavior: "instant",
+      ...opts,
+    };
+    if (el?.current && !preventAutoFocus && typeof window !== "undefined") {
       // Focus heading and scroll to top
-      el.focus({ preventScroll: false });
-      window.scrollTo({ top, left, behavior });
+      el.current.focus({ preventScroll: false });
+      window.scrollTo(restOpts);
     }
     // NOTE: This is an on mount hook
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  return el;
 }
 
 export default useScrollToOnMount;

--- a/apps/web/src/hooks/useScrollToOnMount.ts
+++ b/apps/web/src/hooks/useScrollToOnMount.ts
@@ -5,7 +5,7 @@ interface UseScrollToOnMountOptions extends ScrollToOptions {
 }
 
 function useScrollToOnMount(
-  el: HTMLElement,
+  el: HTMLElement | null | undefined,
   {
     behavior = "instant",
     top = 0,

--- a/apps/web/src/hooks/useScrollToOnMount.ts
+++ b/apps/web/src/hooks/useScrollToOnMount.ts
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+
+interface UseScrollToOnMountOptions extends ScrollToOptions {
+  preventAutoFocus?: boolean;
+}
+
+function useScrollToOnMount(
+  el: HTMLElement,
+  {
+    behavior = "instant",
+    top = 0,
+    left = 0,
+    preventAutoFocus,
+  }: UseScrollToOnMountOptions,
+) {
+  useEffect(() => {
+    if (el && !preventAutoFocus && typeof window !== "undefined") {
+      // Focus heading and scroll to top
+      el.focus({ preventScroll: false });
+      window.scrollTo({ top, left, behavior });
+    }
+    // NOTE: This is an on mount hook
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}
+
+export default useScrollToOnMount;

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/SubHeading.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/SubHeading.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 
 import { Heading, HeadingProps, HeadingRef } from "@gc-digital-talent/ui";
+
+import useScrollToOnMount from "~/hooks/useScrollToOnMount";
 
 interface SubHeadingProps extends HeadingProps {
   preventAutoFocus?: boolean;
@@ -8,15 +10,12 @@ interface SubHeadingProps extends HeadingProps {
 
 const SubHeading = ({ preventAutoFocus, ...rest }: SubHeadingProps) => {
   const headingRef = useRef<HeadingRef>(null);
-
-  useEffect(() => {
-    if (headingRef.current && !preventAutoFocus) {
-      // Focus heading and scroll to top
-      headingRef.current.focus({ preventScroll: false });
-      window.scrollTo({ top: 0, left: 0, behavior: "instant" });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  useScrollToOnMount(headingRef.current, {
+    top: 0,
+    left: 0,
+    behavior: "instant",
+    preventAutoFocus,
+  });
 
   return (
     <Heading

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/SubHeading.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/SubHeading.tsx
@@ -1,5 +1,3 @@
-import { useRef } from "react";
-
 import { Heading, HeadingProps, HeadingRef } from "@gc-digital-talent/ui";
 
 import useScrollToOnMount from "~/hooks/useScrollToOnMount";
@@ -9,8 +7,7 @@ interface SubHeadingProps extends HeadingProps {
 }
 
 const SubHeading = ({ preventAutoFocus, ...rest }: SubHeadingProps) => {
-  const headingRef = useRef<HeadingRef>(null);
-  useScrollToOnMount(headingRef.current, {
+  const headingRef = useScrollToOnMount<HeadingRef>({
     top: 0,
     left: 0,
     behavior: "instant",


### PR DESCRIPTION
🤖 Resolves #13476 

## 👋 Introduction

Extracts our scroll to X on mount functionality into a hook to be re-used elsewhere in the future.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Start a nomination
4. On a step where you can scroll, scroll to the bottom
5. Navigate to a different step using the next/prev buttons
6. Confirm scroll position is reset to top of page