### PR TITLE
[Fix] Storybook watch mode

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -35,14 +35,6 @@ const main: StorybookConfig = {
     const { mergeConfig } = await import("vite");
     return mergeConfig(config, {
       plugins: [
-        ...(config.plugins ?? []).filter(
-          (plugin) =>
-            plugin &&
-            "name" in plugin &&
-            // Filter out git version plugin to hardcode for
-            // Stable snapshots
-            plugin.name !== "git-version",
-        ),
         // Weird thing to get tailwind working with storybook
         (await import("@tailwindcss/vite")).default(),
       ],


### PR DESCRIPTION
🤖 Resolves #14631.

## 👋 Introduction

This PR removes filter for `git-version` plugin to fix storybook watch mode.

## 🧪 Testing

1. `pnpm storybook`
2. Verify stories render
3. `pnpm build-storybook; npx http-server storybook-static -o`
4. Verify stories build and render