### PR TITLE
[Feature] Filters under consideration status from pool status options

### DIFF
--- a/apps/web/src/components/CandidateDialog/ChangeStatusDialog.tsx
+++ b/apps/web/src/components/CandidateDialog/ChangeStatusDialog.tsx
@@ -176,6 +176,7 @@ const ChangeStatusDialogForm = ({
     "SCREENED_OUT_NOT_INTERESTED",
     "SCREENED_OUT_NOT_RESPONSIVE",
     "UNDER_ASSESSMENT",
+    "UNDER_CONSIDERATION",
   ];
 
   const poolCandidateStatusesFiltered = options?.poolCandidateStatuses?.filter(


### PR DESCRIPTION
🤖 Resolves #14382.

## 👋 Introduction

This PR filters under consideration status from pool status options so that it is no longer able to be saved. It also renames the variable for the statuses to be filtered out to be more descriptive.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to a pool candidate with a status of under consideration
3. In the candidate status section, click the status value to open the dialog
4. Verify the under consideration is not in the pool status `select` input field

## 🎥  Screen recording

https://github.com/user-attachments/assets/d04d2dd1-5078-40ea-8363-d759ba314b7a