### PR TITLE
[Fix] Sub menu link colour

### DIFF
--- a/packages/ui/src/components/NavMenu/NavMenu.tsx
+++ b/packages/ui/src/components/NavMenu/NavMenu.tsx
@@ -155,7 +155,8 @@ const navMenuLink = tv({
     },
     type: {
       link: "",
-      subMenuLink: "",
+      subMenuLink:
+        "hover:text-primary-600 data-active:text-primary-600 data-active:hover:text-primary-700 data-active:dark:text-primary-200 data-active:dark:hover:text-primary-100",
     },
   },
   defaultVariants: {


### PR DESCRIPTION
🤖 Resolves #14270 

## 👋 Introduction

Fix the light mode colours for ourt main menu dropdown links.

## 🕵️ Details

We had some colouts set but since our main nav has a dark background in light mode as well as dark, we missed the dropdown colours which do have light backrounds.

This updates those sub links specifically to work on a dynamic background colour.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login to `admin@test.com`
3. Set an active dashboard
4. Open the role switcher
5. Confirm no colour constrast issues on both light and dark mode for:
    1. Active link
    2. Base link
    3. Base hover
    4. Active hover

## 📸 Screenshot

<img width="333" height="218" alt="swappy-20250730_153136" src="https://github.com/user-attachments/assets/ada21ebf-d8dd-41c2-93dc-a33c4b37072d" />

