### PR TITLE
[Fix] Pool billingual field check

### DIFF
--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -548,7 +548,10 @@ class Pool extends Model
                 continue;
             }
 
-            if (empty($value['en']) || empty($value['fr'])) {
+            if (
+                (empty($value['en']) && ! empty($value['fr'])) ||
+                (! empty($value['en']) && empty($value['fr']))
+            ) {
                 return false;
             }
         }


### PR DESCRIPTION
resolves #14675
## 👋 Introduction

Fixes the billingual field check for pool completeness.

## 🕵️ Details

We were only checking that either was empty, but it fails if one is empty and the other is not.

## 🧪 Testing

1. "Complete" a pool
2. confirm badge updates to complete