### PR TITLE
[Fix] Footer layout shift

### DIFF
--- a/apps/web/src/components/Footer/Footer.tsx
+++ b/apps/web/src/components/Footer/Footer.tsx
@@ -63,7 +63,7 @@ const Footer = () => {
   ];
 
   return (
-    <footer className="mt-auto border-t border-black/20 bg-white py-12 dark:bg-gray-700">
+    <footer className="relative z-10 mt-auto border-t border-black/20 bg-white py-12 dark:bg-gray-700">
       <Container center size="lg">
         <div className="grid items-center gap-6 xs:grid-cols-2 xs:gap-12 md:grid-cols-3">
           <div className="text-center xs:text-left md:col-start-1 md:col-end-3">

--- a/apps/web/src/components/Layout/Layout.tsx
+++ b/apps/web/src/components/Layout/Layout.tsx
@@ -50,7 +50,7 @@ const Layout = ({
         ) : (
           <IAPNavMenu {...{ loggedIn, userAuthInfo }} />
         )}
-        <main id="main">
+        <main id="main" className="h-full min-h-max grow">
           <Outlet />
         </main>
         <Footer />

--- a/apps/web/src/components/Layout/Layout.tsx
+++ b/apps/web/src/components/Layout/Layout.tsx
@@ -50,7 +50,11 @@ const Layout = ({
         ) : (
           <IAPNavMenu {...{ loggedIn, userAuthInfo }} />
         )}
-        <main id="main" className="h-full min-h-max grow">
+        <main
+          id="main"
+          // 10rem is header + nav height
+          className="flex min-h-[calc(100vh-10rem))] w-full grow flex-col"
+        >
           <Outlet />
         </main>
         <Footer />

--- a/apps/web/src/components/Layout/RouteErrorBoundary/RouteErrorBoundary.tsx
+++ b/apps/web/src/components/Layout/RouteErrorBoundary/RouteErrorBoundary.tsx
@@ -31,11 +31,11 @@ export const RouteErrorBoundary = () => {
   const imgPath = mode === "dark" ? darkPug : lightPug;
 
   return (
-    <>
-      <Flourish />
+    <div className="flex grow flex-col justify-between">
+      <Flourish className="hidden sm:block" />
       <div className="bg-gray-100 py-18 text-black dark:bg-gray-700 dark:text-white">
         <Container size="lg" center className="text-center">
-          <Heading level="h1" size="h4" className="my-0 font-bold">
+          <Heading level="h1" size="h4" className="mt-0 font-bold">
             {error.messages.title}
           </Heading>
           <img
@@ -74,7 +74,7 @@ export const RouteErrorBoundary = () => {
         </Container>
       </div>
       <Flourish />
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
🤖 Resolves #14138 

## 👋 Introduction

Attempt to reduce the layout shift of the footer caused by the dynamic content loaded after painting has ocurred. 

## 🕵️ Details

> [!NOTE]
> tldr; With an SPA and nearly fully dynamic content, there is not perfect solution and we may need to deal with some minor layout shift and just attempt to reduce it rather than completelty remove it. 

I don't think this is a great solution but the one I went with since others are more invovled. On smaller pages (404) it will show a a gap between the content and the footer.

Since we have an SPA and just update the content in `main` and have no idea how tall the content is, we may need to just deal with some layout shift. 

In the ideal scenario, we would do a normal browser nagivation and replace the contents of the entire page rather than just the `main`, or at least have all the content before pushing to reduce the shift, but unfortunatlety, we cannot do that.

Another option is to adjust our `Pending` component. Right now, it covers the screen until data is recieved then goes away during the paint. Since this is a transparent component, it does not fully hide the shift. We could:

 1. Make it fully opaque to hide as much as the layout shift as possible
 2. Instead of a spinner in fixed position, we could give it a set height (100vh) and place it inside main
     - Issue because we also query stuff for the header in rare cases (auth info) but that should already be loaded so probably won't need a spinner?
     - Still could cause layout shift if the content is less than the height of the spinner and the footer shifts back into view

## 🧪 Testing

> [!TIP]
> Logging in helps because the paginated tables is pretty darn obvious 

1. Build `pnpm dev:fresh`
2. Throttle your connection to make the shift easier to see
3. Reload the page and track that layout shift is reduced
