### PR TITLE
[Feature] Update "Offer in progress" copy on job placement status dialog

### DIFF
--- a/api/lang/en/placement_type.php
+++ b/api/lang/en/placement_type.php
@@ -2,7 +2,7 @@
 
 return [
     'under_consideration' => 'Under consideration',
-    'placed_tentative' => 'Tentatively placed (Verbal or email confirmation)',
+    'placed_tentative' => 'Offer in progress',
     'placed_casual' => 'Placed casual',
     'placed_term' => 'Placed term',
     'placed_indeterminate' => 'Placed indeterminate',

--- a/api/lang/fr/placement_type.php
+++ b/api/lang/fr/placement_type.php
@@ -2,7 +2,7 @@
 
 return [
     'under_consideration' => 'En cours d’étude',
-    'placed_tentative' => 'En placement provisoire (confirmation verbale ou par courriel)',
+    'placed_tentative' => 'Offre en cours',
     'placed_casual' => 'Placé occasionnels',
     'placed_term' => 'Période déterminée',
     'placed_indeterminate' => 'Période indéterminée',

--- a/apps/web/src/components/PoolCandidateDialogs/JobPlacementForm.tsx
+++ b/apps/web/src/components/PoolCandidateDialogs/JobPlacementForm.tsx
@@ -81,6 +81,14 @@ const JobPlacementForm = ({ optionsQuery }: JobPlacementFormProps) => {
         ),
       };
     }
+    if (option.value === PlacementType.PlacedTentative.toString()) {
+      return {
+        ...option,
+        contentBelow: intl.formatMessage(
+          poolCandidateMessages.PlacedTentativeDesc,
+        ),
+      };
+    }
 
     return option;
   });

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4019,6 +4019,10 @@
     "defaultMessage": "Ministère de placement",
     "description": "Label for the placed department field"
   },
+  "G8P9fw": {
+    "defaultMessage": "En placement provisoire (confirmation verbale ou par courriel)",
+    "description": "Description for the offer in progress candidate placement type"
+  },
   "G9oyzn": {
     "defaultMessage": "Titre de l’évaluation",
     "description": "Label for assessment title input on the assessment details dialog"

--- a/apps/web/src/messages/poolCandidateMessages.ts
+++ b/apps/web/src/messages/poolCandidateMessages.ts
@@ -98,6 +98,12 @@ const messages = defineMessages({
     description:
       "Description for the under consideration candidate placement type",
   },
+  PlacedTentativeDesc: {
+    defaultMessage: "Tentatively placed (verbal or email confirmation)",
+    id: "G8P9fw",
+    description:
+      "Description for the offer in progress candidate placement type",
+  },
 });
 
 export default messages;


### PR DESCRIPTION
🤖 Resolves #14088

## 👋 Introduction

This PR updates the radio choice label in the job placement status dialog to match the sidebar `Offer in progress`

## 🕵️ Details

The sidebar is currently showing `Offer in progress` but the dialog displays `Tentatively placed (verbal or email confirmation)` This PR updates the radio choice label to match the sidebar. 


## 🧪 Testing

1. Build app
2. Login in as `admin`
3. Navigate to `/pool-candidates` and select a candidate
4. In the sidebar open the status dialogue from the Job placement field
5. Confirm that the option now displays:
    - Label: `Offer in progress` 
    - subtitle `Tentatively placed (verbal or email confirmation)` 
6. Confirm updates appear correctly in French

## 📸 Screenshot

<img width="601" height="437" alt="image" src="https://github.com/user-attachments/assets/22b6f8a9-cb71-4a74-acf4-130a5a153d27" />

<img width="581" height="436" alt="image" src="https://github.com/user-attachments/assets/2a976754-de55-4fcb-8349-ddf0f956f509" />


