### PR TITLE
[Copy] Updates `one` case for results section of search page

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -9495,7 +9495,7 @@
     "description": "Description of how to use the form to filter job poster templates"
   },
   "e5N39X": {
-    "defaultMessage": "Résultats : {totalCandidateCount, plural, =0 {<testId><b>#</b></testId> candidats correspondants} one {<testId><b>#</b></testId> candidats correspondants} other {<testId><b>#</b></testId> candidats correspondants à l'échelle } } de {numPools, plural, =0 {<b>#</b> bassins} one {<b>#</b> bassins} other {<b>#</b> bassins} }",
+    "defaultMessage": "Résultats : {totalCandidateCount, plural, =0 {<testId><b>#</b></testId> candidats correspondants} one {<testId><b>#</b></testId> candidat correspondant} other {<testId><b>#</b></testId> candidats correspondants à l'échelle } } de {numPools, plural, =0 {<b>#</b> bassins} one {<b>#</b> bassin} other {<b>#</b> bassins} }",
     "description": "Heading for total matching candidates across a certain number of pools in results section of search page."
   },
   "e5xrSy": {


### PR DESCRIPTION
🤖 Resolves #13585.

## 👋 Introduction

This PR updates `one` case for results section of search page.
## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/fr/search
3. Adjust filters so that there is only one candidate and one pool
4. Verify copy is correct

## 📸 Screenshot

<img width="1344" height="692" alt="Screenshot 2025-10-17 at 13 41 36" src="https://github.com/user-attachments/assets/c1389270-c8e3-4a68-93db-192b56d75caa" />
