### PR TITLE
[Copy] Updates work stream to be two words in English; consistent term in French

### DIFF
--- a/api/lang/en/headings.php
+++ b/api/lang/en/headings.php
@@ -120,7 +120,7 @@ return [
     'reference_id' => 'Reference ID',
     'description' => 'Description',
     'classification' => 'Classification',
-    'work_stream' => 'Workstream',
+    'work_stream' => 'Work stream',
     'role_type' => 'Type of role',
     'work_description' => 'Generic work description',
     'key_tasks_examples' => 'Key tasks – Examples',

--- a/api/lang/fr/headings.php
+++ b/api/lang/fr/headings.php
@@ -122,7 +122,7 @@ return [
     'reference_id' => 'Identifiant de référence',
     'description' => 'Description ',
     'classification' => 'Classification',
-    'work_stream' => 'Flux de travail',
+    'work_stream' => 'Volet de travail',
     'role_type' => 'Type de poste',
     'work_description' => 'Description générique du travail',
     'key_tasks_examples' => 'Tâches principales - Exemples',

--- a/api/tests/Feature/Generators/__snapshots__/JobPosterTemplateGeneratorTest__testJobPosterTemplateDocSnapshot__1.html
+++ b/api/tests/Feature/Generators/__snapshots__/JobPosterTemplateGeneratorTest__testJobPosterTemplateDocSnapshot__1.html
@@ -32,7 +32,7 @@ div > *:first-child {page-break-before: auto;}
 <p>Job title: Healthcare Practitioner (EN)</p>
 <p>Description: Incidunt at cumque cumque non dolores. Sint velit vel sit quisquam accusantium odio rerum. Eius pariatur eos nesciunt et accusamus. (EN)</p>
 <p>Classification: QZ-00</p>
-<p>Workstream: Deondre Walsh</p>
+<p>Work stream: Deondre Walsh</p>
 <p>Type of role: Individual contributor</p>
 <p>Generic work description: <a href="http://www.rolfson.com/enim-saepe-animi-eligendi-qui">View on GCPedia</a><a name="footnote-0"></a><a href="#note-1" class="NoteRef"><sup>1</sup></a></p>
 <p>Reference ID: labore_reiciendis_ut</p>


### PR DESCRIPTION
🤖 Resolves #14451.

## 👋 Introduction
This PR updates **Work stream** to be two words in English and to use the consistent term for its translation, **Volet de travail**, in French.

## 🧪 Testing

1. `make refresh-api; pnpm build:fresh`
2. Navigate to a job template in http://localhost:8000/en/job-templates
3. Download and verify the document contains Work stream and not Workstream
4. Switch to French
5. Download and verify the document contains Volet de travail and not Flux de travail
