### PR TITLE
[Fix] Prevent notification polling when interval is `<= 0`

### DIFF
--- a/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
+++ b/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
@@ -191,6 +191,7 @@ const NotificationDialog = ({
   const [{ data }, executeQuery] = usePollingQuery(
     { query: NotificationCount_Query },
     pollingInterval * 60,
+    pollingInterval <= 0,
   );
   const notificationCount = unpackMaybes(data?.notifications?.data).length;
   const buttonLabel = open

--- a/apps/web/src/hooks/usePollingQuery.ts
+++ b/apps/web/src/hooks/usePollingQuery.ts
@@ -9,12 +9,13 @@ type QueryArgs<TData, TVariables extends AnyVariables> = UseQueryArgs<
 const usePollingQuery = <TData, TVariables extends AnyVariables>(
   queryArgs: QueryArgs<TData, TVariables>,
   delay: number,
+  disabled = false,
 ): ReturnType<typeof useQuery<TData, TVariables>> => {
   const [result, executeQuery] = useQuery<TData, TVariables>(queryArgs);
 
   useEffect(() => {
     // Do nothing if we are already fetching
-    if (!result.fetching) {
+    if (!result.fetching && !disabled) {
       const timeout = setTimeout(() => {
         executeQuery({ requestPolicy: "network-only" });
       }, delay * 1000);
@@ -25,7 +26,7 @@ const usePollingQuery = <TData, TVariables extends AnyVariables>(
     }
 
     return undefined;
-  }, [result.fetching, executeQuery, queryArgs.variables, delay]);
+  }, [result.fetching, executeQuery, queryArgs.variables, delay, disabled]);
 
   return [result, executeQuery];
 };


### PR DESCRIPTION
## 👋 Introduction

Addresses an issue where, if you set the polling interval to 0, it would continuously run. Or, could cause issues if less than 0.

This simply disables polling if the value is `<= 0`.

## 🧪 Testing

1. Set the `NOTIFICATION_POLLING_INTERVAL=0`
2. Rebuild `pnpm dev:fresh`
3. Login as any user
4. Observe the netwwork and confirm no polling requests are sent
