### PR TITLE
[Fix] Updates `whereClosed` on `PoolBuilder` logic

### DIFF
--- a/api/app/Builders/PoolBuilder.php
+++ b/api/app/Builders/PoolBuilder.php
@@ -24,7 +24,10 @@ class PoolBuilder extends Builder
 
     public function whereClosed(): self
     {
-        return $this->where('closing_date', '<=', now());
+        return $this->where(function ($query) {
+            $query->whereNotNull('published_at')
+                ->where('closing_date', '<=', now());
+        });
     }
 
     public function whereCurrentlyActive(): self


### PR DESCRIPTION
🤖 Resolves #14375.

## 👋 Introduction

This PR updates the `whereClosed` function for processes so that in order to be returned as CLOSED in the query, a process needs to have a `published_at` value that is not `NULL`.

## 🧪 Testing

1. `make refresh-api; make seed-fresh; pnpm i; pnpm run build:fresh;`
2. Create a draft process with a closing date one day in the future from now
3. Manually update the `closing_date` field of that process to be one day in the past from now
4. Navigate to http://localhost:8000/en/admin/pools?f=%7B%22publishingGroups%22%3A%5B%5D%2C%22statuses%22%3A%5B%22CLOSED%22%5D%2C%22workStreams%22%3A%5B%5D%2C%22classifications%22%3A%5B%5D%7D
5. Verify that the draft process created does not render in the table for `CLOSED`