### PR TITLE
[Fix] Enable sourcemaps

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -69,6 +69,7 @@ export default defineConfig(({ command }) => ({
   build: {
     outDir: "./dist",
     chunkSizeWarningLimit: 1000,
+    sourcemap: true,
     rollupOptions: {
       output: {
         manualChunks: {


### PR DESCRIPTION
🤖 Resolves #14137 

## 👋 Introduction

Adds sourcemaps to our prod build.

## 🕵️ Details

Sourcemaps are disabled by default in vite, this simply enables them.

## 🧪 Testing

1. Build `pnpm build:fresh`
2. Confirm source maps are built
3. Navigate to any page
4. Open the source inspector
5. Confirm you see the source maps and not the minified scripts

## 📸 Screenshot

<img width="818" height="502" alt="swappy-20250721_113947" src="https://github.com/user-attachments/assets/0c1e88e2-68f8-4258-8293-a742d4baf1c8" />
