### PR TITLE
[Feature] Hides screening assessment page

### DIFF
--- a/apps/playwright/tests/admin/accessibility.spec.ts
+++ b/apps/playwright/tests/admin/accessibility.spec.ts
@@ -10,19 +10,4 @@ test.describe("Admin accessibility", () => {
     const accessibilityScanResults = await makeAxeBuilder().analyze();
     expect(accessibilityScanResults.violations).toEqual([]);
   });
-
-  test("Assessment step tracker", async ({ appPage, makeAxeBuilder }) => {
-    await loginBySub(appPage.page, "admin@test.com", false);
-    await appPage.page.goto("/en/admin/pools");
-    await appPage.page
-      .getByRole("link", { name: /cmo digital careers/i })
-      .click();
-    await appPage.page
-      .getByRole("link", { name: /screening and assessment/i })
-      .click();
-    await appPage.waitForGraphqlResponse("ScreeningAndEvaluation_Candidates");
-
-    const accessibilityScanResults = await makeAxeBuilder().analyze();
-    expect(accessibilityScanResults.violations).toEqual([]);
-  });
 });

--- a/apps/web/src/components/Router.tsx
+++ b/apps/web/src/components/Router.tsx
@@ -780,13 +780,6 @@ const createRoute = (locale: Locales) =>
                           ],
                         },
                         {
-                          path: "screening",
-                          lazy: () =>
-                            import(
-                              "../pages/Pools/ScreeningAndEvaluationPage/ScreeningAndEvaluationPage"
-                            ),
-                        },
-                        {
                           path: "manage-access",
                           lazy: () =>
                             import(

--- a/apps/web/src/hooks/useRoutes.ts
+++ b/apps/web/src/hooks/useRoutes.ts
@@ -78,8 +78,6 @@ const getRoutes = (lang: Locales) => {
       [adminUrl, "pools", poolId, "edit"].join("/"),
     assessmentPlanBuilder: (poolId: string) =>
       [adminUrl, "pools", poolId, "plan"].join("/"),
-    screeningAndEvaluation: (poolId: string) =>
-      [adminUrl, "pools", poolId, "screening"].join("/"),
     poolPreview: (poolId: string) =>
       [adminUrl, "pools", poolId, "preview"].join("/"),
     poolManageAccess: (poolId: string) =>

--- a/apps/web/src/utils/poolUtils.tsx
+++ b/apps/web/src/utils/poolUtils.tsx
@@ -345,19 +345,6 @@ export const useAdminPoolPages = (
       },
     ],
     [
-      "screening",
-      {
-        title: intl.formatMessage({
-          defaultMessage: "Screening and assessment",
-          id: "R8Naqm",
-          description: "Heading for the information of an application",
-        }),
-        link: {
-          url: paths.screeningAndEvaluation(pool.id),
-        },
-      },
-    ],
-    [
       "candidates",
       {
         icon: UserGroupIcon,


### PR DESCRIPTION
🤖 Resolves #14551.

## 👋 Introduction

This PR hides the screening assessment page that will eventually be deleted.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to a published pool on http://localhost:8000/en/admin/pools
3. Verify there is no Screening and assessment tab
4. Add `/screening` to the URL and navigate to that URL
5. Verify `NotFoundError` rendered

## 📸 Screenshot

<img width="1451" height="866" alt="Screenshot 2025-09-16 at 12 22 12" src="https://github.com/user-attachments/assets/573b472e-2d27-4121-996c-0926f7a6acaa" />
