### PR TITLE
[Feature] Allows `CommunityAdmin` to edit published pool

### DIFF
--- a/apps/web/src/hooks/useCanUserEditPool.ts
+++ b/apps/web/src/hooks/useCanUserEditPool.ts
@@ -11,7 +11,7 @@ const useCanUserEditPool = (status?: Maybe<PoolStatus>) => {
 
   if (status === PoolStatus.Published) {
     return checkRole(
-      [ROLE_NAME.PlatformAdmin],
+      [ROLE_NAME.CommunityAdmin, ROLE_NAME.PlatformAdmin],
       unpackMaybes(userAuthInfo?.roleAssignments),
     );
   }


### PR DESCRIPTION
🤖 Resolves #14495.

## 👋 Introduction

This PR allows users with the community admin role to update some fields of a published process.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to a published process associated with a community that the user is a community admin in
3. Edit special note
4. Verify special note can be saved
5. Navigate to a published process associated with a community that the user is a not a community admin in (but is a community recruiter or community talent coordinator)
6. Edit special note
4. Verify special note cannot be saved and unauthorized toast is returned