### PR TITLE
Add NEW_APPLICATION back to the status change dialog

### DIFF
--- a/apps/web/src/components/CandidateDialog/ChangeStatusDialog.tsx
+++ b/apps/web/src/components/CandidateDialog/ChangeStatusDialog.tsx
@@ -163,7 +163,6 @@ const ChangeStatusDialogForm = ({
     "DRAFT_EXPIRED",
     "DRAFT",
     "EXPIRED",
-    "NEW_APPLICATION",
     "PLACED_CASUAL",
     "PLACED_INDETERMINATE",
     "PLACED_TENTATIVE",


### PR DESCRIPTION
🤖 Resolves #14457

## 👋 Introduction

Adds NEW_APPLICATION back to the status change dialog.

## 🧪 Testing

1. Log in as one of the admin roles.
2. Navigate to a pool candidate evaluation.
3. Use the status dialog to change the status to NEW_APPLICATION.

## 📸 Screenshot

<img width="875" height="822" alt="image" src="https://github.com/user-attachments/assets/5f06c73c-3045-4d3d-bb8b-39d571a3ec5b" />

