### PR TITLE
[Debt] Update pool candidate breadcrumbs

### DIFF
--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -11,7 +11,7 @@ import {
   Chip,
   Chips,
 } from "@gc-digital-talent/ui";
-import { commonMessages } from "@gc-digital-talent/i18n";
+import { commonMessages, navigationMessages } from "@gc-digital-talent/i18n";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 import {
   User,
@@ -179,8 +179,8 @@ export const ViewPoolCandidate = ({
         url: paths.poolView(poolCandidate.pool.id),
       },
       {
-        label: intl.formatMessage(screeningAndAssessmentTitle),
-        url: paths.screeningAndEvaluation(poolCandidate.pool.id),
+        label: intl.formatMessage(navigationMessages.candidates),
+        url: paths.poolCandidateTable(poolCandidate.pool.id),
       },
       {
         label: candidateName,


### PR DESCRIPTION
🤖 Resolves #14501 

## 👋 Introduction

Updates the pool candidate page breadcrumbs, replacing the screening and assessment breadcrumb to be one to the process candidates table.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to a pool candidate `/admin/pools/{id}/pool-candidates`
4. Confirm there is no longer a "Screning and assessment" breadcrumb
5. Confirm there is one labelled "Candidates" in place of it
6. Confitm it links to the candidates table for the process the user applied to

## 📸 Screenshot

<img width="1288" height="351" alt="swappy-20250908_144538" src="https://github.com/user-attachments/assets/ce63fc44-11a8-428e-93c0-f32411d8e025" />
