### PR TITLE
[Fix] Gray text colour contrast in dark mode

### DIFF
--- a/apps/web/src/components/NotificationList/NotificationItem.tsx
+++ b/apps/web/src/components/NotificationList/NotificationItem.tsx
@@ -248,7 +248,7 @@ const NotificationItem = ({
               </DropdownMenu.Content>
             </DropdownMenu.Root>
           </div>
-          <p className="col-start-2 row-start-1 text-sm/none text-gray-500 dark:text-gray-300">
+          <p className="col-start-2 row-start-1 text-sm/none text-gray-500 dark:text-gray-200">
             {createdAt}
           </p>
         </div>

--- a/packages/forms/src/components/DateInput/ControlledInput.tsx
+++ b/packages/forms/src/components/DateInput/ControlledInput.tsx
@@ -123,7 +123,7 @@ const ControlledInput = ({
             defaultValue={month ?? ""}
             className={selectInput({ state: stateStyles })}
           >
-            <option className="text-gray-600/70 dark:text-gray-300/70" value="">
+            <option className="text-gray-600/70 dark:text-gray-200/70" value="">
               {intl.formatMessage(dateMessages.selectAMonth)}
             </option>
             {months.map((monthName, index) => (

--- a/packages/forms/src/components/Repeater/ActionButton.tsx
+++ b/packages/forms/src/components/Repeater/ActionButton.tsx
@@ -15,7 +15,7 @@ const actionBtn = tv({
   variants: {
     disabled: {
       true: {
-        base: "cursor-default text-gray-500 dark:text-gray-300",
+        base: "cursor-default text-gray-500 dark:text-gray-200",
       },
       false: {
         base: "hover:bg-gray-100 focus-visible:bg-focus focus-visible:text-black dark:hover:bg-gray-700",

--- a/packages/i18n/src/components/richTextElements.tsx
+++ b/packages/i18n/src/components/richTextElements.tsx
@@ -96,7 +96,7 @@ const heavyWarning = (text: ReactNode) => (
  * @param text  text to wrap
  */
 const gray = (text: ReactNode) => (
-  <span className="text-gray-500 dark:text-gray-300">{text}</span>
+  <span className="text-gray-500 dark:text-gray-200">{text}</span>
 );
 
 /**

--- a/packages/i18n/src/utils/lang.tsx
+++ b/packages/i18n/src/utils/lang.tsx
@@ -6,7 +6,7 @@ import { Locales } from "../types";
 
 // style should be the same as gray in packages/i18n/src/components/richTextElements.tsx.
 const Gray = ({ children }: { children: ReactNode }) => (
-  <span className="text-gray-500 dark:text-gray-300">{children}</span>
+  <span className="text-gray-500 dark:text-gray-200">{children}</span>
 );
 
 export const appendLanguageName = ({


### PR DESCRIPTION
🤖 Resolves #14268 

## 👋 Introduction

Updates instances of `dark:text-gray-300` with `dark:text-gray-200` to improve colour contrast.

## 🧪 Testing

1. Confirm no instances of `dark:text-gray-300`
2. Confirm the `dark:text-gray-200` meets colour contrast ratio requirements