### PR TITLE
[Fix] Null state for `employeeProfile.communityInterests`

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -675,6 +675,10 @@
     "defaultMessage": "Ce rôle nécessitait la gestion d'un budget dédié ou un pouvoir de signature délégué pour un budget.",
     "description": "Label displayed for budget management"
   },
+  "14DTOr": {
+    "defaultMessage": "Ce membre du personnel n'a ajouté aucune collectivité fonctionnelle à son profil.",
+    "description": "Description for Community interest section null state"
+  },
   "14ZYuD": {
     "defaultMessage": "la participation au processus de gestion des talents est <strong>obligatoire</strong> pour l'ensemble des cadres de la gestion financière, ainsi que pour les dirigeantes et dirigeants principaux des finances, et les dirigeantes et dirigeants adjoints principaux des finances, qui n'occupent pas un poste du groupe EX.",
     "description": "Employee group list item description"

--- a/apps/web/src/pages/Users/UserEmployeeInformationPage/UserEmployeeInformationPage.tsx
+++ b/apps/web/src/pages/Users/UserEmployeeInformationPage/UserEmployeeInformationPage.tsx
@@ -9,6 +9,7 @@ import {
   Pending,
   TableOfContents,
   ThrowNotFound,
+  Well,
 } from "@gc-digital-talent/ui";
 import {
   FragmentType,
@@ -162,27 +163,42 @@ export const UserEmployeeInformation = ({
                   "Description for Community interest section of user employee information page",
               })}
             </p>
-            <Accordion.Root type="multiple" mode="card" className="my-6">
-              {employeeProfile.communityInterests?.map((communityInterest) => (
-                <Accordion.Item
-                  value={communityInterest.id}
-                  key={communityInterest.id}
-                >
-                  <Accordion.Trigger as="h3">
-                    {communityInterest.community?.name?.localized ??
-                      intl.formatMessage(commonMessages.notAvailable)}
-                  </Accordion.Trigger>
-                  <Accordion.Content>
-                    <CommunityInterest
-                      communityInterestQuery={communityInterest}
-                      communityInterestOptionsQuery={
-                        communityInterestOptionsQuery
-                      }
-                    />
-                  </Accordion.Content>
-                </Accordion.Item>
-              ))}
-            </Accordion.Root>
+            {employeeProfile?.communityInterests?.length &&
+            employeeProfile.communityInterests.length > 0 ? (
+              <Accordion.Root type="multiple" mode="card" className="my-6">
+                {employeeProfile.communityInterests?.map(
+                  (communityInterest) => (
+                    <Accordion.Item
+                      value={communityInterest.id}
+                      key={communityInterest.id}
+                    >
+                      <Accordion.Trigger as="h3">
+                        {communityInterest.community?.name?.localized ??
+                          intl.formatMessage(commonMessages.notAvailable)}
+                      </Accordion.Trigger>
+                      <Accordion.Content>
+                        <CommunityInterest
+                          communityInterestQuery={communityInterest}
+                          communityInterestOptionsQuery={
+                            communityInterestOptionsQuery
+                          }
+                        />
+                      </Accordion.Content>
+                    </Accordion.Item>
+                  ),
+                )}
+              </Accordion.Root>
+            ) : (
+              <Well className="my-6">
+                {intl.formatMessage({
+                  defaultMessage:
+                    "This employee hasn’t added any functional communities to their profile.",
+                  id: "14DTOr",
+                  description:
+                    "Description for Community interest section null state",
+                })}
+              </Well>
+            )}
           </TableOfContents.Section>
           <TableOfContents.Section id={SECTION_ID.CAREER_PLANNING}>
             <Heading


### PR DESCRIPTION
🤖 Resolves #14021.

## 👋 Introduction

This adds a `null` state for the employee profile for when community interests are empty.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to a GC employee profile where the user has not set any community interests
3. Verify null state includes a `Well` with a message

## 📸 Screenshot

<img width="1164" height="725" alt="Screen Shot 2025-07-28 at 17 09 55" src="https://github.com/user-attachments/assets/5a9b2a7b-908a-4fe4-a97a-403538287734" />