### PR TITLE
[Fix] Stabilize snapshots (again)

### DIFF
--- a/api/database/factories/CommunityExperienceFactory.php
+++ b/api/database/factories/CommunityExperienceFactory.php
@@ -33,7 +33,7 @@ class CommunityExperienceFactory extends Factory
             'organization' => $this->faker->company(),
             'project' => $this->faker->bs(),
             'start_date' => $startDate,
-            'end_date' => $this->faker->boolean() ? $this->faker->dateTimeBetween($startDate) : null,
+            'end_date' => $this->faker->optional()->dateTimeBetween($startDate),
             'details' => $this->faker->text(),
         ];
     }

--- a/api/database/factories/EducationExperienceFactory.php
+++ b/api/database/factories/EducationExperienceFactory.php
@@ -33,7 +33,7 @@ class EducationExperienceFactory extends Factory
             'area_of_study' => $this->faker->jobTitle(),
             'thesis_title' => $this->faker->bs(),
             'start_date' => $startDate,
-            'end_date' => $this->faker->boolean() ? $this->faker->dateTimeBetween($startDate) : null,
+            'end_date' => $this->faker->optional()->dateTimeBetween($startDate),
             'type' => $this->faker->randomElement(
                 [
                     'DIPLOMA',

--- a/api/database/factories/PersonalExperienceFactory.php
+++ b/api/database/factories/PersonalExperienceFactory.php
@@ -32,7 +32,7 @@ class PersonalExperienceFactory extends Factory
             'title' => $this->faker->jobTitle(),
             'description' => $this->faker->text(),
             'start_date' => $startDate,
-            'end_date' => $this->faker->boolean() ? $this->faker->dateTimeBetween($startDate) : null,
+            'end_date' => $this->faker->optional()->dateTimeBetween($startDate),
             'details' => $this->faker->text(),
         ];
     }

--- a/api/database/factories/WorkExperienceFactory.php
+++ b/api/database/factories/WorkExperienceFactory.php
@@ -53,7 +53,7 @@ class WorkExperienceFactory extends Factory
                     null : $this->faker->bs();
             },
             'start_date' => $startDate,
-            'end_date' => $this->faker->boolean() ? $this->faker->dateTimeBetween($startDate) : null,
+            'end_date' => $this->faker->optional()->dateTimeBetween($startDate),
             'details' => $this->faker->text(),
             'employment_category' => $this->faker->randomElement(EmploymentCategory::cases())->name,
             'ext_size_of_organization' => function (array $attributes) {


### PR DESCRIPTION
🤖 Resolves #14253 

## 👋 Introduction

This is another attempt to stabilize the snapshots.

## 🕵️ Details

It looks like we had another date issue with the snapshots either from an un-updated snapdhot getting merged or the dates not being stable.

The one thing I noticed was the use of `$this->faker->boolean()` to optional set end date. I'm not sure if this is stable and it does seem like it is always end date having the issue.

Since this is a non-standard way of setting a field optionally, I updated this to use the `$this->faker->optional()` modifier instead. I think maybe this could be more deterministic? :thinking: 

## 🧪 Testing

1. Run snapshot tests multiple times
2. Confirm they consistnelty pass