### PR TITLE
[Fix] Only show qualified applications on user recruitment tab

### DIFF
--- a/apps/web/src/components/PoolStatusTable/PoolStatusTable.tsx
+++ b/apps/web/src/components/PoolStatusTable/PoolStatusTable.tsx
@@ -234,7 +234,7 @@ const PoolStatusTable = ({
   }
   if (onlyRecruitmentProcesses) {
     data = data.filter(({ finalDecision }) =>
-      isQualifiedFinalDecision(finalDecision.value),
+      isQualifiedFinalDecision(finalDecision?.value),
     );
   }
 

--- a/apps/web/src/pages/Users/AdminUserRecruitmentPage/components/RecruitmentProcesses.tsx
+++ b/apps/web/src/pages/Users/AdminUserRecruitmentPage/components/RecruitmentProcesses.tsx
@@ -32,7 +32,7 @@ const RecruitmentProcesses = ({ query }: RecruitmentProcessesProps) => {
       >
         {intl.formatMessage(navigationMessages.recruitmentProcesses)}
       </TableOfContents.Heading>
-      <PoolStatusTable userQuery={user} />
+      <PoolStatusTable userQuery={user} onlyRecruitmentProcesses />
     </TableOfContents.Section>
   );
 };


### PR DESCRIPTION
🤖 Resolves #14611 

## 👋 Introduction

Updates the recruitment tab for viewing a user in the context of a admin to only show applications that have been qaulified (recruitment processes).

## 🕵️ Details

This adds a prop to the `PoolStatusTable` component called `onlyRecruitmentProcesses` which tells the table to filter out any pool candidates that have not been qualified.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as any user (preferrably one with no pool candidates to make testing easier)
3. Apply to a process, or multiple
4. Login as `admin@test.com`
5. Go to view that user
6. Navigate to the recruitment tab
7. Confirm the table shows no pool candidates
8. Update one of the pool candidates you applied to in step 3 to be qualified
9. Relead the recruitment tab
10. Confirm the qualified pool candidates now appear

## 📸 Screenshot

<img width="973" height="332" alt="swappy-20250918_120040" src="https://github.com/user-attachments/assets/ab8df017-3ad5-4059-9a62-4c056950464d" />
