### PR TITLE
[Fix] Old/Initial talent requests not loading

### DIFF
--- a/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useIntl } from "react-intl";
-import { useQuery } from "urql";
+import { OperationContext, useQuery } from "urql";
 
 import {
   Pending,
@@ -437,6 +437,10 @@ export const DashboardPage = ({
   );
 };
 
+const context: Partial<OperationContext> = {
+  additionalTypenames: ["PoolCandidateSearchRequest"],
+};
+
 const ApplicantDashboard_Query = graphql(/* GraphQL */ `
   query ApplicantDashboard {
     me {
@@ -450,6 +454,7 @@ export const ApplicantDashboardPageApi = () => {
   const intl = useIntl();
   const [{ data, fetching, error }] = useQuery({
     query: ApplicantDashboard_Query,
+    context,
   });
 
   return (


### PR DESCRIPTION
🤖 Resolves #14272 

## 👋 Introduction

Attempt to fix the talent requests not loading old/initial talent requests.

## 🕵️ Details

Typically, when a new item needs to be added to a cached query, it has trouble so we need to add `additionalTypenames`. I did this and it seems to work :thinking: 

## 🧪 Testing

1. Check out v2.53.0
2. Rebuild entire env `make down; make up; make refresh-api; make seed-freshl pnpm i; pnpm dev:fresh`
3. Login as `admin@test.com`
4. Ensure you have no existing talent requests
5. Submit a talent request
6. Swiotch to this branch and do a partial rebuild `make refresh-api; pnpm i; pnpm dev:fresh`
    - Do **not** do a fresh seed, we need the old data to persist
8. Reload and go to your dashboard
9. Confirm the talent request appeats immediatley