### PR TITLE
[Debt] Avoid deprecated `strtolower` call in `LanguageCode`

### DIFF
--- a/api/app/Casts/LanguageCode.php
+++ b/api/app/Casts/LanguageCode.php
@@ -29,6 +29,6 @@ class LanguageCode implements CastsAttributes
      */
     public function set(Model $model, string $key, mixed $value, array $attributes): mixed
     {
-        return ! is_string($value) ? strtolower($value) : null;
+        return is_string($value) ? strtolower($value) : null;
     }
 }


### PR DESCRIPTION
🤖 Resolves #14773 

## 👋 Introduction

Updates the setter for `LanguageCode` to avoid passing `null` to `strtolower` (deprecated)

## 🧪 Testing

1. Run `make artisan CMD="tinker"`
2. Create `User` `User::factory()->create();`
3. Confirm no warnings about deprecated call
