### PR TITLE
[Bug] Fix verification email without name

### DIFF
--- a/api/app/Notifications/VerifyEmails.php
+++ b/api/app/Notifications/VerifyEmails.php
@@ -60,7 +60,8 @@ class VerifyEmails extends Notification implements CanBeSentViaGcNotifyEmail
                 $templateId,
                 $this->emailAddress,
                 [
-                    'person name' => $notifiable->first_name,
+                    // if triggered during the onboarding flow the user might not have a first name yet
+                    'person name' => $notifiable->first_name ?? $this->emailAddress,
                     'verification code' => $this->createVerificationCode($notifiable),
                 ]
             );


### PR DESCRIPTION
🤖 Resolves #14910 

## 👋 Introduction

Adds a fallback "person name" variable to the email verification notification.

## 🕵️ Details

When verifying email addresses in the onboarding flow, we don't yet have the user's first name. As suggested by Josh, this will use the email address itself as the name as a fallback.

<img width="720" height="423" alt="image" src="https://github.com/user-attachments/assets/18a1df9b-2233-4cf1-b86a-0deae4515200" />


## 🧪 Testing

1. Set up GC Notify integration
2. Rebuild the app

- [ ] In the onboarding flow, the notification email will say "Hey example@example.org,"
- [ ] In the account settings page, the notification email will say "Hey first_name,"
