### PR TITLE
Adjust Chromatic workflow on push

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -20,7 +20,7 @@ jobs:
   chromatic:
     name: Chromatic
     # On pull request open, merge, or rerun
-    if: (github.event.action == 'opened' || github.event.pull_request.merged == true || github.run_attempt > 1) && github.actor != 'dependabot[bot]'
+    if: (github.event.action == 'opened' || github.event.ref == 'refs/remotes/origin/main' || github.run_attempt > 1) && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-24.04
     env:
       PNPM_VERSION: "10.17.0"


### PR DESCRIPTION
🤖 Resolves <!-- issue # -->

## 👋 Introduction

Adjust it to run off push to main, I think the pull request event doesn't apply for our purposes.
Used https://docs.github.com/en/rest/using-the-rest-api/github-event-types?apiVersion=2022-11-28#pushevent

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

<!--
1. ...
2. ...
 -->

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

## 🚚 Deployment

<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the PR if deployment steps are needed

 -->
