### PR TITLE
[Fix] Stabilize compute final decision test

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -590,7 +590,7 @@ class PoolCandidate extends Model
         };
 
         $assessmentStatus = $this->computed_assessment_status;
-        $currentStep = $this->assessmentStep?->sort_order;
+        $currentStep = $this->assessmentStep->sort_order ?? 0;
 
         if ($decision === FinalDecision::TO_ASSESS->name && $currentStep) {
             $weight = $weight + $currentStep * 10;

--- a/api/tests/Feature/CandidateFinalDecisionTest.php
+++ b/api/tests/Feature/CandidateFinalDecisionTest.php
@@ -44,7 +44,11 @@ class CandidateFinalDecisionTest extends TestCase
      */
     public function testFinalDecisionComputation($status, $expected): void
     {
+        $step = $this->candidate->pool->assessmentSteps->firstWhere('sort_order', 1);
+        $this->candidate->assessment_step_id = $step->id;
         $this->candidate->pool_candidate_status = $status;
+        $this->candidate->save();
+        $this->candidate->refresh();
         $decision = $this->candidate->computeFinalDecision();
         $this->assertEquals($expected, $decision);
     }


### PR DESCRIPTION
🤖 Resolves #14554 

## 👋 Introduction

Makes some changes to the setup of the final decision test in an attempt to stabilize it.

## 🕵️ Details

I believe this test was flaky because the factory could create a candidate who has no assessment step set. This attempts to address that by manually setting it to the first step and then refreshes the candidate before computing the decision. This should help keep the candidate the same across tests.

## 🧪 Testing

```sh
make artisan CMD="test --filter=testFinalDecisionComputation"
```

1. Run the test multiple times (try 20+)
2. Confirm it consistently passes