### PR TITLE
[Debt] Replace deprecated arrow icon

### DIFF
--- a/packages/ui/src/components/ResourceBlock/SingleLinkItem.tsx
+++ b/packages/ui/src/components/ResourceBlock/SingleLinkItem.tsx
@@ -1,4 +1,4 @@
-import ArrowRightIcon from "@heroicons/react/16/solid/ArrowRightIcon";
+import ArrowLongRightIcon from "@heroicons/react/16/solid/ArrowLongRightIcon";
 import { ReactNode } from "react";
 
 import Link, { LinkProps } from "../Link";
@@ -41,7 +41,7 @@ const SingleLinkItem = ({
           href={href}
           color="black"
           className="font-bold"
-          utilityIcon={ArrowRightIcon}
+          utilityIcon={ArrowLongRightIcon}
         >
           {title}
         </Link>

--- a/packages/ui/src/components/ResourceBlock/SingleLinkItem.tsx
+++ b/packages/ui/src/components/ResourceBlock/SingleLinkItem.tsx
@@ -1,4 +1,4 @@
-import ArrowSmallRightIcon from "@heroicons/react/20/solid/ArrowSmallRightIcon";
+import ArrowRightIcon from "@heroicons/react/16/solid/ArrowRightIcon";
 import { ReactNode } from "react";
 
 import Link, { LinkProps } from "../Link";
@@ -41,8 +41,7 @@ const SingleLinkItem = ({
           href={href}
           color="black"
           className="font-bold"
-          // eslint-disable-next-line @typescript-eslint/no-deprecated
-          utilityIcon={ArrowSmallRightIcon}
+          utilityIcon={ArrowRightIcon}
         >
           {title}
         </Link>


### PR DESCRIPTION
🤖 Resolves #11284 

## 👋 Introduction

Replaces the deprecated `ArrowRightSmallIcon` with the mini version of the `ArrowRightIcon`.

## 🧪 Testing

1. Confirm no uses of `ArrowSmallRightIcon`
2. Confirm resource block arrow is the mini version of `ArrowRightIcon`