### PR TITLE
[Feat] Add off-platform recruitment processes section to admin user page

### DIFF
--- a/apps/web/src/components/RecruitmentProcesses/RecruitmentProcessesPreviewList.tsx
+++ b/apps/web/src/components/RecruitmentProcesses/RecruitmentProcessesPreviewList.tsx
@@ -1,7 +1,7 @@
 import { useIntl } from "react-intl";
 
 import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
-import { commonMessages } from "@gc-digital-talent/i18n";
+import { commonMessages, navigationMessages } from "@gc-digital-talent/i18n";
 import {
   Heading,
   PreviewList,
@@ -163,11 +163,9 @@ const RecruitmentProcessPreviewList = ({
       )}
       <div className="mt-6 border-t border-t-gray-300 pt-6">
         <Heading level="h3" className="mt-0 text-base font-bold lg:text-base">
-          {intl.formatMessage({
-            defaultMessage: "Off-platform recruitment processes",
-            id: "tpXtAJ",
-            description: "Off-platform section header",
-          })}
+          {intl.formatMessage(
+            navigationMessages.offPlatformRecruitmentProcesses,
+          )}
         </Heading>
         <p className="mb-6 text-sm text-gray-600 dark:text-gray-200">
           {intl.formatMessage({

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -12517,10 +12517,6 @@
     "defaultMessage": "Démontrée avec les expériences suivantes :",
     "description": "Lead in text for experiences that demonstrate minimum education experience"
   },
-  "tpXtAJ": {
-    "defaultMessage": "Processus hors plateforme",
-    "description": "Off-platform section header"
-  },
   "trerKD": {
     "defaultMessage": "Type",
     "description": "Button to filter experiences by type"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -10053,6 +10053,10 @@
     "defaultMessage": "Recherche de candidat",
     "description": "Title for the all pool candidates page"
   },
+  "i28Yrb": {
+    "defaultMessage": "Les processus de recrutement pour lesquels l'utilisateur a été qualifié sur d'autres plateformes du gouvernement du Canada. Il est à noter que ces renseignements sont fournis par l'utilisateur sans vérification. Veillez à vérifier la validité des renseignements relatifs au processus avant de les utiliser à des fins d'embauche ou de placement.",
+    "description": "Description of a users off-platform recruitment processes"
+  },
   "i2LB7R": {
     "defaultMessage": "Veuillez envoyer votre curriculum vitae et votre lettre de présentation expliquant votre passion pour la TI et pourquoi vous souhaitez vous joindre au programme, à : <mailLink>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</mailLink>. Un membre de l’équipe communiquera avec vous dans 5 à 10 jours ouvrables.",
     "description": "First paragraph for apply now dialog"

--- a/apps/web/src/pages/ApplicantDashboardPage/components/ReviewRecruitmentProcessPreviewList.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/ReviewRecruitmentProcessPreviewList.tsx
@@ -2,7 +2,7 @@ import { useIntl } from "react-intl";
 import { useQuery } from "urql";
 
 import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
-import { commonMessages } from "@gc-digital-talent/i18n";
+import { commonMessages, navigationMessages } from "@gc-digital-talent/i18n";
 import {
   Heading,
   Pending,
@@ -191,11 +191,9 @@ const ReviewRecruitmentProcessPreviewList = ({
       <Separator space="sm" />
       <Pending fetching={fetching} error={error} inline>
         <Heading level="h3" size="h6" className="mb-0.75 font-bold">
-          {intl.formatMessage({
-            defaultMessage: "Off-platform recruitment processes",
-            id: "tpXtAJ",
-            description: "Off-platform section header",
-          })}
+          {intl.formatMessage(
+            navigationMessages.offPlatformRecruitmentProcesses,
+          )}
         </Heading>
         <p className="mb-6 text-sm text-gray-600 dark:text-gray-200">
           {intl.formatMessage({

--- a/apps/web/src/pages/Users/AdminUserRecruitmentPage/AdminUserRecruitmentPage.tsx
+++ b/apps/web/src/pages/Users/AdminUserRecruitmentPage/AdminUserRecruitmentPage.tsx
@@ -29,12 +29,16 @@ import RecruitmentTools, {
   RECRUITMENT_TOOLS_ID,
   title as recruitmentToolsTitle,
 } from "./components/RecruitmentTools";
+import AdminOffPlatformRecruitmentProcesseses, {
+  OFF_PLATFORM_RECRUITMENT_PROCESSES_ID,
+} from "./components/OffPlatformRecruitmentProcesses";
 
 const AdminUserRecruitment_Fragment = graphql(/** GraphQL */ `
   fragment AdminUserRecruitment on User {
     id
     ...AdminRecruitmentProcesses
     ...RecruitmentTools
+    ...AdminOffPlatformRecruitmentProcesseses
   }
 `);
 
@@ -57,6 +61,15 @@ const AdminUserRecruitment = ({ query }: AdminUserRecruitmentProps) => {
               </TableOfContents.AnchorLink>
             </TableOfContents.ListItem>
             <TableOfContents.ListItem>
+              <TableOfContents.AnchorLink
+                id={OFF_PLATFORM_RECRUITMENT_PROCESSES_ID}
+              >
+                {intl.formatMessage(
+                  navigationMessages.offPlatformRecruitmentProcesses,
+                )}
+              </TableOfContents.AnchorLink>
+            </TableOfContents.ListItem>
+            <TableOfContents.ListItem>
               <TableOfContents.AnchorLink id={RECRUITMENT_TOOLS_ID}>
                 {intl.formatMessage(recruitmentToolsTitle)}
               </TableOfContents.AnchorLink>
@@ -67,6 +80,7 @@ const AdminUserRecruitment = ({ query }: AdminUserRecruitmentProps) => {
         </TableOfContents.Navigation>
         <TableOfContents.Content>
           <RecruitmentProcesses query={user} />
+          <AdminOffPlatformRecruitmentProcesseses query={user} />
           <RecruitmentTools query={user} />
         </TableOfContents.Content>
       </TableOfContents.Wrapper>

--- a/apps/web/src/pages/Users/AdminUserRecruitmentPage/AdminUserRecruitmentPage.tsx
+++ b/apps/web/src/pages/Users/AdminUserRecruitmentPage/AdminUserRecruitmentPage.tsx
@@ -29,7 +29,7 @@ import RecruitmentTools, {
   RECRUITMENT_TOOLS_ID,
   title as recruitmentToolsTitle,
 } from "./components/RecruitmentTools";
-import AdminOffPlatformRecruitmentProcesseses, {
+import AdminOffPlatformRecruitmentProcesses, {
   OFF_PLATFORM_RECRUITMENT_PROCESSES_ID,
 } from "./components/OffPlatformRecruitmentProcesses";
 
@@ -38,7 +38,7 @@ const AdminUserRecruitment_Fragment = graphql(/** GraphQL */ `
     id
     ...AdminRecruitmentProcesses
     ...RecruitmentTools
-    ...AdminOffPlatformRecruitmentProcesseses
+    ...AdminOffPlatformRecruitmentProcesses
   }
 `);
 
@@ -80,7 +80,7 @@ const AdminUserRecruitment = ({ query }: AdminUserRecruitmentProps) => {
         </TableOfContents.Navigation>
         <TableOfContents.Content>
           <RecruitmentProcesses query={user} />
-          <AdminOffPlatformRecruitmentProcesseses query={user} />
+          <AdminOffPlatformRecruitmentProcesses query={user} />
           <RecruitmentTools query={user} />
         </TableOfContents.Content>
       </TableOfContents.Wrapper>

--- a/apps/web/src/pages/Users/AdminUserRecruitmentPage/components/OffPlatformRecruitmentProcesses.tsx
+++ b/apps/web/src/pages/Users/AdminUserRecruitmentPage/components/OffPlatformRecruitmentProcesses.tsx
@@ -8,27 +8,27 @@ import { unpackMaybes } from "@gc-digital-talent/helpers";
 
 import OffPlatformRecruitmentProcessList from "~/components/RecruitmentProcesses/OffPlatformRecruitmentProcessList";
 
-const AdminOffPlatformRecruitmentProcesseses_Fragment = graphql(/** GraphQL */ `
-  fragment AdminOffPlatformRecruitmentProcesseses on User {
+const AdminOffPlatformRecruitmentProcesses_Fragment = graphql(/** GraphQL */ `
+  fragment AdminOffPlatformRecruitmentProcesses on User {
     offPlatformRecruitmentProcesses {
       ...OffPlatformRecruitmentProcessList
     }
   }
 `);
 
-interface AdminOffPlatformRecruitmentProcessesesProps {
-  query: FragmentType<typeof AdminOffPlatformRecruitmentProcesseses_Fragment>;
+interface AdminOffPlatformRecruitmentProcessesProps {
+  query: FragmentType<typeof AdminOffPlatformRecruitmentProcesses_Fragment>;
 }
 
 export const OFF_PLATFORM_RECRUITMENT_PROCESSES_ID =
-  "off-platform-recrtuiment-processes";
+  "off-platform-recruitment-processes";
 
-const AdminOffPlatformRecruitmentProcesseses = ({
+const AdminOffPlatformRecruitmentProcesses = ({
   query,
-}: AdminOffPlatformRecruitmentProcessesesProps) => {
+}: AdminOffPlatformRecruitmentProcessesProps) => {
   const intl = useIntl();
   const user = getFragment(
-    AdminOffPlatformRecruitmentProcesseses_Fragment,
+    AdminOffPlatformRecruitmentProcesses_Fragment,
     query,
   );
   const processes = unpackMaybes(user.offPlatformRecruitmentProcesses);
@@ -63,4 +63,4 @@ const AdminOffPlatformRecruitmentProcesseses = ({
   );
 };
 
-export default AdminOffPlatformRecruitmentProcesseses;
+export default AdminOffPlatformRecruitmentProcesses;

--- a/apps/web/src/pages/Users/AdminUserRecruitmentPage/components/OffPlatformRecruitmentProcesses.tsx
+++ b/apps/web/src/pages/Users/AdminUserRecruitmentPage/components/OffPlatformRecruitmentProcesses.tsx
@@ -1,0 +1,66 @@
+import GlobeAltIcon from "@heroicons/react/24/outline/GlobeAltIcon";
+import { useIntl } from "react-intl";
+
+import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
+import { navigationMessages } from "@gc-digital-talent/i18n";
+import { Card, TableOfContents } from "@gc-digital-talent/ui";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
+
+import OffPlatformRecruitmentProcessList from "~/components/RecruitmentProcesses/OffPlatformRecruitmentProcessList";
+
+const AdminOffPlatformRecruitmentProcesseses_Fragment = graphql(/** GraphQL */ `
+  fragment AdminOffPlatformRecruitmentProcesseses on User {
+    offPlatformRecruitmentProcesses {
+      ...OffPlatformRecruitmentProcessList
+    }
+  }
+`);
+
+interface AdminOffPlatformRecruitmentProcessesesProps {
+  query: FragmentType<typeof AdminOffPlatformRecruitmentProcesseses_Fragment>;
+}
+
+export const OFF_PLATFORM_RECRUITMENT_PROCESSES_ID =
+  "off-platform-recrtuiment-processes";
+
+const AdminOffPlatformRecruitmentProcesseses = ({
+  query,
+}: AdminOffPlatformRecruitmentProcessesesProps) => {
+  const intl = useIntl();
+  const user = getFragment(
+    AdminOffPlatformRecruitmentProcesseses_Fragment,
+    query,
+  );
+  const processes = unpackMaybes(user.offPlatformRecruitmentProcesses);
+
+  return (
+    <TableOfContents.Section
+      id={OFF_PLATFORM_RECRUITMENT_PROCESSES_ID}
+      className="mb-18"
+    >
+      <TableOfContents.Heading
+        icon={GlobeAltIcon}
+        color="secondary"
+        className="mt-0 mb-6"
+      >
+        {intl.formatMessage(navigationMessages.offPlatformRecruitmentProcesses)}
+      </TableOfContents.Heading>
+      <p className="my-6">
+        {intl.formatMessage({
+          defaultMessage:
+            "This is any information processes that this candidate has successfully qualified in on other Government of Canada platforms. This information is provided by the user without verification. Please ensure you verify the validity of process information before using it for hiring or placement purposes.",
+          id: "s4vPLC",
+          description:
+            "Description of a users off-platform recruitment processes",
+        })}
+      </p>
+      {processes.length > 0 ? (
+        <Card className="overflow-hidden p-0 [&>ul]:mb-0">
+          <OffPlatformRecruitmentProcessList processesQuery={processes} />
+        </Card>
+      ) : null}
+    </TableOfContents.Section>
+  );
+};
+
+export default AdminOffPlatformRecruitmentProcesseses;

--- a/apps/web/src/pages/Users/AdminUserRecruitmentPage/components/OffPlatformRecruitmentProcesses.tsx
+++ b/apps/web/src/pages/Users/AdminUserRecruitmentPage/components/OffPlatformRecruitmentProcesses.tsx
@@ -48,8 +48,8 @@ const AdminOffPlatformRecruitmentProcesses = ({
       <p className="my-6">
         {intl.formatMessage({
           defaultMessage:
-            "This is any information processes that this candidate has successfully qualified in on other Government of Canada platforms. This information is provided by the user without verification. Please ensure you verify the validity of process information before using it for hiring or placement purposes.",
-          id: "s4vPLC",
+            "Recruitment processes that the user has qualified in on other Government of Canada platforms. Note that this information is provided by the nominee without verification. Please ensure you verify the validity of process information before using it for hiring or placement purposes.",
+          id: "i28Yrb",
           description:
             "Description of a users off-platform recruitment processes",
         })}

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1599,6 +1599,10 @@
     "defaultMessage": "Renseignements manquants",
     "description": "Message displayed when a user has not provided some form of information"
   },
+  "tpXtAJ": {
+    "defaultMessage": "Processus hors plateforme",
+    "description": "Off-platform section header"
+  },
   "tyc8W0": {
     "defaultMessage": "(anglais)",
     "description": "Name of English language formatted for appending"

--- a/packages/i18n/src/messages/navigationMessages.ts
+++ b/packages/i18n/src/messages/navigationMessages.ts
@@ -227,6 +227,11 @@ const navigationMessages = defineMessages({
     id: "dVZjaj",
     description: "Name of the recruitment processes section",
   },
+  offPlatformRecruitmentProcesses: {
+    defaultMessage: "Off-platform recruitment processes",
+    id: "tpXtAJ",
+    description: "Off-platform section header",
+  },
 });
 
 export default navigationMessages;

--- a/packages/ui/src/components/TableOfContents/Section.tsx
+++ b/packages/ui/src/components/TableOfContents/Section.tsx
@@ -1,4 +1,7 @@
 import { HTMLAttributes } from "react";
+import { tv } from "tailwind-variants";
+
+const section = tv({ base: "outline-none" });
 
 export interface SectionProps {
   id: string;
@@ -7,13 +10,14 @@ export interface SectionProps {
 const Section = ({
   id,
   children,
+  className,
   ...rest
 }: SectionProps & HTMLAttributes<HTMLDivElement>) => (
   <div
     data-is-toc-section // Used to find section elements in the Navigation component
     id={id}
     tabIndex={-1}
-    className="outline-none"
+    className={section({ class: className })}
     {...rest}
   >
     {children}


### PR DESCRIPTION
🤖 Resolves #14383 

## 👋 Introduction

This adds the off-platform recruitment processes section to the admin user page.

## :de

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as admin `admin@test.com`
3. Add some off-platform processes
4. Navigate to the admin view of your own user
5. Navigate to the "Recruitment" tab
6. Confirm you see the new section and it matches the mockup

## 📸 Screenshot

<img width="1423" height="745" alt="swappy-20250829_145003" src="https://github.com/user-attachments/assets/3d662e06-4dbb-4979-8630-c08cd4b1ec23" />
