### PR TITLE
[Tooling] Suppresses `dotenv` runtime logging messages

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -16,7 +16,7 @@ const stories = [
   "!**/node_modules/**",
 ];
 
-dotenv.config({ path: "./apps/web/.env" });
+dotenv.config({ path: "./apps/web/.env", quiet: true });
 
 const main: StorybookConfig = {
   stories,

--- a/apps/playwright/playwright.config.ts
+++ b/apps/playwright/playwright.config.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { defineConfig, devices } from "@playwright/test";
 import dotenv from "dotenv";
 
-dotenv.config({ path: path.resolve(__dirname, ".env") });
+dotenv.config({ path: path.resolve(__dirname, ".env"), quiet: true });
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/apps/playwright/utils/featureFlags.ts
+++ b/apps/playwright/utils/featureFlags.ts
@@ -7,6 +7,7 @@ export type FeatureFlags = Record<`FEATURE_${string}`, boolean | null>;
 export function getFeatureFlagConfig(flags: Partial<FeatureFlags>) {
   const { parsed } = dotenv.config({
     path: path.resolve(__dirname, "..", "..", "web", ".env"),
+    quiet: true,
   });
   const env = { ...parsed, ...flags };
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -8,7 +8,7 @@ import { createHtmlPlugin } from "vite-plugin-html";
 import { compression } from "vite-plugin-compression2";
 import { defineConfig } from "vite";
 
-dotenv.config({ path: "./.env" });
+dotenv.config({ path: "./.env", quiet: true });
 
 const appUrl = "https://talent.canada.ca";
 


### PR DESCRIPTION
🤖 Resolves #14426.

## 👋 Introduction

This PR suppresses `dotenv` runtime logging message that is annoying (I am tired of its "tips"!).

## 🧪 Testing

1. `pnpm storybook` or `pnpm build` or `pnpm e2e:playwright`
2. Verify no `dotenv' runtime logging