### PR TITLE
[Fix] Create department form `DepartmentType`

### DIFF
--- a/apps/web/src/pages/Departments/CreateDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/CreateDepartmentPage.tsx
@@ -37,7 +37,7 @@ interface FormValues {
   departmentNumber: number;
   orgIdentifier: number;
   size: DepartmentSize;
-  departmentType: DepartmentType[];
+  departmentType?: DepartmentType[] | boolean;
 }
 
 export function formValuesToCreateInput({

--- a/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
@@ -47,7 +47,7 @@ interface FormValues {
   departmentNumber: Maybe<number>;
   orgIdentifier: Maybe<number>;
   size: Maybe<DepartmentSize>;
-  departmentType: DepartmentType[];
+  departmentType: DepartmentType[] | boolean;
 }
 
 export function formValuesToUpdateInput({

--- a/apps/web/src/pages/Departments/utils.ts
+++ b/apps/web/src/pages/Departments/utils.ts
@@ -9,13 +9,19 @@ export type DepartmentType =
   | "isScience"
   | "isRegulatory";
 
-export function departmentTypeToInput(types?: DepartmentType[]) {
+export function departmentTypeToInput(types?: DepartmentType[] | boolean) {
   return {
     isCorePublicAdministration:
-      types?.includes("isCorePublicAdministration") ?? false,
-    isCentralAgency: types?.includes("isCentralAgency") ?? false,
-    isScience: types?.includes("isScience") ?? false,
-    isRegulatory: types?.includes("isRegulatory") ?? false,
+      (typeof types === "object" &&
+        types?.includes("isCorePublicAdministration")) ??
+      false,
+    isCentralAgency:
+      (typeof types === "object" && types?.includes("isCentralAgency")) ??
+      false,
+    isScience:
+      (typeof types === "object" && types?.includes("isScience")) ?? false,
+    isRegulatory:
+      (typeof types === "object" && types?.includes("isRegulatory")) ?? false,
   };
 }
 


### PR DESCRIPTION
🤖 Resolves #14342.

## 👋 Introduction

This PR fixes the `DepartmentType` to include boolean as a type since submitting the create department forms with none of the department type checkboxes checked results in a value of `false`.

## 🧪 Testing

1. `pnpm build:fresh`
2. Log in as admin@test.com
3. Navigate to http://localhost:8000/en/admin/settings/departments/create
4. Fill out the form without selecting any Department type checkboxes
5. Verify the form saves the data correctly
6. Repeat this for the update department form
7. Verify the form saves the data correctly 
