### PR TITLE
[Fix] Resolve deleted education requirement experiences in snapshot

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -18,6 +18,7 @@ use App\Observers\PoolCandidateObserver;
 use App\Traits\EnrichedNotifiable;
 use App\ValueObjects\ProfileSnapshot;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -27,6 +28,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
@@ -63,6 +65,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property ?int $computed_final_decision_weight
  * @property ?string $computed_final_decision
  * @property array<string, mixed> $profile_snapshot
+ * @property array<string> $education_requirement_experience_ids
  * @property string $assessment_step_id
  */
 class PoolCandidate extends Model
@@ -313,6 +316,19 @@ class PoolCandidate extends Model
             'value' => $category->name,
             'label' => PriorityWeight::localizedString($category->name),
         ];
+    }
+
+    /**
+     *  Array of education requirement experience IDs
+     *
+     *  This is used for referencing deleted experiences in the snapshot
+     */
+    public function educationRequirementExperienceIds(): Attribute
+    {
+        return Attribute::get(fn () => DB::table('pool_candidate_education_requirement_experience')
+            ->where('pool_candidate_id', $this->id)
+            ->pluck('experience_id')->all()
+        );
     }
 
     /**

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -634,6 +634,8 @@ type PoolCandidate {
     @with(relation: "educationRequirementEducationExperiences")
     @with(relation: "educationRequirementPersonalExperiences")
     @with(relation: "educationRequirementWorkExperiences")
+  educationRequirementExperienceIds: [UUID!]
+    @rename(attribute: "education_requirement_experience_ids")
   # record of decision
   assessmentResults: [AssessmentResult]
     @hasMany

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1,4 +1,4 @@
-"A date string with format `Y-m-d`, e.g. `2011-05-23`."
+"A date string with format `Y-m-d`, e.g. `2011-05-23`."schema
 scalar Date @scalar(class: "Nuwave\\Lighthouse\\Schema\\Types\\Scalars\\Date")
 
 "A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`."
@@ -634,6 +634,7 @@ type PoolCandidate {
     @with(relation: "educationRequirementEducationExperiences")
     @with(relation: "educationRequirementPersonalExperiences")
     @with(relation: "educationRequirementWorkExperiences")
+  # Array of IDs needed to resolve experiences in the snapshot if they happen to be deleted
   educationRequirementExperienceIds: [UUID!]
     @rename(attribute: "education_requirement_experience_ids")
   # record of decision

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1,4 +1,4 @@
-"A date string with format `Y-m-d`, e.g. `2011-05-23`."schema
+"A date string with format `Y-m-d`, e.g. `2011-05-23`."
 scalar Date @scalar(class: "Nuwave\\Lighthouse\\Schema\\Types\\Scalars\\Date")
 
 "A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`."

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1129,6 +1129,7 @@ type PoolCandidate {
   screeningQuestionResponses: [ScreeningQuestionResponse]
   educationRequirementOption: LocalizedEducationRequirementOption
   educationRequirementExperiences: [Experience]
+  educationRequirementExperienceIds: [UUID!]
   assessmentResults: [AssessmentResult]
   assessmentStatus: AssessmentResultStatus
   assessmentStep: AssessmentStep

--- a/api/tests/Feature/PoolCandidateTest.php
+++ b/api/tests/Feature/PoolCandidateTest.php
@@ -811,4 +811,18 @@ class PoolCandidateTest extends TestCase
             ])->assertJsonFragment(['total' => 1])
             ->assertJsonFragment(['id' => $communityCandidate->id]);
     }
+
+    public function testAccessingDeletedEducationExperienceIds()
+    {
+        $candidate = PoolCandidate::factory()
+            ->availableInSearch()
+            ->withSnapshot()
+            ->create();
+
+        $expected = $candidate->education_requirement_experiences->map(fn ($exp) => $exp->id)->toArray();
+        $candidate->education_requirement_experiences->each(fn ($exp) => $exp->delete());
+
+        $this->assertEqualsCanonicalizing($expected, $candidate->education_requirement_experience_ids);
+
+    }
 }

--- a/apps/web/src/components/ScreeningDecisions/SupportingEvidence.tsx
+++ b/apps/web/src/components/ScreeningDecisions/SupportingEvidence.tsx
@@ -19,9 +19,7 @@ import { DIALOG_TYPE } from "./utils";
 
 const ScreeningDialogSupportingEvidence_Fragment = graphql(/** GraphQL */ `
   fragment ScreeningDialogSupportingEvidence on PoolCandidate {
-    educationRequirementExperiences {
-      id
-    }
+    educationRequirementExperienceIds
   }
 `);
 
@@ -44,8 +42,8 @@ const SupportingEvidence = ({
     query,
   );
   const educationRequirementExperienceIds = unpackMaybes(
-    candidate?.educationRequirementExperiences,
-  ).flatMap((exp) => exp.id);
+    candidate.educationRequirementExperienceIds,
+  );
   const experiencesFiltered =
     dialogType === DIALOG_TYPE.Education
       ? experiences.filter((experience) =>

--- a/packages/fake-data/src/fakePoolCandidates.ts
+++ b/packages/fake-data/src/fakePoolCandidates.ts
@@ -40,12 +40,16 @@ const generatePoolCandidate = (
       answer: faker.lorem.sentence(),
       screeningQuestion,
     })) ?? [];
+  const educationRequirementExperiences = fakeExperiences(1);
 
   return {
     id: faker.string.uuid(),
     pool,
     user,
-    educationRequirementExperiences: fakeExperiences(1),
+    educationRequirementExperiences,
+    educationRequirementExperienceIds: educationRequirementExperiences.flatMap(
+      ({ id }) => id,
+    ),
     educationRequirementOption: toLocalizedEnum(
       faker.helpers.arrayElement<EducationRequirementOption>(
         Object.values(EducationRequirementOption),


### PR DESCRIPTION
🤖 Resolves #14629 

## 👋 Introduction

Fixes an issue where the snapshot could not resolve the experiences marked as education requirements after they had been deleted.

## 🕵️ Details

This is accomplished by adding an attibute to get the IDs for those experiences from the pivit table since it still exists even when the referenced table row does not.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Apply to a process taking note of the experiences you used in the educaiton requirement section
4. Delete all your experiences
5. View the  application as an admin
6. Confirm the experiences from the snapshot are still rendered even when the live versions do not exist
