### PR TITLE
[Fix] Employee profile heading size

### DIFF
--- a/apps/web/src/pages/Users/UserEmployeeInformationPage/UserEmployeeInformationPage.tsx
+++ b/apps/web/src/pages/Users/UserEmployeeInformationPage/UserEmployeeInformationPage.tsx
@@ -147,6 +147,7 @@ export const UserEmployeeInformation = ({
           <TableOfContents.Section id={SECTION_ID.COMMUNITY_INTEREST}>
             <Heading
               level="h2"
+              size="h3"
               icon={FlagIcon}
               color="secondary"
               center
@@ -203,6 +204,7 @@ export const UserEmployeeInformation = ({
           <TableOfContents.Section id={SECTION_ID.CAREER_PLANNING}>
             <Heading
               level="h2"
+              size="h3"
               icon={ChartBarSquareIcon}
               color="secondary"
               className="mt-0 font-normal sm:justify-start sm:text-left"

--- a/apps/web/src/pages/Users/UserEmployeeInformationPage/UserEmployeeInformationPage.tsx
+++ b/apps/web/src/pages/Users/UserEmployeeInformationPage/UserEmployeeInformationPage.tsx
@@ -150,7 +150,6 @@ export const UserEmployeeInformation = ({
               size="h3"
               icon={FlagIcon}
               color="secondary"
-              center
               className="mt-0 font-normal sm:justify-start sm:text-left"
             >
               {intl.formatMessage(commonMessages.communityInterest)}


### PR DESCRIPTION
🤖 Resolves #14502.

## 👋 Introduction

This PR fixes the employee profile heading size to be the same as other sections.

## 🕵️ Details

It also removes `center` attribute to that didn't match other headings on the same page.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to a user profile
3. Verify heading sizes match other tabs headings sizes
