### PR TITLE
[Bug] Stop CSV generation from failing on null input

### DIFF
--- a/api/app/Builders/PoolCandidateBuilder.php
+++ b/api/app/Builders/PoolCandidateBuilder.php
@@ -155,6 +155,10 @@ class PoolCandidateBuilder extends Builder
     // Given input in the shape of PoolCandidateSearchInput, adjust then call User::whereFlexibleLocationAndRegionSpecialMatching()
     public function wherePoolCandidateSearchInputToSpecialLocationMatching(?array $filter): self
     {
+        if (empty($filter)) {
+            return $this;
+        }
+
         if (array_key_exists('locationPreferences', $filter) || array_key_exists('flexibleWorkLocations', $filter)) {
 
             return $this->whereHas('user', function ($userQuery) use ($filter) {


### PR DESCRIPTION
🤖 Resolves #14906

## 👋 Introduction

Get the download working again

## 🕵️ Details

Empty/null input not handled in a scope
Man, PHP feels like a lawless wasteland for type safety compared to TypeScript 😒 

## 🧪 Testing

1. Can download CSVs again by selecting users (this nulls out inputs in the operation)

