### PR TITLE
[Fix] Allow `BoolCheckIcon` label to be read out by screen readers

### DIFF
--- a/apps/web/src/components/BoolCheckIcon/BoolCheckIcon.tsx
+++ b/apps/web/src/components/BoolCheckIcon/BoolCheckIcon.tsx
@@ -1,6 +1,6 @@
 import XCircleIcon from "@heroicons/react/20/solid/XCircleIcon";
 import CheckCircleIcon from "@heroicons/react/20/solid/CheckCircleIcon";
-import { ReactNode } from "react";
+import { ReactNode, useId } from "react";
 import { tv } from "tailwind-variants";
 
 import { Maybe } from "@gc-digital-talent/graphql";
@@ -35,12 +35,21 @@ const BoolCheckIcon = ({
   className,
   ...rest
 }: BoolCheckIconProps) => {
+  const id = useId();
   const Icon = value ? CheckCircleIcon : XCircleIcon;
   const { base, icon } = boolCheck({ checked: value ?? false });
 
   return (
     <div className={base({ class: className })} {...rest}>
-      <Icon className={icon()} aria-label={value ? trueLabel : falseLabel} />
+      <span hidden id={id}>
+        {value ? trueLabel : falseLabel}
+      </span>
+      <Icon
+        className={icon()}
+        role="img"
+        aria-hidden="false"
+        aria-labelledby={id}
+      />
       <span>{children}</span>
     </div>
   );


### PR DESCRIPTION
🤖 Resolves #14857 

## 👋 Introduction

Fixes an issue where screen readers were having difficulty reading out the label for the `BoolCheckIcon`

## 🕵️ Details

All of our icons have `aria-hidden` by defualt, this is be cause for the most part, they are decorative. However, the `BoolCheckIcon` needs to convey information to the user. This does more than just set `aria-hidden="false"` since our current approach has a gap in support for firefox + JAWs (using `aria-label` on svgs).

The fix with the least amount of gaps is moving the label to a real element and associcating it with an image via `aria-labelledby`.

Why `hidden` instead of `className="sr-only`"? With `sr-only`, it creates a redundant announcment since `sr-only` only visually hides the element but leaves it in the acccessibility tree. So, but the element and the icon announce the message. By using `hidden` we remove the element from the accessibility tree, only exposing it via its relation to the svg with `aria-labelledby`.

## 🧪 Testing

> [!IMPORTANT]
> You should probably test Firefox since it has the most gaps in this specific scenario. 

1. Build `pnpm dev:fresh`
2. Navigate to a page that includes the `BoolCheckIcon` (employee profile has some)
3. Open a screen reader
4. Confirm the label is read out
    - E.g. "Not interested, image, {text}"