### PR TITLE
[Fix] Support arrays in protected user checker

### DIFF
--- a/api/app/Checkers/ProtectedRequestUserChecker.php
+++ b/api/app/Checkers/ProtectedRequestUserChecker.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Request;
+use Illuminate\Support\Facades\Route;
 use Laratrust\Checkers\User\UserDefaultChecker;
 use Laratrust\Helper;
 
@@ -27,7 +28,7 @@ class ProtectedRequestUserChecker extends UserDefaultChecker
         $name = Helper::standardize($name);
 
         $isProtectedRequest = Request::get('isProtectedRequest');
-        $isNotRoutedRequest = is_null(Request::route());
+        $isNotRoutedRequest = is_null(Route::current());
 
         $isLimitedRole = in_array($name, $this::LIMITED_ROLES);
         if (is_array($name)) {
@@ -78,7 +79,7 @@ class ProtectedRequestUserChecker extends UserDefaultChecker
                 }
             }
         }
-        $isNotRoutedRequest = is_null(Request::route());
+        $isNotRoutedRequest = is_null(Route::current());
 
         return $isProtectedRequest  // if it's a protected request then any permission is safe to use
         || $isLimitedPermission     // if it's a limited (unprivileged) permission then it's always safe to use

--- a/api/tests/Unit/ProtectedRequestUserCheckerTest.php
+++ b/api/tests/Unit/ProtectedRequestUserCheckerTest.php
@@ -11,9 +11,6 @@ use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Route;
 use Tests\TestCase;
 
-use function PHPUnit\Framework\assertFalse;
-use function PHPUnit\Framework\assertTrue;
-
 class ProtectedRequestUserCheckerTest extends TestCase
 {
     use RefreshDatabase;
@@ -39,113 +36,82 @@ class ProtectedRequestUserCheckerTest extends TestCase
         $this->testRoute = new RoutingRoute('get', '/test', fn () => null);
     }
 
-    public function testCanUseLimitedPermissionUnprotected()
+    /**
+     * @dataProvider userCheckerProvider
+     */
+    public function testHasPermission(string|array $permission, ?bool $isProtectedRequest, bool $expected)
     {
-        // simulate a regular request context
-        Request::merge(['isProtectedRequest' => null]);
+        Request::merge(['isProtectedRequest' => $isProtectedRequest]);
+        Route::shouldReceive('current')->andReturn($this->testRoute);
         $checker = new ProtectedRequestUserChecker($this->adminUser);
+        $result = $checker->currentUserHasPermission($permission);
 
-        // a limited permission can be used in an unprotected request
-        $limitedPermission = 'view-any-skill';
-
-        assertTrue($checker->currentUserHasPermission($limitedPermission));
+        $this->assertEquals($expected, $result);
     }
 
-    public function testCanUseLimitedPermissionProtected()
+    public static function userCheckerProvider()
     {
-        // simulate a protected request context
-        Request::merge(['isProtectedRequest' => true]);
-        $checker = new ProtectedRequestUserChecker($this->adminUser);
+        /**
+         * [
+         *   string|array $permission - Permissions to be checked
+         *   ?bool $isProtectedRequest - If this is a protected request
+         *   bool $expected - The expected result of the check
+         * ]
+         */
+        return [
+            // Single permission checks
+            'limited permission unprotected' => [
+                'view-any-skill',
+                null,
+                true,
+            ],
+            'limited permission protected' => [
+                'view-any-skill',
+                true,
+                true,
+            ],
+            'privileged permission protected' => [
+                'create-any-classification',
+                true,
+                true,
+            ],
+            'privileged permission unprotected' => [
+                'create-any-classification',
+                null,
+                false,
+            ],
+            'unknown permission unprotected' => [
+                'not-a-real-permission',
+                null,
+                false,
+            ],
 
-        // a limited permission can be used in an protected request
-        $limitedPermission = 'view-any-skill';
-
-        assertTrue($checker->currentUserHasPermission($limitedPermission));
-    }
-
-    public function testCanUsePrivilegedPermissionProtected()
-    {
-        // simulate a protected request context
-        Request::merge(['isProtectedRequest' => true]);
-        $checker = new ProtectedRequestUserChecker($this->adminUser);
-
-        // a privileged permission can be used only in a protected request
-        $privilegedPermission = 'create-any-classification';
-
-        assertTrue($checker->currentUserHasPermission($privilegedPermission));
-    }
-
-    public function testCanNotUsePrivilegedPermissionUnprotected()
-    {
-        // simulate an unprotected request context
-        Request::merge(['isProtectedRequest' => null]);
-        Route::expects('current')->andReturn($this->testRoute);
-        $checker = new ProtectedRequestUserChecker($this->adminUser);
-
-        // a privileged permission can be used only in a protected request
-        $privilegedPermission = 'create-any-classification';
-
-        assertFalse($checker->currentUserHasPermission($privilegedPermission));
-    }
-
-    public function testCanNotUseUnknownPermissionUnprotected()
-    {
-        // simulate an unprotected request context
-        Request::merge(['isProtectedRequest' => null]);
-        $checker = new ProtectedRequestUserChecker($this->adminUser);
-
-        // an unknown permission can not be used in a protected request
-        $unknownPermission = 'not-a-real-permission';
-
-        assertFalse($checker->currentUserHasPermission($unknownPermission));
-    }
-
-    public function testCanUseLimitedArrayPermissionUnprotected()
-    {
-        // simulate a regular request context
-        Request::merge(['isProtectedRequest' => null]);
-        $checker = new ProtectedRequestUserChecker($this->adminUser);
-
-        // a limited permission can be used in an unprotected request
-        $limitedPermission = ['view-any-skill', 'view-any-skillFamily'];
-
-        assertTrue($checker->currentUserHasPermission($limitedPermission));
-    }
-
-    public function testCanUseLimitedArrayPermissionProtected()
-    {
-        // simulate a protected request context
-        Request::merge(['isProtectedRequest' => true]);
-        $checker = new ProtectedRequestUserChecker($this->adminUser);
-
-        // a limited permission can be used in an protected request
-        $limitedPermission = ['view-any-skill', 'view-any-skillFamily'];
-
-        assertTrue($checker->currentUserHasPermission($limitedPermission));
-    }
-
-    public function testCanUsePrivilegedArrayPermissionProtected()
-    {
-        // simulate a protected request context
-        Request::merge(['isProtectedRequest' => true]);
-        $checker = new ProtectedRequestUserChecker($this->adminUser);
-
-        // a privileged permission can be used only in a protected request
-        $privilegedPermission = ['create-any-classification', 'create-any-department'];
-
-        assertTrue($checker->currentUserHasPermission($privilegedPermission));
-    }
-
-    public function testCanNotUsePrivilegedArrayPermissionUnprotected()
-    {
-        // simulate an unprotected request context
-        Request::merge(['isProtectedRequest' => null]);
-        Route::expects('current')->andReturn($this->testRoute);
-        $checker = new ProtectedRequestUserChecker($this->adminUser);
-
-        // a privileged permission can be used only in a protected request
-        $privilegedPermission = ['create-any-classification', 'create-any-department'];
-
-        assertFalse($checker->currentUserHasPermission($privilegedPermission));
+            // permission array checks checks
+            'limited permission array unprotected' => [
+                ['view-any-skill', 'view-any-skillFamily'],
+                null,
+                true,
+            ],
+            'limited permission array protected' => [
+                ['view-any-skill', 'view-any-skillFamily'],
+                true,
+                true,
+            ],
+            'privileged permission array protected' => [
+                ['create-any-classification', 'create-any-department'],
+                true,
+                true,
+            ],
+            'privileged permission array unprotected' => [
+                ['create-any-classification', 'create-any-department'],
+                null,
+                false,
+            ],
+            'unknown permission array unprotected' => [
+                ['not-a-real-permission', 'another-not-real-permission'],
+                null,
+                false,
+            ],
+        ];
     }
 }

--- a/api/tests/Unit/ProtectedRequestUserCheckerTest.php
+++ b/api/tests/Unit/ProtectedRequestUserCheckerTest.php
@@ -94,4 +94,54 @@ class ProtectedRequestUserCheckerTest extends TestCase
 
         assertFalse($checker->currentUserHasPermission($unknownPermission));
     }
+
+    public function testCanUseLimitedArrayPermissionUnprotected()
+    {
+        // simulate a regular request context
+        Request::merge(['isProtectedRequest' => null]);
+        $checker = new ProtectedRequestUserChecker($this->adminUser);
+
+        // a limited permission can be used in an unprotected request
+        $limitedPermission = ['view-any-skill', 'view-any-skillFamily'];
+
+        assertTrue($checker->currentUserHasPermission($limitedPermission));
+    }
+
+    public function testCanUseLimitedArrayPermissionProtected()
+    {
+        // simulate a protected request context
+        Request::merge(['isProtectedRequest' => true]);
+        $checker = new ProtectedRequestUserChecker($this->adminUser);
+
+        // a limited permission can be used in an protected request
+        $limitedPermission = ['view-any-skill', 'view-any-skillFamily'];
+
+        assertTrue($checker->currentUserHasPermission($limitedPermission));
+    }
+
+    public function testCanUsePrivilegedArrayPermissionProtected()
+    {
+        // simulate a protected request context
+        Request::merge(['isProtectedRequest' => true]);
+        $checker = new ProtectedRequestUserChecker($this->adminUser);
+
+        // a privileged permission can be used only in a protected request
+        $privilegedPermission = ['create-any-classification', 'create-any-department'];
+
+        assertTrue($checker->currentUserHasPermission($privilegedPermission));
+    }
+
+    public function testCanNotUsePrivilegedArrayPermissionUnprotected()
+    {
+        $this->markTestSkipped('Enable to test the route protection logic.');
+
+        // simulate an unprotected request context
+        Request::merge(['isProtectedRequest' => null]);
+        $checker = new ProtectedRequestUserChecker($this->adminUser);
+
+        // a privileged permission can be used only in a protected request
+        $privilegedPermission = ['create-any-classification', 'create-any-department'];
+
+        assertFalse($checker->currentUserHasPermission($privilegedPermission));
+    }
 }

--- a/api/tests/Unit/ProtectedRequestUserCheckerTest.php
+++ b/api/tests/Unit/ProtectedRequestUserCheckerTest.php
@@ -38,7 +38,7 @@ class ProtectedRequestUserCheckerTest extends TestCase
     }
 
     #[DataProvider('userCheckerProvider')]
-    public function test_has_permission(array|string $permission, ?bool $requireAll, ?bool $isProtectedRequest, bool $expected)
+    public function testHasPermission(array|string $permission, ?bool $requireAll, ?bool $isProtectedRequest, bool $expected)
     {
         Request::merge(['isProtectedRequest' => $isProtectedRequest]);
         Route::shouldReceive('current')->andReturn($this->testRoute);

--- a/api/tests/Unit/ProtectedRequestUserCheckerTest.php
+++ b/api/tests/Unit/ProtectedRequestUserCheckerTest.php
@@ -6,7 +6,9 @@ use App\Checkers\ProtectedRequestUserChecker;
 use App\Models\User;
 use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Route as RoutingRoute;
 use Illuminate\Support\Facades\Request;
+use Illuminate\Support\Facades\Route;
 use Tests\TestCase;
 
 use function PHPUnit\Framework\assertFalse;
@@ -17,6 +19,8 @@ class ProtectedRequestUserCheckerTest extends TestCase
     use RefreshDatabase;
 
     protected $adminUser;
+
+    protected RoutingRoute $testRoute;
 
     protected function setUp(): void
     {
@@ -31,6 +35,8 @@ class ProtectedRequestUserCheckerTest extends TestCase
                 'email' => 'platform-admin-user@test.com',
                 'sub' => 'platform-admin-user@test.com',
             ]);
+
+        $this->testRoute = new RoutingRoute('get', '/test', fn () => null);
     }
 
     public function testCanUseLimitedPermissionUnprotected()
@@ -71,10 +77,9 @@ class ProtectedRequestUserCheckerTest extends TestCase
 
     public function testCanNotUsePrivilegedPermissionUnprotected()
     {
-        $this->markTestSkipped('Enable to test the route protection logic.');
-
         // simulate an unprotected request context
         Request::merge(['isProtectedRequest' => null]);
+        Route::expects('current')->andReturn($this->testRoute);
         $checker = new ProtectedRequestUserChecker($this->adminUser);
 
         // a privileged permission can be used only in a protected request
@@ -133,10 +138,9 @@ class ProtectedRequestUserCheckerTest extends TestCase
 
     public function testCanNotUsePrivilegedArrayPermissionUnprotected()
     {
-        $this->markTestSkipped('Enable to test the route protection logic.');
-
         // simulate an unprotected request context
         Request::merge(['isProtectedRequest' => null]);
+        Route::expects('current')->andReturn($this->testRoute);
         $checker = new ProtectedRequestUserChecker($this->adminUser);
 
         // a privileged permission can be used only in a protected request


### PR DESCRIPTION
🤖 Resolves #11149 

## 👋 Introduction

Updates the protected user checker to support array values.

## 🧪 Testing

1. Confirm new tests pass
2. Open a laravel tinker session `make artisan CMD="tinker"`
3. Find applicant user `$applicant = User::where('email', 'applicant@test.com')->first()`
4. Compare the results of `$applicant->isAbleTo('view-own-application') and $applicant->isAbleTo(['view-own-application'])`
