### PR TITLE
[Feat] Renamed Talent placement tab to Candidates

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -583,10 +583,6 @@
     "defaultMessage": "Il s’agit du carrefour de l’administrateur de Talents numériques du GC. À partir d’ici, il est possible de recruter et gérer des talents, trouver des ressources et ajuster les paramètres de la plateforme.",
     "description": "Subtitle for the admin dashboard page"
   },
-  "0YpfAG": {
-    "defaultMessage": "Placement de talents",
-    "description": "Title for candidates tab for a process"
-  },
   "0Z7Ux8": {
     "defaultMessage": "Durée de l'emploi",
     "description": "Label for process employment duration"
@@ -7617,6 +7613,10 @@
   "YEYD5j": {
     "defaultMessage": "Créer<hidden> une possibilité de formation</hidden>",
     "description": "Breadcrumb title for the create training opportunity page link."
+  },
+  "YFEaeG": {
+    "defaultMessage": "Candidats",
+    "description": "Title for candidates tab for a process"
   },
   "YGM/D5": {
     "defaultMessage": "Le programme dure 24 mois et les apprentis ont accès à un soutien pendant leur période de participation au programme.",

--- a/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/IndexPoolCandidatePage/IndexPoolCandidatePage.tsx
@@ -55,8 +55,8 @@ export const IndexPoolCandidatePage = () => {
     <>
       <SEO
         title={intl.formatMessage({
-          defaultMessage: "Talent placement",
-          id: "0YpfAG",
+          defaultMessage: "Candidates",
+          id: "YFEaeG",
           description: "Title for candidates tab for a process",
         })}
         description={formattedSubTitle}

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -353,8 +353,8 @@ export const useAdminPoolPages = (
       {
         icon: UserGroupIcon,
         title: intl.formatMessage({
-          defaultMessage: "Talent placement",
-          id: "0YpfAG",
+          defaultMessage: "Candidates",
+          id: "YFEaeG",
           description: "Title for candidates tab for a process",
         }),
         link: {


### PR DESCRIPTION
🤖 Resolves  #14110

## 👋 Introduction

Renames the "Talent Placement" tab to "Candidates". Breadcrumbs will be addressed in a separate ticket.

## 🕵️ Details

- Updated the tab label from "Talent Placement" to "Candidates"
- No breadcrumb changes were needed (will be handled in a follow-up ticket).

## 🧪 Testing

1. Build app `pnpm run dev`
2. Login as `admin` and select Community as your role and select `processes`
3. Select a process
4. Confirm the tab displays "Candidates" / "Candidats" instead of "Talent Placement"
5. Verify tab functionality (i.e.., clicking, loading candidates) remains unchanged.
 

## 📸 Screenshot

<img width="1470" height="927" alt="image" src="https://github.com/user-attachments/assets/184bf7c6-6c12-426c-b155-ba1437c369b4" />
<img width="1508" height="934" alt="image" src="https://github.com/user-attachments/assets/47d7a898-7d20-4028-b0ae-799f67761483" />

## Notes

📌 I spoke with @Jerryescandon regarding the breadcrumbs as there were no breadcrumbs on the page. Breadcrumbs will be addressed in a separate ticket