### PR TITLE
[Debt] Remove redundant flexible location scope for `User` model

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -935,18 +935,6 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
         );
     }
 
-    /**
-     * Scope a query to only include users with the specified flexible work locations.
-     */
-    public function scopeWhereFlexibleWorkLocationsIn($query, array $locations)
-    {
-        return $query->where(function ($q) use ($locations) {
-            foreach ($locations as $location) {
-                $q->orWhereJsonContains('flexible_work_locations', $location);
-            }
-        });
-    }
-
     public static function scopeWhereGeneralSearch(Builder $query, ?string $searchTerm): Builder
     {
         if ($searchTerm) {


### PR DESCRIPTION
🤖 Resolves #14860 

## 👋 Introduction

Removes a redundant scope on `User` that was doing the same thing as the scope on `UserBuilder`.

## 🧪 Testing

1. Confirm the flexible work location scope still functions as expected
