### PR TITLE
[Tooling] Updates Chromatic workflow triggers

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -11,6 +11,7 @@ on:
   merge_group:
     branches: [main]
   pull_request:
+    types: [opened]
     paths:
       - .github/workflows/chromatic.yml
       - packages/**

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,7 @@
 name: Chromatic
 
 on:
+  workflow_dispatch:
   push:
     branches: ["main"]
     paths:


### PR DESCRIPTION
🤖 Resolves #14639.

## 👋 Introduction

This PR updates the Chromatic GitHub workflow to:
- only automatically trigger the Chromatic GitHub workflow when a PR is opened instead of on every push to a PR
- allow for manual run of the Chromatic GitHub workflow via the `workflow_dispatch` event

## 🕵️ Details

- Pull request activity types: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request
- `workflow_dispatch` event: https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_dispatch
- Manually trigger workflow: https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow#running-a-workflow

## 🧪 Testing

1. Read documentation
2. Verify it seems correct
3. 🤞 
4. Merge this branch into `main`
5. Test with creation of a PR and subsequent pushes that there is only one initial run of the workflow
6. Test manually triggering a workflow after a subsequent push
