### PR TITLE
[Debt] Move assessment step to own DB column

### DIFF
--- a/api/app/Console/Commands/SyncAssessmentStatus.php
+++ b/api/app/Console/Commands/SyncAssessmentStatus.php
@@ -30,9 +30,10 @@ class SyncAssessmentStatus extends Command
     {
         PoolCandidate::chunk(100, function (Collection $candidates) {
             foreach ($candidates as $candidate) {
-                $assessmentStatus = $candidate->computeAssessmentStatus();
+                [$currentStep, $assessmentStatus] = $candidate->computeAssessmentStatus();
 
                 $candidate->computed_assessment_status = $assessmentStatus;
+                $candidate->computed_assessment_step = $currentStep;
 
                 $candidate->save();
 

--- a/api/app/Generators/PoolCandidateCsvGenerator.php
+++ b/api/app/Generators/PoolCandidateCsvGenerator.php
@@ -357,14 +357,14 @@ class PoolCandidateCsvGenerator extends CsvGenerator implements FileGeneratorInt
                         } else {
                             if ($candidate->computed_assessment_status['overallAssessmentStatus'] === OverallAssessmentStatus::DISQUALIFIED->name) {
                                 $decision = Lang::get('final_decision.disqualified_pending', [], $this->lang);
-                            } elseif ($candidate->computed_assessment_status['currentStep'] === null) {
+                            } elseif ($candidate->computed_assessment_step === null) {
                                 $decision = Lang::get('final_decision.qualified_pending', [], $this->lang);
                             } else {
                                 $decision = Lang::get('final_decision.to_assess', [], $this->lang)
                                             .$this->colon()
                                             .Lang::get('common.step', [], $this->lang)
                                             .' '
-                                            .$candidate->computed_assessment_status['currentStep'];
+                                            .$candidate->computed_assessment_step;
                             }
                         }
                     } else {

--- a/api/app/GraphQL/Mutations/SubmitApplication.php
+++ b/api/app/GraphQL/Mutations/SubmitApplication.php
@@ -50,9 +50,10 @@ final class SubmitApplication
 
         $application->setApplicationSnapshot(false);
 
-        $assessmentStatus = $application->computeAssessmentStatus();
+        [$currentStep, $assessmentStatus] = $application->computeAssessmentStatus();
 
         $application->computed_assessment_status = $assessmentStatus;
+        $application->computed_assessment_step = $currentStep;
 
         $application->save();
 

--- a/api/app/Listeners/ComputeCandidateAssessmentStatus.php
+++ b/api/app/Listeners/ComputeCandidateAssessmentStatus.php
@@ -30,8 +30,9 @@ class ComputeCandidateAssessmentStatus
         /** @var \App\Models\PoolCandidate */
         $candidate = $result->poolCandidate;
 
-        $assessmentStatus = $candidate->computeAssessmentStatus();
+        [$currentStep, $assessmentStatus] = $candidate->computeAssessmentStatus();
 
+        $candidate->computed_assessment_step = $currentStep;
         $candidate->computed_assessment_status = $assessmentStatus;
 
         if ($candidate->pool_candidate_status === PoolCandidateStatus::NEW_APPLICATION->name) {

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -59,6 +59,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property ?string $priority_verification
  * @property ?\Illuminate\Support\Carbon $priority_verification_expiry
  * @property array $computed_assessment_status
+ * @property ?int $computed_assessment_step
  * @property ?int $computed_final_decision_weight
  * @property ?string $computed_final_decision
  * @property array<string, mixed> $profile_snapshot
@@ -88,6 +89,7 @@ class PoolCandidate extends Model
         'veteran_verification_expiry' => 'date',
         'priority_verification_expiry' => 'date',
         'computed_assessment_status' => 'array',
+        'computed_assessment_step' => 'integer',
     ];
 
     /**
@@ -534,9 +536,11 @@ class PoolCandidate extends Model
         }
 
         return [
-            'currentStep' => $currentStep,
-            'overallAssessmentStatus' => $overallAssessmentStatus,
-            'assessmentStepStatuses' => $decisions,
+            $currentStep,
+            [
+                'overallAssessmentStatus' => $overallAssessmentStatus,
+                'assessmentStepStatuses' => $decisions,
+            ],
         ];
     }
 
@@ -609,10 +613,7 @@ class PoolCandidate extends Model
         };
 
         $assessmentStatus = $this->computed_assessment_status;
-        $currentStep = null;
-        if (isset($assessmentStatus)) {
-            $currentStep = $assessmentStatus['currentStep'];
-        }
+        $currentStep = $this->computed_assessment_step;
 
         if ($decision === FinalDecision::TO_ASSESS->name && $currentStep) {
             $weight = $weight + $currentStep * 10;

--- a/api/database/migrations/2025_07_23_135112_add_assessment_step_column_pool_candidates_table.php
+++ b/api/database/migrations/2025_07_23_135112_add_assessment_step_column_pool_candidates_table.php
@@ -13,10 +13,10 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('pool_candidates', function (Blueprint $table) {
-            $table->integer('assessment_step')->nullable()->default(1);
+            $table->integer('computed_assessment_step')->nullable()->default(1);
         });
 
-        DB::statement("UPDATE pool_candidates SET assessment_step = (computed_assessment_status->>'currentStep')::int WHERE computed_assessment_status IS NOT NULL");
+        DB::statement("UPDATE pool_candidates SET computed_assessment_step = (computed_assessment_status->>'currentStep')::int WHERE computed_assessment_status IS NOT NULL");
     }
 
     /**
@@ -29,12 +29,12 @@ return new class extends Migration
                 SET computed_assessment_status = jsonb_set(
                     COALESCE(computed_assessment_status, '{}'::jsonb),
                     '{currentStep}',
-                    to_jsonb(assessment_step)
+                    to_jsonb(computed_assessment_step)
                 )
         SQL);
 
         Schema::table('pool_candidates', function (Blueprint $table) {
-            $table->dropColumn('assessment_step');
+            $table->dropColumn('computed_assessment_step');
         });
 
     }

--- a/api/database/migrations/2025_07_23_135112_add_assessment_step_column_pool_candidates_table.php
+++ b/api/database/migrations/2025_07_23_135112_add_assessment_step_column_pool_candidates_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('pool_candidates', function (Blueprint $table) {
+            $table->integer('assessment_step')->nullable()->default(1);
+        });
+
+        DB::statement("UPDATE pool_candidates SET assessment_step = (computed_assessment_status->>'currentStep')::int WHERE computed_assessment_status IS NOT NULL");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement(<<<'SQL'
+            UPDATE pool_candidates
+                SET computed_assessment_status = jsonb_set(
+                    COALESCE(computed_assessment_status, '{}'::jsonb),
+                    '{currentStep}',
+                    to_jsonb(assessment_step)
+                )
+        SQL);
+
+        Schema::table('pool_candidates', function (Blueprint $table) {
+            $table->dropColumn('assessment_step');
+        });
+
+    }
+};

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -489,7 +489,6 @@ type AssessmentStepDecision {
 type AssessmentResultStatus {
   assessmentStepStatuses: [AssessmentStepDecision]
   overallAssessmentStatus: OverallAssessmentStatus
-  currentStep: Int # Starts at 1, null indicates all steps successful
 }
 
 type PoolSkill {
@@ -559,6 +558,7 @@ type PoolCandidate {
     @canRoot(ability: "viewAssessment")
   assessmentStatus: AssessmentResultStatus
     @rename(attribute: "computed_assessment_status")
+  assessmentStep: Int @rename(attribute: "computed_assessment_step")
   finalDecision: LocalizedFinalDecision
     @rename(attribute: "computed_final_decision")
   finalDecisionAt: DateTime
@@ -605,6 +605,7 @@ type PoolCandidateAdminView {
   category: PoolCandidateCategory @with(relation: "user")
   assessmentStatus: AssessmentResultStatus
     @rename(attribute: "computed_assessment_status")
+  assessmentStep: Int @rename(attribute: "computed_assessment_step")
   finalDecision: LocalizedFinalDecision
     @rename(attribute: "computed_final_decision")
   placedDepartment: Department @belongsTo

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1000,7 +1000,6 @@ type AssessmentStepDecision {
 type AssessmentResultStatus {
   assessmentStepStatuses: [AssessmentStepDecision]
   overallAssessmentStatus: OverallAssessmentStatus
-  currentStep: Int
 }
 
 type PoolSkill {
@@ -1043,6 +1042,7 @@ type PoolCandidate {
   educationRequirementExperiences: [Experience]
   assessmentResults: [AssessmentResult]
   assessmentStatus: AssessmentResultStatus
+  assessmentStep: Int
   finalDecision: LocalizedFinalDecision
   finalDecisionAt: DateTime
   placedAt: DateTime
@@ -1070,6 +1070,7 @@ type PoolCandidateAdminView {
   isBookmarked: Boolean
   category: PoolCandidateCategory
   assessmentStatus: AssessmentResultStatus
+  assessmentStep: Int
   finalDecision: LocalizedFinalDecision
   placedDepartment: Department
   closingDate: DateTime

--- a/api/tests/Feature/CandidateFinalDecisionTest.php
+++ b/api/tests/Feature/CandidateFinalDecisionTest.php
@@ -48,9 +48,9 @@ class CandidateFinalDecisionTest extends TestCase
     {
         $this->candidate->pool_candidate_status = PoolCandidateStatus::NEW_APPLICATION->name;
         $this->candidate->computed_assessment_status = [
-            'currentStep' => $step,
             'overallAssessmentStatus' => $overallStatus,
         ];
+        $this->candidate->computed_assessment_step = $step;
         $decision = $this->candidate->computeFinalDecision();
         $this->assertEquals($expected, $decision);
     }

--- a/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
+++ b/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
@@ -56,8 +56,8 @@ export const AssessmentResultsTable_Fragment = graphql(/* GraphQL */ `
         }
       }
     }
+    assessmentStep
     assessmentStatus {
-      currentStep
       overallAssessmentStatus
     }
     assessmentResults {

--- a/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
@@ -57,8 +57,8 @@ export const AssessmentStepTracker_CandidateFragment = graphql(/* GraphQL */ `
       }
       hasPriorityEntitlement
     }
+    assessmentStep
     assessmentStatus {
-      currentStep
       assessmentStepStatuses {
         decision
         step

--- a/apps/web/src/components/AssessmentStepTracker/testData.ts
+++ b/apps/web/src/components/AssessmentStepTracker/testData.ts
@@ -55,8 +55,8 @@ export const priorityEntitlementCandidate: PoolCandidate = {
   isBookmarked: false,
   assessmentResults: [getAssessmentResult()],
   priorityVerification: ClaimVerificationResult.Accepted,
+  assessmentStep: 2,
   assessmentStatus: {
-    currentStep: 2,
     assessmentStepStatuses: [
       {
         step: requiredAssessment.id,
@@ -78,8 +78,8 @@ export const armedForcesCandidate: PoolCandidate = {
   isBookmarked: false,
   assessmentResults: [getAssessmentResult()],
   veteranVerification: ClaimVerificationResult.Accepted,
+  assessmentStep: 2,
   assessmentStatus: {
-    currentStep: 2,
     assessmentStepStatuses: [
       {
         step: requiredAssessment.id,
@@ -100,8 +100,8 @@ export const bookmarkedCandidate: PoolCandidate = {
   },
   isBookmarked: true,
   assessmentResults: [getAssessmentResult()],
+  assessmentStep: 2,
   assessmentStatus: {
-    currentStep: 2,
     assessmentStepStatuses: [
       {
         step: requiredAssessment.id,
@@ -132,8 +132,8 @@ export const unassessedCandidate: PoolCandidate = {
       },
     },
   ],
+  assessmentStep: 1,
   assessmentStatus: {
-    currentStep: 1,
     assessmentStepStatuses: [],
   },
 };
@@ -142,8 +142,8 @@ export const lastByFirstName: PoolCandidate = {
   id: "last-by-first-name",
   isBookmarked: false,
   assessmentResults: [getAssessmentResult()],
+  assessmentStep: 2,
   assessmentStatus: {
-    currentStep: 2,
     assessmentStepStatuses: [
       {
         step: requiredAssessment.id,
@@ -164,8 +164,9 @@ export const firstByName: PoolCandidate = {
   id: "first-by-name",
   isBookmarked: false,
   assessmentResults: [getAssessmentResult()],
+
+  assessmentStep: 2,
   assessmentStatus: {
-    currentStep: 2,
     assessmentStepStatuses: [
       {
         step: requiredAssessment.id,
@@ -185,8 +186,8 @@ export const secondLastByStatus: PoolCandidate = {
   id: "second-last-by-status",
   isBookmarked: false,
   assessmentResults: [getAssessmentResult(AssessmentDecision.Hold)],
+  assessmentStep: 1,
   assessmentStatus: {
-    currentStep: 1,
     assessmentStepStatuses: [
       {
         step: requiredAssessment.id,
@@ -207,8 +208,8 @@ export const lastByStatus: PoolCandidate = {
   id: "last-by-status",
   isBookmarked: false,
   assessmentResults: [getAssessmentResult(AssessmentDecision.Unsuccessful)],
+  assessmentStep: 1,
   assessmentStatus: {
-    currentStep: 1,
     overallAssessmentStatus: OverallAssessmentStatus.Disqualified,
     assessmentStepStatuses: [
       {

--- a/apps/web/src/components/AssessmentStepTracker/utils.ts
+++ b/apps/web/src/components/AssessmentStepTracker/utils.ts
@@ -201,8 +201,8 @@ export const groupPoolCandidatesByStep = (
     orderedSteps.map((step, index) => {
       const stepCandidates = candidates
         .filter((candidate) => {
-          return candidate.assessmentStatus?.currentStep
-            ? index + 1 <= candidate.assessmentStatus?.currentStep
+          return candidate.assessmentStep
+            ? index + 1 <= candidate.assessmentStep
             : true; // Null step indicates user passed all steps
         })
         .map((candidate) => {

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -215,12 +215,12 @@ const CandidatesTableCandidatesPaginated_Query = graphql(/* GraphQL */ `
           finalDecision {
             value
           }
+          assessmentStep
           assessmentStatus {
             assessmentStepStatuses {
               step
             }
             overallAssessmentStatus
-            currentStep
           }
           pool {
             id
@@ -261,8 +261,8 @@ const CandidatesTableCandidatesPaginated_Query = graphql(/* GraphQL */ `
               fr
             }
           }
+          assessmentStep
           assessmentStatus {
-            currentStep
             overallAssessmentStatus
           }
           user {
@@ -800,16 +800,27 @@ const PoolCandidatesTable = ({
         cell: ({
           row: {
             original: {
-              poolCandidate: { finalDecision, assessmentStatus },
+              poolCandidate: {
+                finalDecision,
+                assessmentStatus,
+                assessmentStep,
+              },
             },
           },
-        }) => finalDecisionCell(finalDecision, assessmentStatus, intl),
+        }) =>
+          finalDecisionCell(
+            finalDecision,
+            assessmentStep,
+            assessmentStatus,
+            intl,
+          ),
       },
     ),
     columnHelper.accessor(
       ({
         poolCandidate: {
           submittedAt,
+          assessmentStep,
           assessmentStatus,
           removedAt,
           finalDecisionAt,
@@ -824,6 +835,7 @@ const PoolCandidatesTable = ({
           finalDecisionAt,
           finalDecision?.value,
           areaOfSelection?.value,
+          assessmentStep,
           assessmentStatus,
           screeningQuestionsCount,
           intl,

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -201,11 +201,13 @@ export const currentLocationAccessor = (
 
 export const finalDecisionCell = (
   finalDecision: Maybe<LocalizedFinalDecision> | undefined,
+  assessmentStep: Maybe<number> | undefined,
   assessmentStatus: Maybe<AssessmentResultStatus> | undefined,
   intl: IntlShape,
 ) => {
   const { color, label } = getCandidateStatusChip(
     finalDecision,
+    assessmentStep,
     assessmentStatus,
     intl,
   );
@@ -219,6 +221,7 @@ export const candidateFacingStatusCell = (
   finalDecisionAt: PoolCandidate["finalDecisionAt"],
   finalDecision: Maybe<FinalDecision> | undefined,
   areaOfSelection: Maybe<PoolAreaOfSelection> | undefined,
+  assessmentStep: PoolCandidate["assessmentStep"],
   assessmentStatus: PoolCandidate["assessmentStatus"],
   screeningQuestions: Pool["screeningQuestionsCount"],
   intl: IntlShape,
@@ -230,6 +233,7 @@ export const candidateFacingStatusCell = (
     finalDecisionAt,
     finalDecision,
     areaOfSelection,
+    assessmentStep,
     assessmentStatus,
     screeningQuestions,
     intl,

--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationDialog.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationDialog.tsx
@@ -45,12 +45,12 @@ const ReviewApplicationDialog_Fragment = graphql(/* GraphQL */ `
     finalDecision {
       value
     }
+    assessmentStep
     assessmentStatus {
       assessmentStepStatuses {
         step
       }
       overallAssessmentStatus
-      currentStep
     }
     pool {
       id
@@ -171,6 +171,7 @@ const ReviewApplicationDialog = ({
     application.finalDecisionAt,
     application.finalDecision?.value,
     pool.areaOfSelection?.value,
+    application.assessmentStep,
     application.assessmentStatus,
     pool.screeningQuestionsCount,
     intl,

--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationPreviewList.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationPreviewList.tsx
@@ -27,12 +27,12 @@ const ReviewApplicationPreviewList_Fragment = graphql(/* GraphQL */ `
     finalDecision {
       value
     }
+    assessmentStep
     assessmentStatus {
       assessmentStepStatuses {
         step
       }
       overallAssessmentStatus
-      currentStep
     }
     pool {
       id
@@ -98,6 +98,7 @@ const ReviewApplicationPreviewList = ({
                 application.finalDecisionAt,
                 application.finalDecision?.value,
                 application.pool.areaOfSelection?.value,
+                application.assessmentStep,
                 application.assessmentStatus,
                 application.pool.screeningQuestionsCount,
                 intl,

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -69,8 +69,8 @@ const PoolCandidate_SnapshotQuery = graphql(/* GraphQL */ `
           fr
         }
       }
+      assessmentStep
       assessmentStatus {
-        currentStep
         assessmentStepStatuses {
           decision
           step
@@ -150,6 +150,7 @@ export const ViewPoolCandidate = ({
   const nonEmptyExperiences = unpackMaybes(parsedSnapshot?.experiences);
   const statusChip = getCandidateStatusChip(
     poolCandidate.finalDecision,
+    poolCandidate.assessmentStep,
     poolCandidate.assessmentStatus,
     intl,
   );

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/MoreActions.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/MoreActions.tsx
@@ -54,9 +54,7 @@ export const MoreActions_Fragment = graphql(/* GraphQL */ `
       }
     }
     isBookmarked
-    assessmentStatus {
-      currentStep
-    }
+    assessmentStep
     removalReason {
       label {
         localized
@@ -110,10 +108,9 @@ const MoreActions = ({
 
   const [{ data }] = useQuery({ query: MoreActions_Query });
 
-  const currentStep = poolCandidate.assessmentStatus?.currentStep
+  const currentStep = poolCandidate.assessmentStep
     ? poolCandidate.pool.assessmentSteps?.find(
-        (step) =>
-          step?.sortOrder === poolCandidate.assessmentStatus?.currentStep,
+        (step) => step?.sortOrder === poolCandidate.assessmentStep,
       )
     : null;
 
@@ -139,7 +136,7 @@ const MoreActions = ({
                   id: "XofAAo",
                   description: "Label for a candidates current assessment step",
                 },
-                { stepNumber: poolCandidate.assessmentStatus?.currentStep },
+                { stepNumber: poolCandidate.assessmentStep },
               ) +
                 intl.formatMessage(commonMessages.dividingColon) +
                 currentStepName}

--- a/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/UserCandidatesTable.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/UserCandidatesTable.tsx
@@ -66,8 +66,8 @@ const UserCandidatesTableRow_Fragment = graphql(/* GraphQL */ `
           fr
         }
       }
+      assessmentStep
       assessmentStatus {
-        currentStep
         overallAssessmentStatus
       }
       placedDepartment {
@@ -239,6 +239,7 @@ const UserCandidatesTable = ({
         cell: ({ row: { original: poolCandidate } }) =>
           finalDecisionCell(
             poolCandidate.finalDecision,
+            poolCandidate.assessmentStep,
             poolCandidate.assessmentStatus,
             intl,
           ),

--- a/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/helpers.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/helpers.tsx
@@ -191,11 +191,13 @@ export const notesCell = (
 
 export const finalDecisionCell = (
   finalDecision: Maybe<LocalizedFinalDecision> | undefined,
+  assessmentStep: Maybe<number> | undefined,
   assessmentStatus: Maybe<AssessmentResultStatus> | undefined,
   intl: IntlShape,
 ) => {
   const { color, label } = getCandidateStatusChip(
     finalDecision,
+    assessmentStep,
     assessmentStatus,
     intl,
   );

--- a/apps/web/src/utils/poolCandidate.test.ts
+++ b/apps/web/src/utils/poolCandidate.test.ts
@@ -49,6 +49,7 @@ describe("PoolCandidate utils", () => {
             value: finalDecision,
             label: { en: "Qualified" },
           },
+          candidate.assessmentStep,
           candidate.assessmentStatus,
           intl,
         );
@@ -65,6 +66,7 @@ describe("PoolCandidate utils", () => {
               value: finalDecision,
               label: { en: "Disqualified" },
             },
+            candidate.assessmentStep,
             candidate.assessmentStatus,
             intl,
           );
@@ -82,6 +84,7 @@ describe("PoolCandidate utils", () => {
             en: "Removed: To assess",
           },
         },
+        candidate.assessmentStep,
         candidate.assessmentStatus,
         intl,
       );
@@ -95,6 +98,7 @@ describe("PoolCandidate utils", () => {
             en: "Removed: Qualified",
           },
         },
+        candidate.assessmentStep,
         candidate.assessmentStatus,
         intl,
       );
@@ -109,6 +113,7 @@ describe("PoolCandidate utils", () => {
             en: "Removed",
           },
         },
+        candidate.assessmentStep,
         candidate.assessmentStatus,
         intl,
       );
@@ -122,6 +127,7 @@ describe("PoolCandidate utils", () => {
             en: "Expired: Qualified",
           },
         },
+        candidate.assessmentStep,
         candidate.assessmentStatus,
         intl,
       );
@@ -137,6 +143,7 @@ describe("PoolCandidate utils", () => {
               en: "Qualified: Pending decision",
             },
           },
+          candidateFullyQualified.assessmentStep,
           candidateFullyQualified.assessmentStatus,
           intl,
         );
@@ -151,6 +158,7 @@ describe("PoolCandidate utils", () => {
               en: "Qualified: Pending decision",
             },
           },
+          candidateQualifiedExceptHoldOnMiddleAssessment.assessmentStep,
           candidateQualifiedExceptHoldOnMiddleAssessment.assessmentStatus,
           intl,
         );
@@ -163,6 +171,7 @@ describe("PoolCandidate utils", () => {
             value: FinalDecision.ToAssess,
             label: { en: "To assess" },
           },
+          candidateFullyQualifiedExceptMissingEducation.assessmentStep,
           candidateFullyQualifiedExceptMissingEducation.assessmentStatus,
           intl,
         );
@@ -175,6 +184,8 @@ describe("PoolCandidate utils", () => {
             value: FinalDecision.ToAssess,
             label: { en: "To assess" },
           },
+
+          candidateNoAssessments.assessmentStep,
           candidateNoAssessments.assessmentStatus,
           intl,
         );
@@ -187,6 +198,7 @@ describe("PoolCandidate utils", () => {
             value: FinalDecision.ToAssess,
             label: { en: "To assess" },
           },
+          candidateQualifiedExceptHoldOnFinalAssessment.assessmentStep,
           candidateQualifiedExceptHoldOnFinalAssessment.assessmentStatus,
           intl,
         );
@@ -199,6 +211,7 @@ describe("PoolCandidate utils", () => {
             value: FinalDecision.ToAssess,
             label: { en: "To assess" },
           },
+          candidateHoldOnMiddleStepAndNoResultsOnFinalStep.assessmentStep,
           candidateHoldOnMiddleStepAndNoResultsOnFinalStep.assessmentStatus,
           intl,
         );
@@ -210,6 +223,7 @@ describe("PoolCandidate utils", () => {
             value: FinalDecision.ToAssess,
             label: { en: "To assess" },
           },
+          candidateUnfinishedFinalAssessment.assessmentStep,
           candidateUnfinishedFinalAssessment.assessmentStatus,
           intl,
         );
@@ -222,6 +236,7 @@ describe("PoolCandidate utils", () => {
             value: FinalDecision.DisqualifiedPending,
             label: { en: "Disqualified: Pending decision" },
           },
+          candidateOneFailingAssessment.assessmentStep,
           candidateOneFailingAssessment.assessmentStatus,
           intl,
         );

--- a/apps/web/src/utils/poolCandidate.ts
+++ b/apps/web/src/utils/poolCandidate.ts
@@ -187,6 +187,7 @@ const getFinalDecisionChipColor = (
  * since the candidate may or may not be ready for a final decision.
  */
 const computeInAssessmentStatusChip = (
+  assessmentStep: Maybe<number> | undefined,
   assessmentStatus: Maybe<AssessmentResultStatus> | undefined,
   intl: IntlShape,
 ): StatusChip => {
@@ -212,9 +213,7 @@ const computeInAssessmentStatusChip = (
   }
 
   const currentStep =
-    typeof assessmentStatus?.currentStep === "undefined"
-      ? 1
-      : assessmentStatus.currentStep;
+    typeof assessmentStep === "undefined" ? 1 : assessmentStep;
 
   // currentStep of null means that the candidate has passed all steps and is tentatively qualified!
   if (currentStep === null) {
@@ -286,6 +285,7 @@ export interface StatusChipWithDescription extends StatusChip {
  */
 export const getCandidateStatusChip = (
   finalDecision: Maybe<LocalizedFinalDecision> | undefined,
+  assessmentStep: Maybe<number> | undefined,
   assessmentStatus: Maybe<AssessmentResultStatus> | undefined,
   intl: IntlShape,
 ): StatusChip => {
@@ -293,7 +293,11 @@ export const getCandidateStatusChip = (
     finalDecision?.value === FinalDecision.ToAssess ||
     !finalDecision?.value
   ) {
-    return computeInAssessmentStatusChip(assessmentStatus, intl);
+    return computeInAssessmentStatusChip(
+      assessmentStep,
+      assessmentStatus,
+      intl,
+    );
   }
 
   return {
@@ -418,6 +422,7 @@ export const getApplicationStatusChip = (
   finalDecisionAt: PoolCandidate["finalDecisionAt"],
   finalDecision: Maybe<FinalDecision> | undefined,
   areaOfSelection: Maybe<PoolAreaOfSelection> | undefined,
+  assessmentStep: PoolCandidate["assessmentStep"],
   assessmentStatus: PoolCandidate["assessmentStatus"],
   screeningQuestionsCount: Pool["screeningQuestionsCount"],
   intl: IntlShape,
@@ -493,7 +498,7 @@ export const getApplicationStatusChip = (
   }
 
   // Partially assessed applications
-  const currentStep = assessmentStatus?.currentStep ?? 0;
+  const currentStep = assessmentStep ?? 0;
   const numberOfScreeningSteps =
     screeningQuestionsCount && screeningQuestionsCount > 0 ? 2 : 1;
   const numberOfStepStatuses =

--- a/apps/web/src/utils/testData.ts
+++ b/apps/web/src/utils/testData.ts
@@ -64,10 +64,10 @@ const makeAssessmentResult = (
 
 export const candidateFullyQualifiedExceptMissingEducation: PoolCandidate = {
   ...fakeCandidates[0],
+  assessmentStep: 1,
   assessmentStatus: {
     assessmentStepStatuses: [],
     overallAssessmentStatus: OverallAssessmentStatus.ToAssess,
-    currentStep: 1,
   },
   assessmentResults: [
     ...fakePoolAssessmentSteps.flatMap((step) =>
@@ -80,9 +80,9 @@ export const candidateFullyQualifiedExceptMissingEducation: PoolCandidate = {
 
 export const candidateFullyQualified: PoolCandidate = {
   ...fakeCandidates[1],
+  assessmentStep: null,
   assessmentStatus: {
     overallAssessmentStatus: OverallAssessmentStatus.Qualified,
-    currentStep: null,
   },
   assessmentResults: [
     ...fakePoolAssessmentSteps.flatMap((step) =>
@@ -101,9 +101,9 @@ export const candidateFullyQualified: PoolCandidate = {
 
 export const candidateQualifiedExceptHoldOnMiddleAssessment: PoolCandidate = {
   ...fakeCandidates[2],
+  assessmentStep: null,
   assessmentStatus: {
     overallAssessmentStatus: OverallAssessmentStatus.Qualified,
-    currentStep: null,
   },
   assessmentResults: [
     ...fakePoolAssessmentSteps.flatMap((step, index) =>
@@ -128,10 +128,10 @@ export const candidateQualifiedExceptHoldOnMiddleAssessment: PoolCandidate = {
 
 export const candidateQualifiedExceptHoldOnFinalAssessment: PoolCandidate = {
   ...fakeCandidates[3],
+  assessmentStep: 3,
   assessmentStatus: {
     assessmentStepStatuses: [],
     overallAssessmentStatus: OverallAssessmentStatus.Qualified,
-    currentStep: 3,
   },
   assessmentResults: [
     ...fakePoolAssessmentSteps.flatMap((step, index) =>
@@ -156,13 +156,13 @@ export const candidateQualifiedExceptHoldOnFinalAssessment: PoolCandidate = {
 
 export const candidateUnfinishedFinalAssessment: PoolCandidate = {
   ...fakeCandidates[4],
+  assessmentStep: 3,
   assessmentStatus: {
     assessmentStepStatuses: fakePoolAssessmentSteps.flatMap((step) => ({
       step: step.id,
       decision: null,
     })),
     overallAssessmentStatus: OverallAssessmentStatus.ToAssess,
-    currentStep: 3,
   },
   assessmentResults: [
     ...fakePoolAssessmentSteps.flatMap((step, stepIndex) =>
@@ -187,10 +187,10 @@ export const candidateUnfinishedFinalAssessment: PoolCandidate = {
 
 export const candidateHoldOnMiddleStepAndNoResultsOnFinalStep: PoolCandidate = {
   ...fakeCandidates[5],
+  assessmentStep: 3,
   assessmentStatus: {
     assessmentStepStatuses: [],
     overallAssessmentStatus: OverallAssessmentStatus.ToAssess,
-    currentStep: 3,
   },
   assessmentResults: [
     ...fakePoolAssessmentSteps
@@ -217,13 +217,13 @@ export const candidateHoldOnMiddleStepAndNoResultsOnFinalStep: PoolCandidate = {
 
 export const candidateOneFailingAssessment: PoolCandidate = {
   ...fakeCandidates[6],
+  assessmentStep: 1,
   assessmentStatus: {
     assessmentStepStatuses: fakePoolAssessmentSteps.flatMap((step) => ({
       step: step.id,
       decision: AssessmentDecision.Unsuccessful,
     })),
     overallAssessmentStatus: OverallAssessmentStatus.Disqualified,
-    currentStep: 1,
   },
   assessmentResults: [
     ...fakePoolAssessmentSteps.flatMap((step, stepIndex) =>

--- a/packages/fake-data/src/fakePoolCandidates.ts
+++ b/packages/fake-data/src/fakePoolCandidates.ts
@@ -68,10 +68,10 @@ const generatePoolCandidate = (
     isBookmarked: faker.datatype.boolean(0.2),
     generalQuestionResponses,
     screeningQuestionResponses,
+    assessmentStep: 1,
     assessmentStatus: {
       assessmentStepStatuses: [],
       overallAssessmentStatus: OverallAssessmentStatus.ToAssess,
-      currentStep: 1,
     },
     finalDecision: toLocalizedEnum(
       faker.helpers.arrayElement<FinalDecision>(Object.values(FinalDecision)),


### PR DESCRIPTION
🤖 Resolves #14090 

## 👋 Introduction

This moves the candidates current assessment step to a real database column from the existing `computed_assessment_status` json column.

## 🕵️ Details

I suggest taking a good look at the migration, I'm not that familiar with the `jsonb` syntax in postgres so my confidence on that is not super high :sweat_smile: 

Also, I did not remove it from the JSON, it just isnt getting used and as we re-compute the assessment status, it should slowly be removed from the DB over time.

## 🧪 Testing

1. Take note of the `pool_candidates` tables `computed_assessment_status->>currentStep` columns data
2. Run migration `make artisan CMD="migrate"`
3. Confirm the step is properly copied to the new field
4. Confirm everything still works as expected
5. Rollback  migration `make artisan CMD="migrate:rollback --step=1"`
6. Confirm the database reflects the original structure and expected values