### PR TITLE
[Feat] New `Image` component

### DIFF
--- a/apps/web/src/components/FeatureBlock/FeatureBlock.tsx
+++ b/apps/web/src/components/FeatureBlock/FeatureBlock.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 
-import { Heading, Link } from "@gc-digital-talent/ui";
+import { Heading, Link, Image } from "@gc-digital-talent/ui";
 
 interface FeatureBlockProps {
   content: {
@@ -9,6 +9,8 @@ interface FeatureBlockProps {
     img: {
       path: string;
       position?: string;
+      width?: number;
+      height?: number;
     };
     link: {
       external?: boolean;
@@ -27,7 +29,8 @@ const FeatureBlock = ({ content }: FeatureBlockProps) => {
         </Heading>
       </div>
       <div>
-        <img
+        <Image
+          loading="lazy"
           src={content.img.path}
           alt={content.title}
           className="block h-auto w-full object-cover object-center"

--- a/apps/web/src/components/GradientImage/GradientImage.tsx
+++ b/apps/web/src/components/GradientImage/GradientImage.tsx
@@ -1,45 +1,14 @@
-import { HTMLAttributes, ImgHTMLAttributes } from "react";
+import { HTMLAttributes } from "react";
 import { tv } from "tailwind-variants";
 
-import { notEmpty } from "@gc-digital-talent/helpers";
+import {
+  Image as BaseImage,
+  ImgProps as BaseImgProps,
+} from "@gc-digital-talent/ui";
 
-type Breakpoint = "xs" | "sm" | "md" | "lg";
-type PartialBreakpoints = Partial<Record<Breakpoint, string>>;
-
-export interface ImgProps extends ImgHTMLAttributes<HTMLImageElement> {
-  sources?: PartialBreakpoints;
+export interface ImgProps extends BaseImgProps {
   wrapperClassname?: string;
 }
-
-const sourceMediaMap = new Map<Breakpoint, string>([
-  ["xs", "(max-width: 48rem)"],
-  ["sm", "(max-width: 67.5rem)"],
-  ["md", "(max-width: 80rem)"],
-  ["lg", "(max-width: 100rem)"],
-]);
-
-interface PictureSource {
-  srcSet: string;
-  media: string;
-}
-
-const buildPictureSource = (
-  sources?: PartialBreakpoints,
-): PictureSource[] | null => {
-  if (!sources) {
-    return null;
-  }
-
-  return Object.keys(sources)
-    .map((k) => {
-      const srcSet = sources[k as Breakpoint];
-      const media = sourceMediaMap.get(k as Breakpoint);
-      if (!media || !srcSet) return null;
-
-      return { srcSet, media };
-    })
-    .filter(notEmpty);
-};
 
 const image = tv({
   slots: {
@@ -49,33 +18,13 @@ const image = tv({
   },
 });
 
-const Image = ({
-  className,
-  sources,
-  wrapperClassname,
-  alt,
-  src,
-  ...rest
-}: ImgProps) => {
-  const pictureSources = buildPictureSource(sources);
+const Image = ({ className, wrapperClassname, ...rest }: ImgProps) => {
   const { base, wrapper } = image();
 
   return (
     <div className={wrapper({ class: wrapperClassname })}>
       <div className="absolute inset-0 z-[1] -m-px size-[calc(100%+2px)] bg-linear-[180deg,rgba(0,0,0,1)_0%,rgba(0,0,0,0)_65%,rgba(0,0,0,0)_100%] xs:bg-linear-[90deg,rgba(0,0,0,1)_0%,rgba(0,0,0,0)_45%,_rgba(0,0,0,0)_55%,_rgba(0,0,0,1)_100%]" />
-      <picture>
-        {pictureSources?.length
-          ? pictureSources?.map((sourceProps) => (
-              <source key={sourceProps.srcSet} {...sourceProps} />
-            ))
-          : null}
-        <img
-          src={src}
-          alt={alt ?? ""}
-          className={base({ class: className })}
-          {...rest}
-        />
-      </picture>
+      <BaseImage className={base({ class: className })} {...rest} />
     </div>
   );
 };

--- a/apps/web/src/components/SkewedContainer/SkewedImageContainer.tsx
+++ b/apps/web/src/components/SkewedContainer/SkewedImageContainer.tsx
@@ -17,7 +17,11 @@ const SkewedImageContainer = ({ children, img }: SkewedImageContainerProps) => (
         <GradientImage.Content className="pt-24 pb-12 xs:py-30 sm:py-42 sm:pb-36">
           {children}
         </GradientImage.Content>
-        <GradientImage.Image {...img} wrapperClassname="xs:-inset-y-3" />
+        <GradientImage.Image
+          loading="lazy"
+          wrapperClassname="xs:-inset-y-3"
+          {...img}
+        />
       </Container>
     </div>
     <Flourish className="absolute inset-0 top-auto z-20" />

--- a/apps/web/src/pages/Home/HomePage/components/Hero.tsx
+++ b/apps/web/src/pages/Home/HomePage/components/Hero.tsx
@@ -68,6 +68,7 @@ const Hero = ({ defaultImage }: HeroProps) => {
         sources: { sm: img.sm },
         src: img.src,
         className: img?.className,
+        fetchPriority: "high",
         alt: intl.formatMessage({
           defaultMessage:
             "A diverse group of people, representing all races, genders, and backgrounds, gathered together in unity. Everyone is welcome here!",

--- a/apps/web/src/pages/Home/HomePage/components/Hero.tsx
+++ b/apps/web/src/pages/Home/HomePage/components/Hero.tsx
@@ -68,7 +68,6 @@ const Hero = ({ defaultImage }: HeroProps) => {
         sources: { sm: img.sm },
         src: img.src,
         className: img?.className,
-        fetchPriority: "high",
         alt: intl.formatMessage({
           defaultMessage:
             "A diverse group of people, representing all races, genders, and backgrounds, gathered together in unity. Everyone is welcome here!",

--- a/axe-linter.yml
+++ b/axe-linter.yml
@@ -12,6 +12,7 @@ global-components:
   DescriptionList.Root: dl
   DescriptionList.Item: dt
   Heading: h*
+  Image: img
   Separator: hr
   Step: a
   Checkbox: input[type="checkbox"]

--- a/packages/ui/src/components/Image/Image.stories.tsx
+++ b/packages/ui/src/components/Image/Image.stories.tsx
@@ -1,0 +1,33 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import { allModes } from "@gc-digital-talent/storybook-helpers";
+
+import Image from "./Image";
+
+const meta = {
+  component: Image,
+  parameters: {
+    chromatic: {
+      modes: {
+        light: allModes.light,
+        "light mobile": allModes["light mobile"],
+      },
+    },
+  },
+} satisfies Meta<typeof Image>;
+
+export default meta;
+
+export const Default: StoryObj<typeof Image> = {
+  render: () => (
+    <Image
+      src="https://placehold.co/1920x1080?text=default"
+      sources={{
+        xs: "https://placehold.co/768x768?text=xs",
+        sm: "https://placehold.co/1080x1080?text=sm",
+        md: "https://placehold.co/1280x800?text=md",
+        lg: "https://placehold.co/1600x1000?text=lg",
+      }}
+    />
+  ),
+};

--- a/packages/ui/src/components/Image/Image.tsx
+++ b/packages/ui/src/components/Image/Image.tsx
@@ -5,6 +5,14 @@ import { notEmpty } from "@gc-digital-talent/helpers";
 type Breakpoint = "xs" | "sm" | "md" | "lg";
 type PartialBreakpoints = Partial<Record<Breakpoint, string>>;
 
+/**
+ * NOTE:
+ *  Should match breakpoints defined in tailwind.css config
+ *  This is required because we cannot use css variables in
+ *  media queries
+ *
+ *  REF: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascading_variables/Using_CSS_custom_properties
+ */
 const sourceMediaMap = new Map<Breakpoint, string>([
   ["xs", "(max-width: 48rem)"],
   ["sm", "(max-width: 67.5rem)"],

--- a/packages/ui/src/components/Image/Image.tsx
+++ b/packages/ui/src/components/Image/Image.tsx
@@ -1,0 +1,57 @@
+import { ImgHTMLAttributes } from "react";
+
+import { notEmpty } from "@gc-digital-talent/helpers";
+
+type Breakpoint = "xs" | "sm" | "md" | "lg";
+type PartialBreakpoints = Partial<Record<Breakpoint, string>>;
+
+const sourceMediaMap = new Map<Breakpoint, string>([
+  ["xs", "(max-width: 48rem)"],
+  ["sm", "(max-width: 67.5rem)"],
+  ["md", "(max-width: 80rem)"],
+  ["lg", "(max-width: 100rem)"],
+]);
+
+interface PictureSource {
+  srcSet: string;
+  media: string;
+}
+
+const buildPictureSource = (
+  sources?: PartialBreakpoints,
+): PictureSource[] | null => {
+  if (!sources) {
+    return null;
+  }
+
+  return Object.keys(sources)
+    .map((k) => {
+      const srcSet = sources[k as Breakpoint];
+      const media = sourceMediaMap.get(k as Breakpoint);
+      if (!media || !srcSet) return null;
+
+      return { srcSet, media };
+    })
+    .filter(notEmpty);
+};
+
+export interface ImgProps extends ImgHTMLAttributes<HTMLImageElement> {
+  sources?: PartialBreakpoints;
+}
+
+const Image = ({ sources, alt, ...rest }: ImgProps) => {
+  const pictureSources = buildPictureSource(sources);
+
+  return (
+    <picture>
+      {pictureSources?.length
+        ? pictureSources?.map((sourceProps) => (
+            <source key={sourceProps.srcSet} {...sourceProps} />
+          ))
+        : null}
+      <img alt={alt ?? ""} {...rest} />
+    </picture>
+  );
+};
+
+export default Image;

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -39,7 +39,7 @@ import IconButton, {
   type IconButtonProps,
 } from "./components/Button/IconButton";
 import IconLink, { type IconLinkProps } from "./components/Link/IconLink";
-import Image, { BaseImgProps, type ImgProps } from "./components/Image/Image";
+import Image, { type ImgProps } from "./components/Image/Image";
 import Link, {
   DownloadCsv,
   ScrollToLink,
@@ -118,7 +118,6 @@ export type {
   ScrollToLinkProps,
   ScrollLinkClickFunc,
   ImgProps,
-  BaseImgProps,
   MenuLinkProps,
   MetadataItemProps,
   LoadingProps,

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -39,6 +39,7 @@ import IconButton, {
   type IconButtonProps,
 } from "./components/Button/IconButton";
 import IconLink, { type IconLinkProps } from "./components/Link/IconLink";
+import Image, { BaseImgProps, type ImgProps } from "./components/Image/Image";
 import Link, {
   DownloadCsv,
   ScrollToLink,
@@ -116,6 +117,8 @@ export type {
   IconType,
   ScrollToLinkProps,
   ScrollLinkClickFunc,
+  ImgProps,
+  BaseImgProps,
   MenuLinkProps,
   MetadataItemProps,
   LoadingProps,
@@ -167,6 +170,7 @@ export {
   Heading,
   IconButton,
   IconLink,
+  Image,
   Link,
   DownloadCsv,
   ScrollToLink,


### PR DESCRIPTION
🤖 Resolves #14186 

## 👋 Introduction

Adds a new `Image` component to handle source sets and lazy loading.

## 🕵️ Details

It looks like wdith and height are no longer a hard requirement for `loading=lazy` so I tweakerd this a bit. Instead of providing a `boolean` prop for the `lazy` properties, I simply use the `img` attributes to handle this to make it eaiser when passing in multiple sources.

We should still be providing these values when we can, however when you provide multiple sources, you can't really set them since each source would have a different width/height.

We can likely improve this over time if we feel the need.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Open the network tab and filter by `img` requests
3. Navigate to the homepage
4. Observe, only those near the viewport are loaded
5. Scroll the page and notice that as images approach the viewport, they show up in the network tab and are loaded