### PR TITLE
[Bug] Resolve ambiguity of ids for users table query

### DIFF
--- a/api/app/Builders/UserBuilder.php
+++ b/api/app/Builders/UserBuilder.php
@@ -612,10 +612,10 @@ class UserBuilder extends Builder
                             ->where(function (Builder $query) use ($teamIds) {
                                 $query
                                     ->whereHas('team', function (Builder $query) use ($teamIds) {
-                                        return $query->whereIn('id', $teamIds);
+                                        return $query->whereIn('teams.id', $teamIds);
                                     })
                                     ->orWhereHas('community.team', function (Builder $query) use ($teamIds) {
-                                        return $query->whereIn('id', $teamIds);
+                                        return $query->whereIn('teams.id', $teamIds);
                                     });
                             });
                     });
@@ -623,7 +623,7 @@ class UserBuilder extends Builder
             }
 
             if ($user?->isAbleTo('view-own-user')) {
-                $query->orWhere('id', $user->id);
+                $query->orWhere('users.id', $user->id);
             }
         });
 
@@ -633,7 +633,7 @@ class UserBuilder extends Builder
         }
 
         // fall through - return nothing
-        return $this->where('id', null);
+        return $this->where('users.id', null);
     }
 
     public function whereAuthorizedToViewBasicInfo(): self


### PR DESCRIPTION
🤖 Resolves #14853

## 👋 Introduction

Resolve the ambiguous id error through explicit table naming in query building, as the proposed solution suggested. 

## 🕵️ Details

Problem appears to occur in the authorization scope, there are multiple tables that have ids referenced so it is understandable how this could be an issue. Makes me think other places need to be checked too for issue

> [!TIP]
> The reason you need to login in with a different user is because platform admin bypasses the block with the issue entirely. Highlighting the importance of testing with different user roles  

## 🧪 Testing

1. Login with various users
2. Navigate to users table
3. Test the general search


