### PR TITLE
[Fix] Notification dialog, action dropdown z-index

### DIFF
--- a/apps/web/src/components/NotificationList/NotificationItem.tsx
+++ b/apps/web/src/components/NotificationList/NotificationItem.tsx
@@ -220,7 +220,7 @@ const NotificationItem = ({
                   )}
                 />
               </DropdownMenu.Trigger>
-              <DropdownMenu.Content align="end">
+              <DropdownMenu.Content align="end" className="z-[98]">
                 <DropdownMenu.Item asChild onSelect={toggleReadStatus}>
                   <Button mode="inline" block disabled={isTogglingReadStatus}>
                     {isUnread


### PR DESCRIPTION
🤖 Resolves #14371 

## 👋 Introduction

Fixes the notification dialog action dropdown by bumping its `z-index` one above the notification dialog.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as any role
3. Seed a notification or create one
    - I found a good way is to login as `admin@test.com` start the worker queue `make queue-work` and then download multiple users
4. Confirm the action dropdown is visible when invoked

## 📸 Screenshot

<img width="497" height="267" alt="swappy-20250827_124645" src="https://github.com/user-attachments/assets/1c8bc2a0-1a6a-4ef9-b33d-a72897973a0c" />
