### PR TITLE
[Feat] Add divider component for cards

### DIFF
--- a/packages/ui/src/components/Card/Card.stories.tsx
+++ b/packages/ui/src/components/Card/Card.stories.tsx
@@ -43,3 +43,55 @@ export const Default: StoryObj<typeof Card> = {
     </div>
   ),
 };
+
+export const WithGrid: StoryObj<typeof Card> = {
+  render: (args) => (
+    <div className="flex flex-col gap-y-6">
+      <Card space="sm" {...args}>
+        <Card.Grid columns={2}>
+          <Card.GridItem>
+            <p>Small space: {faker.lorem.paragraph()}</p>
+          </Card.GridItem>
+          <Card.GridItem>
+            <p>2 columns: {faker.lorem.paragraph()}</p>
+          </Card.GridItem>
+        </Card.Grid>
+        <Card.Separator className="my-4" />
+        <p>{faker.lorem.paragraph()}</p>
+      </Card>
+      <Card space="md" {...args}>
+        <Card.Grid columns={3}>
+          <Card.GridItem>
+            <p>Medium space: {faker.lorem.paragraph()}</p>
+          </Card.GridItem>
+          <Card.GridItem>
+            <p>3 columns: {faker.lorem.paragraph()}</p>
+          </Card.GridItem>
+          <Card.GridItem>
+            <p>{faker.lorem.paragraph()}</p>
+          </Card.GridItem>
+        </Card.Grid>
+        <Card.Separator className="my-4" />
+        <p>{faker.lorem.paragraph()}</p>
+      </Card>
+      <Card space="lg" {...args}>
+        <Card.Grid columns={4}>
+          <Card.GridItem>
+            <p>Large space: {faker.lorem.paragraph()}</p>
+          </Card.GridItem>
+          <Card.GridItem>
+            <p>4 columns: {faker.lorem.paragraph()}</p>
+          </Card.GridItem>
+          <Card.GridItem>
+            <p>{faker.lorem.paragraph()}</p>
+          </Card.GridItem>
+          <Card.GridItem>
+            <p>{faker.lorem.paragraph()}</p>
+          </Card.GridItem>
+        </Card.Grid>
+        <Card.Separator className="my-4" />
+        <p>{faker.lorem.paragraph()}</p>
+      </Card>
+    </div>
+  ),
+};

--- a/packages/ui/src/components/Card/Card.stories.tsx
+++ b/packages/ui/src/components/Card/Card.stories.tsx
@@ -71,7 +71,7 @@ export const WithGrid: StoryObj<typeof Card> = {
             <p>{faker.lorem.paragraph()}</p>
           </Card.GridItem>
         </Card.Grid>
-        <Card.Separator className="my-4" />
+        <Card.Separator className="my-6" />
         <p>{faker.lorem.paragraph()}</p>
       </Card>
       <Card space="lg" {...args}>
@@ -89,7 +89,7 @@ export const WithGrid: StoryObj<typeof Card> = {
             <p>{faker.lorem.paragraph()}</p>
           </Card.GridItem>
         </Card.Grid>
-        <Card.Separator className="my-4" />
+        <Card.Separator className="my-6 sm:my-9" />
         <p>{faker.lorem.paragraph()}</p>
       </Card>
     </div>

--- a/packages/ui/src/components/Card/Card.tsx
+++ b/packages/ui/src/components/Card/Card.tsx
@@ -3,15 +3,16 @@ import { tv, VariantProps } from "tailwind-variants";
 
 import Separator from "../Separator";
 import { SeparatorProps } from "../Separator/Separator";
+import { Grid, GridItem } from "./CardGrid";
 
 const card = tv({
   base: "rounded-md bg-white text-black shadow-xl dark:bg-gray-600 dark:text-white",
   variants: {
     space: {
-      xs: "p-3 [&>.CardSeparator]:-mx-3",
-      sm: "p-4 [&>.CardSeparator]:-mx-4",
-      md: "p-6 [&>.CardSeparator]:-mx-6",
-      lg: "p-6 sm:p-9 [&>.CardSeparator]:-mx-6 sm:[&>.CardSeparator]:-mx-9",
+      xs: "p-3",
+      sm: "p-4",
+      md: "p-6",
+      lg: "p-6 sm:p-9",
     },
   },
 });
@@ -26,15 +27,25 @@ export interface CardProps
 
 const Card = ({ as = "div", space = "md", className, ...rest }: CardProps) => {
   const El = as;
-  return <El className={card({ space, class: className })} {...rest} />;
+  return (
+    <El
+      className={card({
+        space,
+        class: [className, `group Card--${space}`],
+      })}
+      {...rest}
+    />
+  );
 };
 
 const CardSeparator = (props: SeparatorProps) => (
-  <div className="CardSeparator">
+  <div className="group-[.Card--lg]:-mx-6 group-[.Card--md]:-mx-6 group-[.Card--sm]:-mx-4 group-[.Card--xs]:-mx-3 group-[.Card--lg]:sm:-mx-9">
     <Separator decorative orientation="horizontal" space="none" {...props} />
   </div>
 );
 
 Card.Separator = CardSeparator;
+Card.Grid = Grid;
+Card.GridItem = GridItem;
 
 export default Card;

--- a/packages/ui/src/components/Card/CardGrid.tsx
+++ b/packages/ui/src/components/Card/CardGrid.tsx
@@ -22,7 +22,7 @@ const grid = tv({
 
 type GridVariants = VariantProps<typeof grid>;
 
-export type GridProps<T extends keyof JSX.IntrinsicElements = "div"> =
+type GridProps<T extends keyof JSX.IntrinsicElements = "div"> =
   PolymorphicProps<T, GridVariants & { className?: string }>;
 
 export const Grid = ({
@@ -44,7 +44,7 @@ const item = tv({
   base: "bg-white group-[.Card--lg]:p-6 group-[.Card--md]:p-6 group-[.Card--sm]:p-4 group-[.Card--xs]:p-3 group-[.Card--lg]:sm:p-9 dark:bg-gray-600",
 });
 
-export type GridItemProps<T extends keyof JSX.IntrinsicElements = "div"> =
+type GridItemProps<T extends keyof JSX.IntrinsicElements = "div"> =
   PolymorphicProps<T, { className?: string }>;
 
 export const GridItem = ({

--- a/packages/ui/src/components/Card/CardGrid.tsx
+++ b/packages/ui/src/components/Card/CardGrid.tsx
@@ -5,7 +5,7 @@ import { PolymorphicProps } from "../../types";
 
 const grid = tv({
   base: [
-    "grid divide-y divide-gray-300 overflow-hidden sm:divide-x",
+    "grid gap-px overflow-hidden bg-gray",
     "group-[.Card--lg]:-m-6 group-[.Card--md]:-m-6 group-[.Card--sm]:-m-4 group-[.Card--xs]:-m-3 group-[.Card--lg]:sm:-m-9",
   ],
   variants: {
@@ -41,7 +41,7 @@ export const Grid = ({
 };
 
 const item = tv({
-  base: "group-[.Card--lg]:p-6 group-[.Card--md]:p-6 group-[.Card--sm]:p-4 group-[.Card--xs]:p-3 group-[.Card--lg]:sm:p-9",
+  base: "bg-white group-[.Card--lg]:p-6 group-[.Card--md]:p-6 group-[.Card--sm]:p-4 group-[.Card--xs]:p-3 group-[.Card--lg]:sm:p-9 dark:bg-gray-600",
 });
 
 export type GridItemProps<T extends keyof JSX.IntrinsicElements = "div"> =

--- a/packages/ui/src/components/Card/CardGrid.tsx
+++ b/packages/ui/src/components/Card/CardGrid.tsx
@@ -5,13 +5,13 @@ import { PolymorphicProps } from "../../types";
 
 const grid = tv({
   base: [
-    "grid divide-y divide-gray-300 overflow-hidden sm:divide-x sm:divide-y-0",
+    "grid divide-y divide-gray-300 overflow-hidden sm:divide-x",
     "group-[.Card--lg]:-m-6 group-[.Card--md]:-m-6 group-[.Card--sm]:-m-4 group-[.Card--xs]:-m-3 group-[.Card--lg]:sm:-m-9",
   ],
   variants: {
     columns: {
       2: "grid-cols-1 sm:grid-cols-2",
-      3: "grid-cols-1 sm:grid-cols-2 md:grid-cols-3",
+      3: "grid-cols-1 sm:grid-cols-3",
       4: "grid-cols-1 sm:grid-cols-2 md:grid-cols-4",
     },
   },

--- a/packages/ui/src/components/Card/CardGrid.tsx
+++ b/packages/ui/src/components/Card/CardGrid.tsx
@@ -1,0 +1,62 @@
+import { JSX } from "react";
+import { tv, VariantProps } from "tailwind-variants";
+
+import { PolymorphicProps } from "../../types";
+
+const grid = tv({
+  base: [
+    "grid divide-y divide-gray-300 overflow-hidden sm:divide-x sm:divide-y-0",
+    "group-[.Card--lg]:-m-6 group-[.Card--md]:-m-6 group-[.Card--sm]:-m-4 group-[.Card--xs]:-m-3 group-[.Card--lg]:sm:-m-9",
+  ],
+  variants: {
+    columns: {
+      2: "grid-cols-1 sm:grid-cols-2",
+      3: "grid-cols-1 sm:grid-cols-2 md:grid-cols-3",
+      4: "grid-cols-1 sm:grid-cols-2 md:grid-cols-4",
+    },
+  },
+  defaultVariants: {
+    columns: 3,
+  },
+});
+
+type GridVariants = VariantProps<typeof grid>;
+
+export type GridProps<T extends keyof JSX.IntrinsicElements = "div"> =
+  PolymorphicProps<T, GridVariants & { className?: string }>;
+
+export const Grid = ({
+  as = "div",
+  columns,
+  className,
+  children,
+  ...rest
+}: GridProps) => {
+  const El = as;
+  return (
+    <El className={grid({ columns, class: className })} {...rest}>
+      {children}
+    </El>
+  );
+};
+
+const item = tv({
+  base: "group-[.Card--lg]:p-6 group-[.Card--md]:p-6 group-[.Card--sm]:p-4 group-[.Card--xs]:p-3 group-[.Card--lg]:sm:p-9",
+});
+
+export type GridItemProps<T extends keyof JSX.IntrinsicElements = "div"> =
+  PolymorphicProps<T, { className?: string }>;
+
+export const GridItem = ({
+  as = "div",
+  className,
+  children,
+  ...rest
+}: GridItemProps) => {
+  const El = as;
+  return (
+    <El className={item({ class: className })} {...rest}>
+      {children}
+    </El>
+  );
+};

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -4,6 +4,7 @@ import {
   RefAttributes,
   ElementType,
   ForwardRefExoticComponent,
+  JSX,
 } from "react";
 
 export type Color =
@@ -31,3 +32,9 @@ export type IconProps = PropsWithoutRef<SVGProps<SVGSVGElement>> & {
 export type IconType =
   | ElementType<IconProps>
   | ForwardRefExoticComponent<IconProps>;
+
+type PropsOf<T extends keyof JSX.IntrinsicElements> = JSX.IntrinsicElements[T];
+export type PolymorphicProps<
+  T extends keyof JSX.IntrinsicElements,
+  P = object,
+> = P & { as?: T } & Omit<PropsOf<T>, keyof P | "as">;


### PR DESCRIPTION
🤖 Resolves #14547 

## 👋 Introduction

Adds the ability to add a grid to a `Card` component with sub component sof `Card.Grid` and `Card.GridItem`

## 🕵️ Details

This inherits the space from the card like the separator (which was hopefully the correct design decision). 

### Usage

```
<Card space="md">
  <Card.Grid coloums={2}>
     <Card.GridItem>...</Card.GridItem>
     <Card.GridItem>...</Card.GridItem>
     <Card.GridItem>...</Card.GridItem>
     <Card.GridItem>...</Card.GridItem>
  </Card.Grid>
  <Card.Separator />
  <p>Some footer content</p>
</Card>
```

## 🧪 Testing

1. Run storybook `pnpm storybook`
2. Confirm the component matches [the mockup](https://www.figma.com/design/ToAqDP2DsrAOaNJPh4qsF9/Digital-careers-at-National-Defence--All-users-?node-id=110-4200&m=dev)

## 📸 Screenshot

<img width="1272" height="581" alt="swappy-20250905_113100" src="https://github.com/user-attachments/assets/96e55b82-d906-4bb4-bd3f-a6e788fac6d6" />
