### PR TITLE
[Fix] `BigSeederPoolCandidateUser` creating duplicate assessment steps

### DIFF
--- a/api/database/factories/PoolFactory.php
+++ b/api/database/factories/PoolFactory.php
@@ -318,10 +318,15 @@ class PoolFactory extends Factory
     {
         return $this->afterCreating(function (Pool $pool, $noOfAssessmentSteps) {
             $steps = [];
-            $this->createAssessmentStepWithPoolSkills($pool, AssessmentStepType::SCREENING_QUESTIONS_AT_APPLICATION->name);
+
+            // Only select from steps that do not appear in the first two positions
+            // First position created automatically, second step should be created via `withQuestions`
+            $availableTypes = array_filter(array_column(AssessmentStepType::cases(), 'name'), function ($item) {
+                return $item !== AssessmentStepType::SCREENING_QUESTIONS_AT_APPLICATION->name;
+            });
 
             for ($i = 0; $i < $noOfAssessmentSteps - 1; $i++) {
-                $steps[$i] = $this->createAssessmentStepWithPoolSkills($pool, $this->faker->randomElement(array_column(AssessmentStepType::cases(), 'name'))->name);
+                $steps[$i] = $this->createAssessmentStepWithPoolSkills($pool, $this->faker->randomElement($availableTypes)->name);
             }
         });
     }


### PR DESCRIPTION
🤖 Resolves #14478 

## 👋 Introduction

Fixes an issue where the `PoolFactory` could create duplicate assessment steps that violate the unique constraint.

## 🕵️ Details

This was caused by a combination of two states `withQuestions` and `withAssessments`. Both of these methods were attempting to insert a screening question step at position 2. Since this is now a unique field, we can no longer do that.

To fix this, I simply prevented the `withAssessments` from creating any screening question types. If we want a screening question step, we should use `withQuestions`.

## 🧪 Testing

1. Run `make artisan CMD="db:seed --class=BigSeederPoolCandidateUser"`
2. Enter a large number
3. Confirm no unique constraint errors
