### PR TITLE
Add a work stream to a work experience e2e test

### DIFF
--- a/apps/playwright/fixtures/ExperiencePage.ts
+++ b/apps/playwright/fixtures/ExperiencePage.ts
@@ -101,6 +101,21 @@ class ExperiencePage extends AppPage {
       .getByRole("textbox", { name: /additional details/i })
       .fill(input.details ?? "test details");
 
+    await this.page.getByRole("button", { name: /add work streams/i }).click();
+
+    await this.page
+      .getByRole("combobox", { name: /functional communities/i })
+      .selectOption({ label: "Digital Community" });
+
+    await this.page
+      .getByRole("group", { name: /work streams/i })
+      .getByRole("checkbox", {
+        name: /security/i,
+      })
+      .click();
+
+    await this.page.getByRole("button", { name: /add work streams/i }).click();
+
     await this.save();
     await this.waitForGraphqlResponse("CreateWorkExperience");
   }


### PR DESCRIPTION
🤖 Resolves #13632

## 👋 Introduction

Updates one of the work experience e2e tests to include adding a work stream.

## 🧪 Testing

1. Confirm e2e tests pass in CI.
2. Confirm e2e tests pass locally.