### PR TITLE
[Fix] Add missing "additional details" fields to DOCX files

### DIFF
--- a/api/app/Traits/Generator/GeneratesUserDoc.php
+++ b/api/app/Traits/Generator/GeneratesUserDoc.php
@@ -333,6 +333,7 @@ trait GeneratesUserDoc
             $this->addLabelText($section, $this->localize('experiences.awarded_to'), $this->localizeEnum($experience->awarded_to, AwardedTo::class));
             $this->addLabelText($section, $this->localize('experiences.issuing_organization'), $experience->issued_by);
             $this->addLabelText($section, $this->localize('experiences.awarded_scope'), $this->localizeEnum($experience->awarded_scope, AwardedScope::class));
+            $this->addLabelText($section, $this->localize('experiences.additional_details'), $experience->details);
         }
 
         if ($type === CommunityExperience::class) {
@@ -375,6 +376,7 @@ trait GeneratesUserDoc
             $section->addTitle($experience->getTitle(), $headingRank);
             $section->addText($experience->getDateRange($this->lang));
             $this->addLabelText($section, $this->localize('experiences.learning_description'), $experience->description);
+            $this->addLabelText($section, $this->localize('experiences.additional_details'), $experience->details);
         }
 
         if ($type === WorkExperience::class) {
@@ -512,10 +514,7 @@ trait GeneratesUserDoc
                 $section->addText($experience->getDateRange($this->lang));
                 $this->addLabelText($section, $this->localize('experiences.team_group_division'), $experience->division);
             }
-        }
 
-        if ($type === WorkExperience::class) {
-            /** @var WorkExperience $experience */
             if ($experience->employment_category === EmploymentCategory::GOVERNMENT_OF_CANADA->name || $experience->employment_category === EmploymentCategory::CANADIAN_ARMED_FORCES->name) {
                 $experience->loadMissing(['workStreams']);
                 if ($experience->workStreams && count($experience->workStreams) > 0) {
@@ -540,23 +539,24 @@ trait GeneratesUserDoc
                     });
                 }
             }
-        }
 
-        if ($type === WorkExperience::class && $withSkills) {
-            $experience->load(['userSkills' => ['skill']]);
+            if ($withSkills) {
+                $experience->load(['userSkills' => ['skill']]);
 
-            if ($experience->userSkills->count() > 0) {
-                $section->addText($this->localize('common.featured_skills'));
-            }
-
-            $experience->userSkills->sortBy('skill.name.'.$this->lang)->each(function ($userSkill) use ($section) {
-                $skillRun = $section->addListItemRun();
-                /** @var UserSkill $userSkill */
-                $skillRun->addText($userSkill->skill->name[$this->lang], $this->strong);
-                if (isset($userSkill->experience_skill->details)) {
-                    $skillRun->addText($this->colon().$userSkill->experience_skill->details);
+                if ($experience->userSkills->count() > 0) {
+                    $section->addText($this->localize('common.featured_skills'));
                 }
-            });
+
+                $experience->userSkills->sortBy('skill.name.'.$this->lang)->each(function ($userSkill) use ($section) {
+                    $skillRun = $section->addListItemRun();
+                    /** @var UserSkill $userSkill */
+                    $skillRun->addText($userSkill->skill->name[$this->lang], $this->strong);
+                    if (isset($userSkill->experience_skill->details)) {
+                        $skillRun->addText($this->colon().$userSkill->experience_skill->details);
+                    }
+                });
+            }
+            $this->addLabelText($section, $this->localize('experiences.additional_details'), $experience->details);
         }
     }
 

--- a/api/app/Traits/Generator/GeneratesUserDoc.php
+++ b/api/app/Traits/Generator/GeneratesUserDoc.php
@@ -480,7 +480,6 @@ trait GeneratesUserDoc
                         $classification ? $classification->group.'-'.$classification->level : Lang::get('common.not_found', [], $this->lang),
                     );
                 }
-                $this->addLabelText($section, $this->localize('experiences.additional_details'), $experience->details);
                 $this->addLabelText($section, $this->localize('experiences.supervisory_position'), $this->yesOrNo($experience->supervisory_position));
                 if ($experience->supervisory_position === true) {
                     $this->addLabelText($section, $this->localize('experiences.supervised_employees'), $this->yesOrNo($experience->supervised_employees));


### PR DESCRIPTION
🤖 Resolves #14377 

## 👋 Introduction

Adds the "additional details" field to award, personal, and work experiences in the DOCX downloads.  

The scope of the issue was education and work experiences but Nienke confirmed that all experience types should have the field.  

I never found anything wrong with education experiences.  Dasha is OK with proceeding with just the fix for work experiences.

Additionally, a small refactor to consolidate the three "if work experience" blocks together.  It seems like having three blocks led to [the original bug](https://github.com/GCTC-NTGC/gc-digital-talent/pull/13883/files#diff-7324a58fd6f56a2082cfb8bad8301e54fa4e0710b3da3da6fee03873bda8518cL465).

## 🧪 Testing

1. As an applicant...
    1.  add an experience from all five types to your profile.
    2.  submit an application to a pool
2. As an admin....
    1. download a profile and application DOCX for the application
    2. confirm that the "additional details" appears for each experience type

## 📸 Screenshot

<img width="363" height="179" alt="image" src="https://github.com/user-attachments/assets/56649c1c-f8c2-494f-95b5-e8346b723f18" />
