### PR TITLE
[Fix] Applicant Profile On this page menu Links

### DIFF
--- a/apps/web/src/pages/Users/AdminApplicantProfilePage/AdminApplicantProfilePage.tsx
+++ b/apps/web/src/pages/Users/AdminApplicantProfilePage/AdminApplicantProfilePage.tsx
@@ -124,6 +124,7 @@ const AdminApplicantProfile = ({ query }: AdminApplicantProfileProps) => {
               icon={UserCircleIcon}
               color="secondary"
               className="m-0"
+              id="basic-information"
             >
               {intl.formatMessage({
                 defaultMessage: "Basic information",


### PR DESCRIPTION
🤖 Resolves #14728

## 👋 Introduction

This PR fixes the "On this page" menu links in the Applicant Profile tab. The issue was missing `id` props on the `Accordion.Item` and the menu links were looking for IDs that weren’t there.


## 🧪 Testing

1. Log in as `admin@test.com`
2. Navigate to the users table and select a user
3. In the Applicant profile tab, open the accordions. 
4. Click on any section link in the "On the page" navigation and verify the page scrolls to the selected section. 


## 📸 Screenshot


https://github.com/user-attachments/assets/2bb9f76f-6fbc-449f-9869-995fb6185682




