### PR TITLE
[Fix] Allow `-` in hashes for nginx long cache rule

### DIFF
--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -179,7 +179,7 @@ server {
     # serve other asset files
     location ~ "\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest|webp|pptx)$" {
         # contenthashed asset files get cached for a year
-        location ~ "-[A-z0-9]{8}\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest|webp|pptx)$" {
+        location ~ "-[A-z0-9-]{8}\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest|webp|pptx)$" {
             add_header Cache-Control "public, max-age=31536000"; # 1 year
             try_files /apps/web/dist/$uri =404;
         }

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -227,7 +227,7 @@ server {
     # NOTE2: this excludes assets starting with /static/ since there's a redirect to static hosting for that case below
     location ~ "^(?!/static/).*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest|webp|pptx)$" {
         # contenthashed asset files get cached for a year
-        location ~ "-[A-z0-9]{8}\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest|webp|pptx)$" {
+        location ~ "-[A-z0-9-]{8}\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest|webp|pptx)$" {
             # add_header Cache-Control "public, max-age=31536000"; # 1 year
             try_files /apps/web/dist/$uri =404;
         }


### PR DESCRIPTION
🤖 Resolves #14717 

## 👋 Introduction

Expands the location rule for our long (1 year) cache rule for assets.

## 🧪 Testing

> [!TIP]
>  This is disabled locally so you need to make some changes to test

1. open the local nginx config (`infrastructure/conf/nginx-conf-local/default`)
2. Uncomment the cache control header on L231
3. Reload nginx (i usually just do `make down; make up`)
4. Navigate to any page
5. Check the headers for files that have a `-` in their hash
6. Confirm it has a cache control for `31536000` (1 year)

## 📸 Screenshot

<img width="946" height="160" alt="swappy-20251002_143405" src="https://github.com/user-attachments/assets/74bd9bec-a2d8-4b28-aa74-1cf38999b91b" />

