### PR TITLE
Make email columns case sensitive

### DIFF
--- a/api/database/migrations/2025_08_29_220331_make_email_columns_case_insensitive.php
+++ b/api/database/migrations/2025_08_29_220331_make_email_columns_case_insensitive.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::statement('CREATE EXTENSION IF NOT EXISTS citext');
+        DB::statement('ALTER TABLE users ALTER COLUMN email TYPE citext');
+        DB::statement('ALTER TABLE users ALTER COLUMN work_email TYPE citext');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('email')->nullable()->change();
+            $table->string('work_email')->nullable()->change();
+        });
+    }
+};


### PR DESCRIPTION
🤖 Resolves #13874.

## 👋 Introduction

Changes the email and work_email columns to the [citext](https://www.postgresql.org/docs/current/citext.html) type which is case insensitive.

## 🧪 Testing

1. Get a user with a capitalised email.
2. Attempt to set another users email to a lowercase version of that.
3. Confirm you get a uniqueness error.
4. Repeat for work emails.

## 🚚 Deployment

Any duplicate emails will need to be manually cleaned up **before** running the migration.
