### PR TITLE
[Fix] Update validation for job locations if only remote work selected.

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -6,6 +6,7 @@ use App\Builders\UserBuilder;
 use App\Casts\LanguageCode;
 use App\Enums\EmailType;
 use App\Enums\EmploymentCategory;
+use App\Enums\FlexibleWorkLocation;
 use App\Enums\GovPositionType;
 use App\Enums\OperationalRequirement;
 use App\Enums\PositionDuration;
@@ -550,10 +551,13 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
             is_null($this->attributes['computed_is_gov_employee']) or
             is_null($this->attributes['has_priority_entitlement']) or
             ($this->attributes['has_priority_entitlement'] && is_null($this->attributes['priority_number'])) or
-            is_null($this->attributes['location_preferences']) or
-            empty($this->attributes['location_preferences']) or
             is_null($this->attributes['flexible_work_locations']) or
             empty($this->attributes['flexible_work_locations']) or
+            ((in_array(FlexibleWorkLocation::HYBRID->name, $this->flexible_work_locations) or
+                in_array(FlexibleWorkLocation::ONSITE->name, $this->flexible_work_locations)) &&
+                (is_null($this->attributes['location_preferences']) or
+                empty($this->attributes['location_preferences']))
+            ) or
             empty($this->attributes['position_duration']) or
             is_null($this->attributes['citizenship']) or
             is_null($this->attributes['armed_forces_status'])

--- a/apps/web/src/validators/profile/workPreferences.ts
+++ b/apps/web/src/validators/profile/workPreferences.ts
@@ -1,6 +1,7 @@
 import isEmpty from "lodash/isEmpty";
 
 import {
+  FlexibleWorkLocation,
   LocalizedFlexibleWorkLocation,
   LocalizedProvinceOrTerritory,
   LocalizedWorkRegion,
@@ -45,8 +46,13 @@ export function hasEmptyRequiredFields({
 }: PartialUser): boolean {
   return (
     isEmpty(positionDuration) ||
-    isEmpty(locationPreferences) ||
     isEmpty(flexibleWorkLocations) ||
+    (flexibleWorkLocations?.find(
+      (location) =>
+        location?.value === FlexibleWorkLocation.Hybrid ||
+        location?.value === FlexibleWorkLocation.Onsite,
+    ) &&
+      isEmpty(locationPreferences)) ||
     !currentCity ||
     !currentProvince
   );


### PR DESCRIPTION
🤖 Resolves #14869.

## 👋 Introduction

Updates profile completeness logic for the job locations field if only the "Remote work" flexible location is selected.

## 🧪 Testing

1. As a user navigate to edit the work preferences form in the profile.
2. For **Flexible work location options** select only "Remote work".
3. Don't select any **Work location preferences**.
4. Fill any other required fields and submit the form.
5. Confirm the work preferences section is now marked complete.
6. Confirm the section is also marked complete in the application process.

## 📸 Screenshot

<img width="1026" height="717" alt="image" src="https://github.com/user-attachments/assets/b1546b67-c1d3-4460-93b0-02c60cfffe2a" />
