### PR TITLE
[Debt] Remove step number from candidate status chip

### DIFF
--- a/apps/web/src/utils/poolCandidate.test.ts
+++ b/apps/web/src/utils/poolCandidate.test.ts
@@ -205,7 +205,7 @@ describe("PoolCandidate utils", () => {
           candidateQualifiedExceptHoldOnFinalAssessment.assessmentStatus,
           intl,
         );
-        expect(chip.label).toBe("To assess:");
+        expect(chip.label).toBe("To assess");
         expect(chip.color).toBe("warning");
       });
       it('should return "To assess" with warning color for candidate with incomplete final (third) step', () => {

--- a/apps/web/src/utils/poolCandidate.test.ts
+++ b/apps/web/src/utils/poolCandidate.test.ts
@@ -166,7 +166,7 @@ describe("PoolCandidate utils", () => {
         expect(chip.label).toBe("Qualified: Pending decision");
         expect(chip.color).toBe("success");
       });
-      it('should return "To assess: Step 1" with warning color for candidates missing education assessment', () => {
+      it('should return "To assess" with warning color for candidates missing education assessment', () => {
         const chip = getCandidateStatusChip(
           {
             value: FinalDecision.ToAssess,
@@ -177,10 +177,10 @@ describe("PoolCandidate utils", () => {
           candidateFullyQualifiedExceptMissingEducation.assessmentStatus,
           intl,
         );
-        expect(chip.label).toBe("To assess: Step 1");
+        expect(chip.label).toBe("To assess");
         expect(chip.color).toBe("warning");
       });
-      it('should return "To assess: Step 1" with warning color for candidates with no assessments', () => {
+      it('should return "To assess" with warning color for candidates with no assessments', () => {
         const chip = getCandidateStatusChip(
           {
             value: FinalDecision.ToAssess,
@@ -191,10 +191,10 @@ describe("PoolCandidate utils", () => {
           candidateNoAssessments.assessmentStatus,
           intl,
         );
-        expect(chip.label).toBe("To assess: Step 1");
+        expect(chip.label).toBe("To assess");
         expect(chip.color).toBe("warning");
       });
-      it('should return "To assess: Step 3" with warning color for candidate qualified except for hold on final (third) step', () => {
+      it('should return "To assess" with warning color for candidate qualified except for hold on final (third) step', () => {
         const chip = getCandidateStatusChip(
           {
             value: FinalDecision.ToAssess,
@@ -205,10 +205,10 @@ describe("PoolCandidate utils", () => {
           candidateQualifiedExceptHoldOnFinalAssessment.assessmentStatus,
           intl,
         );
-        expect(chip.label).toBe("To assess: Step 3");
+        expect(chip.label).toBe("To assess:");
         expect(chip.color).toBe("warning");
       });
-      it('should return "To assess: Step 3" with warning color for candidate with incomplete final (third) step', () => {
+      it('should return "To assess" with warning color for candidate with incomplete final (third) step', () => {
         let chip = getCandidateStatusChip(
           {
             value: FinalDecision.ToAssess,
@@ -219,7 +219,7 @@ describe("PoolCandidate utils", () => {
           candidateHoldOnMiddleStepAndNoResultsOnFinalStep.assessmentStatus,
           intl,
         );
-        expect(chip.label).toBe("To assess: Step 3");
+        expect(chip.label).toBe("To assess");
         expect(chip.color).toBe("warning");
 
         chip = getCandidateStatusChip(
@@ -231,7 +231,7 @@ describe("PoolCandidate utils", () => {
           candidateUnfinishedFinalAssessment.assessmentStatus,
           intl,
         );
-        expect(chip.label).toBe("To assess: Step 3");
+        expect(chip.label).toBe("To assess");
         expect(chip.color).toBe("warning");
       });
       it('should return "Disqualified: Pending decision" with error color for candidate with any one unsuccessful step', () => {

--- a/apps/web/src/utils/poolCandidate.ts
+++ b/apps/web/src/utils/poolCandidate.ts
@@ -228,12 +228,7 @@ const computeInAssessmentStatusChip = (
   }
 
   return {
-    label:
-      intl.formatMessage(poolCandidateMessages.toAssess) +
-      intl.formatMessage(commonMessages.dividingColon) +
-      intl.formatMessage(poolCandidateMessages.assessmentStepNumber, {
-        stepNumber: currentStep,
-      }),
+    label: intl.formatMessage(poolCandidateMessages.toAssess),
     color: "warning",
   };
 };


### PR DESCRIPTION
🤖 Resolves #14384 

## 👋 Introduction

Removes the candidates current assessment step number from the candidate status chip.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to the candidates table `/admin/pool-candidates`
4. Confiorm the "To assess" chips under the "Final decision" column no longer display the users current step number

## 📸 Screenshot

<img width="617" height="296" alt="swappy-20250827_123952" src="https://github.com/user-attachments/assets/62fc21a1-f322-4878-a29c-18cef68020d5" />
