### PR TITLE
14808: Fix Flaky test: Can submit application

### DIFF
--- a/apps/playwright/tests/applicant/application.spec.ts
+++ b/apps/playwright/tests/applicant/application.spec.ts
@@ -310,7 +310,7 @@ test.describe("Application", () => {
     // Quit trying to skip and continue step three honestly
     await expect(
       application.page.locator("text=Your career timeline currently includes:"),
-    ).toHaveCount(0);
+    ).toBeHidden();
     await expect(
       application.page.getByText(
         /you don’t have any career timeline experiences yet./i,


### PR DESCRIPTION
🤖 Resolves [14808](https://github.com/GCTC-NTGC/gc-digital-talent/issues/14808)

## 👋 Introduction

- Fix the flakiness of one of the scripts - Can submit application

## 🕵️ Details

- The fix includes the assertion which made before verifying the career timeline, whether the career timeline is present

## 🧪 Testing

1. `pnpm run build`
2. Run this command to execute the script - `pnpm playwright test application.spec.ts -g "Can submit application" --headed --ui --workers=1`
3. Observe the results

## 📸 Screenshot

<img width="267" height="489" alt="image" src="https://github.com/user-attachments/assets/1efde8f7-1770-4bd4-812b-05164068f1bb" />
