### PR TITLE
[Fix] Hide remove candidate button when removed or disqualified 

### DIFF
--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/MoreActions.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/MoreActions.tsx
@@ -14,6 +14,7 @@ import { getFullNameLabel } from "~/utils/nameUtils";
 import useRoutes from "~/hooks/useRoutes";
 import JobPlacementDialog from "~/components/PoolCandidateDialogs/JobPlacementDialog";
 import {
+  isDisqualifiedStatus,
   isQualifiedStatus,
   isRemovedStatus,
   isRevertableStatus,
@@ -200,10 +201,12 @@ const MoreActions = ({
 
         <Card.Separator space="xs" />
 
-        <RemoveCandidateDialog
-          removalQuery={poolCandidate}
-          optionsQuery={data}
-        />
+        {!isRemovedStatus(status) && !isDisqualifiedStatus(status) && (
+          <RemoveCandidateDialog
+            removalQuery={poolCandidate}
+            optionsQuery={data}
+          />
+        )}
 
         <Link
           href={paths.userProfile(poolCandidate.user.id)}


### PR DESCRIPTION
🤖 Resolves #14450 

## 👋 Introduction

Fixes the candidate page to no longer show the dialog to remove a candidate when they have already been removed or disqualified from a process.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to a candidate
4. Remove them from the process
5. Confirm the button to remove dissapears
6. Reinstante the candidate
7. Disqualify them
8. Confirm the button to remove dissapears

## 📸 Screenshot

<img width="807" height="412" alt="swappy-20250828_142614" src="https://github.com/user-attachments/assets/d7137dcb-fa54-42c4-a4ff-e6a2f542c601" />
<img width="808" height="385" alt="swappy-20250828_142628" src="https://github.com/user-attachments/assets/44bc2e0a-6b8d-4e24-ac63-233cf068a333" />
