### PR TITLE
[Copy] Replaces abbreviation CIO with Chief Information Officer

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -11129,6 +11129,10 @@
     "defaultMessage": "Les apprenti·es autochtones sont embauché·es par une organisation d’accueil au niveau d’entrée du groupe des TI (IT-01 ou équivalent) pour une période de 24 mois.",
     "description": "Paragraph 1 of the 'Hired as a term employee' subsection"
   },
+  "oGA8Cz": {
+    "defaultMessage": "Qu’il s’agisse d’un poste de cadre débutant ou d’un poste de dirigeant principal de l'information au sein du gouvernement du Canada, vous êtes au bon endroit pour franchir une nouvelle étape dans le leadership numérique.",
+    "description": "Description of the executive community"
+  },
   "oGNR16": {
     "defaultMessage": "<link>Communiquez avec notre équipe de soutien</link> dès que possible si vous rencontrez un problème technique qui pourrait vous empêcher de présenter votre demande. Vous pouvez soumettre un billet à tout moment pour nous aviser des difficultés que vous rencontrez. Il est important que vous agissiez dès qu’un problème survient afin que nous puissions consigner son heure exacte, même s'il se produit en dehors des heures normales de travail.",
     "description": "Text explaining the importance of reporting technical issues"
@@ -12980,10 +12984,6 @@
   "xmAF0A": {
     "defaultMessage": "Personne candidate",
     "description": "Label or header"
-  },
-  "xnNnwu": {
-    "defaultMessage": "Qu’il s’agisse d’un poste de cadre débutant ou d’un poste de DPI au sein du gouvernement du Canada, vous êtes au bon endroit pour franchir une nouvelle étape dans le leadership numérique.",
-    "description": "Description of the executive community"
   },
   "xnlBSd": {
     "defaultMessage": "Erreur : la mise à jour du processus a échoué",

--- a/apps/web/src/pages/Home/HomePage/components/Opportunities.tsx
+++ b/apps/web/src/pages/Home/HomePage/components/Opportunities.tsx
@@ -121,8 +121,8 @@ const Opportunities = () => {
           <p>
             {intl.formatMessage({
               defaultMessage:
-                "From entry-level executive roles to CIO opportunities across the Government of Canada, this is the place to come if you're ready to take your next step in digital leadership.",
-              id: "xnNnwu",
+                "From entry-level executive roles to Chief Information Officer opportunities across the Government of Canada, this is the place to come if you're ready to take your next step in digital leadership.",
+              id: "oGA8Cz",
               description: "Description of the executive community",
             })}
           </p>


### PR DESCRIPTION
🤖 Resolves #14233.

## 👋 Introduction

This PR replaces the abbreviation of CIO in executive community block on the homepage for clarity.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/
3. Verify no instances of CIO
4. Switch to French
5. Verify no instances of DPI

## 📸 Screenshots

<img width="1169" height="607" alt="Screen Shot 2025-07-29 at 11 14 58" src="https://github.com/user-attachments/assets/b1c14a85-6e23-4a72-8a10-3c24b9942c44" />

<img width="1171" height="534" alt="Screen Shot 2025-07-29 at 11 14 43" src="https://github.com/user-attachments/assets/b5ef9aae-9037-4530-8151-640bc5c0abb1" />