### PR TITLE
[Feat] Allow editing process number after publishing

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -2732,6 +2732,7 @@ input UpdatePoolInput {
 }
 
 input UpdatePublishedPoolInput @validator {
+  processNumber: String @rename(attribute: "process_number")
   changeJustification: String! @rename(attribute: "change_justification")
   yourImpact: LocalizedStringInput @rename(attribute: "your_impact")
   keyTasks: LocalizedStringInput @rename(attribute: "key_tasks")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -2580,6 +2580,7 @@ input UpdatePoolInput {
 }
 
 input UpdatePublishedPoolInput {
+  processNumber: String
   changeJustification: String!
   yourImpact: LocalizedStringInput
   keyTasks: LocalizedStringInput

--- a/apps/playwright/tests/admin/process-action-update.spec.ts
+++ b/apps/playwright/tests/admin/process-action-update.spec.ts
@@ -36,9 +36,6 @@ test.describe("Update pool", () => {
       .getByRole("combobox", { name: /work stream/i })
       .selectOption({ label: "Business Line Advisory Services" });
     await appPage.page
-      .getByRole("textbox", { name: /process number/i })
-      .fill("123");
-    await appPage.page
       .getByRole("button", { name: /save advertisement details/i })
       .click();
     await appPage.waitForGraphqlResponse(UPDATE_MUTATION);

--- a/apps/playwright/tests/admin/process-action-update.spec.ts
+++ b/apps/playwright/tests/admin/process-action-update.spec.ts
@@ -47,6 +47,22 @@ test.describe("Update pool", () => {
     );
   });
 
+  test("Update process number", async ({ appPage }) => {
+    await appPage.page
+      .getByRole("button", { name: /edit process number/i })
+      .click();
+    await appPage.page
+      .getByRole("textbox", { name: /process number/i })
+      .fill("123");
+    await appPage.page
+      .getByRole("button", { name: /save process number/i })
+      .click();
+    await appPage.waitForGraphqlResponse(UPDATE_MUTATION);
+    await expect(appPage.page.getByRole("alert").last()).toContainText(
+      /process updated successfully/i,
+    );
+  });
+
   test("Update pool closing date", async ({ appPage }) => {
     // Update closing date
     await appPage.page

--- a/apps/playwright/tests/admin/process-published-action-update.spec.ts
+++ b/apps/playwright/tests/admin/process-published-action-update.spec.ts
@@ -74,7 +74,7 @@ test.describe("Update published process", () => {
   test("Platform admin cannot update process number when published", async ({
     appPage,
   }) => {
-    await loginAndNavigate(appPage, "admin@test.com");
+    await loginAndNavigate(appPage, "platform@test.com");
 
     await expect(
       appPage.page.getByRole("button", { name: /edit process number/i }),

--- a/apps/playwright/tests/admin/process-published-action-update.spec.ts
+++ b/apps/playwright/tests/admin/process-published-action-update.spec.ts
@@ -6,11 +6,18 @@ import graphql from "~/utils/graphql";
 import { createAndPublishPool } from "~/utils/pools";
 import { me } from "~/utils/user";
 import { loginBySub } from "~/utils/auth";
+import AppPage from "~/fixtures/AppPage";
 
 const UPDATE_PUBLISHED_MUTATION = "UpdatePublishedPool";
 
 test.describe("Update published process", () => {
   let pool: Pool;
+
+  async function loginAndNavigate(appPage: AppPage, sub: string) {
+    await loginBySub(appPage.page, "community@test.com");
+    await appPage.page.goto(`/en/admin/pools/${pool.id}/edit`);
+    await appPage.waitForGraphqlResponse("EditPoolPage");
+  }
 
   test.beforeAll(async () => {
     const communityCtx = await graphql.newContext("community@test.com");
@@ -35,10 +42,10 @@ test.describe("Update published process", () => {
     pool = createdPool;
   });
 
-  test("Can update process number when published", async ({ appPage }) => {
-    await loginBySub(appPage.page, "community@test.com");
-    await appPage.page.goto(`/en/admin/pools/${pool.id}/edit`);
-    await appPage.waitForGraphqlResponse("EditPoolPage");
+  test("Community admin can update process number when published", async ({
+    appPage,
+  }) => {
+    await loginAndNavigate(appPage, "community@test.com");
 
     await appPage.page
       .getByRole("button", { name: /edit process number/i })
@@ -62,5 +69,35 @@ test.describe("Update published process", () => {
     await expect(appPage.page.getByRole("alert").last()).toContainText(
       /process updated successfully/i,
     );
+  });
+
+  test("Platform admin cannot update process number when published", async ({
+    appPage,
+  }) => {
+    await loginAndNavigate(appPage, "admin@test.com");
+
+    await expect(
+      appPage.page.getByRole("button", { name: /edit process number/i }),
+    ).toBeHidden();
+  });
+
+  test("Platform admin cannot update process number when published", async ({
+    appPage,
+  }) => {
+    await loginAndNavigate(appPage, "admin@test.com");
+
+    await expect(
+      appPage.page.getByRole("button", { name: /edit process number/i }),
+    ).toBeHidden();
+  });
+
+  test("Community recruiter cannot update process number when published", async ({
+    appPage,
+  }) => {
+    await loginAndNavigate(appPage, "recruiter@test.com");
+
+    await expect(
+      appPage.page.getByRole("button", { name: /edit process number/i }),
+    ).toBeHidden();
   });
 });

--- a/apps/playwright/tests/admin/process-published-action-update.spec.ts
+++ b/apps/playwright/tests/admin/process-published-action-update.spec.ts
@@ -50,7 +50,7 @@ test.describe("Update published process", () => {
       .getByRole("button", { name: /save process number/i })
       .click();
 
-    const justificationDialog =  appPage.page.getByRole("dialog", {
+    const justificationDialog = appPage.page.getByRole("dialog", {
       name: /change justification/i,
     });
 

--- a/apps/playwright/tests/admin/process-published-action-update.spec.ts
+++ b/apps/playwright/tests/admin/process-published-action-update.spec.ts
@@ -1,0 +1,68 @@
+import { Pool, SkillCategory } from "@gc-digital-talent/graphql";
+
+import { test, expect } from "~/fixtures";
+import { getSkills } from "~/utils/skills";
+import graphql from "~/utils/graphql";
+import { createAndPublishPool } from "~/utils/pools";
+import { me } from "~/utils/user";
+import { loginBySub } from "~/utils/auth";
+
+const UPDATE_PUBLISHED_MUTATION = "UpdatePublishedPool";
+
+test.describe("Update published process", () => {
+  let pool: Pool;
+
+  test.beforeAll(async () => {
+    const communityCtx = await graphql.newContext("community@test.com");
+    const adminCtx = await graphql.newContext();
+    const technicalSkill = await getSkills(adminCtx, {}).then((skills) => {
+      return skills.find(
+        (skill) => skill.category.value === SkillCategory.Technical,
+      );
+    });
+
+    const user = await me(communityCtx, {});
+
+    const createdPool = await createAndPublishPool(adminCtx, {
+      userId: user.id,
+      skillIds: technicalSkill ? [technicalSkill?.id] : undefined,
+      name: {
+        en: "Test published pool EN",
+        fr: "Test published pool FR",
+      },
+    });
+
+    pool = createdPool;
+  });
+
+  test("Can update process number when published", async ({ appPage }) => {
+    await loginBySub(appPage.page, "community@test.com");
+    await appPage.page.goto(`/en/admin/pools/${pool.id}/edit`);
+    await appPage.waitForGraphqlResponse("EditPoolPage");
+
+    await appPage.page
+      .getByRole("button", { name: /edit process number/i })
+      .click();
+    await appPage.page
+      .getByRole("textbox", { name: /process number/i })
+      .fill("123");
+    await appPage.page
+      .getByRole("button", { name: /save process number/i })
+      .click();
+
+    const justificationDialog =  appPage.page.getByRole("dialog", {
+      name: /change justification/i,
+    });
+
+    await justificationDialog
+      .getByRole("textbox", { name: /change justification/i })
+      .fill("Some justification");
+    await justificationDialog
+      .getByRole("button", { name: /save changes/i })
+      .click();
+    await appPage.waitForGraphqlResponse(UPDATE_PUBLISHED_MUTATION);
+    await expect(appPage.page.getByRole("alert").last()).toContainText(
+      /process updated successfully/i,
+    );
+  });
+});

--- a/apps/playwright/tests/admin/process-published-action-update.spec.ts
+++ b/apps/playwright/tests/admin/process-published-action-update.spec.ts
@@ -14,7 +14,7 @@ test.describe("Update published process", () => {
   let pool: Pool;
 
   async function loginAndNavigate(appPage: AppPage, sub: string) {
-    await loginBySub(appPage.page, "community@test.com");
+    await loginBySub(appPage.page, sub);
     await appPage.page.goto(`/en/admin/pools/${pool.id}/edit`);
     await appPage.waitForGraphqlResponse("EditPoolPage");
   }

--- a/apps/playwright/tests/admin/process-published-action-update.spec.ts
+++ b/apps/playwright/tests/admin/process-published-action-update.spec.ts
@@ -81,16 +81,6 @@ test.describe("Update published process", () => {
     ).toBeHidden();
   });
 
-  test("Platform admin cannot update process number when published", async ({
-    appPage,
-  }) => {
-    await loginAndNavigate(appPage, "admin@test.com");
-
-    await expect(
-      appPage.page.getByRole("button", { name: /edit process number/i }),
-    ).toBeHidden();
-  });
-
   test("Community recruiter cannot update process number when published", async ({
     appPage,
   }) => {

--- a/apps/playwright/tests/admin/process-published-action-update.spec.ts
+++ b/apps/playwright/tests/admin/process-published-action-update.spec.ts
@@ -47,7 +47,7 @@ test.describe("Update published process", () => {
       .getByRole("textbox", { name: /process number/i })
       .fill("123");
     await appPage.page
-      .getByRole("button", { name: /save process number/i })
+      .getByRole("button", { name: /save changes/i })
       .click();
 
     const justificationDialog = appPage.page.getByRole("dialog", {

--- a/apps/playwright/tests/admin/process-published-action-update.spec.ts
+++ b/apps/playwright/tests/admin/process-published-action-update.spec.ts
@@ -46,9 +46,7 @@ test.describe("Update published process", () => {
     await appPage.page
       .getByRole("textbox", { name: /process number/i })
       .fill("123");
-    await appPage.page
-      .getByRole("button", { name: /save changes/i })
-      .click();
+    await appPage.page.getByRole("button", { name: /save changes/i }).click();
 
     const justificationDialog = appPage.page.getByRole("dialog", {
       name: /change justification/i,

--- a/apps/web/src/components/ToggleForm/LabelledTrigger.tsx
+++ b/apps/web/src/components/ToggleForm/LabelledTrigger.tsx
@@ -12,8 +12,9 @@ interface LabelledTriggerProps {
 
 const LabelledTrigger = ({ disabled, sectionTitle }: LabelledTriggerProps) => {
   const intl = useIntl();
+  if (disabled) return null;
 
-  return !disabled ? (
+  return (
     <SectionTrigger
       aria-label={intl.formatMessage(
         {
@@ -28,7 +29,7 @@ const LabelledTrigger = ({ disabled, sectionTitle }: LabelledTriggerProps) => {
     >
       {intl.formatMessage(commonMessages.edit)}
     </SectionTrigger>
-  ) : undefined;
+  );
 };
 
 export default LabelledTrigger;

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2879,10 +2879,6 @@
     "defaultMessage": "* Il s’agit d’une offre d’emploi au sein d’un ministère ou d’un organisme qui n’est pas assujetti à la <a><italic>Loi sur l’emploi dans la fonction publique</italic></a>. Par conséquent, le processus d’embauche et la terminologie employée peuvent différer de ceux habituellement utilisés dans la fonction publique fédérale.",
     "description": "Body p2 of a note describing that a pool is only open to canadian citizens"
   },
-  "Ao/+Ba": {
-    "defaultMessage": "Ce numéro de processus est obtenu auprès de votre atelier RH",
-    "description": "Additional context describing the pools process number."
-  },
   "Aqz3Ma": {
     "defaultMessage": "La spécialisation est pertinente à l’exigence du diplôme",
     "description": "Text for education accepted information context in screening decision dialog"
@@ -7429,6 +7425,10 @@
   "WAcWqh": {
     "defaultMessage": "{title} évaluation - {skillName}",
     "description": "Header for application screening decision dialog."
+  },
+  "WBvYyt": {
+    "defaultMessage": "Enregistrer le numéro de processus",
+    "description": "Text on a button to save the process number"
   },
   "WDKT2K": {
     "defaultMessage": "Qu'est-ce qu'une CléGC?",
@@ -12604,6 +12604,10 @@
   "tc3sSC": {
     "defaultMessage": "L'équipe",
     "description": "Card title, team"
+  },
+  "teUR2H": {
+    "defaultMessage": "Ce numéro de processus provient de votre conseillère ou conseiller en RH",
+    "description": "Additional context describing the pools process number."
   },
   "tgPKAn": {
     "defaultMessage": "Nominations",

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.test.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.test.tsx
@@ -43,6 +43,13 @@ describe("EditPoolPage", () => {
     );
 
     await user.click(
+      screen.getByRole("button", { name: /edit process number/i }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /save process number/i }),
+    );
+
+    await user.click(
       screen.getByRole("button", { name: /edit closing date/i }),
     );
     await user.click(
@@ -106,6 +113,6 @@ describe("EditPoolPage", () => {
       }),
     );
 
-    expect(handleSave).toHaveBeenCalledTimes(9);
+    expect(handleSave).toHaveBeenCalledTimes(10);
   });
 });

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -389,7 +389,6 @@ export const EditPoolForm = ({
       hasError: educationRequirementIsNull({
         workStream: pool.workStream,
         name: pool.name,
-        processNumber: pool.processNumber,
         publishingGroup: pool.publishingGroup,
       }),
       title: intl.formatMessage({

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -54,6 +54,9 @@ import PoolNameSection, {
   PoolDepartment_Fragment,
   type PoolNameSubmitData,
 } from "./components/PoolNameSection/PoolNameSection";
+import ProcessNumberSection, {
+  type ProcessNumberSubmitData,
+} from "./components/ProcessNumberSection";
 import ClosingDateSection, {
   type ClosingDateSubmitData,
 } from "./components/ClosingDateSection/ClosingDateSection";
@@ -99,6 +102,7 @@ export const EditPool_Fragment = graphql(/* GraphQL */ `
     ...EditPoolGeneralQuestions
     ...EditPoolKeyTasks
     ...EditPoolName
+    ...EditPoolProcessNumber
     ...EditPoolSkills
     ...EditPoolSpecialNote
     ...EditPoolWhatToExpectAdmission
@@ -235,6 +239,7 @@ export type PoolSubmitData =
   | ClosingDateSubmitData
   | CoreRequirementsSubmitData
   | PoolNameSubmitData
+  | ProcessNumberSubmitData
   | WorkTasksSubmitData
   | YourImpactSubmitData
   | WhatToExpectSubmitData
@@ -286,7 +291,6 @@ export const EditPoolForm = ({
       department: pool.department,
       workStream: pool.workStream,
       name: pool.name,
-      processNumber: pool.processNumber,
       publishingGroup: pool.publishingGroup,
       opportunityLength: pool.opportunityLength,
     }) ||
@@ -325,7 +329,6 @@ export const EditPoolForm = ({
         department: pool.department,
         workStream: pool.workStream,
         name: pool.name,
-        processNumber: pool.processNumber,
         publishingGroup: pool.publishingGroup,
         opportunityLength: pool.opportunityLength,
       }),
@@ -334,6 +337,12 @@ export const EditPoolForm = ({
         id: "KEm64j",
         description: "Sub title for advertisement details",
       }),
+      inList: false,
+    },
+    processNumber: {
+      id: "process-number",
+      hasError: !pool.processNumber,
+      title: intl.formatMessage(processMessages.processNumber),
       inList: false,
     },
     closingDate: {
@@ -573,6 +582,12 @@ export const EditPoolForm = ({
                     departmentsQuery={departments}
                     sectionMetadata={sectionMetadata.poolName}
                     onSave={onSave}
+                  />
+                  <ProcessNumberSection
+                    poolQuery={pool}
+                    sectionMetadata={sectionMetadata.processNumber}
+                    onSave={onSave}
+                    onUpdatePublished={onUpdatePublished}
                   />
                   <ClosingDateSection
                     poolQuery={pool}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/Display.tsx
@@ -32,7 +32,6 @@ const Display = ({
     department,
     workStream,
     name,
-    processNumber,
     publishingGroup,
     opportunityLength,
   } = pool;
@@ -153,12 +152,6 @@ const Display = ({
           label={intl.formatMessage(processMessages.employmentDuration)}
         >
           {getLocalizedName(opportunityLength?.label, intl)}
-        </ToggleForm.FieldDisplay>
-        <ToggleForm.FieldDisplay
-          hasError={!processNumber}
-          label={intl.formatMessage(processMessages.processNumber)}
-        >
-          {processNumber ?? notProvided}
         </ToggleForm.FieldDisplay>
         <ToggleForm.FieldDisplay
           hasError={!publishingGroup}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
@@ -63,7 +63,6 @@ const EditPoolName_Fragment = graphql(/* GraphQL */ `
         fr
       }
     }
-    processNumber
     publishingGroup {
       value
       label {
@@ -495,20 +494,6 @@ const PoolNameSection = ({
                   )}
                   disabled={formDisabled}
                   doNotSort
-                />
-                <Input
-                  id="processNumber"
-                  name="processNumber"
-                  type="text"
-                  label={intl.formatMessage(processMessages.processNumber)}
-                  context={intl.formatMessage({
-                    defaultMessage:
-                      "This process number is obtained from your HR shop",
-                    id: "Ao/+Ba",
-                    description:
-                      "Additional context describing the pools process number.",
-                  })}
-                  disabled={formDisabled}
                 />
                 <Select
                   id="publishingGroup"

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/utils.ts
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/utils.ts
@@ -25,7 +25,6 @@ export interface FormValues {
   stream?: WorkStream["id"];
   specificTitleEn?: LocalizedString["en"];
   specificTitleFr?: LocalizedString["fr"];
-  processNumber?: string;
   publishingGroup?: Maybe<PublishingGroup>;
   opportunityLength?: Maybe<PoolOpportunityLength>;
 }
@@ -38,7 +37,6 @@ export const dataToFormValues = (initialData: Pool): FormValues => ({
   stream: initialData.workStream?.id ?? undefined,
   specificTitleEn: initialData.name?.en ?? "",
   specificTitleFr: initialData.name?.fr ?? "",
-  processNumber: initialData.processNumber ?? "",
   publishingGroup: initialData.publishingGroup?.value,
   opportunityLength: initialData.opportunityLength?.value,
 });
@@ -51,7 +49,6 @@ export type PoolNameSubmitData = Pick<
   | "department"
   | "name"
   | "workStream"
-  | "processNumber"
   | "publishingGroup"
   | "opportunityLength"
 >;
@@ -76,7 +73,6 @@ export const formValuesToSubmitData = (
     en: formValues.specificTitleEn,
     fr: formValues.specificTitleFr,
   },
-  processNumber: formValues.processNumber ?? null,
   publishingGroup: formValues.publishingGroup ?? undefined, // can't be set to null, assume not updating if empty
   opportunityLength: formValues.opportunityLength ?? undefined, // can't be set to null, assume not updating if empty
 });

--- a/apps/web/src/pages/Pools/EditPoolPage/components/ProcessNumberSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/ProcessNumberSection.tsx
@@ -1,0 +1,189 @@
+import TagIcon from "@heroicons/react/24/outline/TagIcon";
+import { useIntl } from "react-intl";
+import { FormProvider, useForm } from "react-hook-form";
+
+import {
+  FragmentType,
+  getFragment,
+  graphql,
+  Maybe,
+  PoolStatus,
+  UpdatePoolInput,
+} from "@gc-digital-talent/graphql";
+import { Button, ToggleSection } from "@gc-digital-talent/ui";
+import { commonMessages, formMessages } from "@gc-digital-talent/i18n";
+import { Input, Submit } from "@gc-digital-talent/forms";
+
+import processMessages from "~/messages/processMessages";
+import useToggleSectionInfo from "~/hooks/useToggleSectionInfo";
+import ToggleForm from "~/components/ToggleForm/ToggleForm";
+import useCanUserEditPool from "~/hooks/useCanUserEditPool";
+
+import { useEditPoolContext } from "./EditPoolContext";
+import { PublishedEditableSectionProps, SectionProps } from "../types";
+import UpdatePublishedProcessDialog, {
+  type FormValues as UpdateFormValues,
+} from "./UpdatePublishedProcessDialog/UpdatePublishedProcessDialog";
+import ActionWrapper from "./ActionWrapper";
+
+export type ProcessNumberSubmitData = Pick<UpdatePoolInput, "processNumber">;
+
+interface FormValues {
+  processNumber?: string;
+}
+
+const dataToFormValues = (initialData: {
+  processNumber?: Maybe<string>;
+}): FormValues => ({
+  processNumber: initialData.processNumber ?? "",
+});
+
+const formValuesToSubmitData = (
+  formValues: FormValues,
+): ProcessNumberSubmitData => ({
+  processNumber: formValues.processNumber ?? null,
+});
+
+const EditPoolProcessNumber_Fragment = graphql(/** GraphQL */ `
+  fragment EditPoolProcessNumber on Pool {
+    ...UpdatePublishedProcessDialog
+    processNumber
+    status {
+      value
+    }
+  }
+`);
+
+interface ProcessNumberSectionProps
+  extends SectionProps<
+      ProcessNumberSubmitData,
+      FragmentType<typeof EditPoolProcessNumber_Fragment>
+    >,
+    PublishedEditableSectionProps {}
+
+const ProcessNumberSection = ({
+  poolQuery,
+  onSave,
+  sectionMetadata,
+  onUpdatePublished,
+}: ProcessNumberSectionProps) => {
+  const intl = useIntl();
+  const pool = getFragment(EditPoolProcessNumber_Fragment, poolQuery);
+  const isNull = !pool?.processNumber;
+  const canEdit = useCanUserEditPool(pool.status?.value);
+  const { isSubmitting } = useEditPoolContext();
+  const { isEditing, setIsEditing, icon } = useToggleSectionInfo({
+    isNull,
+    emptyRequired: isNull,
+    fallbackIcon: TagIcon,
+  });
+
+  const methods = useForm<FormValues>({
+    defaultValues: dataToFormValues(pool),
+  });
+  const { handleSubmit, watch } = methods;
+  const values = watch();
+
+  const onSuccess = (formValues: FormValues) => {
+    methods.reset(formValues, { keepDirty: true });
+    setIsEditing(false);
+  };
+
+  const handleSave = async (formValues: FormValues) => {
+    return onSave(formValuesToSubmitData(formValues))
+      .then(() => onSuccess(formValues))
+      .catch(() => methods.reset(formValues));
+  };
+
+  const handleUpdatePublished = async (formValues: UpdateFormValues) => {
+    await onUpdatePublished({
+      ...formValues,
+      processNumber: values.processNumber,
+    }).then(() => onSuccess({ ...values }));
+  };
+
+  return (
+    <ToggleSection.Root
+      id={`${sectionMetadata.id}-form`}
+      open={isEditing}
+      onOpenChange={setIsEditing}
+    >
+      <ToggleSection.Header
+        icon={icon.icon}
+        color={icon.color}
+        level="h3"
+        size="h4"
+        toggle={
+          <ToggleForm.LabelledTrigger sectionTitle={sectionMetadata.title} />
+        }
+        className="font-bold"
+      >
+        {sectionMetadata.title}
+      </ToggleSection.Header>
+      <ToggleSection.Content>
+        <ToggleSection.InitialContent>
+          {isNull ? (
+            <ToggleForm.NullDisplay />
+          ) : (
+            <ToggleForm.FieldDisplay
+              label={intl.formatMessage(processMessages.processNumber)}
+            >
+              {pool.processNumber ??
+                intl.formatMessage(commonMessages.notProvided)}
+            </ToggleForm.FieldDisplay>
+          )}
+        </ToggleSection.InitialContent>
+        <ToggleSection.OpenContent>
+          <FormProvider {...methods}>
+            <form onSubmit={handleSubmit(handleSave)}>
+              <div className="mb-6">
+                <Input
+                  id="processNumber"
+                  name="processNumber"
+                  type="text"
+                  label={intl.formatMessage(processMessages.processNumber)}
+                  context={intl.formatMessage({
+                    defaultMessage:
+                      "This process number is obtained from your HR shop",
+                    id: "Ao/+Ba",
+                    description:
+                      "Additional context describing the pools process number.",
+                  })}
+                />
+              </div>
+              <ActionWrapper>
+                {canEdit && pool.status?.value === PoolStatus.Draft && (
+                  <Submit
+                    text={intl.formatMessage(formMessages.saveChanges)}
+                    aria-label={intl.formatMessage({
+                      defaultMessage: "Save process number",
+                      id: "WBvYyt",
+                      description:
+                        "Text on a button to save the process number",
+                    })}
+                    color="secondary"
+                    mode="solid"
+                    isSubmitting={isSubmitting}
+                  />
+                )}
+                {canEdit && pool.status?.value === PoolStatus.Published && (
+                  <UpdatePublishedProcessDialog
+                    poolQuery={pool}
+                    onUpdatePublished={handleUpdatePublished}
+                  />
+                )}
+                <ToggleSection.Close>
+                  <Button mode="inline" type="button" color="warning">
+                    {intl.formatMessage(commonMessages.cancel)}
+                  </Button>
+                </ToggleSection.Close>
+              </ActionWrapper>
+            </form>
+          </FormProvider>
+        </ToggleSection.OpenContent>
+      </ToggleSection.Content>
+    </ToggleSection.Root>
+  );
+};
+
+export default ProcessNumberSection;

--- a/apps/web/src/pages/Pools/EditPoolPage/components/ProcessNumberSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/ProcessNumberSection.tsx
@@ -144,8 +144,8 @@ const ProcessNumberSection = ({
                   label={intl.formatMessage(processMessages.processNumber)}
                   context={intl.formatMessage({
                     defaultMessage:
-                      "This process number is obtained from your HR shop",
-                    id: "Ao/+Ba",
+                      "This process number is obtained from your HR advisor",
+                    id: "teUR2H",
                     description:
                       "Additional context describing the pools process number.",
                   })}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/ProcessNumberSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/ProcessNumberSection.tsx
@@ -114,7 +114,10 @@ const ProcessNumberSection = ({
         level="h3"
         size="h4"
         toggle={
-          <ToggleForm.LabelledTrigger sectionTitle={sectionMetadata.title} />
+          <ToggleForm.LabelledTrigger
+            disabled={!canEdit}
+            sectionTitle={sectionMetadata.title}
+          />
         }
         className="font-bold"
       >

--- a/apps/web/src/pages/Pools/EditPoolPage/types.ts
+++ b/apps/web/src/pages/Pools/EditPoolPage/types.ts
@@ -54,6 +54,7 @@ export interface PublishedEditableSectionProps {
 export type SectionKey =
   | "basicInfo"
   | "poolName"
+  | "processNumber"
   | "closingDate"
   | "coreRequirements"
   | "specialNote"

--- a/apps/web/src/validators/process/classification.ts
+++ b/apps/web/src/validators/process/classification.ts
@@ -7,17 +7,12 @@ import { Pool } from "@gc-digital-talent/graphql";
 export function isInNullState({
   workStream,
   name,
-  processNumber,
   publishingGroup,
-}: Pick<
-  Pool,
-  "workStream" | "name" | "processNumber" | "publishingGroup"
->): boolean {
+}: Pick<Pool, "workStream" | "name" | "publishingGroup">): boolean {
   return !!(
     !workStream &&
     !name?.en &&
     !name?.fr &&
-    !processNumber &&
     !publishingGroup &&
     !publishingGroup
   );
@@ -29,7 +24,6 @@ export function hasEmptyRequiredFields({
   department,
   workStream,
   name,
-  processNumber,
   publishingGroup,
   opportunityLength,
 }: Pick<
@@ -39,7 +33,6 @@ export function hasEmptyRequiredFields({
   | "department"
   | "workStream"
   | "name"
-  | "processNumber"
   | "publishingGroup"
   | "opportunityLength"
 >): boolean {
@@ -50,7 +43,6 @@ export function hasEmptyRequiredFields({
     !workStream ||
     !name?.en ||
     !name?.fr ||
-    !processNumber ||
     !publishingGroup ||
     !opportunityLength
   );


### PR DESCRIPTION
🤖 Resolves #13925 

## 👋 Introduction

Updates the process number to allow it to be edited after publishing.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `community@test.com`
3. Create and publish a pool
4. Edit the process number
5. Confirm it requires justification and can be updated
6. Confirm the change is tracked in the activity log

## 📸 Screenshot

<img width="988" height="225" alt="swappy-20251001_125352" src="https://github.com/user-attachments/assets/9e4315bb-6b7e-46f5-bcdc-8dbdf5c06cf5" />
