### PR TITLE
[Feat] Employee WFA update form

### DIFF
--- a/api/app/Enums/WfaInterest.php
+++ b/api/app/Enums/WfaInterest.php
@@ -4,7 +4,7 @@ namespace App\Enums;
 
 use App\Traits\HasLocalization;
 
-enum WFAInterest
+enum WfaInterest
 {
     use HasLocalization;
 

--- a/api/app/Observers/UserObserver.php
+++ b/api/app/Observers/UserObserver.php
@@ -2,6 +2,7 @@
 
 namespace App\Observers;
 
+use App\Enums\WfaInterest;
 use App\Models\User;
 
 class UserObserver
@@ -19,9 +20,10 @@ class UserObserver
         if ($user->isDirty(['wfa_date', 'wfa_interest'])) {
             $newInterest = $user->wfa_interest;
 
-            if (is_null($newInterest)) {
+            if (is_null($newInterest) || $newInterest === WfaInterest::NOT_APPLICABLE->name) {
                 $user->wfa_date = null;
             }
+
             $user->wfa_updated_at = now();
         }
     }

--- a/api/app/Observers/UserObserver.php
+++ b/api/app/Observers/UserObserver.php
@@ -4,6 +4,7 @@ namespace App\Observers;
 
 use App\Enums\WfaInterest;
 use App\Models\User;
+use Illuminate\Support\Facades\Log;
 
 class UserObserver
 {
@@ -17,14 +18,15 @@ class UserObserver
 
     public function updating(User $user)
     {
-        if ($user->isDirty(['wfa_date', 'wfa_interest'])) {
-            $newInterest = $user->wfa_interest;
+        $interestDirty = $user->isDirty('wfa_interest');
+        $wfaDateDirty = $user->isDirty('wfa_date');
 
-            if (is_null($newInterest) || $newInterest === WfaInterest::NOT_APPLICABLE->name) {
-                $user->wfa_date = null;
-            }
-
+        if($interestDirty || $wfaDateDirty) {
             $user->wfa_updated_at = now();
+        }
+
+        if (is_null($user->wfa_interest) || $user->wfa_interest === WfaInterest::NOT_APPLICABLE->name) {
+            $user->wfa_date = null;
         }
     }
 

--- a/api/database/factories/UserFactory.php
+++ b/api/database/factories/UserFactory.php
@@ -21,7 +21,7 @@ use App\Enums\PositionDuration;
 use App\Enums\ProvinceOrTerritory;
 use App\Enums\TargetRole;
 use App\Enums\TimeFrame;
-use App\Enums\WFAInterest;
+use App\Enums\WfaInterest;
 use App\Enums\WorkExperienceGovEmployeeType;
 use App\Models\AwardExperience;
 use App\Models\Classification;
@@ -235,7 +235,7 @@ class UserFactory extends Factory
             ]);
 
             if ($withWfa) {
-                $user->wfa_interest = $this->faker->randomElement(WFAInterest::cases())->name;
+                $user->wfa_interest = $this->faker->randomElement(WfaInterest::cases())->name;
                 $user->wfa_date = $this->faker->dateTimeBetween('now', '+1 year')->format('Y-m-d');
                 $user->saveQuietly();
 

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -428,7 +428,7 @@ type UserEmployeeWFA @model(class: "\\App\\Models\\User") {
 
 type EmployeeWFA @model(class: "\\App\\Models\\User") {
   id: UUID!
-  wfaInterest: LocalizedWFAInterest @rename(attribute: "wfa_interest")
+  wfaInterest: LocalizedWfaInterest @rename(attribute: "wfa_interest")
   wfaDate: Date @rename(attribute: "wfa_date")
   wfaUpdatedAt: DateTime @rename(attribute: "wfa_updated_at")
 }
@@ -2003,7 +2003,7 @@ input UpdateEmployeeProfileInput @validator {
 }
 
 input UpdateEmployeeWFAInput {
-  wfaInterest: WFAInterest @rename(attribute: "wfa_interest")
+  wfaInterest: WfaInterest @rename(attribute: "wfa_interest")
   wfaDate: Date @rename(attribute: "wfa_date")
 }
 

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -363,8 +363,8 @@ type LocalizedTimeFrame implements LocalizedEnumOption {
   label: LocalizedString!
 }
 
-type LocalizedWFAInterest implements LocalizedEnumOption {
-  value: WFAInterest!
+type LocalizedWfaInterest implements LocalizedEnumOption {
+  value: WfaInterest!
   label: LocalizedString!
 }
 
@@ -971,7 +971,7 @@ type UserEmployeeWFA {
 
 type EmployeeWFA {
   id: UUID!
-  wfaInterest: LocalizedWFAInterest
+  wfaInterest: LocalizedWfaInterest
   wfaDate: Date
   wfaUpdatedAt: DateTime
 }
@@ -1963,7 +1963,7 @@ input UpdateEmployeeProfileInput {
 }
 
 input UpdateEmployeeWFAInput {
-  wfaInterest: WFAInterest
+  wfaInterest: WfaInterest
   wfaDate: Date
 }
 
@@ -3884,7 +3884,7 @@ enum TimeFrame {
   THREE_OR_MORE_YEARS
 }
 
-enum WFAInterest {
+enum WfaInterest {
   NOT_APPLICABLE
   TERM_ENDING
   LETTER_RECEIVED

--- a/api/tests/Feature/EmployeeWFATest.php
+++ b/api/tests/Feature/EmployeeWFATest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature;
 
-use App\Enums\WFAInterest;
+use App\Enums\WFaInterest;
 use App\Models\Community;
 use App\Models\Pool;
 use App\Models\PoolCandidate;
@@ -83,12 +83,12 @@ class EmployeeWFATest extends TestCase
             ->graphQL($this->mutation, [
                 'id' => $this->employee->id,
                 'employeeWFA' => [
-                    'wfaInterest' => WFAInterest::LETTER_RECEIVED->name,
+                    'wfaInterest' => WFaInterest::LETTER_RECEIVED->name,
                     'wfaDate' => $futureDate,
                 ],
             ])->assertJsonFragment([
                 'wfaInterest' => [
-                    'value' => WFAInterest::LETTER_RECEIVED->name,
+                    'value' => WfaInterest::LETTER_RECEIVED->name,
                 ],
                 'wfaDate' => $futureDate,
             ]);
@@ -102,7 +102,7 @@ class EmployeeWFATest extends TestCase
             ->graphQL($this->mutation, [
                 'id' => $user->id,
                 'employeeWFA' => [
-                    'wfaInterest' => WFAInterest::LETTER_RECEIVED->name,
+                    'wfaInterest' => WfaInterest::LETTER_RECEIVED->name,
                 ],
             ])->assertGraphQLValidationError('id', ApiErrorEnums::MISSING_SUBSTANTIVE_EXPERIENCE);
     }
@@ -121,7 +121,7 @@ class EmployeeWFATest extends TestCase
             ->graphQL($this->mutation, [
                 'id' => $user->id,
                 'employeeWFA' => [
-                    'wfaInterest' => WFAInterest::LETTER_RECEIVED->name,
+                    'wfaInterest' => WfaInterest::LETTER_RECEIVED->name,
                 ],
             ])->assertGraphQLValidationError('id', ApiErrorEnums::TOO_MANY_SUBSTANTIVE_EXPERIENCES);
     }
@@ -133,14 +133,14 @@ class EmployeeWFATest extends TestCase
         Carbon::setTestNow($nowInUtc);
 
         // Ensure interest is different
-        $this->employee->wfa_interest = WFAInterest::NOT_SURE->name;
+        $this->employee->wfa_interest = WfaInterest::NOT_SURE->name;
         $this->employee->save();
 
         $this->actingAs($this->employee, 'api')
             ->graphQL($this->mutation, [
                 'id' => $this->employee->id,
                 'employeeWFA' => [
-                    'wfaInterest' => WFAInterest::VOLUNTARY_DEPARTURE->name,
+                    'wfaInterest' => WfaInterest::VOLUNTARY_DEPARTURE->name,
                 ],
             ])->assertJsonFragment([
                 'wfaUpdatedAt' => $nowInUtc,

--- a/apps/playwright/fixtures/EmployeeProfile.ts
+++ b/apps/playwright/fixtures/EmployeeProfile.ts
@@ -1,0 +1,67 @@
+import { Page } from "@playwright/test";
+
+import AppPage from "./AppPage";
+
+type ObjectValues<T> = T[keyof T];
+
+export const EMPLOYEE_PROFILE_FORM = {
+  CareerDevelopment: "career-development",
+  NextRole: "next-role",
+  CareerObjective: "career-objective",
+  GoalsWorkStyle: "goals-work-style",
+  Wfa: "wfa",
+};
+
+type EmployeeProfileForm = ObjectValues<typeof EMPLOYEE_PROFILE_FORM>;
+
+/**
+ * GC Employee Profile Page
+ */
+class EmployeeProfile extends AppPage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async goToEmployeeProfile() {
+    await this.page.goto("/en/applicant/employee-profile");
+    await this.waitForGraphqlResponse("EmployeeProfilePage");
+  }
+
+  async toggleForm(form: EmployeeProfileForm) {
+    const formMap = new Map<EmployeeProfileForm, RegExp>([
+      [
+        EMPLOYEE_PROFILE_FORM.CareerDevelopment,
+        /edit career development preferences/i,
+      ],
+      [EMPLOYEE_PROFILE_FORM.NextRole, /edit your next role/i],
+      [EMPLOYEE_PROFILE_FORM.CareerObjective, /edit your career objective/i],
+      [EMPLOYEE_PROFILE_FORM.GoalsWorkStyle, /edit your goals and work style/i],
+      [EMPLOYEE_PROFILE_FORM.Wfa, /edit workforce adjustment/i],
+    ]);
+
+    const formLabel = formMap.get(form);
+    if (formLabel) {
+      await this.page.getByRole("button", { name: formLabel }).click();
+    }
+  }
+
+  async submitForm(form: EmployeeProfileForm) {
+    const formMap = new Map<EmployeeProfileForm, RegExp>([
+      [
+        EMPLOYEE_PROFILE_FORM.CareerDevelopment,
+        /edit career development preferences/i,
+      ],
+      [EMPLOYEE_PROFILE_FORM.NextRole, /save your next role/i],
+      [EMPLOYEE_PROFILE_FORM.CareerObjective, /save your career objective/i],
+      [EMPLOYEE_PROFILE_FORM.GoalsWorkStyle, /save your goals and work style/i],
+      [EMPLOYEE_PROFILE_FORM.Wfa, /save workforce adjustment/i],
+    ]);
+
+    const formLabel = formMap.get(form);
+    if (formLabel) {
+      await this.page.getByRole("button", { name: formLabel }).click();
+    }
+  }
+}
+
+export default EmployeeProfile;

--- a/apps/playwright/tests/applicant/employee-profile.spec.ts
+++ b/apps/playwright/tests/applicant/employee-profile.spec.ts
@@ -1,6 +1,9 @@
 import { nowUTCDateTime } from "@gc-digital-talent/date-helpers";
 
 import { test, expect } from "~/fixtures";
+import EmployeeProfile, {
+  EMPLOYEE_PROFILE_FORM,
+} from "~/fixtures/EmployeeProfile";
 import { loginBySub } from "~/utils/auth";
 import graphql from "~/utils/graphql";
 import { generateUniqueTestId } from "~/utils/id";
@@ -289,5 +292,45 @@ test.describe("Employee Profile", () => {
         name: /complete - goals and work style/i,
       }),
     ).toBeVisible();
+  });
+
+  test.describe("Workforce adjustment", () => {
+    test("Can set not applicable", async ({ appPage }) => {
+      const employeeProfile = new EmployeeProfile(appPage.page);
+      await loginBySub(employeeProfile.page, sub);
+      await employeeProfile.goToEmployeeProfile();
+
+      await employeeProfile.toggleForm(EMPLOYEE_PROFILE_FORM.Wfa);
+
+      await employeeProfile.page
+        .getByRole("radio", { name: /this section does not apply to me/i })
+        .click();
+
+      await expect(
+        employeeProfile.page.getByRole("heading", { name: /key details/i }),
+      ).toBeHidden();
+
+      await employeeProfile.submitForm(EMPLOYEE_PROFILE_FORM.Wfa);
+
+      await expect(
+        employeeProfile.page.getByText(/this section does not apply to me/i),
+      ).toBeVisible();
+    });
+
+    test("Error with no experiences", async ({ appPage }) => {
+      const employeeProfile = new EmployeeProfile(appPage.page);
+      await loginBySub(employeeProfile.page, sub);
+      await employeeProfile.goToEmployeeProfile();
+
+      await employeeProfile.toggleForm(EMPLOYEE_PROFILE_FORM.Wfa);
+
+      await employeeProfile.page
+        .getByRole("radio", { name: /i believe my position may be affected/i })
+        .click();
+
+      await expect(
+        employeeProfile.page.getByText(/missing a substantive experience/i),
+      ).toBeVisible();
+    });
   });
 });

--- a/apps/web/src/pages/CommunityInterests/CreateCommunityInterestPage/CreateCommunityInterestPage.tsx
+++ b/apps/web/src/pages/CommunityInterests/CreateCommunityInterestPage/CreateCommunityInterestPage.tsx
@@ -1,7 +1,7 @@
 import { useIntl } from "react-intl";
 import { useMutation, useQuery } from "urql";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
-import { useNavigate } from "react-router";
+import { useNavigate, useSearchParams } from "react-router";
 
 import { Card, Pending } from "@gc-digital-talent/ui";
 import { ROLE_NAME, useAuthorization } from "@gc-digital-talent/auth";
@@ -140,7 +140,9 @@ const CreateCommunityInterestPage_Mutation = graphql(/* GraphQL */ `
 export const CreateCommunityInterestPage = () => {
   const intl = useIntl();
   const routes = useRoutes();
+  const [searchParams] = useSearchParams();
   const { userAuthInfo } = useAuthorization();
+  const returnPath = searchParams?.get("from") ?? routes.applicantDashboard();
 
   const navigate = useNavigate();
   const [{ data: queryData, fetching: queryFetching, error: queryError }] =
@@ -196,7 +198,7 @@ export const CreateCommunityInterestPage = () => {
             description: "Toast for successful community interest creation",
           }),
         );
-        await navigate(routes.applicantDashboard());
+        await navigate(returnPath);
       })
       .catch(() => {
         toast.error(

--- a/apps/web/src/pages/EmployeeProfile/EmployeeProfilePage.tsx
+++ b/apps/web/src/pages/EmployeeProfile/EmployeeProfilePage.tsx
@@ -37,6 +37,10 @@ import {
   hasAllEmptyFields as goalsWorkStyleHasAllEmptyFields,
   hasEmptyRequiredFields as goalsWorkStyleHasEmptyRequiredFields,
 } from "~/validators/employeeProfile/goalsWorkStyle";
+import {
+  hasAllEmptyFields as wfaHasAllEmptyFields,
+  hasEmptyRequiredFields as wfaHasEmptyRequiredFields,
+} from "~/validators/employeeProfile/wfa";
 
 import messages from "./messages";
 import GoalsWorkStyleSection, {
@@ -50,6 +54,9 @@ import NextRoleSection, {
 import CareerObjectiveSection, {
   EmployeeProfileCareerObjective_Fragment,
 } from "./components/CareerObjective/CareerObjectiveSection";
+import WfaSection, {
+  EmployeeProfileWfa_Fragment,
+} from "./components/WfaSection/WfaSection";
 
 const SECTION_ID = {
   CAREER_PLANNING: "career-planning-section",
@@ -57,6 +64,7 @@ const SECTION_ID = {
   NEXT_ROLE: "next-role-section",
   CAREER_OBJECTIVE: "career-objective-section",
   GOALS_WORK_STYLE: "goals-work-style-section",
+  WFA: "wfa-section",
 };
 
 const EmployeeProfileOptions_Fragment = graphql(/** GraphQL */ `
@@ -64,6 +72,7 @@ const EmployeeProfileOptions_Fragment = graphql(/** GraphQL */ `
     ...EmployeeProfileCareerDevelopmentOptions
     ...EmployeeProfileNextRoleOptions
     ...EmployeeProfileCareerObjectiveOptions
+    ...EmployeeWfaOptions
   }
 `);
 
@@ -76,6 +85,7 @@ const EmployeeProfile_Fragment = graphql(/** GraphQL */ `
       ...EmployeeProfileNextRole
       ...EmployeeProfileGoalsWorkStyle
     }
+    ...EmployeeProfileWfa
   }
 `);
 
@@ -150,13 +160,15 @@ const EmployeeProfile = ({
     EmployeeProfileGoalsWorkStyle_Fragment,
     user.employeeProfile,
   );
+  const wfa = getFragment(EmployeeProfileWfa_Fragment, user);
 
   let overallStatus: Status = "success";
   if (
     careerDevelopmentHasEmptyRequiredFields(careerDevelopment) ||
     nextRoleHasEmptyRequiredFields(nextRole) ||
     careerObjectiveHasEmptyRequiredFields(careerObjective) ||
-    goalsWorkStyleHasEmptyRequiredFields(goalsWorkStyle)
+    goalsWorkStyleHasEmptyRequiredFields(goalsWorkStyle) ||
+    wfaHasEmptyRequiredFields(wfa.employeeWFA)
   ) {
     overallStatus = "error";
   }
@@ -274,6 +286,27 @@ const EmployeeProfile = ({
                       )}
                     />
                   </TableOfContents.ListItem>
+                  <TableOfContents.ListItem>
+                    <StatusItem
+                      asListItem={false}
+                      title={intl.formatMessage(messages.wfa)}
+                      status={
+                        wfaHasEmptyRequiredFields(wfa.employeeWFA)
+                          ? "error"
+                          : wfaHasAllEmptyFields(wfa.employeeWFA)
+                            ? "optional"
+                            : "success"
+                      }
+                      scrollTo={SECTION_ID.GOALS_WORK_STYLE}
+                      hiddenContextPrefix={intl.formatMessage(
+                        wfaHasEmptyRequiredFields(wfa.employeeWFA)
+                          ? commonMessages.incomplete
+                          : wfaHasAllEmptyFields(wfa.employeeWFA)
+                            ? commonMessages.optional
+                            : commonMessages.complete,
+                      )}
+                    />
+                  </TableOfContents.ListItem>
                 </TableOfContents.List>
               </TableOfContents.ListItem>
             </TableOfContents.List>
@@ -322,6 +355,9 @@ const EmployeeProfile = ({
                 <GoalsWorkStyleSection
                   employeeProfileQuery={user.employeeProfile}
                 />
+              </TableOfContents.Section>
+              <TableOfContents.Section id={SECTION_ID.WFA}>
+                <WfaSection employeeWfaQuery={user} optionsQuery={options} />
               </TableOfContents.Section>
             </div>
           </TableOfContents.Content>

--- a/apps/web/src/pages/EmployeeProfile/EmployeeProfilePage.tsx
+++ b/apps/web/src/pages/EmployeeProfile/EmployeeProfilePage.tsx
@@ -297,7 +297,7 @@ const EmployeeProfile = ({
                             ? "optional"
                             : "success"
                       }
-                      scrollTo={SECTION_ID.GOALS_WORK_STYLE}
+                      scrollTo={SECTION_ID.WFA}
                       hiddenContextPrefix={intl.formatMessage(
                         wfaHasEmptyRequiredFields(wfa.employeeWFA)
                           ? commonMessages.incomplete

--- a/apps/web/src/pages/EmployeeProfile/components/WfaSection/Display.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/WfaSection/Display.tsx
@@ -48,7 +48,7 @@ const Display = ({ user }: DisplayProps) => {
               label={intl.formatMessage(messages.currentSubstantivePosition)}
             >
               {experiences.length > 0 ? (
-                <div className="flex flex-col gap-y-3">
+                <div className="mt-3 flex flex-col gap-y-3">
                   {experiences.map((exp) => (
                     <ExperienceCard
                       key={exp.id}

--- a/apps/web/src/pages/EmployeeProfile/components/WfaSection/Display.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/WfaSection/Display.tsx
@@ -1,0 +1,120 @@
+import { useIntl } from "react-intl";
+
+import {
+  EmployeeProfileWfaFragment,
+  WfaInterest,
+} from "@gc-digital-talent/graphql";
+import {
+  commonMessages,
+  getWfaInterestFirstPerson,
+} from "@gc-digital-talent/i18n";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
+import { Ul } from "@gc-digital-talent/ui";
+
+import ToggleForm from "~/components/ToggleForm/ToggleForm";
+import ExperienceCard from "~/components/ExperienceCard/ExperienceCard";
+import { formattedDate } from "~/utils/dateUtils";
+import processMessages from "~/messages/processMessages";
+
+import messages from "../../messages";
+
+interface DisplayProps {
+  user: EmployeeProfileWfaFragment;
+}
+
+const Display = ({ user }: DisplayProps) => {
+  const intl = useIntl();
+  const notProvided = intl.formatMessage(
+    commonMessages.missingOptionalInformation,
+  );
+  const experiences = unpackMaybes(user.currentSubstantiveExperiences);
+  const communities = unpackMaybes(user.employeeProfile?.communityInterests);
+
+  return (
+    <div className="flex flex-col gap-y-6">
+      <ToggleForm.FieldDisplay
+        label={intl.formatMessage(messages.wfaSituation)}
+      >
+        {user.employeeWFA?.wfaInterest?.value
+          ? intl.formatMessage(
+              getWfaInterestFirstPerson(user.employeeWFA.wfaInterest.value),
+            )
+          : notProvided}
+      </ToggleForm.FieldDisplay>
+      {user.employeeWFA?.wfaInterest?.value &&
+        user.employeeWFA.wfaInterest.value !== WfaInterest.NotApplicable && (
+          <>
+            <ToggleForm.FieldDisplay
+              label={intl.formatMessage(messages.currentSubstantivePosition)}
+            >
+              {experiences.length > 0 ? (
+                <div className="flex flex-col gap-y-3">
+                  {experiences.map((exp) => (
+                    <ExperienceCard
+                      key={exp.id}
+                      experienceQuery={exp}
+                      showEdit={false}
+                    />
+                  ))}
+                </div>
+              ) : (
+                notProvided
+              )}
+            </ToggleForm.FieldDisplay>
+            <ToggleForm.FieldDisplay
+              label={intl.formatMessage(messages.expectedEndDate)}
+            >
+              {user.employeeWFA.wfaDate
+                ? formattedDate(user.employeeWFA.wfaDate, intl)
+                : notProvided}
+            </ToggleForm.FieldDisplay>
+            <ToggleForm.FieldDisplay
+              label={intl.formatMessage(messages.currentCommunity)}
+            >
+              {communities.length > 0 ? (
+                <Ul space="sm">
+                  {communities.map((interest) => (
+                    <li key={interest.community.id}>
+                      {interest?.community?.name?.localized ??
+                        intl.formatMessage(commonMessages.notAvailable)}
+                    </li>
+                  ))}
+                </Ul>
+              ) : (
+                notProvided
+              )}
+            </ToggleForm.FieldDisplay>
+            <ToggleForm.FieldDisplay
+              label={
+                intl.formatMessage(processMessages.whatToExpect) +
+                intl.formatMessage(commonMessages.dividingColon)
+              }
+            >
+              <Ul space="sm">
+                <li>
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "The recruitment team of your functional community will contact you.",
+                    id: "PUTcqK",
+                    description:
+                      "Expectation of recrtuitment team contact after wfa",
+                  })}
+                </li>
+                <li>
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "There is no guarantee that this will lead to a new position.",
+                    id: "3kRiqA",
+                    description:
+                      "Expectation of not guaranteed position after wfa",
+                  })}
+                </li>
+              </Ul>
+            </ToggleForm.FieldDisplay>
+          </>
+        )}
+    </div>
+  );
+};
+
+export default Display;

--- a/apps/web/src/pages/EmployeeProfile/components/WfaSection/SubstantiveExperiences.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/WfaSection/SubstantiveExperiences.tsx
@@ -1,0 +1,120 @@
+import { useIntl } from "react-intl";
+
+import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
+import { Link } from "@gc-digital-talent/ui";
+
+import useRoutes from "~/hooks/useRoutes";
+import ExperienceCard from "~/components/ExperienceCard/ExperienceCard";
+
+import Warning from "./Warning";
+
+const UpdateLink = () => {
+  const intl = useIntl();
+  const paths = useRoutes();
+
+  return (
+    <p className="mb-6">
+      <Link
+        color="secondary"
+        mode="inline"
+        newTab
+        href={paths.careerTimeline()}
+      >
+        {intl.formatMessage({
+          defaultMessage: "Update your current position",
+          id: "pTXZxW",
+          description: "Link text to page to update experiences",
+        })}
+      </Link>
+    </p>
+  );
+};
+
+const SubstantiveExperiences_Fragment = graphql(/** GraphQL */ `
+  fragment SubstantiveExperiences on WorkExperience {
+    id
+    department {
+      isCorePublicAdministration
+    }
+    ...ExperienceCard
+  }
+`);
+
+interface SubstantiveExperiencesProps {
+  query: FragmentType<typeof SubstantiveExperiences_Fragment>[];
+}
+
+const SubstantiveExperiences = ({ query }: SubstantiveExperiencesProps) => {
+  const intl = useIntl();
+  const substantiveExperiences = getFragment(
+    SubstantiveExperiences_Fragment,
+    query,
+  );
+  const experiences = unpackMaybes(substantiveExperiences);
+  // Could be more, confirm at least one is CPA
+  const isCPA = experiences
+    .flatMap((exp) => !!exp.department?.isCorePublicAdministration)
+    .reduce((acc, curr) => acc || curr, false);
+
+  if (!experiences.length) {
+    return (
+      <>
+        <Warning isError>
+          <p>
+            {intl.formatMessage({
+              defaultMessage: "Missing a substantive position",
+              id: "L+N6IY",
+              description:
+                "Title for when a user is missing a substantive experience",
+            })}
+          </p>
+          <p>
+            {intl.formatMessage({
+              defaultMessage:
+                "Your current position is either missing, not marked as substantive or not marked as a Government of Canada experience.",
+              id: "ZYdnjA",
+              description:
+                "Error message that appears when a user is missing a substantive experience",
+            })}
+          </p>
+        </Warning>
+        <UpdateLink />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex flex-col gap-y-3">
+        {experiences.map((exp) => (
+          <ExperienceCard key={exp.id} experienceQuery={exp} showEdit={false} />
+        ))}
+        {!isCPA && (
+          <Warning>
+            <p>
+              {intl.formatMessage({
+                defaultMessage: "This position is not with a CPA department",
+                id: "CYMMd0",
+                description:
+                  "Title for when the users substantive experience is not work a core public admin department",
+              })}
+            </p>
+            <p>
+              {intl.formatMessage({
+                defaultMessage:
+                  "This functionality is available only if your substantive position is with a department in the core public administration.",
+                id: "9XY9Ok",
+                description:
+                  "Description that wfa is only available for core public admin departments",
+              })}
+            </p>
+          </Warning>
+        )}
+      </div>
+      <UpdateLink />
+    </>
+  );
+};
+
+export default SubstantiveExperiences;

--- a/apps/web/src/pages/EmployeeProfile/components/WfaSection/SubstantiveExperiences.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/WfaSection/SubstantiveExperiences.tsx
@@ -86,12 +86,12 @@ const SubstantiveExperiences = ({ query }: SubstantiveExperiencesProps) => {
 
   return (
     <>
-      <div className="flex flex-col gap-y-3">
+      <div className="mb-6 flex flex-col gap-y-3">
         {experiences.map((exp) => (
           <ExperienceCard key={exp.id} experienceQuery={exp} showEdit={false} />
         ))}
         {!isCPA && (
-          <Warning>
+          <Warning className="mb-0">
             <p>
               {intl.formatMessage({
                 defaultMessage: "This position is not with a CPA department",

--- a/apps/web/src/pages/EmployeeProfile/components/WfaSection/Warning.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/WfaSection/Warning.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from "react";
+import ExclamationTriangleIcon from "@heroicons/react/20/solid/ExclamationTriangleIcon";
+
+import { Well } from "@gc-digital-talent/ui";
+
+interface WarningProps {
+  children: ReactNode;
+  isError?: boolean;
+}
+
+const Warning = ({ children, isError }: WarningProps) => (
+  <Well
+    color={isError ? "error" : "warning"}
+    className="mb-6 flex items-start gap-x-1.5"
+  >
+    <ExclamationTriangleIcon className="mt-1 size-4 shrink-0" />
+    <div className="flex-grow">{children}</div>
+  </Well>
+);
+
+export default Warning;

--- a/apps/web/src/pages/EmployeeProfile/components/WfaSection/Warning.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/WfaSection/Warning.tsx
@@ -1,17 +1,21 @@
 import { ReactNode } from "react";
 import ExclamationTriangleIcon from "@heroicons/react/20/solid/ExclamationTriangleIcon";
+import { tv } from "tailwind-variants";
 
 import { Well } from "@gc-digital-talent/ui";
 
+const warning = tv({ base: "mb-6 flex items-start gap-x-1.5" });
+
 interface WarningProps {
   children: ReactNode;
+  className?: string;
   isError?: boolean;
 }
 
-const Warning = ({ children, isError }: WarningProps) => (
+const Warning = ({ children, className, isError }: WarningProps) => (
   <Well
     color={isError ? "error" : "warning"}
-    className="mb-6 flex items-start gap-x-1.5"
+    className={warning({ class: className })}
   >
     <ExclamationTriangleIcon className="mt-1 size-4 shrink-0" />
     <div className="flex-grow">{children}</div>

--- a/apps/web/src/pages/EmployeeProfile/components/WfaSection/WfaSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/WfaSection/WfaSection.tsx
@@ -1,0 +1,233 @@
+import { useIntl } from "react-intl";
+import { useMutation } from "urql";
+import QuestionMarkCircleIcon from "@heroicons/react/24/outline/QuestionMarkCircleIcon";
+import { FormProvider, useForm } from "react-hook-form";
+
+import {
+  EmployeeWfa,
+  FragmentType,
+  getFragment,
+  graphql,
+  Maybe,
+  Scalars,
+  WfaInterest,
+} from "@gc-digital-talent/graphql";
+import { toast } from "@gc-digital-talent/toast";
+import { Button, Heading, ToggleSection } from "@gc-digital-talent/ui";
+import { RadioGroup, Submit } from "@gc-digital-talent/forms";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
+import {
+  commonMessages,
+  errorMessages,
+  formMessages,
+  narrowEnumType,
+} from "@gc-digital-talent/i18n";
+
+import { hasAllEmptyFields } from "~/validators/employeeProfile/wfa";
+import useToggleSectionInfo from "~/hooks/useToggleSectionInfo";
+import ToggleForm from "~/components/ToggleForm/ToggleForm";
+
+import messages from "../../messages";
+import Display from "./Display";
+
+const EmployeeWfaOptions_Fragment = graphql(/** GraphQL */ `
+  fragment EmployeeWfaOptions on Query {
+    wfaInterests: localizedEnumOptions(enumName: "WfaInterest") {
+      ... on LocalizedWfaInterest {
+        value
+        label {
+          localized
+        }
+      }
+    }
+  }
+`);
+
+export const EmployeeProfileWfa_Fragment = graphql(/** GraphQL */ `
+  fragment EmployeeProfileWfa on User {
+    id
+    employeeWFA {
+      wfaInterest {
+        value
+        label {
+          localized
+        }
+      }
+      wfaDate
+    }
+    currentSubstantiveExperiences {
+      id
+      ...ExperienceCard
+    }
+    employeeProfile {
+      communityInterests {
+        community {
+          id
+          name {
+            localized
+          }
+        }
+      }
+    }
+  }
+`);
+
+const UpdateEmployeeWfa_Mutation = graphql(/** GraphQL */ `
+  mutation UpdateEmployeeWfa(
+    $id: UUID!
+    $employeeWfa: UpdateEmployeeWFAInput!
+  ) {
+    updateEmployeeWFA(id: $id, employeeWFA: $employeeWfa) {
+      id
+    }
+  }
+`);
+
+interface FormValues {
+  wfaInterest?: Maybe<WfaInterest>;
+  wfaDate?: Maybe<Scalars["Date"]["input"]>;
+  experienceCount?: number;
+}
+
+const dataToFormValues = (
+  initialData?: Maybe<Pick<EmployeeWfa, "wfaInterest" | "wfaDate">>,
+): FormValues => ({
+  wfaInterest: initialData?.wfaInterest?.value,
+  wfaDate: initialData?.wfaDate,
+});
+
+interface WfaSectionProps {
+  employeeWfaQuery: FragmentType<typeof EmployeeProfileWfa_Fragment>;
+  optionsQuery: FragmentType<typeof EmployeeWfaOptions_Fragment>;
+}
+
+const WfaSection = ({ employeeWfaQuery, optionsQuery }: WfaSectionProps) => {
+  const intl = useIntl();
+  const [{ fetching }, executeMutation] = useMutation(
+    UpdateEmployeeWfa_Mutation,
+  );
+  const user = getFragment(EmployeeProfileWfa_Fragment, employeeWfaQuery);
+  const options = getFragment(EmployeeWfaOptions_Fragment, optionsQuery);
+  const employeeWFA = user?.employeeWFA ?? {};
+  const isNull = hasAllEmptyFields(employeeWFA);
+  const { isEditing, setIsEditing, icon } = useToggleSectionInfo({
+    isNull,
+    emptyRequired: false,
+    fallbackIcon: QuestionMarkCircleIcon,
+    optional: true,
+  });
+
+  const methods = useForm<FormValues>({
+    defaultValues: dataToFormValues(user?.employeeWFA),
+  });
+
+  const handleError = () => {
+    toast.error(
+      intl.formatMessage({
+        defaultMessage: "Failed updating workforce adjustment information",
+        id: "NOjAPn",
+        description:
+          "Messages displayed when a user fails to update wfa information",
+      }),
+    );
+  };
+
+  const handleSave = async (values: FormValues) => {
+    return executeMutation({ id: user.id, employeeWfa: values })
+      .then((res) => {
+        if (res.data?.updateEmployeeWFA) {
+          toast.success(
+            intl.formatMessage({
+              defaultMessage:
+                "Workforce adjustment information updated successfully!",
+              id: "0vk6td",
+              description:
+                "Message displayed when a user successfully updates wfa information:",
+            }),
+          );
+          setIsEditing(false);
+        } else {
+          handleError();
+        }
+      })
+      .catch(handleError);
+  };
+
+  const wfaInterests = narrowEnumType(
+    unpackMaybes(options.wfaInterests),
+    "WfaInterest",
+  ).map(({ value, label }) => ({
+    value,
+    label: label.localized ?? intl.formatMessage(commonMessages.notAvailable),
+  }));
+
+  return (
+    <ToggleSection.Root
+      id="wfa-form"
+      open={isEditing}
+      onOpenChange={setIsEditing}
+    >
+      <ToggleSection.Header
+        icon={icon.icon}
+        color={icon.color}
+        level="h3"
+        size="h4"
+        className="font-bold"
+        toggle={
+          <ToggleForm.LabelledTrigger
+            sectionTitle={intl.formatMessage(messages.wfa)}
+          />
+        }
+      >
+        {intl.formatMessage(messages.wfa)}
+      </ToggleSection.Header>
+      <ToggleSection.Content>
+        <ToggleSection.InitialContent>
+          {isNull ? <ToggleForm.NullDisplay /> : <Display user={user} />}
+        </ToggleSection.InitialContent>
+        <ToggleSection.OpenContent>
+          <FormProvider {...methods}>
+            <form onSubmit={methods.handleSubmit(handleSave)}>
+              <Heading level="h4" size="h5" className="mt-0">
+                {intl.formatMessage({
+                  defaultMessage: "Workforce adjustment information",
+                  id: "9+lpKK",
+                  description:
+                    "Title for the information specifically related to workfoce adjustment",
+                })}
+              </Heading>
+              <RadioGroup
+                idPrefix="wfaInterest"
+                name="wfaInterest"
+                legend={intl.formatMessage(messages.wfaSituation)}
+                rules={{ required: intl.formatMessage(errorMessages.required) }}
+                items={wfaInterests}
+              />
+              <div className="flex flex-wrap items-center gap-6">
+                <Submit
+                  text={intl.formatMessage(formMessages.saveChanges)}
+                  aria-label={intl.formatMessage({
+                    defaultMessage: "Save workforce adjustment",
+                    id: "/LhwX1",
+                    description:
+                      "Text on a button to save workforce adjustment info",
+                  })}
+                  color="secondary"
+                  mode="solid"
+                  isSubmitting={fetching}
+                />
+                <ToggleSection.Close>
+                  <Button mode="inline" type="button" color="warning">
+                    {intl.formatMessage(commonMessages.cancel)}
+                  </Button>
+                </ToggleSection.Close>
+              </div>
+            </form>
+          </FormProvider>
+        </ToggleSection.OpenContent>
+      </ToggleSection.Content>
+    </ToggleSection.Root>
+  );
+};
+
+export default WfaSection;

--- a/apps/web/src/pages/EmployeeProfile/components/WfaSection/WfaSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/WfaSection/WfaSection.tsx
@@ -27,6 +27,7 @@ import {
   commonMessages,
   errorMessages,
   formMessages,
+  getWfaInterestFirstPerson,
   narrowEnumType,
 } from "@gc-digital-talent/i18n";
 
@@ -171,9 +172,9 @@ const WfaSection = ({ employeeWfaQuery, optionsQuery }: WfaSectionProps) => {
   const wfaInterests = narrowEnumType(
     unpackMaybes(options.wfaInterests),
     "WfaInterest",
-  ).map(({ value, label }: LocalizedWfaInterest) => ({
+  ).map(({ value }: LocalizedWfaInterest) => ({
     value,
-    label: label?.localized ?? intl.formatMessage(commonMessages.notAvailable),
+    label: intl.formatMessage(getWfaInterestFirstPerson(value)),
   }));
 
   const communityInterests = unpackMaybes(

--- a/apps/web/src/pages/EmployeeProfile/messages.ts
+++ b/apps/web/src/pages/EmployeeProfile/messages.ts
@@ -27,4 +27,29 @@ export default defineMessages({
     description:
       "Selection or label referring to adding a community that isn't a provided option",
   },
+  wfa: {
+    defaultMessage: "Workforce adjustment",
+    id: "xGsQso",
+    description: "Title for the users wfa information",
+  },
+  wfaSituation: {
+    defaultMessage: "Workforce adjustment situation",
+    id: "W9/kLq",
+    description: "Label for users current wfa situation",
+  },
+  currentSubstantivePosition: {
+    defaultMessage: "Current substantive position",
+    id: "3pK4nh",
+    description: "Label for users current substantive position",
+  },
+  expectedEndDate: {
+    defaultMessage: "Expected end date",
+    id: "JSyD03",
+    description: "Label for the expected end date",
+  },
+  currentCommunity: {
+    defaultMessage: "Current functional community",
+    id: "OU3MYy",
+    description: "Label for users current functional community",
+  },
 });

--- a/apps/web/src/validators/employeeProfile/wfa.ts
+++ b/apps/web/src/validators/employeeProfile/wfa.ts
@@ -1,0 +1,18 @@
+import { EmployeeWfa, Maybe } from "@gc-digital-talent/graphql";
+
+type SimpleWfa =
+  | Maybe<Pick<EmployeeWfa, "wfaInterest" | "wfaDate">>
+  | undefined;
+
+export function hasAllEmptyFields(wfa: SimpleWfa): boolean {
+  return !wfa?.wfaInterest && !wfa?.wfaDate;
+}
+
+export function hasAnyEmptyFields(wfa: SimpleWfa): boolean {
+  return !wfa?.wfaInterest || !wfa?.wfaDate;
+}
+
+export function hasEmptyRequiredFields(_: SimpleWfa): boolean {
+  // no required fields
+  return false;
+}

--- a/packages/i18n/src/index.tsx
+++ b/packages/i18n/src/index.tsx
@@ -52,6 +52,7 @@ import {
   getExecCoachingInterest,
   getTalentNominationLateralMovementOption,
   getLearningOpportunitiesInterest,
+  getWfaInterestFirstPerson,
 } from "./messages/localizedConstants";
 import {
   type MaybeLocalizedEnums,
@@ -73,6 +74,7 @@ import {
   sortPoolLanguage,
   sortPriorityWeight,
   sortSecurityStatus,
+  sortWfaInterest,
   localizedEnumToInput,
   localizedEnumArrayToInput,
   narrowEnumType,
@@ -125,6 +127,7 @@ export {
   sortPoolLanguage,
   sortPriorityWeight,
   sortSecurityStatus,
+  sortWfaInterest,
   appendLanguageName,
 };
 
@@ -153,6 +156,7 @@ export {
   getExecCoachingInterest,
   getTalentNominationLateralMovementOption,
   getLearningOpportunitiesInterest,
+  getWfaInterestFirstPerson,
 };
 
 export type { Locales, Messages, MaybeLocalizedEnums, GenericLocalizedEnum };

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -635,6 +635,10 @@
     "defaultMessage": "Renseignements manquants",
     "description": "Message for when specific item has missing information"
   },
+  "N62XrS": {
+    "defaultMessage": "J’occupe un poste pour une durée indéterminée, mais je souhaite quitter volontairement la fonction publique",
+    "description": "Voluntary departure WFA interest"
+  },
   "NAKad/": {
     "defaultMessage": "Supprimer",
     "description": "Remove action"
@@ -1079,6 +1083,10 @@
     "defaultMessage": "Ce nom d’équipe est déjà utilisé",
     "description": "Error message that the given team name is already in use."
   },
+  "d93frv": {
+    "defaultMessage": "J’occupe un poste pour une durée indéterminée, mais j’ai reçu une lettre sur le réaménagement des effectifs",
+    "description": "Letter received WFA interest"
+  },
   "dBc/+T": {
     "defaultMessage": "Bibliothèque de compétences",
     "description": "Name of the skills library page"
@@ -1094,6 +1102,10 @@
   "dVZjaj": {
     "defaultMessage": "Processus de recrutement",
     "description": "Name of the recruitment processes section"
+  },
+  "dXEHu0": {
+    "defaultMessage": "Je ne sais pas vraiment si le réaménagement des effectifs touche mon poste",
+    "description": "Unsure WFA interest"
   },
   "dXiRk8": {
     "defaultMessage": "Capacité démontrée à accomplir de façon constante des tâches de faible complexité sous une supervision minimale et des tâches de complexité modérée sous une forte supervision ou un mentorat direct. Généralement associée à des postes juniors ou de niveau d’entrée.",
@@ -1487,6 +1499,10 @@
     "defaultMessage": "Demandes",
     "description": "Name of Requests page"
   },
+  "qOVygs": {
+    "defaultMessage": "Cette section ne me concerne pas",
+    "description": "Not applicable WFA interest"
+  },
   "qP2HGB": {
     "defaultMessage": "Outils avancés",
     "description": "Name of Advanced tools page"
@@ -1694,6 +1710,10 @@
   "wdfDZH": {
     "defaultMessage": "Je consens à travailler dans la région de la Colombie-Britannique.",
     "description": "The work region of Canada described as British Columbia."
+  },
+  "wjhC48": {
+    "defaultMessage": "Mon poste pour une période déterminée n’est pas renouvelé ou prend fin tôt",
+    "description": "Term ending WFA interest"
   },
   "wqBryV": {
     "defaultMessage": "Tableau de bord du (de la) candidat(e)",

--- a/packages/i18n/src/messages/localizedConstants.tsx
+++ b/packages/i18n/src/messages/localizedConstants.tsx
@@ -14,6 +14,7 @@ import {
   ExecCoaching,
   TalentNominationLateralMovementOption,
   LearningOpportunitiesInterest,
+  WfaInterest,
 } from "@gc-digital-talent/graphql";
 import { hasKey } from "@gc-digital-talent/helpers";
 import { defaultLogger } from "@gc-digital-talent/logger";
@@ -1021,5 +1022,46 @@ export const getLearningOpportunitiesInterest = (
       : learningOpportunitiesInterestFalseLabels,
     messageKey,
     `Invalid learning opportunity interest '${messageKey}'`,
+  );
+};
+
+const wfaInterestFirstPerson = defineMessages({
+  [WfaInterest.NotApplicable]: {
+    defaultMessage: "This section does not apply to me",
+    id: "qOVygs",
+    description: "Not applicable WFA interest",
+  },
+  [WfaInterest.TermEnding]: {
+    defaultMessage:
+      "I have a term position that isn't being renewed or is ending early",
+    id: "wjhC48",
+    description: "Term ending WFA interest",
+  },
+  [WfaInterest.LetterReceived]: {
+    defaultMessage:
+      "I'm an indeterminate employee and have received a workforce adjustment letter",
+    id: "d93frv",
+    description: "Letter received WFA interest",
+  },
+  [WfaInterest.NotSure]: {
+    defaultMessage: "I believe my position may be affected but I'm not sure",
+    id: "dXEHu0",
+    description: "Unsure WFA interest",
+  },
+  [WfaInterest.VoluntaryDeparture]: {
+    defaultMessage:
+      "I'm an indeterminate employee interested in voluntarily leaving the public service",
+    id: "N62XrS",
+    description: "Voluntary departure WFA interest",
+  },
+});
+
+export const getWfaInterestFirstPerson = (
+  wfaInterest: string,
+): MessageDescriptor => {
+  return getOrDisplayError(
+    wfaInterestFirstPerson,
+    wfaInterest,
+    `Invalid WFA interest '${wfaInterest}'`,
   );
 };

--- a/packages/i18n/src/utils/enum.ts
+++ b/packages/i18n/src/utils/enum.ts
@@ -17,6 +17,7 @@ import {
   PoolOpportunityLength,
   PriorityWeight,
   SecurityStatus,
+  WfaInterest,
   WorkRegion,
 } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
@@ -355,5 +356,18 @@ export function sortWorkRegion(workRegions?: MaybeLocalizedEnums) {
       WorkRegion.BritishColumbia,
     ],
     workRegions,
+  );
+}
+
+export function sortWfaInterest(wfaInterests?: MaybeLocalizedEnums) {
+  return sortLocalizedEnums(
+    [
+      WfaInterest.NotApplicable,
+      WfaInterest.TermEnding,
+      WfaInterest.LetterReceived,
+      WfaInterest.NotSure,
+      WfaInterest.VoluntaryDeparture,
+    ],
+    wfaInterests,
   );
 }


### PR DESCRIPTION
🤖 Resolves #14594 

## 👋 Introduction

Adds the workforce adjustment form to the employee profile page for applicatnts.

## 🕵️ Details

### Enum rename

Sadly, it seems something happened where `WFAInterest` in some cases was changing to `WfaInterest` causing a lot of odd workarounds. Found the easiest soluton was to rename it to `WfaInterest`.

### Observer changes

Not sure why but the user observer was being really odd. I moved some stuff around and it seems to be more consistent in working :woman_shrugging: 

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as any user
3. Navigate to `/en/applicant/employee-profile/`
4. Confrm the new WFa section appears
5. Edit the form setting different values to test state:
    - No substantive experience shows error
    - Substantive expereience but not CPA shows wanring
    - Substantive and CPA shows no warnign or error
    - No communiitied shows warning
    - Selecting "not applicable" hide "key details"

## 📸 Screenshot

<img width="481" height="939" alt="swappy-20250919_160109" src="https://github.com/user-attachments/assets/ba7888b7-1de3-4873-86c4-1eb7977bc757" />
