### PR TITLE
[Feature] Adds ability to control `meta.url`

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -2,12 +2,11 @@ API_HOST="http://localhost:8000"
 # Vite requires build-time variable to have the VITE_ prefix
 VITE_API_URI="/graphql"
 VITE_API_PROTECTED_URI="/admin/graphql"
-
 # Controls meta data for the app (used in vite.config.ts)
-# APP_URL=
-# APP_TITLE=
-# APP_DESCRIPTION=
-# APP_DOMAIN=
+# VITE_APP_URL=
+# VITE_APP_TITLE=
+# VITE_APP_DESCRIPTION=
+# VITE_APP_DOMAIN=
 
 OAUTH_POST_LOGOUT_REDIRECT_EN="http://localhost:8000/en/logged-out"
 OAUTH_POST_LOGOUT_REDIRECT_FR="http://localhost:8000/fr/logged-out"

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -10,7 +10,7 @@ import { defineConfig } from "vite";
 
 dotenv.config({ path: "./.env", quiet: true });
 
-const appUrl = "https://talent.canada.ca";
+const appUrl = process.env.APP_URL ?? "https://talent.canada.ca";
 
 const meta = {
   type: "website",

--- a/infrastructure/azure-pipelines.yml
+++ b/infrastructure/azure-pipelines.yml
@@ -50,6 +50,10 @@ jobs:
           # Vite requires build-time variable to have the VITE_ prefix
           VITE_API_URI: /graphql
           VITE_API_PROTECTED_URI: /admin/graphql
+          VITE_APP_URL:
+          VITE_APP_TITLE:
+          VITE_APP_DESCRIPTION:
+          VITE_APP_DOMAIN:
 
       - task: CopyFiles@2
         displayName: "Copy files to staging directory"


### PR DESCRIPTION
🤖 Resolves #9206.

## 👋 Introduction

This PR adds the ability to control `meta.url` via environment variables.

## 🧪 Testing

1. In `apps/web/.env`, set `APP_URL="http://cowabunga:8000"`
2. `pnpm build:fresh`
3. Navigate to view-source:http://localhost:8000/
4. Verify `meta property="og:url"` `content` attribute value is http://cowabunga:8000



## 📸 Screenshot

<img width="574" height="108" alt="Screenshot 2025-09-16 at 11 20 31" src="https://github.com/user-attachments/assets/c8d9af93-32d9-404d-8618-871ffd06a714" />


## 🚚 Deployment

- For each vertical, set the appropriate value for `process.env.APP_URL` (production doesn't need to be set as the fallback is the correct production value)