### PR TITLE
[Fix] Exec coahcing status for user download

### DIFF
--- a/api/app/Traits/Generator/GeneratesUserDoc.php
+++ b/api/app/Traits/Generator/GeneratesUserDoc.php
@@ -14,6 +14,7 @@ use App\Enums\EducationStatus;
 use App\Enums\EducationType;
 use App\Enums\EmploymentCategory;
 use App\Enums\EstimatedLanguageAbility;
+use App\Enums\ExecCoaching;
 use App\Enums\ExternalRoleSeniority;
 use App\Enums\ExternalSizeOfOrganization;
 use App\Enums\GovContractorRoleSeniority;
@@ -48,6 +49,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Lang;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Number;
 use PhpOffice\PhpWord\Element\Section;
 
@@ -809,14 +811,18 @@ trait GeneratesUserDoc
         // Executive Opportunities
         $this->addLabelText($section, $this->localize('gc_employee.exec_interest'),
             $this->yesOrNo($profile->career_planning_exec_interest ?? false));
-        $coachingStatus = match (true) {
-            $profile->career_planning_exec_interest => 'coaching_others',
-            $profile->career_planning_exec_coaching_status === 'COACHING' => 'coaching_others',
-            $profile->career_planning_exec_coaching_status === 'LEARNING' => 'has_coach',
-            $profile->career_planning_exec_coaching_status === 'BOTH' => 'coaching_and_learning',
-            $profile->career_planning_exec_coaching_status === 'not_participating' => 'not_participating',
+        $coachingStatus = match ($profile->career_planning_exec_coaching_status) {
+            [ExecCoaching::COACHING->name, ExecCoaching::LEARNING->name] => 'coaching_and_learning',
+            [ExecCoaching::COACHING->name] => 'coaching_others',
+            [ExecCoaching::LEARNING->name] => 'has_coach',
+            [] => 'not_participating',
             default => 'not_provided'
         };
+
+        Log::debug([
+            'value' => $profile->career_planning_exec_coaching_status,
+            'key' => $coachingStatus,
+        ]);
 
         $this->addLabelText($section, $this->localize('gc_employee.exec_coaching_status'),
             $this->localize("gc_employee.$coachingStatus"));
@@ -824,8 +830,8 @@ trait GeneratesUserDoc
         if (! empty($profile->career_planning_exec_coaching_interest)) {
             $section->addText($this->localize('gc_employee.exec_coaching_interest'));
             $translationMap = [
-                'COACHING' => 'interested_coaching',
-                'LEARNING' => 'interested_receiving',
+                ExecCoaching::COACHING->name => 'interested_coaching',
+                ExecCoaching::LEARNING->name => 'interested_receiving',
             ];
             foreach ($profile->career_planning_exec_coaching_interest as $interest) {
                 if (isset($translationMap[$interest])) {


### PR DESCRIPTION
🤖 Resolves #14420 

## 👋 Introduction

Fixes an issue where the profile download did not match for executive coaching status.

## 🧪 Testing

1. Login as `admin@test.com`
2. Cycle through the different Executive coaching options on your GC employee profile
3. As you do so, download your profile
4. Open each download and confirm the values in the download match the profile