### PR TITLE
[Fix] Adds a space in the pool title between classification plus level and work stream name

### DIFF
--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -137,7 +137,7 @@ export const formattedPoolPosterTitle = ({
       <>
         {title ?? ""} <span>{UNICODE_CHAR.LEFT_PAREN}</span>
         {wrapAbbr(groupAndLevel, intl)}
-        {streamString ?? <span className="m1-1">{streamString}</span>}
+        {streamString && ` ${streamString}`}
         <span>{UNICODE_CHAR.RIGHT_PAREN}</span>
       </>
     ),


### PR DESCRIPTION
🤖 Resolves #14595.

## 👋 Introduction

This PR fixes a missing space in the pool title between classification plus level and work stream name.

## 🕵️ Details

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to browse jobs page
3. Apply to a job
4. Verify pool title has space between classification plus level and work stream name

## 📸 Screenshot

<img width="1382" height="532" alt="Screenshot 2025-09-11 at 15 32 35" src="https://github.com/user-attachments/assets/5082e6a3-987d-42c2-a027-44873ded9664" />