### PR TITLE
[Bug] Undo `UserObserver` deletion from user model

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -12,6 +12,7 @@ use App\Enums\PositionDuration;
 use App\Enums\PriorityWeight;
 use App\Enums\WorkExperienceGovEmployeeType;
 use App\Notifications\VerifyEmail;
+use App\Observers\UserObserver;
 use App\Traits\EnrichedNotifiable;
 use App\Traits\HasLocalizedEnums;
 use App\Traits\HydratesSnapshot;
@@ -183,6 +184,15 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
     public function newEloquentBuilder($query): Builder
     {
         return new UserBuilder($query);
+    }
+
+    /**
+     * The "booted" method of the model.
+     * Activates the Observer class
+     */
+    protected static function booted(): void
+    {
+        User::observe(UserObserver::class);
     }
 
     /**


### PR DESCRIPTION
🤖 Resolves #14668

## 👋 Introduction

The observer class was deleted (by accident I assume) from the user model, turns out it doesn't run if you do that. Added it back in 

## 🧪 Testing

1. PHP tests pass


