### PR TITLE
[Fix] Set signature default value on application review page

### DIFF
--- a/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
@@ -111,7 +111,9 @@ const ApplicationReview = ({ application }: ApplicationPageProps) => {
   const [{ fetching: mutating }, executeMutation] = useMutation(
     Application_SubmitMutation,
   );
-  const methods = useForm<FormValues>();
+  const methods = useForm<FormValues>({
+    defaultValues: { signature: application.signature ?? "" },
+  });
   const {
     formState: { isSubmitting },
   } = methods;


### PR DESCRIPTION
🤖 Resolves #13787 

## 👋 Introduction

Sets the signature default value on the application review page if a user navigates back to it after submission.

## 🕵️ Details

This is an interim solution untl we replace the applicatioin with some read-only view in the future.

REF: https://github.com/GCTC-NTGC/gc-digital-talent/issues/13787#issuecomment-3233830378

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as any user
3. Apply to a job
4. Navigate back to the review section
5. Confirm the signature field has your signature as a default value
    - NOTE: You still can;t re-submit but at least it shows all the relevant info now
