### PR TITLE
⌨️ Mobile Menu Button Accessibility

### DIFF
--- a/apps/web/src/components/NavMenu/Menu.tsx
+++ b/apps/web/src/components/NavMenu/Menu.tsx
@@ -117,18 +117,18 @@ const Menu = ({
   }, [isMenuOpen]);
 
   return (
-    <div
-      className="fixed right-4.5 bottom-21 left-4.5 z-40 max-h-[85vh] overflow-y-auto sm:sticky sm:top-[-1px] sm:right-auto sm:bottom-auto sm:left-auto sm:w-full sm:overflow-y-visible md:max-h-none"
-      // NOTE: Do not remove, required by anchor link offsets
-      id="main-nav"
-    >
+    <div className="fixed right-4.5 bottom-21 left-4.5 z-40 max-h-[85vh] overflow-y-auto sm:sticky sm:top-[-1px] sm:right-auto sm:bottom-auto sm:left-auto sm:w-full sm:overflow-y-visible md:max-h-none">
       <FocusLock returnFocus disabled={!showOverlay}>
         <NavMenuProvider
           open={isMenuOpen}
           onOpenToggle={handleOpenToggle}
           onOpenChange={setMenuOpen}
         >
-          <div className="relative z-10">
+          <div
+            className="relative z-10"
+            // NOTE: Do not remove, required by anchor link offsets
+            id="main-nav"
+          >
             {showMenu ? (
               <NavMenu.Root
                 onKeyDown={handleKeyDown}


### PR DESCRIPTION
🤖 Resolves  #13142

## 👋 Introduction

This pull request addresses an accessibility issue where the mobile menu button wasn’t being correctly recognized by screen readers. The problem was caused by missing ARIA attributes that identify the button’s purpose and whether the menu is open or closed.

## 🕵️ Details

- Added `aria-expanded={isMenuOpen}` so screen readers know if the menu is open or collapsed.
- Added `aria-controls="main-nav"` to link the button with the menu it toggles

## 🧪 Testing

1. Build app
2. Using your browser's dev tools resize the viewport until the mobile menu appears
3. Using a screen reader, use the tab keys to navigate to the mobile menu button
4. Confirm the screen reader announces:
    -  "Open menu button collapsed" when the menu is closed
    -  "Close menu button expanded" when the menu is open
5. Confirm the button properly toggles the menu open/closed state    


## 📸 Screenshot

<img width="1392" height="658" alt="image" src="https://github.com/user-attachments/assets/d9d7ce12-9076-41d2-a472-b4b52bee4fe6" />

<img width="923" height="447" alt="image" src="https://github.com/user-attachments/assets/3b569e1a-952f-4818-aa4c-fa6c90363305" />

