### PR TITLE
[Debt] Update current assessment step to be a relationship

### DIFF
--- a/api/app/Console/Commands/SyncAssessmentStatus.php
+++ b/api/app/Console/Commands/SyncAssessmentStatus.php
@@ -30,10 +30,10 @@ class SyncAssessmentStatus extends Command
     {
         PoolCandidate::chunk(100, function (Collection $candidates) {
             foreach ($candidates as $candidate) {
-                [$currentStep, $assessmentStatus] = $candidate->computeAssessmentStatus();
+                [$stepId, $assessmentStatus] = $candidate->computeAssessmentStatus();
 
                 $candidate->computed_assessment_status = $assessmentStatus;
-                $candidate->assessment_step = $currentStep;
+                $candidate->assessment_step_id = $stepId;
 
                 $candidate->save();
 

--- a/api/app/Generators/PoolCandidateCsvGenerator.php
+++ b/api/app/Generators/PoolCandidateCsvGenerator.php
@@ -357,14 +357,14 @@ class PoolCandidateCsvGenerator extends CsvGenerator implements FileGeneratorInt
                         } else {
                             if ($candidate->computed_assessment_status['overallAssessmentStatus'] === OverallAssessmentStatus::DISQUALIFIED->name) {
                                 $decision = Lang::get('final_decision.disqualified_pending', [], $this->lang);
-                            } elseif ($candidate->assessment_step === null) {
+                            } elseif ($candidate->assessment_step_id === null) {
                                 $decision = Lang::get('final_decision.qualified_pending', [], $this->lang);
                             } else {
                                 $decision = Lang::get('final_decision.to_assess', [], $this->lang)
                                             .$this->colon()
                                             .Lang::get('common.step', [], $this->lang)
                                             .' '
-                                            .$candidate->assessment_step;
+                                            .$candidate->assessmentStep->sort_order;
                             }
                         }
                     } else {

--- a/api/app/GraphQL/Mutations/SubmitApplication.php
+++ b/api/app/GraphQL/Mutations/SubmitApplication.php
@@ -50,10 +50,10 @@ final class SubmitApplication
 
         $application->setApplicationSnapshot(false);
 
-        [$currentStep, $assessmentStatus] = $application->computeAssessmentStatus();
+        [$stepId, $assessmentStatus] = $application->computeAssessmentStatus();
 
         $application->computed_assessment_status = $assessmentStatus;
-        $application->assessment_step = $currentStep;
+        $application->assessment_step_id = $stepId;
 
         $application->save();
 

--- a/api/app/Listeners/ComputeCandidateAssessmentStatus.php
+++ b/api/app/Listeners/ComputeCandidateAssessmentStatus.php
@@ -30,9 +30,9 @@ class ComputeCandidateAssessmentStatus
         /** @var \App\Models\PoolCandidate */
         $candidate = $result->poolCandidate;
 
-        [$currentStep, $assessmentStatus] = $candidate->computeAssessmentStatus();
+        [$stepId, $assessmentStatus] = $candidate->computeAssessmentStatus();
 
-        $candidate->assessment_step = $currentStep;
+        $candidate->assessment_step_id = $stepId;
         $candidate->computed_assessment_status = $assessmentStatus;
 
         if ($candidate->pool_candidate_status === PoolCandidateStatus::NEW_APPLICATION->name) {

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -112,6 +112,7 @@ class PoolCandidate extends Model
         'priority_verification',
         'priority_verification_expiry',
         'is_bookmarked',
+        'assessment_step_id',
     ];
 
     protected $touches = ['user'];
@@ -512,7 +513,7 @@ class PoolCandidate extends Model
 
     public function computeFinalDecision()
     {
-        $this->load(['user']);
+        $this->load(['user', 'assessmentStep']);
 
         $status = $this->pool_candidate_status;
         $decision = null;

--- a/api/database/factories/PoolCandidateFactory.php
+++ b/api/database/factories/PoolCandidateFactory.php
@@ -117,10 +117,12 @@ class PoolCandidateFactory extends Factory
             if ($candidateStatus != PoolCandidateStatus::DRAFT->name && $candidateStatus != PoolCandidateStatus::DRAFT_EXPIRED->name) {
                 $submittedDate = $this->faker->dateTimeBetween('-3 months', 'now');
                 $fakeSignature = $this->faker->firstName();
+                $step = $poolCandidate->pool->assessmentSteps->first();
                 $poolCandidate->update([
                     'submitted_at' => $submittedDate,
                     'signature' => $fakeSignature,
                     'submitted_steps' => array_column(ApplicationStep::cases(), 'name'),
+                    'assessment_step_id' => $step?->id ?? null,
                 ]);
             }
 

--- a/api/database/migrations/2025_08_21_133125_add_assessment_step_id_column_pool_candidates_table.php
+++ b/api/database/migrations/2025_08_21_133125_add_assessment_step_id_column_pool_candidates_table.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('pool_candidates', function (Blueprint $table) {
+            $table->foreignUuid('assessment_step_id')
+                ->nullable()
+                ->constrained()
+                ->onDelete('cascade');
+        });
+
+        DB::statement(<<<'SQL'
+            UPDATE pool_candidates
+            SET assessment_step_id = step.id
+            FROM assessment_steps AS step
+            WHERE pool_candidates.pool_id = step.pool_id
+              AND pool_candidates.assessment_step = step."sort_order"
+              AND pool_candidates.assessment_step IS NOT NULL
+            SQL);
+
+        Schema::table('pool_candidates', function (Blueprint $table) {
+            $table->dropColumn('assessment_step');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('pool_candidates', function (Blueprint $table) {
+            $table->integer('assessment_step')->nullable()->default(1);
+        });
+
+        DB::statement(<<<'SQL'
+            UPDATE pool_candidates
+            SET assessment_step = step."order"
+            FROM assessment_steps AS step
+            WHERE pool_candidates.assessment_step_id = step.id
+              AND pool_candidates.assessment_step_id IS NOT NULL
+        SQL);
+
+        Schema::table('pool_candidates', function (Blueprint $table) {
+            $table->dropForeign(['assessment_step_id']);
+            $table->dropColumn('assessment_step_id');
+        });
+    }
+};

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -559,7 +559,7 @@ type PoolCandidate {
   assessmentStatus: AssessmentResultStatus
     @rename(attribute: "computed_assessment_status")
   # Starts at 1, null indicates all steps successful
-  assessmentStep: AssessmentStep @belongsTo @canResolved(ability: "view")
+  assessmentStep: AssessmentStep @belongsTo
   finalDecision: LocalizedFinalDecision
     @rename(attribute: "computed_final_decision")
   finalDecisionAt: DateTime

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -559,7 +559,7 @@ type PoolCandidate {
   assessmentStatus: AssessmentResultStatus
     @rename(attribute: "computed_assessment_status")
   # Starts at 1, null indicates all steps successful
-  assessmentStep: Int @rename(attribute: "assessment_step")
+  assessmentStep: AssessmentStep @belongsTo @canResolved(ability: "view")
   finalDecision: LocalizedFinalDecision
     @rename(attribute: "computed_final_decision")
   finalDecisionAt: DateTime
@@ -606,7 +606,7 @@ type PoolCandidateAdminView {
   category: PoolCandidateCategory @with(relation: "user")
   assessmentStatus: AssessmentResultStatus
     @rename(attribute: "computed_assessment_status")
-  assessmentStep: Int @rename(attribute: "assessment_step")
+  assessmentStep: AssessmentStep @belongsTo
   finalDecision: LocalizedFinalDecision
     @rename(attribute: "computed_final_decision")
   placedDepartment: Department @belongsTo

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1043,7 +1043,7 @@ type PoolCandidate {
   educationRequirementExperiences: [Experience]
   assessmentResults: [AssessmentResult]
   assessmentStatus: AssessmentResultStatus
-  assessmentStep: Int
+  assessmentStep: AssessmentStep
   finalDecision: LocalizedFinalDecision
   finalDecisionAt: DateTime
   placedAt: DateTime
@@ -1071,7 +1071,7 @@ type PoolCandidateAdminView {
   isBookmarked: Boolean
   category: PoolCandidateCategory
   assessmentStatus: AssessmentResultStatus
-  assessmentStep: Int
+  assessmentStep: AssessmentStep
   finalDecision: LocalizedFinalDecision
   placedDepartment: Department
   closingDate: DateTime

--- a/api/tests/Feature/CandidateAssessmentStatusTest.php
+++ b/api/tests/Feature/CandidateAssessmentStatusTest.php
@@ -51,7 +51,9 @@ class CandidateAssessmentStatusTest extends TestCase
     protected $query = <<<'GRAPHQL'
         query poolCandidate($id: UUID!) {
             poolCandidate(id: $id) {
-                assessmentStep
+                assessmentStep {
+                    sortOrder
+                }
                 assessmentStatus {
                     overallAssessmentStatus
                     assessmentStepStatuses {
@@ -112,14 +114,14 @@ class CandidateAssessmentStatusTest extends TestCase
         ];
     }
 
-    public function testDefaultAssessmentStatus(): void
+    public function test_default_assessment_status(): void
     {
         $this->actingAs($this->adminUser, 'api')
             ->graphQL($this->query, $this->queryVars)
             ->assertJson([
                 'data' => [
                     'poolCandidate' => [
-                        'assessmentStep' => 1,
+                        'assessmentStep' => ['sortOrder' => 1],
                         'assessmentStatus' => [
                             'assessmentStepStatuses' => [],
                             'overallAssessmentStatus' => OverallAssessmentStatus::TO_ASSESS->name,
@@ -129,7 +131,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ]);
     }
 
-    public function testSuccessPassesFirstStep(): void
+    public function test_success_passes_first_step(): void
     {
         $stepOne = $this->pool->assessmentSteps->where('sort_order', 1)->first();
 
@@ -155,7 +157,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ->assertJson([
                 'data' => [
                     'poolCandidate' => [
-                        'assessmentStep' => 2,
+                        'assessmentStep' => ['sortOrder' => 2],
                         'assessmentStatus' => [
                             'assessmentStepStatuses' => [
                                 [
@@ -170,7 +172,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ]);
     }
 
-    public function testHoldPassesFirstStep(): void
+    public function test_hold_passes_first_step(): void
     {
         $stepOne = $this->pool->assessmentSteps->where('sort_order', 1)->first();
 
@@ -188,7 +190,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ->assertJson([
                 'data' => [
                     'poolCandidate' => [
-                        'assessmentStep' => 2,
+                        'assessmentStep' => ['sortOrder' => 2],
                         'assessmentStatus' => [
                             'assessmentStepStatuses' => [
                                 [
@@ -203,7 +205,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ]);
     }
 
-    public function testUnsuccessfulEducationDisqualifies(): void
+    public function test_unsuccessful_education_disqualifies(): void
     {
         $stepOne = $this->pool->assessmentSteps->where('sort_order', 1)->first();
 
@@ -221,7 +223,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ->assertJson([
                 'data' => [
                     'poolCandidate' => [
-                        'assessmentStep' => 1,
+                        'assessmentStep' => ['sortOrder' => 1],
                         'assessmentStatus' => [
                             'assessmentStepStatuses' => [
                                 [
@@ -236,7 +238,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ]);
     }
 
-    public function testUnsuccessfulEssentialSkillDisqualifies(): void
+    public function test_unsuccessful_essential_skill_disqualifies(): void
     {
         $technicalSkill = Skill::factory()->create([
             'category' => SkillCategory::TECHNICAL->name,
@@ -262,7 +264,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ->assertJson([
                 'data' => [
                     'poolCandidate' => [
-                        'assessmentStep' => 1,
+                        'assessmentStep' => ['sortOrder' => 1],
                         'assessmentStatus' => [
                             'assessmentStepStatuses' => [
                                 [
@@ -277,7 +279,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ]);
     }
 
-    public function testFinalStepHoldStillNeedsAssessment(): void
+    public function test_final_step_hold_still_needs_assessment(): void
     {
 
         $steps = $this->pool->assessmentSteps;
@@ -305,7 +307,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ->assertJson([
                 'data' => [
                     'poolCandidate' => [
-                        'assessmentStep' => 2,
+                        'assessmentStep' => ['sortOrder' => 2],
                         'assessmentStatus' => [
                             'assessmentStepStatuses' => [
                                 [
@@ -324,7 +326,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ]);
     }
 
-    public function testSucceedsAllQualifies(): void
+    public function test_succeeds_all_qualifies(): void
     {
         $steps = $this->pool->assessmentSteps;
 
@@ -370,7 +372,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ]);
     }
 
-    public function testFailedEssentialSkillMissingEducation()
+    public function test_failed_essential_skill_missing_education()
     {
         $steps = $this->pool->assessmentSteps;
 
@@ -388,7 +390,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ->assertJson([
                 'data' => [
                     'poolCandidate' => [
-                        'assessmentStep' => 1,
+                        'assessmentStep' => ['sortOrder' => 1],
                         'assessmentStatus' => [
                             'overallAssessmentStatus' => OverallAssessmentStatus::DISQUALIFIED->name,
                             'assessmentStepStatuses' => [
@@ -404,7 +406,7 @@ class CandidateAssessmentStatusTest extends TestCase
 
     }
 
-    public function testNoEssentialSkillOrEducationIsSuccess()
+    public function test_no_essential_skill_or_education_is_success()
     {
 
         $pool = Pool::factory()
@@ -469,7 +471,7 @@ class CandidateAssessmentStatusTest extends TestCase
 
     }
 
-    public function testOutOfOrderAssessmentsDoNotIncrementStep()
+    public function test_out_of_order_assessments_do_not_increment_step()
     {
         $steps = $this->pool->assessmentSteps;
 
@@ -487,7 +489,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ->assertJson([
                 'data' => [
                     'poolCandidate' => [
-                        'assessmentStep' => 1,
+                        'assessmentStep' => ['sortOrder' => 1],
                         'assessmentStatus' => [
                             'overallAssessmentStatus' => OverallAssessmentStatus::TO_ASSESS->name,
                             'assessmentStepStatuses' => [
@@ -502,7 +504,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ]);
     }
 
-    public function testOnlyEssentialSkillsMustPassToIncrementStep()
+    public function test_only_essential_skills_must_pass_to_increment_step()
     {
         $pool = Pool::factory()
             ->published()
@@ -565,7 +567,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ->assertJson([
                 'data' => [
                     'poolCandidate' => [
-                        'assessmentStep' => 2,
+                        'assessmentStep' => ['sortOrder' => 2],
                         'assessmentStatus' => [
                             'overallAssessmentStatus' => OverallAssessmentStatus::TO_ASSESS->name,
                             'assessmentStepStatuses' => [
@@ -580,7 +582,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ]);
     }
 
-    public function testNonEssentialAssessmentDisqualifiedPasses()
+    public function test_non_essential_assessment_disqualified_passes()
     {
 
         $pool = Pool::factory()
@@ -708,7 +710,7 @@ class CandidateAssessmentStatusTest extends TestCase
 
     }
 
-    public function testStepWithNoSkillsAlwaysPasses()
+    public function test_step_with_no_skills_always_passes()
     {
 
         $pool = Pool::factory()
@@ -760,7 +762,7 @@ class CandidateAssessmentStatusTest extends TestCase
 
     }
 
-    public function testApplicationScreeningStepEducationResult()
+    public function test_application_screening_step_education_result()
     {
         // pool with two steps, both steps associated with one technical pool skill
         $pool = Pool::factory()
@@ -817,7 +819,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ->assertJson([
                 'data' => [
                     'poolCandidate' => [
-                        'assessmentStep' => 1,
+                        'assessmentStep' => ['sortOrder' => 1],
                         'assessmentStatus' => [
                             'overallAssessmentStatus' => OverallAssessmentStatus::TO_ASSESS->name,
                             'assessmentStepStatuses' => [
@@ -845,7 +847,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ->assertJson([
                 'data' => [
                     'poolCandidate' => [
-                        'assessmentStep' => 2,
+                        'assessmentStep' => ['sortOrder' => 2],
                         'assessmentStatus' => [
                             'overallAssessmentStatus' => OverallAssessmentStatus::TO_ASSESS->name,
                             'assessmentStepStatuses' => [
@@ -865,7 +867,7 @@ class CandidateAssessmentStatusTest extends TestCase
      * except for a single skill in the final step which is Unsuccessful,
      * then the overall status is Disqualified.
      */
-    public function testUnsuccessfulEssentialInFinalStepMeansDisqualified(): void
+    public function test_unsuccessful_essential_in_final_step_means_disqualified(): void
     {
         $steps = $this->pool->assessmentSteps;
 
@@ -900,7 +902,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ->assertJson([
                 'data' => [
                     'poolCandidate' => [
-                        'assessmentStep' => 2,
+                        'assessmentStep' => ['sortOrder' => 2],
                         'assessmentStatus' => [
                             'assessmentStepStatuses' => [
                                 [
@@ -922,7 +924,7 @@ class CandidateAssessmentStatusTest extends TestCase
     /** Event ComputeCandidateAssessmentStatus can change the pool_candidate_status field
      * Assert it is changed when the initial status is NEW_APPLICATION and unchanged otherwise
      */
-    public function testComputeCandidateAssessmentStatusUpdatesPoolCandidateStatus(): void
+    public function test_compute_candidate_assessment_status_updates_pool_candidate_status(): void
     {
         $step = $this->pool->assessmentSteps[0];
         $statuses = array_merge(

--- a/api/tests/Feature/CandidateAssessmentStatusTest.php
+++ b/api/tests/Feature/CandidateAssessmentStatusTest.php
@@ -107,6 +107,7 @@ class CandidateAssessmentStatusTest extends TestCase
             'pool_id' => $this->pool->id,
             'submitted_at' => config('constants.past_date'),
             'expiry_date' => config('constants.far_future_date'),
+            'assessment_step_id' => $this->pool->assessmentSteps->first()?->id,
         ]);
 
         $this->queryVars = [
@@ -157,7 +158,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ->assertJson([
                 'data' => [
                     'poolCandidate' => [
-                        'assessmentStep' => ['sortOrder' => 2],
+                        'assessmentStep' => ['sortOrder' => 3],
                         'assessmentStatus' => [
                             'assessmentStepStatuses' => [
                                 [
@@ -190,7 +191,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ->assertJson([
                 'data' => [
                     'poolCandidate' => [
-                        'assessmentStep' => ['sortOrder' => 2],
+                        'assessmentStep' => ['sortOrder' => 3],
                         'assessmentStatus' => [
                             'assessmentStepStatuses' => [
                                 [
@@ -307,7 +308,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ->assertJson([
                 'data' => [
                     'poolCandidate' => [
-                        'assessmentStep' => ['sortOrder' => 2],
+                        'assessmentStep' => ['sortOrder' => 3],
                         'assessmentStatus' => [
                             'assessmentStepStatuses' => [
                                 [
@@ -567,7 +568,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ->assertJson([
                 'data' => [
                     'poolCandidate' => [
-                        'assessmentStep' => ['sortOrder' => 2],
+                        'assessmentStep' => ['sortOrder' => 3],
                         'assessmentStatus' => [
                             'overallAssessmentStatus' => OverallAssessmentStatus::TO_ASSESS->name,
                             'assessmentStepStatuses' => [
@@ -776,7 +777,7 @@ class CandidateAssessmentStatusTest extends TestCase
             'type' => PoolSkillType::ESSENTIAL->name,
         ]);
         $stepOne = $pool->assessmentSteps->first();
-        $stepTwo = AssessmentStep::factory()
+        AssessmentStep::factory()
             ->afterCreating(function (AssessmentStep $step) use ($poolSkill) {
                 $step->poolSkills()->sync([$poolSkill->id]);
             })->create([
@@ -787,6 +788,7 @@ class CandidateAssessmentStatusTest extends TestCase
             'pool_id' => $pool->id,
             'submitted_at' => config('constants.past_date'),
             'expiry_date' => config('constants.far_future_date'),
+            'assessment_step_id' => $stepOne->id,
         ]);
 
         // overall to assess, step statuses empty
@@ -795,7 +797,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ->assertJson([
                 'data' => [
                     'poolCandidate' => [
-                        'assessmentStep' => 1,
+                        'assessmentStep' => ['sortOrder' => 1],
                         'assessmentStatus' => [
                             'overallAssessmentStatus' => OverallAssessmentStatus::TO_ASSESS->name,
                             'assessmentStepStatuses' => [],
@@ -847,7 +849,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ->assertJson([
                 'data' => [
                     'poolCandidate' => [
-                        'assessmentStep' => ['sortOrder' => 2],
+                        'assessmentStep' => ['sortOrder' => 3],
                         'assessmentStatus' => [
                             'overallAssessmentStatus' => OverallAssessmentStatus::TO_ASSESS->name,
                             'assessmentStepStatuses' => [
@@ -902,7 +904,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ->assertJson([
                 'data' => [
                     'poolCandidate' => [
-                        'assessmentStep' => ['sortOrder' => 2],
+                        'assessmentStep' => ['sortOrder' => 3],
                         'assessmentStatus' => [
                             'assessmentStepStatuses' => [
                                 [

--- a/api/tests/Feature/CandidateAssessmentStatusTest.php
+++ b/api/tests/Feature/CandidateAssessmentStatusTest.php
@@ -115,7 +115,7 @@ class CandidateAssessmentStatusTest extends TestCase
         ];
     }
 
-    public function test_default_assessment_status(): void
+    public function testDefaultAssessmentStatus(): void
     {
         $this->actingAs($this->adminUser, 'api')
             ->graphQL($this->query, $this->queryVars)
@@ -132,7 +132,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ]);
     }
 
-    public function test_success_passes_first_step(): void
+    public function testSuccessPassesFirstStep(): void
     {
         $stepOne = $this->pool->assessmentSteps->where('sort_order', 1)->first();
 
@@ -173,7 +173,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ]);
     }
 
-    public function test_hold_passes_first_step(): void
+    public function testHoldPassesFirstStep(): void
     {
         $stepOne = $this->pool->assessmentSteps->where('sort_order', 1)->first();
 
@@ -206,7 +206,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ]);
     }
 
-    public function test_unsuccessful_education_disqualifies(): void
+    public function testUnsuccessfulEducationDisqualifies(): void
     {
         $stepOne = $this->pool->assessmentSteps->where('sort_order', 1)->first();
 
@@ -239,7 +239,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ]);
     }
 
-    public function test_unsuccessful_essential_skill_disqualifies(): void
+    public function testUnsuccessfulEssentialSkillDisqualifies(): void
     {
         $technicalSkill = Skill::factory()->create([
             'category' => SkillCategory::TECHNICAL->name,
@@ -280,7 +280,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ]);
     }
 
-    public function test_final_step_hold_still_needs_assessment(): void
+    public function testFinalStepHoldStillNeedsAssessment(): void
     {
 
         $steps = $this->pool->assessmentSteps;
@@ -327,7 +327,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ]);
     }
 
-    public function test_succeeds_all_qualifies(): void
+    public function testSucceedsAllQualifies(): void
     {
         $steps = $this->pool->assessmentSteps;
 
@@ -373,7 +373,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ]);
     }
 
-    public function test_failed_essential_skill_missing_education()
+    public function testFailedEssentialSkillMissingEducation()
     {
         $steps = $this->pool->assessmentSteps;
 
@@ -407,7 +407,7 @@ class CandidateAssessmentStatusTest extends TestCase
 
     }
 
-    public function test_no_essential_skill_or_education_is_success()
+    public function testNoEssentialSkillOrEducationIsSuccess()
     {
 
         $pool = Pool::factory()
@@ -472,7 +472,7 @@ class CandidateAssessmentStatusTest extends TestCase
 
     }
 
-    public function test_out_of_order_assessments_do_not_increment_step()
+    public function testOutOfOrderAssessmentsDoNotIncrementStep()
     {
         $steps = $this->pool->assessmentSteps;
 
@@ -505,7 +505,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ]);
     }
 
-    public function test_only_essential_skills_must_pass_to_increment_step()
+    public function testOnlyEssentialSkillsMustPassToIncrementStep()
     {
         $pool = Pool::factory()
             ->published()
@@ -583,7 +583,7 @@ class CandidateAssessmentStatusTest extends TestCase
             ]);
     }
 
-    public function test_non_essential_assessment_disqualified_passes()
+    public function testNonEssentialAssessmentDisqualifiedPasses()
     {
 
         $pool = Pool::factory()
@@ -711,7 +711,7 @@ class CandidateAssessmentStatusTest extends TestCase
 
     }
 
-    public function test_step_with_no_skills_always_passes()
+    public function testStepWithNoSkillsAlwaysPasses()
     {
 
         $pool = Pool::factory()
@@ -763,7 +763,7 @@ class CandidateAssessmentStatusTest extends TestCase
 
     }
 
-    public function test_application_screening_step_education_result()
+    public function testApplicationScreeningStepEducationResult()
     {
         // pool with two steps, both steps associated with one technical pool skill
         $pool = Pool::factory()
@@ -869,7 +869,7 @@ class CandidateAssessmentStatusTest extends TestCase
      * except for a single skill in the final step which is Unsuccessful,
      * then the overall status is Disqualified.
      */
-    public function test_unsuccessful_essential_in_final_step_means_disqualified(): void
+    public function testUnsuccessfulEssentialInFinalStepMeansDisqualified(): void
     {
         $steps = $this->pool->assessmentSteps;
 
@@ -926,7 +926,7 @@ class CandidateAssessmentStatusTest extends TestCase
     /** Event ComputeCandidateAssessmentStatus can change the pool_candidate_status field
      * Assert it is changed when the initial status is NEW_APPLICATION and unchanged otherwise
      */
-    public function test_compute_candidate_assessment_status_updates_pool_candidate_status(): void
+    public function testComputeCandidateAssessmentStatusUpdatesPoolCandidateStatus(): void
     {
         $step = $this->pool->assessmentSteps[0];
         $statuses = array_merge(

--- a/api/tests/Feature/CandidateFinalDecisionTest.php
+++ b/api/tests/Feature/CandidateFinalDecisionTest.php
@@ -32,7 +32,7 @@ class CandidateFinalDecisionTest extends TestCase
     /**
      * @dataProvider statusProvider
      */
-    public function testFinalDecisionComputation($status, $expected): void
+    public function test_final_decision_computation($status, $expected): void
     {
 
         $this->candidate->pool_candidate_status = $status;
@@ -44,12 +44,13 @@ class CandidateFinalDecisionTest extends TestCase
     /**
      * @dataProvider pendingStepProvider
      */
-    public function testPendingFinalDecisionComputation($step, $overallStatus, $expected)
+    public function test_pending_final_decision_computation($stepOrder, $overallStatus, $expected)
     {
         $this->candidate->pool_candidate_status = PoolCandidateStatus::NEW_APPLICATION->name;
         $this->candidate->computed_assessment_status = [
             'overallAssessmentStatus' => $overallStatus,
         ];
+        $step = $this->candidate->pool->assessmentSteps->firstWhere('sort_order', $stepOrder);
         $this->candidate->assessment_step = $step;
         $decision = $this->candidate->computeFinalDecision();
         $this->assertEquals($expected, $decision);

--- a/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
+++ b/apps/web/src/components/AssessmentResultsTable/AssessmentResultsTable.tsx
@@ -54,7 +54,6 @@ export const AssessmentResultsTable_Fragment = graphql(/* GraphQL */ `
         }
       }
     }
-    assessmentStep
     assessmentStatus {
       overallAssessmentStatus
     }

--- a/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
+++ b/apps/web/src/components/AssessmentStepTracker/AssessmentStepTracker.tsx
@@ -57,7 +57,9 @@ export const AssessmentStepTracker_CandidateFragment = graphql(/* GraphQL */ `
       }
       hasPriorityEntitlement
     }
-    assessmentStep
+    assessmentStep {
+      sortOrder
+    }
     assessmentStatus {
       assessmentStepStatuses {
         decision

--- a/apps/web/src/components/AssessmentStepTracker/testData.ts
+++ b/apps/web/src/components/AssessmentStepTracker/testData.ts
@@ -55,7 +55,7 @@ export const priorityEntitlementCandidate: PoolCandidate = {
   isBookmarked: false,
   assessmentResults: [getAssessmentResult()],
   priorityVerification: ClaimVerificationResult.Accepted,
-  assessmentStep: 2,
+  assessmentStep: fakePoolAssessmentSteps[1],
   assessmentStatus: {
     assessmentStepStatuses: [
       {
@@ -78,7 +78,7 @@ export const armedForcesCandidate: PoolCandidate = {
   isBookmarked: false,
   assessmentResults: [getAssessmentResult()],
   veteranVerification: ClaimVerificationResult.Accepted,
-  assessmentStep: 2,
+  assessmentStep: fakePoolAssessmentSteps[1],
   assessmentStatus: {
     assessmentStepStatuses: [
       {
@@ -100,7 +100,7 @@ export const bookmarkedCandidate: PoolCandidate = {
   },
   isBookmarked: true,
   assessmentResults: [getAssessmentResult()],
-  assessmentStep: 2,
+  assessmentStep: fakePoolAssessmentSteps[1],
   assessmentStatus: {
     assessmentStepStatuses: [
       {
@@ -132,7 +132,7 @@ export const unassessedCandidate: PoolCandidate = {
       },
     },
   ],
-  assessmentStep: 1,
+  assessmentStep: fakePoolAssessmentSteps[0],
   assessmentStatus: {
     assessmentStepStatuses: [],
   },
@@ -142,7 +142,7 @@ export const lastByFirstName: PoolCandidate = {
   id: "last-by-first-name",
   isBookmarked: false,
   assessmentResults: [getAssessmentResult()],
-  assessmentStep: 2,
+  assessmentStep: fakePoolAssessmentSteps[1],
   assessmentStatus: {
     assessmentStepStatuses: [
       {
@@ -165,7 +165,7 @@ export const firstByName: PoolCandidate = {
   isBookmarked: false,
   assessmentResults: [getAssessmentResult()],
 
-  assessmentStep: 2,
+  assessmentStep: fakePoolAssessmentSteps[1],
   assessmentStatus: {
     assessmentStepStatuses: [
       {
@@ -186,7 +186,7 @@ export const secondLastByStatus: PoolCandidate = {
   id: "second-last-by-status",
   isBookmarked: false,
   assessmentResults: [getAssessmentResult(AssessmentDecision.Hold)],
-  assessmentStep: 1,
+  assessmentStep: fakePoolAssessmentSteps[0],
   assessmentStatus: {
     assessmentStepStatuses: [
       {
@@ -208,7 +208,7 @@ export const lastByStatus: PoolCandidate = {
   id: "last-by-status",
   isBookmarked: false,
   assessmentResults: [getAssessmentResult(AssessmentDecision.Unsuccessful)],
-  assessmentStep: 1,
+  assessmentStep: fakePoolAssessmentSteps[0],
   assessmentStatus: {
     overallAssessmentStatus: OverallAssessmentStatus.Disqualified,
     assessmentStepStatuses: [

--- a/apps/web/src/components/AssessmentStepTracker/utils.ts
+++ b/apps/web/src/components/AssessmentStepTracker/utils.ts
@@ -201,8 +201,8 @@ export const groupPoolCandidatesByStep = (
     orderedSteps.map((step, index) => {
       const stepCandidates = candidates
         .filter((candidate) => {
-          return candidate.assessmentStep
-            ? index + 1 <= candidate.assessmentStep
+          return candidate.assessmentStep?.sortOrder
+            ? index + 1 <= candidate.assessmentStep?.sortOrder
             : true; // Null step indicates user passed all steps
         })
         .map((candidate) => {

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -218,7 +218,18 @@ const CandidatesTableCandidatesPaginated_Query = graphql(/* GraphQL */ `
           finalDecision {
             value
           }
-          assessmentStep
+          assessmentStep {
+            sortOrder
+            title {
+              localized
+            }
+            type {
+              label {
+                localized
+              }
+            }
+          }
+
           assessmentStatus {
             assessmentStepStatuses {
               step
@@ -256,17 +267,6 @@ const CandidatesTableCandidatesPaginated_Query = graphql(/* GraphQL */ `
               value
             }
             screeningQuestionsCount
-            assessmentSteps {
-              sortOrder
-              title {
-                localized
-              }
-              type {
-                label {
-                  localized
-                }
-              }
-            }
           }
           finalDecision {
             value
@@ -275,7 +275,6 @@ const CandidatesTableCandidatesPaginated_Query = graphql(/* GraphQL */ `
               fr
             }
           }
-          assessmentStep
           assessmentStatus {
             overallAssessmentStatus
           }
@@ -827,7 +826,7 @@ const PoolCandidatesTable = ({
         }) =>
           finalDecisionCell(
             finalDecision,
-            assessmentStep,
+            assessmentStep?.sortOrder,
             assessmentStatus,
             intl,
           ),
@@ -841,23 +840,18 @@ const PoolCandidatesTable = ({
         cell: ({
           row: {
             original: {
-              poolCandidate: {
-                assessmentStep,
-                pool: { assessmentSteps },
-              },
+              poolCandidate: { assessmentStep },
             },
           },
         }) => {
-          const step = assessmentSteps?.find(
-            (s) => s?.sortOrder === assessmentStep,
-          );
           const stepName =
             // NOTE: We do want to pass on empty strings
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            step?.title?.localized || step?.type?.label?.localized;
+            assessmentStep?.title?.localized ||
+            assessmentStep?.type?.label?.localized;
           return stepName
             ? intl.formatMessage(poolCandidateMessages.assessmentStepNumber, {
-                stepNumber: assessmentStep,
+                stepNumber: assessmentStep.sortOrder,
               }) +
                 intl.formatMessage(commonMessages.dividingColon) +
                 stepName
@@ -884,7 +878,7 @@ const PoolCandidatesTable = ({
           finalDecisionAt,
           finalDecision?.value,
           areaOfSelection?.value,
-          assessmentStep,
+          assessmentStep?.sortOrder,
           assessmentStatus,
           screeningQuestionsCount,
           intl,

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -215,7 +215,7 @@ export const candidateFacingStatusCell = (
   finalDecisionAt: PoolCandidate["finalDecisionAt"],
   finalDecision: Maybe<FinalDecision> | undefined,
   areaOfSelection: Maybe<PoolAreaOfSelection> | undefined,
-  assessmentStep: PoolCandidate["assessmentStep"],
+  assessmentStep: Maybe<number> | undefined,
   assessmentStatus: PoolCandidate["assessmentStatus"],
   screeningQuestions: Pool["screeningQuestionsCount"],
   intl: IntlShape,

--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationDialog.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationDialog.tsx
@@ -46,7 +46,9 @@ const ReviewApplicationDialog_Fragment = graphql(/* GraphQL */ `
     finalDecision {
       value
     }
-    assessmentStep
+    assessmentStep {
+      sortOrder
+    }
     assessmentStatus {
       assessmentStepStatuses {
         step
@@ -172,7 +174,7 @@ const ReviewApplicationDialog = ({
     application.finalDecisionAt,
     application.finalDecision?.value,
     pool.areaOfSelection?.value,
-    application.assessmentStep,
+    application.assessmentStep?.sortOrder,
     application.assessmentStatus,
     pool.screeningQuestionsCount,
     intl,

--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationPreviewList.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewApplicationPreviewList.tsx
@@ -27,7 +27,9 @@ const ReviewApplicationPreviewList_Fragment = graphql(/* GraphQL */ `
     finalDecision {
       value
     }
-    assessmentStep
+    assessmentStep {
+      sortOrder
+    }
     assessmentStatus {
       assessmentStepStatuses {
         step
@@ -98,7 +100,7 @@ const ReviewApplicationPreviewList = ({
                 application.finalDecisionAt,
                 application.finalDecision?.value,
                 application.pool.areaOfSelection?.value,
-                application.assessmentStep,
+                application.assessmentStep?.sortOrder,
                 application.assessmentStatus,
                 application.pool.screeningQuestionsCount,
                 intl,

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -69,7 +69,9 @@ const PoolCandidate_SnapshotQuery = graphql(/* GraphQL */ `
           fr
         }
       }
-      assessmentStep
+      assessmentStep {
+        sortOrder
+      }
       assessmentStatus {
         assessmentStepStatuses {
           decision
@@ -150,7 +152,7 @@ export const ViewPoolCandidate = ({
   const nonEmptyExperiences = unpackMaybes(parsedSnapshot?.experiences);
   const statusChip = getCandidateStatusChip(
     poolCandidate.finalDecision,
-    poolCandidate.assessmentStep,
+    poolCandidate.assessmentStep?.sortOrder,
     poolCandidate.assessmentStatus,
     intl,
   );

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/MoreActions.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/MoreActions.tsx
@@ -55,23 +55,21 @@ export const MoreActions_Fragment = graphql(/* GraphQL */ `
       }
     }
     isBookmarked
-    assessmentStep
+    assessmentStep {
+      sortOrder
+      title {
+        localized
+      }
+      type {
+        label {
+          localized
+        }
+      }
+    }
+
     removalReason {
       label {
         localized
-      }
-    }
-    pool {
-      assessmentSteps {
-        sortOrder
-        type {
-          label {
-            localized
-          }
-        }
-        title {
-          localized
-        }
       }
     }
     expiryDate
@@ -109,16 +107,11 @@ const MoreActions = ({
 
   const [{ data }] = useQuery({ query: MoreActions_Query });
 
-  const currentStep = poolCandidate.assessmentStep
-    ? poolCandidate.pool.assessmentSteps?.find(
-        (step) => step?.sortOrder === poolCandidate.assessmentStep,
-      )
-    : null;
-
   const currentStepName =
     // NOTE: Localized can be empty string so || is more suitable
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    currentStep?.title?.localized || currentStep?.type?.label?.localized;
+    poolCandidate.assessmentStep?.title?.localized ||
+    poolCandidate.assessmentStep?.type?.label?.localized;
 
   const status = poolCandidate.status?.value;
 
@@ -132,7 +125,7 @@ const MoreActions = ({
           {currentStepName && (
             <p className="text-gray-600 dark:text-gray-200">
               {intl.formatMessage(poolCandidateMessages.assessmentStepNumber, {
-                stepNumber: poolCandidate.assessmentStep,
+                stepNumber: poolCandidate.assessmentStep?.sortOrder,
               }) +
                 intl.formatMessage(commonMessages.dividingColon) +
                 currentStepName}

--- a/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/UserCandidatesTable.tsx
+++ b/apps/web/src/pages/Users/UserInformationPage/components/UserCandidatesTable/UserCandidatesTable.tsx
@@ -66,7 +66,9 @@ const UserCandidatesTableRow_Fragment = graphql(/* GraphQL */ `
           fr
         }
       }
-      assessmentStep
+      assessmentStep {
+        sortOrder
+      }
       assessmentStatus {
         overallAssessmentStatus
       }
@@ -239,7 +241,7 @@ const UserCandidatesTable = ({
         cell: ({ row: { original: poolCandidate } }) =>
           finalDecisionCell(
             poolCandidate.finalDecision,
-            poolCandidate.assessmentStep,
+            poolCandidate.assessmentStep?.sortOrder,
             poolCandidate.assessmentStatus,
             intl,
           ),

--- a/apps/web/src/utils/poolCandidate.test.ts
+++ b/apps/web/src/utils/poolCandidate.test.ts
@@ -49,7 +49,7 @@ describe("PoolCandidate utils", () => {
             value: finalDecision,
             label: { en: "Qualified" },
           },
-          candidate.assessmentStep,
+          candidate.assessmentStep.sortOrder,
           candidate.assessmentStatus,
           intl,
         );
@@ -66,7 +66,7 @@ describe("PoolCandidate utils", () => {
               value: finalDecision,
               label: { en: "Disqualified" },
             },
-            candidate.assessmentStep,
+            candidate.assessmentStep.sortOrder,
             candidate.assessmentStatus,
             intl,
           );
@@ -84,7 +84,7 @@ describe("PoolCandidate utils", () => {
             en: "Removed: To assess",
           },
         },
-        candidate.assessmentStep,
+        candidate.assessmentStep.sortOrder,
         candidate.assessmentStatus,
         intl,
       );
@@ -98,7 +98,7 @@ describe("PoolCandidate utils", () => {
             en: "Removed: Qualified",
           },
         },
-        candidate.assessmentStep,
+        candidate.assessmentStep.sortOrder,
         candidate.assessmentStatus,
         intl,
       );
@@ -113,7 +113,7 @@ describe("PoolCandidate utils", () => {
             en: "Removed",
           },
         },
-        candidate.assessmentStep,
+        candidate.assessmentStep.sortOrder,
         candidate.assessmentStatus,
         intl,
       );
@@ -127,7 +127,7 @@ describe("PoolCandidate utils", () => {
             en: "Expired: Qualified",
           },
         },
-        candidate.assessmentStep,
+        candidate.assessmentStep.sortOrder,
         candidate.assessmentStatus,
         intl,
       );
@@ -143,7 +143,7 @@ describe("PoolCandidate utils", () => {
               en: "Qualified: Pending decision",
             },
           },
-          candidateFullyQualified.assessmentStep,
+          candidateFullyQualified.assessmentStep.sortOrder,
           candidateFullyQualified.assessmentStatus,
           intl,
         );
@@ -158,7 +158,8 @@ describe("PoolCandidate utils", () => {
               en: "Qualified: Pending decision",
             },
           },
-          candidateQualifiedExceptHoldOnMiddleAssessment.assessmentStep,
+          candidateQualifiedExceptHoldOnMiddleAssessment.assessmentStep
+            .sortOrder,
           candidateQualifiedExceptHoldOnMiddleAssessment.assessmentStatus,
           intl,
         );
@@ -171,7 +172,8 @@ describe("PoolCandidate utils", () => {
             value: FinalDecision.ToAssess,
             label: { en: "To assess" },
           },
-          candidateFullyQualifiedExceptMissingEducation.assessmentStep,
+          candidateFullyQualifiedExceptMissingEducation.assessmentStep
+            .sortOrder,
           candidateFullyQualifiedExceptMissingEducation.assessmentStatus,
           intl,
         );

--- a/apps/web/src/utils/poolCandidate.ts
+++ b/apps/web/src/utils/poolCandidate.ts
@@ -416,7 +416,7 @@ export const getApplicationStatusChip = (
   finalDecisionAt: PoolCandidate["finalDecisionAt"],
   finalDecision: Maybe<FinalDecision> | undefined,
   areaOfSelection: Maybe<PoolAreaOfSelection> | undefined,
-  assessmentStep: PoolCandidate["assessmentStep"],
+  assessmentStep: Maybe<number> | undefined,
   assessmentStatus: PoolCandidate["assessmentStatus"],
   screeningQuestionsCount: Pool["screeningQuestionsCount"],
   intl: IntlShape,

--- a/apps/web/src/utils/testData.ts
+++ b/apps/web/src/utils/testData.ts
@@ -64,7 +64,7 @@ const makeAssessmentResult = (
 
 export const candidateFullyQualifiedExceptMissingEducation: PoolCandidate = {
   ...fakeCandidates[0],
-  assessmentStep: 1,
+  assessmentStep: fakePoolAssessmentSteps[0],
   assessmentStatus: {
     assessmentStepStatuses: [],
     overallAssessmentStatus: OverallAssessmentStatus.ToAssess,
@@ -128,7 +128,7 @@ export const candidateQualifiedExceptHoldOnMiddleAssessment: PoolCandidate = {
 
 export const candidateQualifiedExceptHoldOnFinalAssessment: PoolCandidate = {
   ...fakeCandidates[3],
-  assessmentStep: 3,
+  assessmentStep: fakePoolAssessmentSteps[2],
   assessmentStatus: {
     assessmentStepStatuses: [],
     overallAssessmentStatus: OverallAssessmentStatus.Qualified,
@@ -156,7 +156,7 @@ export const candidateQualifiedExceptHoldOnFinalAssessment: PoolCandidate = {
 
 export const candidateUnfinishedFinalAssessment: PoolCandidate = {
   ...fakeCandidates[4],
-  assessmentStep: 3,
+  assessmentStep: fakePoolAssessmentSteps[2],
   assessmentStatus: {
     assessmentStepStatuses: fakePoolAssessmentSteps.flatMap((step) => ({
       step: step.id,
@@ -187,7 +187,7 @@ export const candidateUnfinishedFinalAssessment: PoolCandidate = {
 
 export const candidateHoldOnMiddleStepAndNoResultsOnFinalStep: PoolCandidate = {
   ...fakeCandidates[5],
-  assessmentStep: 3,
+  assessmentStep: fakePoolAssessmentSteps[2],
   assessmentStatus: {
     assessmentStepStatuses: [],
     overallAssessmentStatus: OverallAssessmentStatus.ToAssess,
@@ -217,7 +217,7 @@ export const candidateHoldOnMiddleStepAndNoResultsOnFinalStep: PoolCandidate = {
 
 export const candidateOneFailingAssessment: PoolCandidate = {
   ...fakeCandidates[6],
-  assessmentStep: 1,
+  assessmentStep: fakePoolAssessmentSteps[0],
   assessmentStatus: {
     assessmentStepStatuses: fakePoolAssessmentSteps.flatMap((step) => ({
       step: step.id,

--- a/packages/fake-data/src/fakePoolCandidates.ts
+++ b/packages/fake-data/src/fakePoolCandidates.ts
@@ -68,7 +68,7 @@ const generatePoolCandidate = (
     isBookmarked: faker.datatype.boolean(0.2),
     generalQuestionResponses,
     screeningQuestionResponses,
-    assessmentStep: 1,
+    assessmentStep: pool.assessmentSteps?.[0] ?? null,
     assessmentStatus: {
       assessmentStepStatuses: [],
       overallAssessmentStatus: OverallAssessmentStatus.ToAssess,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,7 +249,7 @@ importers:
         version: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.31.1)(tsx@4.20.4)(yaml@2.8.0)
       vite-plugin-compression2:
         specifier: ^2.2.0
-        version: 2.2.0(rollup@4.47.1)
+        version: 2.2.0(rollup@4.46.2)
       vite-plugin-html:
         specifier: ^3.2.2
         version: 3.2.2(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.31.1)(tsx@4.20.4)(yaml@2.8.0))
@@ -993,7 +993,7 @@ importers:
         version: 8.6.14(storybook@8.6.14(prettier@3.6.2))
       '@storybook/react-vite':
         specifier: ^8.6.14
-        version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.47.1)(storybook@8.6.14(prettier@3.6.2))(typescript@5.9.2)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.31.1)(tsx@4.20.4)(yaml@2.8.0))
+        version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.46.2)(storybook@8.6.14(prettier@3.6.2))(typescript@5.9.2)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.31.1)(tsx@4.20.4)(yaml@2.8.0))
       '@storybook/types':
         specifier: ^8.6.14
         version: 8.6.14(storybook@8.6.14(prettier@3.6.2))
@@ -2950,103 +2950,103 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.47.1':
-    resolution: {integrity: sha512-lTahKRJip0knffA/GTNFJMrToD+CM+JJ+Qt5kjzBK/sFQ0EWqfKW3AYQSlZXN98tX0lx66083U9JYIMioMMK7g==}
+  '@rollup/rollup-android-arm-eabi@4.46.2':
+    resolution: {integrity: sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.47.1':
-    resolution: {integrity: sha512-uqxkb3RJLzlBbh/bbNQ4r7YpSZnjgMgyoEOY7Fy6GCbelkDSAzeiogxMG9TfLsBbqmGsdDObo3mzGqa8hps4MA==}
+  '@rollup/rollup-android-arm64@4.46.2':
+    resolution: {integrity: sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.47.1':
-    resolution: {integrity: sha512-tV6reObmxBDS4DDyLzTDIpymthNlxrLBGAoQx6m2a7eifSNEZdkXQl1PE4ZjCkEDPVgNXSzND/k9AQ3mC4IOEQ==}
+  '@rollup/rollup-darwin-arm64@4.46.2':
+    resolution: {integrity: sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.47.1':
-    resolution: {integrity: sha512-XuJRPTnMk1lwsSnS3vYyVMu4x/+WIw1MMSiqj5C4j3QOWsMzbJEK90zG+SWV1h0B1ABGCQ0UZUjti+TQK35uHQ==}
+  '@rollup/rollup-darwin-x64@4.46.2':
+    resolution: {integrity: sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.47.1':
-    resolution: {integrity: sha512-79BAm8Ag/tmJ5asCqgOXsb3WY28Rdd5Lxj8ONiQzWzy9LvWORd5qVuOnjlqiWWZJw+dWewEktZb5yiM1DLLaHw==}
+  '@rollup/rollup-freebsd-arm64@4.46.2':
+    resolution: {integrity: sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.47.1':
-    resolution: {integrity: sha512-OQ2/ZDGzdOOlyfqBiip0ZX/jVFekzYrGtUsqAfLDbWy0jh1PUU18+jYp8UMpqhly5ltEqotc2miLngf9FPSWIA==}
+  '@rollup/rollup-freebsd-x64@4.46.2':
+    resolution: {integrity: sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.47.1':
-    resolution: {integrity: sha512-HZZBXJL1udxlCVvoVadstgiU26seKkHbbAMLg7680gAcMnRNP9SAwTMVet02ANA94kXEI2VhBnXs4e5nf7KG2A==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.46.2':
+    resolution: {integrity: sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.47.1':
-    resolution: {integrity: sha512-sZ5p2I9UA7T950JmuZ3pgdKA6+RTBr+0FpK427ExW0t7n+QwYOcmDTK/aRlzoBrWyTpJNlS3kacgSlSTUg6P/Q==}
+  '@rollup/rollup-linux-arm-musleabihf@4.46.2':
+    resolution: {integrity: sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.47.1':
-    resolution: {integrity: sha512-3hBFoqPyU89Dyf1mQRXCdpc6qC6At3LV6jbbIOZd72jcx7xNk3aAp+EjzAtN6sDlmHFzsDJN5yeUySvorWeRXA==}
+  '@rollup/rollup-linux-arm64-gnu@4.46.2':
+    resolution: {integrity: sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.47.1':
-    resolution: {integrity: sha512-49J4FnMHfGodJWPw73Ve+/hsPjZgcXQGkmqBGZFvltzBKRS+cvMiWNLadOMXKGnYRhs1ToTGM0sItKISoSGUNA==}
+  '@rollup/rollup-linux-arm64-musl@4.46.2':
+    resolution: {integrity: sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.47.1':
-    resolution: {integrity: sha512-4yYU8p7AneEpQkRX03pbpLmE21z5JNys16F1BZBZg5fP9rIlb0TkeQjn5du5w4agConCCEoYIG57sNxjryHEGg==}
+  '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
+    resolution: {integrity: sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.47.1':
-    resolution: {integrity: sha512-fAiq+J28l2YMWgC39jz/zPi2jqc0y3GSRo1yyxlBHt6UN0yYgnegHSRPa3pnHS5amT/efXQrm0ug5+aNEu9UuQ==}
+  '@rollup/rollup-linux-ppc64-gnu@4.46.2':
+    resolution: {integrity: sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.47.1':
-    resolution: {integrity: sha512-daoT0PMENNdjVYYU9xec30Y2prb1AbEIbb64sqkcQcSaR0zYuKkoPuhIztfxuqN82KYCKKrj+tQe4Gi7OSm1ow==}
+  '@rollup/rollup-linux-riscv64-gnu@4.46.2':
+    resolution: {integrity: sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.47.1':
-    resolution: {integrity: sha512-JNyXaAhWtdzfXu5pUcHAuNwGQKevR+6z/poYQKVW+pLaYOj9G1meYc57/1Xv2u4uTxfu9qEWmNTjv/H/EpAisw==}
+  '@rollup/rollup-linux-riscv64-musl@4.46.2':
+    resolution: {integrity: sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.47.1':
-    resolution: {integrity: sha512-U/CHbqKSwEQyZXjCpY43/GLYcTVKEXeRHw0rMBJP7fP3x6WpYG4LTJWR3ic6TeYKX6ZK7mrhltP4ppolyVhLVQ==}
+  '@rollup/rollup-linux-s390x-gnu@4.46.2':
+    resolution: {integrity: sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.47.1':
-    resolution: {integrity: sha512-uTLEakjxOTElfeZIGWkC34u2auLHB1AYS6wBjPGI00bWdxdLcCzK5awjs25YXpqB9lS8S0vbO0t9ZcBeNibA7g==}
+  '@rollup/rollup-linux-x64-gnu@4.46.2':
+    resolution: {integrity: sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.47.1':
-    resolution: {integrity: sha512-Ft+d/9DXs30BK7CHCTX11FtQGHUdpNDLJW0HHLign4lgMgBcPFN3NkdIXhC5r9iwsMwYreBBc4Rho5ieOmKNVQ==}
+  '@rollup/rollup-linux-x64-musl@4.46.2':
+    resolution: {integrity: sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.47.1':
-    resolution: {integrity: sha512-N9X5WqGYzZnjGAFsKSfYFtAShYjwOmFJoWbLg3dYixZOZqU7hdMq+/xyS14zKLhFhZDhP9VfkzQnsdk0ZDS9IA==}
+  '@rollup/rollup-win32-arm64-msvc@4.46.2':
+    resolution: {integrity: sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.47.1':
-    resolution: {integrity: sha512-O+KcfeCORZADEY8oQJk4HK8wtEOCRE4MdOkb8qGZQNun3jzmj2nmhV/B/ZaaZOkPmJyvm/gW9n0gsB4eRa1eiQ==}
+  '@rollup/rollup-win32-ia32-msvc@4.46.2':
+    resolution: {integrity: sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.47.1':
-    resolution: {integrity: sha512-CpKnYa8eHthJa3c+C38v/E+/KZyF1Jdh2Cz3DyKZqEWYgrM1IHFArXNWvBLPQCKUEsAqqKX27tTqVEFbDNUcOA==}
+  '@rollup/rollup-win32-x64-msvc@4.46.2':
+    resolution: {integrity: sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==}
     cpu: [x64]
     os: [win32]
 
@@ -3639,8 +3639,8 @@ packages:
   '@types/mdx@2.0.13':
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
 
-  '@types/node@22.17.2':
-    resolution: {integrity: sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==}
+  '@types/node@22.17.1':
+    resolution: {integrity: sha512-y3tBaz+rjspDTylNjAX37jEC3TETEFGNJL6uQDxwF9/8GLLIjW1rvVHlynyuUKMnMr1Roq8jOv3vkopBjC4/VA==}
 
   '@types/node@24.3.0':
     resolution: {integrity: sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==}
@@ -3744,6 +3744,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/tsconfig-utils@8.39.1':
+    resolution: {integrity: sha512-ePUPGVtTMR8XMU2Hee8kD0Pu4NDE1CN9Q1sxGSGd/mbOtGZDM7pnhXNJnzW63zk/q+Z54zVzj44HtwXln5CvHA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/tsconfig-utils@8.40.0':
     resolution: {integrity: sha512-jtMytmUaG9d/9kqSl/W3E3xaWESo4hFDxAIHGVW/WKKtQhesnRIJSAJO6XckluuJ6KDB5woD1EiqknriCtAmcw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3763,6 +3769,10 @@ packages:
 
   '@typescript-eslint/types@8.34.1':
     resolution: {integrity: sha512-rjLVbmE7HR18kDsjNIZQHxmv9RZwlgzavryL5Lnj2ujIRTeXlKtILHgRNmQ3j4daw7zd+mQgy+uyt6Zo6I0IGA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.39.1':
+    resolution: {integrity: sha512-7sPDKQQp+S11laqTrhHqeAbsCfMkwJMrV7oTDvtDds4mEofJYir414bYKUEb8YPUm9QL3U+8f6L6YExSoAGdQw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/types@8.40.0':
@@ -4304,8 +4314,8 @@ packages:
   browser-assert@1.2.1:
     resolution: {integrity: sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==}
 
-  browserslist@4.25.3:
-    resolution: {integrity: sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ==}
+  browserslist@4.25.2:
+    resolution: {integrity: sha512-0si2SJK3ooGzIawRu61ZdPCO1IncZwS8IzuX73sPZsXW6EQ/w/DAfPyKI8l1ETTCr2MnvqWitmlCUxgdul45jA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -4349,8 +4359,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001736:
-    resolution: {integrity: sha512-ImpN5gLEY8gWeqfLUyEF4b7mYWcYoR2Si1VhnrbM4JizRFmfGaAQ12PhNykq6nvI4XvKLrsp8Xde74D5phJOSw==}
+  caniuse-lite@1.0.30001735:
+    resolution: {integrity: sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==}
 
   capital-case@1.0.4:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
@@ -4761,8 +4771,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.5.207:
-    resolution: {integrity: sha512-mryFrrL/GXDTmAtIVMVf+eIXM09BBPlO5IQ7lUyKmK8d+A4VpRGG+M3ofoVef6qyF8s60rJei8ymlJxjUA8Faw==}
+  electron-to-chromium@1.5.203:
+    resolution: {integrity: sha512-uz4i0vLhfm6dLZWbz/iH88KNDV+ivj5+2SA+utpgjKaj9Q0iDLuwk6Idhe9BTxciHudyx6IvTvijhkPvFGUQ0g==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -6987,8 +6997,8 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rollup@4.47.1:
-    resolution: {integrity: sha512-iasGAQoZ5dWDzULEUX3jiW0oB1qyFOepSyDyoU6S/OhVlDIwj5knI5QBa5RRQ0sK7OE0v+8VIi2JuV+G+3tfNg==}
+  rollup@4.46.2:
+    resolution: {integrity: sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -7297,9 +7307,6 @@ packages:
     peerDependenciesMeta:
       tailwind-merge:
         optional: true
-
-  tailwindcss@4.1.11:
-    resolution: {integrity: sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==}
 
   tailwindcss@4.1.12:
     resolution: {integrity: sha512-DzFtxOi+7NsFf7DBtI3BJsynR+0Yp6etH+nRPTbpWnS2pZBaSksv/JGctNwSWzbFjp0vxSqknaUylseZqMDGrA==}
@@ -7988,7 +7995,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.28.0
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.25.3
+      browserslist: 4.25.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -8468,7 +8475,7 @@ snapshots:
     dependencies:
       '@formatjs/icu-messageformat-parser': 2.11.2
       '@types/json-stable-stringify': 1.2.0
-      '@types/node': 22.17.2
+      '@types/node': 22.17.1
       chalk: 4.1.2
       json-stable-stringify: 1.3.0
       tslib: 2.8.1
@@ -9900,80 +9907,80 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 2.3.1
 
-  '@rollup/pluginutils@5.1.4(rollup@4.47.1)':
+  '@rollup/pluginutils@5.1.4(rollup@4.46.2)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.3
     optionalDependencies:
-      rollup: 4.47.1
+      rollup: 4.46.2
 
-  '@rollup/pluginutils@5.2.0(rollup@4.47.1)':
+  '@rollup/pluginutils@5.2.0(rollup@4.46.2)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.3
     optionalDependencies:
-      rollup: 4.47.1
+      rollup: 4.46.2
 
-  '@rollup/rollup-android-arm-eabi@4.47.1':
+  '@rollup/rollup-android-arm-eabi@4.46.2':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.47.1':
+  '@rollup/rollup-android-arm64@4.46.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.47.1':
+  '@rollup/rollup-darwin-arm64@4.46.2':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.47.1':
+  '@rollup/rollup-darwin-x64@4.46.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.47.1':
+  '@rollup/rollup-freebsd-arm64@4.46.2':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.47.1':
+  '@rollup/rollup-freebsd-x64@4.46.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.47.1':
+  '@rollup/rollup-linux-arm-gnueabihf@4.46.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.47.1':
+  '@rollup/rollup-linux-arm-musleabihf@4.46.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.47.1':
+  '@rollup/rollup-linux-arm64-gnu@4.46.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.47.1':
+  '@rollup/rollup-linux-arm64-musl@4.46.2':
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.47.1':
+  '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.47.1':
+  '@rollup/rollup-linux-ppc64-gnu@4.46.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.47.1':
+  '@rollup/rollup-linux-riscv64-gnu@4.46.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.47.1':
+  '@rollup/rollup-linux-riscv64-musl@4.46.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.47.1':
+  '@rollup/rollup-linux-s390x-gnu@4.46.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.47.1':
+  '@rollup/rollup-linux-x64-gnu@4.46.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.47.1':
+  '@rollup/rollup-linux-x64-musl@4.46.2':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.47.1':
+  '@rollup/rollup-win32-arm64-msvc@4.46.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.47.1':
+  '@rollup/rollup-win32-ia32-msvc@4.46.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.47.1':
+  '@rollup/rollup-win32-x64-msvc@4.46.2':
     optional: true
 
   '@rtsao/scc@1.1.0': {}
@@ -10173,10 +10180,10 @@ snapshots:
       react-dom: 19.1.0(react@18.3.1)
       storybook: 8.6.14(prettier@3.6.2)
 
-  '@storybook/react-vite@8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.47.1)(storybook@8.6.14(prettier@3.6.2))(typescript@5.9.2)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.31.1)(tsx@4.20.4)(yaml@2.8.0))':
+  '@storybook/react-vite@8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.46.2)(storybook@8.6.14(prettier@3.6.2))(typescript@5.9.2)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.31.1)(tsx@4.20.4)(yaml@2.8.0))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.9.2)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.31.1)(tsx@4.20.4)(yaml@2.8.0))
-      '@rollup/pluginutils': 5.1.4(rollup@4.47.1)
+      '@rollup/pluginutils': 5.1.4(rollup@4.46.2)
       '@storybook/builder-vite': 8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.31.1)(tsx@4.20.4)(yaml@2.8.0))
       '@storybook/react': 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.6.2))(typescript@5.9.2)
       find-up: 5.0.0
@@ -10660,7 +10667,7 @@ snapshots:
 
   '@types/mdx@2.0.13': {}
 
-  '@types/node@22.17.2':
+  '@types/node@22.17.1':
     dependencies:
       undici-types: 6.21.0
 
@@ -10738,8 +10745,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.33.1(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.40.0(typescript@5.9.2)
-      '@typescript-eslint/types': 8.40.0
+      '@typescript-eslint/tsconfig-utils': 8.39.1(typescript@5.9.2)
+      '@typescript-eslint/types': 8.39.1
       debug: 4.4.1
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -10747,8 +10754,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.34.1(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.40.0(typescript@5.9.2)
-      '@typescript-eslint/types': 8.40.0
+      '@typescript-eslint/tsconfig-utils': 8.39.1(typescript@5.9.2)
+      '@typescript-eslint/types': 8.39.1
       debug: 4.4.1
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -10786,6 +10793,10 @@ snapshots:
     dependencies:
       typescript: 5.9.2
 
+  '@typescript-eslint/tsconfig-utils@8.39.1(typescript@5.9.2)':
+    dependencies:
+      typescript: 5.9.2
+
   '@typescript-eslint/tsconfig-utils@8.40.0(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
@@ -10805,6 +10816,8 @@ snapshots:
   '@typescript-eslint/types@8.33.1': {}
 
   '@typescript-eslint/types@8.34.1': {}
+
+  '@typescript-eslint/types@8.39.1': {}
 
   '@typescript-eslint/types@8.40.0': {}
 
@@ -11389,12 +11402,12 @@ snapshots:
 
   browser-assert@1.2.1: {}
 
-  browserslist@4.25.3:
+  browserslist@4.25.2:
     dependencies:
-      caniuse-lite: 1.0.30001736
-      electron-to-chromium: 1.5.207
+      caniuse-lite: 1.0.30001735
+      electron-to-chromium: 1.5.203
       node-releases: 2.0.19
-      update-browserslist-db: 1.1.3(browserslist@4.25.3)
+      update-browserslist-db: 1.1.3(browserslist@4.25.2)
 
   bs-logger@0.2.6:
     dependencies:
@@ -11439,7 +11452,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001736: {}
+  caniuse-lite@1.0.30001735: {}
 
   capital-case@1.0.4:
     dependencies:
@@ -11811,7 +11824,7 @@ snapshots:
     dependencies:
       jake: 10.9.2
 
-  electron-to-chromium@1.5.207: {}
+  electron-to-chromium@1.5.203: {}
 
   emittery@0.13.1: {}
 
@@ -14563,30 +14576,30 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rollup@4.47.1:
+  rollup@4.46.2:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.47.1
-      '@rollup/rollup-android-arm64': 4.47.1
-      '@rollup/rollup-darwin-arm64': 4.47.1
-      '@rollup/rollup-darwin-x64': 4.47.1
-      '@rollup/rollup-freebsd-arm64': 4.47.1
-      '@rollup/rollup-freebsd-x64': 4.47.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.47.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.47.1
-      '@rollup/rollup-linux-arm64-gnu': 4.47.1
-      '@rollup/rollup-linux-arm64-musl': 4.47.1
-      '@rollup/rollup-linux-loongarch64-gnu': 4.47.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.47.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.47.1
-      '@rollup/rollup-linux-riscv64-musl': 4.47.1
-      '@rollup/rollup-linux-s390x-gnu': 4.47.1
-      '@rollup/rollup-linux-x64-gnu': 4.47.1
-      '@rollup/rollup-linux-x64-musl': 4.47.1
-      '@rollup/rollup-win32-arm64-msvc': 4.47.1
-      '@rollup/rollup-win32-ia32-msvc': 4.47.1
-      '@rollup/rollup-win32-x64-msvc': 4.47.1
+      '@rollup/rollup-android-arm-eabi': 4.46.2
+      '@rollup/rollup-android-arm64': 4.46.2
+      '@rollup/rollup-darwin-arm64': 4.46.2
+      '@rollup/rollup-darwin-x64': 4.46.2
+      '@rollup/rollup-freebsd-arm64': 4.46.2
+      '@rollup/rollup-freebsd-x64': 4.46.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.46.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.46.2
+      '@rollup/rollup-linux-arm64-gnu': 4.46.2
+      '@rollup/rollup-linux-arm64-musl': 4.46.2
+      '@rollup/rollup-linux-loongarch64-gnu': 4.46.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.46.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.46.2
+      '@rollup/rollup-linux-riscv64-musl': 4.46.2
+      '@rollup/rollup-linux-s390x-gnu': 4.46.2
+      '@rollup/rollup-linux-x64-gnu': 4.46.2
+      '@rollup/rollup-linux-x64-musl': 4.46.2
+      '@rollup/rollup-win32-arm64-msvc': 4.46.2
+      '@rollup/rollup-win32-ia32-msvc': 4.46.2
+      '@rollup/rollup-win32-x64-msvc': 4.46.2
       fsevents: 2.3.3
 
   rope-sequence@1.3.4: {}
@@ -14934,14 +14947,6 @@ snapshots:
       tailwindcss: 4.1.12
     optionalDependencies:
       tailwind-merge: 3.3.1
-
-  tailwind-variants@2.1.0(tailwind-merge@3.3.1)(tailwindcss@4.1.12):
-    dependencies:
-      tailwindcss: 4.1.12
-    optionalDependencies:
-      tailwind-merge: 3.3.1
-
-  tailwindcss@4.1.11: {}
 
   tailwindcss@4.1.12: {}
 
@@ -15301,9 +15306,9 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.9.2
       '@unrs/resolver-binding-win32-x64-msvc': 1.9.2
 
-  update-browserslist-db@1.1.3(browserslist@4.25.3):
+  update-browserslist-db@1.1.3(browserslist@4.25.2):
     dependencies:
-      browserslist: 4.25.3
+      browserslist: 4.25.2
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -15367,9 +15372,9 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  vite-plugin-compression2@2.2.0(rollup@4.47.1):
+  vite-plugin-compression2@2.2.0(rollup@4.46.2):
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.47.1)
+      '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
       tar-mini: 0.2.0
     transitivePeerDependencies:
       - rollup
@@ -15396,7 +15401,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.47.1
+      rollup: 4.46.2
       tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 24.3.0


### PR DESCRIPTION
🤖 Resolves #14333 

## 👋 Introduction

Updates pool candidate assessment step to be a relationship instead of an int.

## 🕵️ Details

I'm actually a little worried about this one becuase of how we were computing it before. I think we may want to test well before hand.

The issue I found was, if we do not have screening questions steps, we have an empty one and it skips over the second step. However, our assessment status computation did not take this into considertion and was using a simple incrementing integer.

So, if a user was on step 2 but the pool had no screening questions, the int did not match the sort order. Though, im not sure what impact this would have, it could either fix an existing bug or create a new one and I am having difficulty knowing whichj one it is :sweat: 

## 🧪 Testing

1. Build `make refresh-api; pnpm dev:fresh`
2. Login as any user
3. Go to the pages that contain touched files
4. Coinfirm step is working as expected