### PR TITLE
[Fix] Type of `departmentNumber` in update department form

### DIFF
--- a/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
@@ -63,7 +63,7 @@ export function formValuesToUpdateInput({
       fr: name?.fr,
     },
     size: size ?? undefined,
-    departmentNumber: departmentNumber ?? undefined,
+    departmentNumber: departmentNumber ? Number(departmentNumber) : undefined,
     orgIdentifier: orgIdentifier ? Number(orgIdentifier) : undefined,
     ...departmentTypeToInput(departmentType),
   };


### PR DESCRIPTION
🤖 Resolves #14778.

## 👋 Introduction

This PR sets the `departmentNumber` value to an integer to match the type in the database.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to departments table http://localhost:8000/en/admin/settings/departments
3. Edit a department with a different value that is not an existing department number in the database
4. Verify the form saves without error