### PR TITLE
[Fix] Language information error summary

### DIFF
--- a/apps/web/src/components/Profile/components/LanguageProfile/ConsideredLanguages.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/ConsideredLanguages.tsx
@@ -156,7 +156,7 @@ const ConsideredLanguages = ({
     <>
       <RadioGroup
         idPrefix="firstOfficialLanguage"
-        legend={labels.yourFirstOfficialLang}
+        legend={labels.firstOfficialLanguage}
         name="firstOfficialLanguage"
         id="firstOfficialLanguage"
         rules={{

--- a/apps/web/src/components/Profile/components/LanguageProfile/utils.ts
+++ b/apps/web/src/components/Profile/components/LanguageProfile/utils.ts
@@ -100,7 +100,7 @@ export const getLabels = (intl: IntlShape) => ({
     description:
       "Legend for considered position languages check list in language information form",
   }),
-  yourFirstOfficialLang: intl.formatMessage({
+  firstOfficialLanguage: intl.formatMessage({
     defaultMessage: "Your first official language",
     id: "CwGljY",
     description:


### PR DESCRIPTION
🤖 Resolves #14197 

## 👋 Introduction

Fixes an issue where the error summary was not appearing for the first official language field.

## 🕵️ Details

This was because the `ErrorSummary` works by matching label keys with field ids in order to populate. If they do not match exaclty they do not appear in the summary.

Sadly, this specific feature is pretty birttle and easy to make mistakes. I'd love if we could find a better way of doing this :-1: 

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as a new user `new@test.com`
3. Navigate to language information on profile `/applicant/personal-information#language-section`
4. Turn on your screen reader
5. Select "Billingual"
6. Fill out all fierlds but the first official language one
7. Attempt to submit
8. Confirm the error summary appears and is announced

## 📸 Screenshot

<img width="868" height="1073" alt="swappy-20250724_134532" src="https://github.com/user-attachments/assets/3aae1e02-1756-442a-b9fa-206571a6ae89" />
