### PR TITLE
[Fix] Offset scrolling by menu

### DIFF
--- a/apps/web/src/components/NavMenu/Menu.tsx
+++ b/apps/web/src/components/NavMenu/Menu.tsx
@@ -127,6 +127,7 @@ const Menu = ({
           <div className="relative z-10">
             {showMenu ? (
               <NavMenu.Root
+                // NOTE: Do not remove, required by anchor link offsets
                 id="main-nav"
                 onKeyDown={handleKeyDown}
                 aria-label={

--- a/apps/web/src/components/NavMenu/Menu.tsx
+++ b/apps/web/src/components/NavMenu/Menu.tsx
@@ -127,6 +127,7 @@ const Menu = ({
           <div className="relative z-10">
             {showMenu ? (
               <NavMenu.Root
+                id="main-nav"
                 onKeyDown={handleKeyDown}
                 aria-label={
                   label ??

--- a/packages/ui/src/components/Link/ScrollToLink.tsx
+++ b/packages/ui/src/components/Link/ScrollToLink.tsx
@@ -12,14 +12,30 @@ export type ScrollLinkClickFunc = (
   section: HTMLElement | null,
 ) => void;
 
-const scrollToSection = (section: HTMLElement | null) => {
+const scrollToSection = (
+  section: HTMLElement | null,
+  offsetEl?: HTMLElement | null,
+) => {
   if (section) {
-    setTimeout(() => {
-      section.scrollIntoView({
-        behavior: "smooth",
-        block: "start",
-      });
-    }, 10);
+    if (offsetEl) {
+      setTimeout(() => {
+        window.scrollTo({
+          behavior: "smooth",
+          top:
+            section.getBoundingClientRect().top -
+            document.body.getBoundingClientRect().top -
+            // NOTE: 16 adds a bit of a gap so text doesn't touch element
+            (offsetEl.getBoundingClientRect().height + 16),
+        });
+      }, 10);
+    } else {
+      setTimeout(() => {
+        section.scrollIntoView({
+          behavior: "smooth",
+          block: "start",
+        });
+      }, 10);
+    }
   }
 };
 
@@ -29,6 +45,7 @@ export interface ScrollToLinkProps
   to: string;
   onScrollTo?: ScrollLinkClickFunc;
   disabled?: boolean;
+  offsetId?: string;
 }
 
 const ScrollToLink = ({
@@ -39,6 +56,7 @@ const ScrollToLink = ({
   mode = "text",
   block = false,
   size = "md",
+  offsetId = "main-nav",
   icon,
   utilityIcon,
   disabled = false,
@@ -56,12 +74,13 @@ const ScrollToLink = ({
     size,
     disabled,
   });
+  const offsetEl = document.getElementById(offsetId);
 
   useEffect(() => {
     if (hash && hash === `#${to}`) {
-      scrollToSection(targetSection);
+      scrollToSection(targetSection, offsetEl);
     }
-  }, [pathname, hash, to, targetSection]);
+  }, [pathname, hash, to, targetSection, offsetEl]);
 
   useEffect(() => {
     const section = document.getElementById(to.toString());
@@ -69,7 +88,7 @@ const ScrollToLink = ({
   }, [to]);
 
   const handleClick = (e: ClickEvent) => {
-    scrollToSection(targetSection);
+    scrollToSection(targetSection, offsetEl);
     if (onScrollTo) {
       onScrollTo(e, targetSection);
     }


### PR DESCRIPTION
🤖 Resolves #14574 

## 👋 Introduction

This adds an offset to our scroll link so that the targeted section is not obscured by the sticky nav menu.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Navigate to a page with a tabe of contents
3. Activate a link in the table of contents
4. Confirm the section it scrolls to is not obsrcued by the sticky nav