### PR TITLE
[Fix] Notification dialog poling removes focus

### DIFF
--- a/apps/web/src/components/NotificationList/NotificationListPage.tsx
+++ b/apps/web/src/components/NotificationList/NotificationListPage.tsx
@@ -5,7 +5,7 @@ import { useRef } from "react";
 
 import { Scalars, graphql } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
-import { Link, Loading, Well } from "@gc-digital-talent/ui";
+import { Link, Well } from "@gc-digital-talent/ui";
 
 import NotificationItem from "./NotificationItem";
 import NotificationPortal, {

--- a/apps/web/src/components/NotificationList/NotificationListPage.tsx
+++ b/apps/web/src/components/NotificationList/NotificationListPage.tsx
@@ -78,9 +78,6 @@ const NotificationListPage = ({
 
   const notifications = unpackMaybes(data?.notifications?.data);
 
-  const isLoading =
-    (fetching || fetchingLiveNotifications) && excludeIds.length === 0;
-
   const showNullMessage =
     notifications.length === 0 &&
     page === 1 &&
@@ -94,27 +91,21 @@ const NotificationListPage = ({
 
   return (
     <>
-      {isLoading ? (
-        <Loading inline />
-      ) : (
+      {notifications.length > 0 ? (
         <>
-          {notifications.length > 0 ? (
-            <>
-              {notifications.map((notification, index) => (
-                <NotificationItem
-                  key={notification.id}
-                  focusRef={
-                    index === 0 && page !== 1 ? firstNewNotification : undefined
-                  }
-                  notification={notification}
-                  inDialog={inDialog}
-                  onRead={onRead}
-                />
-              ))}
-            </>
-          ) : null}
+          {notifications.map((notification, index) => (
+            <NotificationItem
+              key={notification.id}
+              focusRef={
+                index === 0 && page !== 1 ? firstNewNotification : undefined
+              }
+              notification={notification}
+              inDialog={inDialog}
+              onRead={onRead}
+            />
+          ))}
         </>
-      )}
+      ) : null}
       {showNullMessage && (
         <NotificationPortal.Portal
           containerId={NULL_MESSAGE_ROOT_ID}


### PR DESCRIPTION
🤖 Resolves #13357 

## 👋 Introduction

Fixes an issue where the notification dialog focus was reset when the polling query fired.

## 🕵️ Details

This results in a little pop-in since the query runs initially when opening but does improve the interactions after that.

I think we could reduce the pop-in by querying notifications outsiode the dialog and drilling them in, or using a cache-first strategy? :thinking: 

## 🧪 Testing

> [!TIP]
> I found it easiest to have two windows open, one to generate files for notifications and another with the dialog open to see it update after a poll.  You can aslo pause the queue, focus an item and then boot it back up so the next poll with have new notifications.

1. Build `pnpm dev:fresh`
2. Start queue so we can eaisly cvrete notifications `make queue-work`
3. Login as admin `admin@test.com`
4. Create some notifications by donwloading files
5. Open the notificaation dialog and focus an item
6. Create another notification
7. Confirm you do not lose your current focus position and the list just updates in place with no loading spinner