### PR TITLE
[Bug] Fix unlock button text on updated dashboard

### DIFF
--- a/apps/web/src/pages/ApplicantDashboardPage/components/CareerDevelopmentTaskCard.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/components/CareerDevelopmentTaskCard.tsx
@@ -162,6 +162,12 @@ const CareerDevelopmentTaskCard = ({
         },
       ];
 
+  const addACommunityLinkText = intl.formatMessage({
+    defaultMessage: "Add a community",
+    id: "kBEib8",
+    description: "Link to a page to add a functional community",
+  });
+
   const functionalCommunitiesMetaData: AccordionMetaData = isVerifiedGovEmployee
     ? // if verified, then a link to the community interest page
       [
@@ -170,15 +176,7 @@ const CareerDevelopmentTaskCard = ({
           type: "link",
           href: paths.createCommunityInterest(),
           color: "primary",
-          children: (
-            <>
-              {intl.formatMessage({
-                defaultMessage: "Add a community",
-                id: "kBEib8",
-                description: "Link to a page to add a functional community",
-              })}
-            </>
-          ),
+          children: <>{addACommunityLinkText}</>,
         },
       ]
     : // if not verified, then a dialog to get verified
@@ -189,7 +187,7 @@ const CareerDevelopmentTaskCard = ({
           component: (
             <UnlockEmployeeToolsDialog query={userFragment}>
               <Button mode="inline" size="sm">
-                {editCareerPlanningLinkText}
+                {addACommunityLinkText}
               </Button>
             </UnlockEmployeeToolsDialog>
           ),


### PR DESCRIPTION
🤖 Resolves #14946 

## 👋 Introduction

Fixes the unlock button text to match the link text when locked.

## 🧪 Testing

1. Log in as applicant-employee@test.com
2. Observe the career development link texts
3. "unverify" employee status (for example, clearing `work_email_verified_at`)
4. Observe the career development link texts


## 📸 Screenshot

<img width="774" height="432" alt="image" src="https://github.com/user-attachments/assets/43001baf-d630-45de-a5cb-2c897479db4e" />
<img width="767" height="425" alt="image" src="https://github.com/user-attachments/assets/6a70fb1b-4b36-4c25-8657-67032ad89d79" />
