### PR TITLE
[Fix] Fixes screening dialog appearing for behavioural skills on appication screening

### DIFF
--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialog.tsx
@@ -8,6 +8,7 @@ import {
   graphql,
   Maybe,
   Scalars,
+  SkillCategory,
   User,
 } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
@@ -52,6 +53,9 @@ export const ScreeningDecisionDialog_Fragment = graphql(/** GraphQL */ `
           id
           skill {
             id
+            category {
+              value
+            }
           }
           ...ScreeningTriggerPoolSkill
           ...ScreeningDialogHeaderPoolSkill
@@ -121,9 +125,18 @@ const ScreeningDecisionDialog = ({
     candidateId: candidate.id,
   });
 
+  /**
+   * Criteria for not showing the dialog:
+   *   1. Education requirement and not application screening
+   *   2. Behavioural skill and is application screening
+   *   3. No pool skill and is application screening
+   */
   if (
-    dialogType === DIALOG_TYPE.Education &&
-    step?.type?.value !== AssessmentStepType.ApplicationScreening
+    (dialogType === DIALOG_TYPE.Education &&
+      step?.type?.value !== AssessmentStepType.ApplicationScreening) ||
+    (step?.type?.value === AssessmentStepType.ApplicationScreening &&
+      poolSkill?.skill?.category.value === SkillCategory.Behavioural) ||
+    (!poolSkill && dialogType !== DIALOG_TYPE.Education)
   ) {
     return null;
   }


### PR DESCRIPTION
🤖 Resolves #14591 

## 👋 Introduction

Fixes an issue where the screening dialog was incorrectly displaying the screening dialog for behavioural skills on the application screening step.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Create a pool with a few behavioural skills both asset and essential
3. Apply to that pool
4. Navigate to the application
5. Confirm the screening dialog trigger does not appear for those bejvioural skills on the applicatino screeing column

## 📸 Screenshot

<img width="2529" height="565" alt="swappy-20250912_091345" src="https://github.com/user-attachments/assets/4cf6468e-696f-49b5-8852-c547b8876439" />

