### PR TITLE
Add Language Strings for Application Snapshot

### DIFF
--- a/api/lang/en/common.php
+++ b/api/lang/en/common.php
@@ -44,5 +44,5 @@ return [
     'digital_talent_processes_text' => 'These processes are run on the GC Digital Talent platform.',
     'off_platform_processes_text' => 'Users can provide information about processes or pools from other Government of Canada platforms in which they’ve been qualified. This information has not been verified.',
     'nominations' => 'Nominations',
-    'skill_requirements' => 'Skill requirements'
+    'skill_requirements' => 'Skill requirements',
 ];

--- a/api/lang/fr/common.php
+++ b/api/lang/fr/common.php
@@ -45,5 +45,5 @@ return [
     'digital_talent_processes_text' => 'Ces processus sont effectués sur la plateforme Talents numériques du GC.',
     'off_platform_processes_text' => 'Les utilisateurs peuvent fournir des renseignements sur les processus ou les bassins d\'autres plateformes du gouvernement du Canada pour lesquels ils ont été qualifiés. Ces informations n\'ont pas été vérifiées.',
     'nominations' => 'Nominations',
-    'skill_requirements' => 'Exigences en matière de compétences'
+    'skill_requirements' => 'Exigences en matière de compétences',
 ];


### PR DESCRIPTION
🤖 Resolves #14203

## 👋 Introduction

This PR fixes a missing language string for the Application snapshot download. "Skill requirements" should be displayed. Previously, the download showed the raw key `common.skill_requirement` instead of the expected translated text.

## 🕵️ Details

- Added the missing skill_requirement key to the common.php language file (En & Fr).
- Confirmed it correctly displays as "Skill requirements" / "Exigences en matière de compétences"

## 🧪 Testing

1. Build app
2. Login as Admin
3. Navigate to `admin/pool-candidates` page and select a candidate
4. Download the applications in both English and French
5. Confirm the label shows `Skill requirements`

## 📸 Screenshot

<img width="391" height="320" alt="image" src="https://github.com/user-attachments/assets/1c9558b7-1012-4024-8b8e-169e4022ff55" />

<img width="382" height="388" alt="image" src="https://github.com/user-attachments/assets/42a6e82d-273f-47e0-8584-de2b302ce747" />

