### PR TITLE
[Fix] Move employee department column

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -836,6 +836,17 @@ const PoolCandidatesTable = ({
       },
     ),
     columnHelper.accessor(
+      ({
+        poolCandidate: {
+          user: { department },
+        },
+      }) => department?.name.localized,
+      {
+        id: "department",
+        header: intl.formatMessage(tableMessages.employeeDepartment),
+      },
+    ),
+    columnHelper.accessor(
       ({ poolCandidate: { status } }) => getLocalizedName(status?.label, intl),
       {
         id: "jobPlacement",
@@ -960,17 +971,6 @@ const PoolCandidatesTable = ({
       {
         id: "currentLocation",
         header: intl.formatMessage(tableMessages.currentLocation),
-      },
-    ),
-    columnHelper.accessor(
-      ({
-        poolCandidate: {
-          user: { department },
-        },
-      }) => department?.name.localized,
-      {
-        id: "department",
-        header: intl.formatMessage(tableMessages.employeeDepartment),
       },
     ),
     columnHelper.accessor(


### PR DESCRIPTION
🤖 Resolves #14193 

## 👋 Introduction

This moves the employee department column on the pool candidates table to the requested position.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to `/admin/pool-candidates`
4. Confirm the "Employee department" column appears between "Candidate status" and "job placement"

## 📸 Screenshot

<img width="728" height="222" alt="swappy-20250731_144725" src="https://github.com/user-attachments/assets/03a2eadd-2003-4699-8cea-253198b2a12c" />
