### PR TITLE
[Fix] Remove edit link from admin career timeline section

### DIFF
--- a/apps/web/src/components/CareerTimelineSection/CareerTimelineSection.tsx
+++ b/apps/web/src/components/CareerTimelineSection/CareerTimelineSection.tsx
@@ -26,6 +26,7 @@ interface CareerTimelineSectionProps {
     typeof CareerTimelineSectionExperience_Fragment
   >[];
   editParam?: string;
+  showEdit?: boolean;
   headingLevel?: HeadingRank;
   userId?: string;
 }
@@ -34,6 +35,7 @@ const CareerTimelineSection = ({
   experiencesQuery,
   editParam,
   headingLevel = "h3",
+  showEdit = true,
   userId,
 }: CareerTimelineSectionProps) => {
   const intl = useIntl();
@@ -89,6 +91,7 @@ const CareerTimelineSection = ({
                 key={experience.id}
                 experienceQuery={experience}
                 editParam={editParam}
+                showEdit={showEdit}
               />
             ))
           ) : (

--- a/apps/web/src/pages/Users/AdminCareerExperiencePage/AdminCareerExperiencePage.tsx
+++ b/apps/web/src/pages/Users/AdminCareerExperiencePage/AdminCareerExperiencePage.tsx
@@ -77,6 +77,7 @@ const AdminCareerExperience = ({
             </p>
             <CareerTimelineSection
               experiencesQuery={unpackMaybes(experiences)}
+              showEdit={false}
             />
           </TableOfContents.Section>
         </TableOfContents.Content>


### PR DESCRIPTION
🤖 Resolves #14301 

## 👋 Introduction

Updates the admin user career timeline page to no longer show an edit link on the experience cards.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to the admin view of a users career timeline
4. Confirm the cards do no have an edit link

## 📸 Screenshot

<img width="1403" height="1261" alt="swappy-20250828_114307" src="https://github.com/user-attachments/assets/c98a854f-4884-4ce5-aa0a-5b81ca352151" />
