### PR TITLE
[Fix] Platform admin not be able to edit published process

### DIFF
--- a/apps/web/src/hooks/useCanUserEditPool.ts
+++ b/apps/web/src/hooks/useCanUserEditPool.ts
@@ -11,7 +11,7 @@ const useCanUserEditPool = (status?: Maybe<PoolStatus>) => {
 
   if (status === PoolStatus.Published) {
     return checkRole(
-      [ROLE_NAME.CommunityAdmin, ROLE_NAME.PlatformAdmin],
+      [ROLE_NAME.CommunityAdmin],
       unpackMaybes(userAuthInfo?.roleAssignments),
     );
   }


### PR DESCRIPTION
🤖 Resolves #14557.

## 👋 Introduction

This PR removes the platform admin role from being able to a edit published process since the platform admin role does not have permission to do so on the backend.

## 🧪 Testing

1. `pnpm build:fresh`
2. Sign in as platform@test.com
3. Navigate to a process that is published http://localhost:8000/en/admin/pools
4. Verify user cannot edit the process
