### PR TITLE
[Fix] Missing space in `ErrorSummary`

### DIFF
--- a/packages/forms/src/components/ErrorSummary.tsx
+++ b/packages/forms/src/components/ErrorSummary.tsx
@@ -53,7 +53,7 @@ const getFieldLabel = (
     // Get the number and assign it to the index so we can show it in the link
     const indices = name.match(numberRegex);
     if (indices) {
-      index = indices.map((i) => `(${Number(i) + 1})`).join(" ");
+      index = indices.map((i) => ` (${Number(i) + 1})`).join(" ");
     }
   }
 


### PR DESCRIPTION
🤖 Resolves #14336 

## 👋 Introduction

Adds a missing space for reapter items in error summary between the label and the paenteses indicating the items index.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Navigate to a repeater field (application questions section works well)
3. Force an error
4. Confirm the error summary has a space between the label and parentheses.

## 📸 Screenshot

<img width="982" height="341" alt="swappy-20250825_094906" src="https://github.com/user-attachments/assets/59e283ad-7919-4e89-b748-bb8c81628998" />
