### PR TITLE
[Fix] Add unique constraint for `assessment_steps` `pool_id` and `sort_order`

### DIFF
--- a/api/database/migrations/2025_08_26_174213_add_unique_constraint_assessment_steps_table_sort_order_pool_id_columns.php
+++ b/api/database/migrations/2025_08_26_174213_add_unique_constraint_assessment_steps_table_sort_order_pool_id_columns.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('assessment_steps', function (Blueprint $table) {
+            $table->unique(['pool_id', 'sort_order']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('assessment_steps', function (Blueprint $table) {
+            $table->dropUnique('assessment_steps_pool_id_sort_order_unique');
+        });
+    }
+};


### PR DESCRIPTION
🤖 Resolves #14441 

## 👋 Introduction

Updates the `assessment_steps` table to have a unique constraint for `pool_id` and `sort_order`.

## 🕵️ Details

We do not want items with the same sort order in the same pool. This constraint should prevent that from happening.

## 🧪 Testing

1. Migrate `make artisan CMD="migrate"`
2. Confirm the contraint is added correctly and works as epxected
3. Rollback `make artisan CMD="migrate:rollback --step=1`
4. Confirm it removes the constraint