### PR TITLE
[Fix] Add unique constraint index to `work_streams.key`

### DIFF
--- a/api/database/migrations/2025_08_26_161523_add_unique_constraint_work_streams_table_key_column.php
+++ b/api/database/migrations/2025_08_26_161523_add_unique_constraint_work_streams_table_key_column.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('work_streams', function (Blueprint $table) {
+            $table->unique('key');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('work_streams', function (Blueprint $table) {
+            $table->dropUnique('work_streams_key_unique');
+        });
+    }
+};


### PR DESCRIPTION
🤖 Resolves #13387 

## 👋 Introduction

Adds a unique constraint to the `key` column on the `work_sreams` table.

## 🧪 Testing

1. Migrate data `make artisan CMD="migrate"
2. Confirm the constraint is added
3. Rollback `make artisan CMD="migrate:rollback --step=1"
4. Confirm it removes the constraint

## 🚚 Deployment

Will need to test to confirm their are no violations first.