### PR TITLE
[Fix] Step skip message appearing before load on application

### DIFF
--- a/apps/web/src/pages/Applications/ApplicationLayout.tsx
+++ b/apps/web/src/pages/Applications/ApplicationLayout.tsx
@@ -214,7 +214,7 @@ const Layout = () => {
   return (
     <>
       {fetching || stale ? (
-        <Loading live="polite" className="bg-white/99" />
+        <Loading live="polite" className="bg-white dark:bg-gray-700" />
       ) : null}
       {data?.poolCandidate ? (
         <ApplicationPageWrapper query={data.poolCandidate} />


### PR DESCRIPTION
🤖 Resolves #14438 

## 👋 Introduction

Updates the loading spinner to be fully opaque to prevent showing a pre-emptive "step skipped" message while loading the submitted steps.

## 🕵️ Details

We already had some code that did this but was not exactly correct. Instead of drilling props to handle this, I just updated the styles to fix dark mode and add a single point of opacirty to hide the uh oh message.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `applicant@test.com`
3. Start an application
4. Submit steps, confirming along the way that you do not see an "uh oh" message behind the loading spinner unless you actually skip a step