### PR TITLE
[Feat] Add current step column to candidates table

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -9,6 +9,7 @@ import {
 } from "@tanstack/react-table";
 import { OperationContext, useMutation, useQuery } from "urql";
 import isEqual from "lodash/isEqual";
+import { col, header } from "motion/react-client";
 
 import {
   notEmpty,
@@ -253,6 +254,12 @@ const CandidatesTableCandidatesPaginated_Query = graphql(/* GraphQL */ `
               value
             }
             screeningQuestionsCount
+            assessmentSteps {
+              sortOrder
+              title {
+                localized
+              }
+            }
           }
           finalDecision {
             value
@@ -814,6 +821,39 @@ const PoolCandidatesTable = ({
             assessmentStatus,
             intl,
           ),
+      },
+    ),
+    columnHelper.accessor(
+      ({ poolCandidate: { assessmentStep } }) => assessmentStep,
+      {
+        id: "assessmentStep",
+        header: intl.formatMessage(tableMessages.assessmentStep),
+        cell: ({
+          row: {
+            original: {
+              poolCandidate: {
+                assessmentStep,
+                pool: { assessmentSteps },
+              },
+            },
+          },
+        }) => {
+          const step = assessmentSteps?.find(
+            (s) => s?.sortOrder === assessmentStep,
+          );
+          return step?.title?.localized
+            ? intl.formatMessage(
+                {
+                  defaultMessage: "Step {step}",
+                  id: "+O4pHs",
+                  description: "Label for current assessment step.",
+                },
+                { step: assessmentStep },
+              ) +
+                intl.formatMessage(commonMessages.dividingColon) +
+                step.title.localized
+            : "";
+        },
       },
     ),
     columnHelper.accessor(

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -272,6 +272,7 @@ function transformSortStateToOrderByClause(
     ["notes", "notes"],
     ["skillCount", "skillCount"],
     ["processNumber", "PROCESS_NUMBER"],
+    ["assessmentStep", "assessment_step"],
   ]);
 
   const sortingRule = sortingRules?.find((rule) => {
@@ -287,6 +288,7 @@ function transformSortStateToOrderByClause(
       "status",
       "notes",
       "finalDecision",
+      "assessmentStep",
     ].includes(sortingRule.id)
   ) {
     const columnName = columnMap.get(sortingRule.id);

--- a/apps/web/src/components/PoolCandidatesTable/tableMessages.ts
+++ b/apps/web/src/components/PoolCandidatesTable/tableMessages.ts
@@ -69,6 +69,11 @@ const messages = defineMessages({
     id: "7g4Mvc",
     description: "Title displayed on the Pool Candidates table bookmark column",
   },
+  assessmentStep: {
+    defaultMessage: "Current step",
+    id: "gqX6/n",
+    description: "Title displayed for a candidates current assessment step",
+  },
 });
 
 export default messages;


### PR DESCRIPTION
🤖 Resolves #13614 

## 👋 Introduction

Adds the current assessment step as a column on the candidates table.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Nacigate to `/admin/pool-candidates`
4. Confirm the new "Current step" column appears with expected values

## 📸 Screenshot

<img width="755" height="655" alt="swappy-20250805_104413" src="https://github.com/user-attachments/assets/48f28f10-f3b5-49d0-b516-b6d1e3847e1f" />
