### PR TITLE
[Fix] Application screening test assessment status computation

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -14,6 +14,7 @@ use App\Enums\OverallAssessmentStatus;
 use App\Enums\PoolCandidateStatus;
 use App\Enums\PoolSkillType;
 use App\Enums\PriorityWeight;
+use App\Enums\SkillCategory;
 use App\Observers\PoolCandidateObserver;
 use App\Traits\EnrichedNotifiable;
 use App\ValueObjects\ProfileSnapshot;
@@ -388,8 +389,10 @@ class PoolCandidate extends Model
         $this->load([
             'pool.assessmentSteps',
             'pool.assessmentSteps.poolSkills',
+            'pool.assessmentSteps.poolSkills.skill',
             'assessmentResults',
             'assessmentResults.poolSkill',
+            'assessmentResults.poolSkill.skill',
         ]);
 
         $steps = $this->pool->assessmentSteps;
@@ -407,7 +410,7 @@ class PoolCandidate extends Model
                 $result = $stepResults->firstWhere('pool_skill_id', $poolSkill->id);
                 $decision = $result?->assessment_decision;
 
-                if ($poolSkill->type === PoolSkillType::ESSENTIAL->name) {
+                if ($poolSkill->type === PoolSkillType::ESSENTIAL->name && ! ($isApplicationScreening && $poolSkill->skill->category === SkillCategory::BEHAVIOURAL->name)) {
                     if (! $result || is_null($result->assessment_decision)) {
                         $hasToAssess = true;
 

--- a/api/tests/Feature/CandidateAssessmentStatusTest.php
+++ b/api/tests/Feature/CandidateAssessmentStatusTest.php
@@ -776,6 +776,13 @@ class CandidateAssessmentStatusTest extends TestCase
             'skill_id' => Skill::factory()->create(['category' => SkillCategory::TECHNICAL->name])->id,
             'type' => PoolSkillType::ESSENTIAL->name,
         ]);
+
+        // Add an essential behavioural that does not need to be assessed to pass the first step
+        PoolSkill::create([
+            'pool_id' => $pool->id,
+            'skill_id' => Skill::factory()->create(['category' => SkillCategory::BEHAVIOURAL->name])->id,
+            'type' => PoolSkillType::ESSENTIAL->name,
+        ]);
         $stepOne = $pool->assessmentSteps->first();
         AssessmentStep::factory()
             ->afterCreating(function (AssessmentStep $step) use ($poolSkill) {


### PR DESCRIPTION
🤖 Resolves #14667 

## 👋 Introduction

Updates the computation of the assessment status for application screening to skip essential skills if they are behavioural.

## 🧪 Testing

1. Login as `admin@test.com`
2. Create a process that has at least 2 assesment steps including essential behavioural skills
3. Apply to the process created in step 2
4. Assess the application created in step 3
5. Confirm you do _**not**_ need to assess any essential behavioural skills to pass the first step only

## 📸 Screenshot

<img width="1625" height="560" alt="swappy-20250926_083426" src="https://github.com/user-attachments/assets/64d2fa44-ea8a-49f7-b21e-5c6bcb709f24" />
