### PR TITLE
[Fix] Add row header semantics to assessment table

### DIFF
--- a/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
+++ b/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
@@ -334,6 +334,9 @@ const AssessmentResultsTable = ({
         description:
           "Header for requirement section of assessment results table",
       }),
+      meta: {
+        isRowHeader: true,
+      },
       cell: ({ row: { original } }) =>
         cells.jsx(
           <span>

--- a/apps/web/src/components/Table/ResponsiveTable/Table.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/Table.tsx
@@ -198,6 +198,7 @@ const Cell = <T,>({ cell, ...rest }: CellProps<T>) => {
   const intl = useIntl();
   const isRowTitle = cell.column.columnDef.meta?.isRowTitle;
   const isRowSelect = cell.column.columnDef.meta?.isRowSelect;
+  const isRowHeader = cell.column.columnDef.meta?.isRowHeader;
   const shouldShrink = cell.column.columnDef.meta?.shrink;
   const header = getColumnHeader(cell.column, "mobileHeader");
 
@@ -210,13 +211,15 @@ const Cell = <T,>({ cell, ...rest }: CellProps<T>) => {
 
   const { base, val } = cellStyles({ isRowTitle, isRowSelect, shouldShrink });
 
+  const El = isRowHeader ? "th" : "td";
+
   return (
-    <td
+    <El
       // Seems like a false positive, cell is the implicit role for this element
       // REF: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#technical_summary:~:text=%3Ctr%3E%20element.-,Implicit%20ARIA%20role,-cell%20if%20a
-      // eslint-disable-next-line jsx-a11y/no-interactive-element-to-noninteractive-role
-      role="cell"
+      role={isRowHeader ? "rowheader" : "cell"}
       className={base()}
+      {...(isRowHeader ? { scope: "row" } : {})}
       {...rest}
     >
       {showHeader && (
@@ -228,7 +231,7 @@ const Cell = <T,>({ cell, ...rest }: CellProps<T>) => {
       <span className={val()}>
         {flexRender(cell.column.columnDef.cell, cell.getContext())}
       </span>
-    </td>
+    </El>
   );
 };
 

--- a/apps/web/src/table.d.ts
+++ b/apps/web/src/table.d.ts
@@ -8,6 +8,8 @@ declare module "@tanstack/table-core" {
     isRowTitle?: boolean;
     /** Mark this column as the row selection column (do not use directly)  */
     isRowSelect?: boolean;
+    /** Mark this column as a head scoped to the row  */
+    isRowHeader?: boolean;
     /** Override the header for the mobile view */
     mobileHeader?: ReactNode;
     /** Override the column dialog header */


### PR DESCRIPTION
🤖 Resolves #12207 

## 👋 Introduction

Adds proper semantics to the assessment table row headers.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to a pool candidate
4. Confirm that the first column in each row has the proper element, role and scope
    - Role: `rowheader`
    - Scope: `row`
    - Element: `th`