### PR TITLE
[Fix] Method call on possible `null` user in community interest scope

### DIFF
--- a/api/app/Models/CommunityInterest.php
+++ b/api/app/Models/CommunityInterest.php
@@ -137,12 +137,12 @@ class CommunityInterest extends Model
         $query->where(function (Builder $query) use ($user) {
 
             // the user might be able to view their own interests
-            if ($user->isAbleTo('view-own-employeeProfile')) {
+            if ($user?->isAbleTo('view-own-employeeProfile')) {
                 $query->orWhere('user_id', $user->id);
             }
 
             // the user might be able to view their communities' interests
-            if ($user->isAbleTo('view-team-communityInterest')) {
+            if ($user?->isAbleTo('view-team-communityInterest')) {
                 $query->orWhere(function (Builder $query) use ($user) {
 
                     // all community teams that the user is a member in


### PR DESCRIPTION
🤖 Resolves #14882 

## 👋 Introduction

Fixes an issue in the `CommunityInterest::scopeAuthorizedToView` method where the user could be `null`.

## 🕵️ Details

While highly unlikley, the user _could_ be null when checking to see if they can view a community interest. In order to address this, optional chaining was added to match our other authoirzation scopes.

## 🧪 Testing

> [!NOTE]
> Honestly, not sure how to test this.  All of the queries for things that expose this should be guarded. My best guess is someone messing around in `graphiql`.

1. Open `/graphiql`
2. Make sure you are not authenticated in anyway
3. Attempt to query a community interest (I think the only possible way is through `communityInterestsPaginated`)
4. Confirm you don't get the internal server error, or atleast not the one mentioned in the ticket :sweat_smile:  