### PR TITLE
[Fix] Close notification dialog on click

### DIFF
--- a/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
+++ b/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
@@ -39,11 +39,15 @@ const NotificationCount_Query = graphql(/* GraphQL */ `
   }
 `);
 
-const DialogPortalWithPresence = ({
-  executeQuery,
-}: {
+interface DialogPortalWithPresenceProps {
+  onClose: () => void;
   executeQuery: UseQueryExecute;
-}) => {
+}
+
+const DialogPortalWithPresence = ({
+  onClose,
+  executeQuery,
+}: DialogPortalWithPresenceProps) => {
   const intl = useIntl();
   const paths = useRoutes();
   const [isPresent] = usePresence();
@@ -68,6 +72,11 @@ const DialogPortalWithPresence = ({
     if (containerRef?.current) {
       containerRef.current.scrollTop = 0;
     }
+  };
+
+  const handleRead = () => {
+    onClose();
+    executeQuery();
   };
 
   return render ? (
@@ -127,7 +136,7 @@ const DialogPortalWithPresence = ({
               })}
             </DialogPrimitive.Description>
           </div>
-          <NotificationList live inDialog limit={30} onRead={executeQuery} />
+          <NotificationList live inDialog limit={30} onRead={handleRead} />
           <p className="m-6">
             <DialogPrimitive.Close asChild>
               <Link href={paths.notifications()} mode="solid" color="primary">
@@ -248,7 +257,12 @@ const NotificationDialog = ({
       )}
 
       <AnimatePresence initial={false}>
-        {open && <DialogPortalWithPresence executeQuery={executeQuery} />}
+        {open && (
+          <DialogPortalWithPresence
+            executeQuery={executeQuery}
+            onClose={() => onOpenChange?.(false)}
+          />
+        )}
       </AnimatePresence>
     </Dialog.Root>
   );


### PR DESCRIPTION
🤖 Resolves #12767 

## 👋 Introduction

Updates the notification dialog to have it close when a user clicks on a link in the dialog.

## 🕵️ Details

This bubbles on the `onRead` prop from the notification dialog so that it can be closed after a click event.

## 🧪 Testing

```sh
make artisan CMD="send-notifications:system notification_location_preferences_update admin@test.com --channelApp"
```

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Trigger a notification witht he command provided
4. Open the dialog and activate the link for the notification
5. Confirm the dialog closes
