### PR TITLE
[Copy] Consistent translation of skill requirements in French

### DIFF
--- a/apps/web/src/lang/__snapshots__/lang.test.ts.snap
+++ b/apps/web/src/lang/__snapshots__/lang.test.ts.snap
@@ -235,13 +235,6 @@ exports[`message files should have no changes to duplicate strings 1`] = `
     ]
   },
   {
-    "en": "Skill requirements",
-    "fr": [
-      "Exigences relatives aux compétences",
-      "Exigences en matière de compétences"
-    ]
-  },
-  {
     "en": "Add a community",
     "fr": [
       "Ajoutez une collectivité",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6107,10 +6107,6 @@
     "defaultMessage": "Cette nomination pour un avancement n'est pas retenue.",
     "description": "Label for advancement nomination is rejected"
   },
-  "Qibs21": {
-    "defaultMessage": "Les exigences en matière de compétences sont classées soit comme étant <strong>essentielles</strong> (le candidat a absolument besoin de cette compétence), soit comme étant un <strong>atout</strong> (la compétence serait utile, mais n'est pas requise). Les critères de compétences seront présentés au candidat en fonction d'une combinaison du statut essentiel ou d'atout de la compétence et si la compétence sera évaluée dans le cadre de sa demande.",
-    "description": "Sub title for  skill requirements"
-  },
   "QjOom4": {
     "defaultMessage": "Je ne suis pas identifié comme membre d'un groupe d'équité en matière d'emploi.",
     "description": "Message on Admin side when user not filled DiversityEquityInclusion section."
@@ -13420,6 +13416,10 @@
   "zlYw3Z": {
     "defaultMessage": "Présentez votre profil en tant que demande",
     "description": "How it works, step 3 heading"
+  },
+  "znWT8z": {
+    "defaultMessage": "Les exigences en matière de compétences sont classées soit comme étant <strong>essentielles</strong> (le candidat a absolument besoin de cette compétence), soit comme étant un <strong>atout</strong> (la compétence serait utile, mais n'est pas requise). Les critères de compétences seront présentés au candidat en fonction d'une combinaison du statut essentiel ou d'atout de la compétence et si la compétence sera évaluée dans le cadre de sa demande.",
+    "description": "Subtitle for skill requirements"
   },
   "znuDvD": {
     "defaultMessage": "Sélectionner des compétences dans votre bibliothèque ou en ajouter de toutes nouvelles.",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -9609,10 +9609,6 @@
     "defaultMessage": "Exigences linguistiques sur la plateforme Talents numériques du GC",
     "description": "Sub-heading for language requirements dialog"
   },
-  "h2h7Df": {
-    "defaultMessage": "Exigences relatives aux compétences",
-    "description": "Title for the skills section of a pool advertisement"
-  },
   "h30KEc": {
     "defaultMessage": "Il manque des données en ce qui concerne vos préférences en matière de travail",
     "description": "Error message displayed when a users work preferences is incomplete"
@@ -12104,10 +12100,6 @@
   "tL6hvG": {
     "defaultMessage": "Modifier une collectivité",
     "description": "Short title for the edit community interest page"
-  },
-  "tON7JL": {
-    "defaultMessage": "Exigences en matière de compétences",
-    "description": "Title for skill requirements"
   },
   "tOohws": {
     "defaultMessage": "Vous êtes membre d'un ou de plusieurs de ces groupes visés par l'équité en matière d'emploi.",

--- a/apps/web/src/messages/talentRequestMessages.ts
+++ b/apps/web/src/messages/talentRequestMessages.ts
@@ -63,11 +63,6 @@ const messages = defineMessages({
     id: "LyUTqa",
     description: "Education requirement title",
   },
-  skillRequirements: {
-    defaultMessage: "Skill requirements",
-    id: "h2h7Df",
-    description: "Title for the skills section of a pool advertisement",
-  },
   equityGroups: {
     defaultMessage: "Employment equity groups",
     id: "m3qn9l",

--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewTalentRequestDialog.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewTalentRequestDialog.tsx
@@ -223,7 +223,7 @@ const ReviewTalentRequestDialogContent = ({
           <Accordion.Item value="skills">
             <Accordion.Trigger>
               <span>
-                {intl.formatMessage(talentRequestMessages.skillRequirements)}
+                {intl.formatMessage(commonMessages.skillRequirements)}
               </span>
               <span
                 className="font-normal"

--- a/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
@@ -12,7 +12,11 @@ import {
   Well,
 } from "@gc-digital-talent/ui";
 import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
-import { errorMessages, getLocale } from "@gc-digital-talent/i18n";
+import {
+  commonMessages,
+  errorMessages,
+  getLocale,
+} from "@gc-digital-talent/i18n";
 import { Input } from "@gc-digital-talent/forms";
 import { toast } from "@gc-digital-talent/toast";
 import {
@@ -347,11 +351,7 @@ const ApplicationReview = ({ application }: ApplicationPageProps) => {
         </div>
       </ReviewSection>
       <ReviewSection
-        title={intl.formatMessage({
-          defaultMessage: "Skill requirements",
-          id: "tON7JL",
-          description: "Title for skill requirements",
-        })}
+        title={intl.formatMessage(commonMessages.skillRequirements)}
         path={editPaths.skills}
         editLinkAriaLabel={intl.formatMessage({
           defaultMessage: "Edit skill requirements",

--- a/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
@@ -12,7 +12,7 @@ import {
 } from "@gc-digital-talent/ui";
 import { toast } from "@gc-digital-talent/toast";
 import { Input } from "@gc-digital-talent/forms";
-import { apiMessages } from "@gc-digital-talent/i18n";
+import { apiMessages, commonMessages } from "@gc-digital-talent/i18n";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 import {
   ApplicationStep,
@@ -52,11 +52,7 @@ export const getPageInfo: GetPageNavInfo = ({
 }) => {
   const path = paths.applicationSkills(application.id);
   return {
-    title: intl.formatMessage({
-      defaultMessage: "Skill requirements",
-      id: "tON7JL",
-      description: "Title for skill requirements",
-    }),
+    title: intl.formatMessage(commonMessages.skillRequirements),
     subtitle: intl.formatMessage({
       defaultMessage:
         "Tell us about how you meet the skill requirements for this opportunity.",

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -385,11 +385,7 @@ export const EditPoolForm = ({
     skillRequirements: {
       id: "skill-requirements",
       hasError: skillRequirementsHasError,
-      title: intl.formatMessage({
-        defaultMessage: "Skill requirements",
-        id: "tON7JL",
-        description: "Title for skill requirements",
-      }),
+      title: intl.formatMessage(commonMessages.skillRequirements),
       subtitle: intl.formatMessage({
         defaultMessage:
           "Skill requirements are categorized as either being <strong>essential</strong> (the candidate absolutely requires this skill) or <strong>asset</strong> (the skill would be helpful but isn't required). Skill criteria will be presented to the applicant based on a combination of the skill's essential/asset status and whether or not the skill will be assessed as a part of their application.",

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -389,8 +389,8 @@ export const EditPoolForm = ({
       subtitle: intl.formatMessage({
         defaultMessage:
           "Skill requirements are categorized as either being <strong>essential</strong> (the candidate absolutely requires this skill) or <strong>asset</strong> (the skill would be helpful but isn't required). Skill criteria will be presented to the applicant based on a combination of the skill's essential/asset status and whether or not the skill will be assessed as a part of their application.",
-        id: "Qibs21",
-        description: "Sub title for  skill requirements",
+        id: "znWT8z",
+        description: "Subtitle for skill requirements",
       }),
       icon: skillRequirementsHasError ? ExclamationCircleIcon : CheckCircleIcon,
       color: skillRequirementsHasError ? "error" : "success",

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -475,11 +475,7 @@ export const PoolPoster = ({
     },
     skillRequirements: {
       id: "skill-requirements",
-      title: intl.formatMessage({
-        defaultMessage: "Skill requirements",
-        id: "h2h7Df",
-        description: "Title for the skills section of a pool advertisement",
-      }),
+      title: intl.formatMessage(commonMessages.skillRequirements),
     },
     aboutRole: {
       id: "about-role",

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -59,6 +59,10 @@
     "defaultMessage": "Date",
     "description": "Label to identify a date element"
   },
+  "0AhbED": {
+    "defaultMessage": "Exigences en matière de compétences",
+    "description": "Label for skill requirements"
+  },
   "0ClMl1": {
     "defaultMessage": "Diversité, équité et inclusion",
     "description": "Name of Diversity, equity, and inclusion page"

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -528,6 +528,11 @@ const commonMessages = defineMessages({
     id: "x/BiQS",
     description: "Label for questions",
   },
+  skillRequirements: {
+    defaultMessage: "Skill requirements",
+    id: "0AhbED",
+    description: "Label for skill requirements",
+  },
 });
 
 export default commonMessages;


### PR DESCRIPTION
🤖 Resolves #14229.

## 👋 Introduction

This PR provides a consistent translation of skill requirements in French, consolidate the string into a single source.

## 🧪 Testing

1. Verify there are no instances of _Exigences relatives aux compétences_ in the codebase
2. Verify Skill requirements is only ever translated as _Exigences en matière de compétences_  in the codebase