### PR TITLE
[Debt] Remove deprecated schema cache boot method

### DIFF
--- a/api/tests/Feature/ActivityLogTest.php
+++ b/api/tests/Feature/ActivityLogTest.php
@@ -34,7 +34,6 @@ class ActivityLogTest extends TestCase
     {
         parent::setUp();
         $this->seed(RolePermissionSeeder::class);
-        $this->bootRefreshesSchemaCache();
         $this->baseUser = User::factory()
             ->asApplicant()
             ->create([

--- a/api/tests/Feature/ApplicantFilterTest.php
+++ b/api/tests/Feature/ApplicantFilterTest.php
@@ -39,7 +39,6 @@ class ApplicantFilterTest extends TestCase
     {
         parent::setUp();
         Notify::spy(); // don't send any notifications
-        $this->bootRefreshesSchemaCache();
 
         $this->seed([
             RolePermissionSeeder::class,

--- a/api/tests/Feature/ApplicantTest.php
+++ b/api/tests/Feature/ApplicantTest.php
@@ -43,8 +43,6 @@ class ApplicantTest extends TestCase
         Notify::spy(); // don't send any notifications
         $this->seed(RolePermissionSeeder::class);
 
-        $this->bootRefreshesSchemaCache();
-
         $this->adminUser = User::factory()
             ->asApplicant()
             ->asAdmin()

--- a/api/tests/Feature/AssessmentResultTest.php
+++ b/api/tests/Feature/AssessmentResultTest.php
@@ -45,7 +45,6 @@ class AssessmentResultTest extends TestCase
         parent::setUp();
         Notify::spy(); // don't send any notifications
         $this->seed(RolePermissionSeeder::class);
-        $this->bootRefreshesSchemaCache();
         $this->community = Community::factory()->create(['name' => 'test-community']);
         $this->pool = Pool::factory()->create([
             'community_id' => $this->community->id,

--- a/api/tests/Feature/AssessmentStepTest.php
+++ b/api/tests/Feature/AssessmentStepTest.php
@@ -39,7 +39,6 @@ class AssessmentStepTest extends TestCase
     {
         parent::setUp();
         $this->seed(RolePermissionSeeder::class);
-        $this->bootRefreshesSchemaCache();
         $this->community = Community::factory()->create(['name' => 'test-community']);
         $this->pool = Pool::factory()->draft()->create([
             'community_id' => $this->community->id,

--- a/api/tests/Feature/ClassificationTest.php
+++ b/api/tests/Feature/ClassificationTest.php
@@ -46,7 +46,6 @@ class ClassificationTest extends TestCase
 
         $this->seed(RolePermissionSeeder::class);
         $this->setUpFaker();
-        $this->bootRefreshesSchemaCache();
 
         $this->community = Community::factory()->create(['name' => 'test-community']);
         $this->teamPool = Pool::factory()->create([

--- a/api/tests/Feature/CommunityTest.php
+++ b/api/tests/Feature/CommunityTest.php
@@ -43,7 +43,6 @@ class CommunityTest extends TestCase
         parent::setUp();
         $this->seed(RolePermissionSeeder::class);
         $this->setUpFaker();
-        $this->bootRefreshesSchemaCache();
 
         // Create communities.
         $this->toBeDeletedUUID = $this->faker->UUID();

--- a/api/tests/Feature/CountPoolCandidatesByPoolTest.php
+++ b/api/tests/Feature/CountPoolCandidatesByPoolTest.php
@@ -35,7 +35,6 @@ class CountPoolCandidatesByPoolTest extends TestCase
     {
         parent::setUp();
         Notify::spy(); // don't send any notifications
-        $this->bootRefreshesSchemaCache();
 
         $this->seed(RolePermissionSeeder::class);
     }

--- a/api/tests/Feature/DepartmentTest.php
+++ b/api/tests/Feature/DepartmentTest.php
@@ -50,7 +50,6 @@ class DepartmentTest extends TestCase
         parent::setUp();
 
         $this->setUpFaker();
-        $this->bootRefreshesSchemaCache();
         $this->seed(RolePermissionSeeder::class);
 
         $this->community = Community::factory()->create(['name' => 'test-team']);

--- a/api/tests/Feature/ExperienceTest.php
+++ b/api/tests/Feature/ExperienceTest.php
@@ -33,7 +33,6 @@ class ExperienceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->bootRefreshesSchemaCache();
         $this->withoutExceptionHandling();
         // Run necessary seeders
         $this->seed(ClassificationSeeder::class);

--- a/api/tests/Feature/GeneralQuestionResponsesTest.php
+++ b/api/tests/Feature/GeneralQuestionResponsesTest.php
@@ -50,7 +50,6 @@ class GeneralQuestionResponsesTest extends TestCase
     {
         parent::setUp();
         $this->seed(RolePermissionSeeder::class);
-        $this->bootRefreshesSchemaCache();
         $this->community = Community::factory()->create(['name' => 'test-community-application']);
         $this->pool = Pool::factory()->draft()->WithPoolSkills(2, 2)->WithQuestions(2, 2)->create([
             'community_id' => $this->community->id,

--- a/api/tests/Feature/GeneralQuestionTest.php
+++ b/api/tests/Feature/GeneralQuestionTest.php
@@ -48,7 +48,6 @@ class GeneralQuestionTest extends TestCase
     {
         parent::setUp();
         $this->seed(RolePermissionSeeder::class);
-        $this->bootRefreshesSchemaCache();
         $this->community = Community::factory()->create(['name' => 'test-community-application']);
         $this->pool = Pool::factory()->draft()->WithPoolSkills(2, 2)->WithQuestions(3, 1)->create([
             'community_id' => $this->community->id,

--- a/api/tests/Feature/KeywordSearchTest.php
+++ b/api/tests/Feature/KeywordSearchTest.php
@@ -27,7 +27,6 @@ class KeywordSearchTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->bootRefreshesSchemaCache();
 
         $this->seed(RolePermissionSeeder::class);
 

--- a/api/tests/Feature/PoolApplicationTest.php
+++ b/api/tests/Feature/PoolApplicationTest.php
@@ -132,7 +132,6 @@ class PoolApplicationTest extends TestCase
         $this->seed(RolePermissionSeeder::class);
 
         $this->setUpFaker();
-        $this->bootRefreshesSchemaCache();
 
         $community = Community::factory()->create();
 

--- a/api/tests/Feature/PoolCandidateSearchRequestPaginatedTest.php
+++ b/api/tests/Feature/PoolCandidateSearchRequestPaginatedTest.php
@@ -37,7 +37,6 @@ class PoolCandidateSearchRequestPaginatedTest extends TestCase
         parent::setUp();
         $this->seed(RolePermissionSeeder::class);
         $this->seed(DepartmentSeeder::class);
-        $this->bootRefreshesSchemaCache();
         $this->adminUser = User::factory()
             ->asAdmin()
             ->create([

--- a/api/tests/Feature/PoolCandidateSearchRequestTest.php
+++ b/api/tests/Feature/PoolCandidateSearchRequestTest.php
@@ -31,7 +31,6 @@ class PoolCandidateSearchRequestTest extends TestCase
     {
         parent::setUp();
         $this->seed(RolePermissionSeeder::class);
-        $this->bootRefreshesSchemaCache();
 
         $this->adminUser = User::factory()
             ->asApplicant()

--- a/api/tests/Feature/PoolCandidateSearchTest.php
+++ b/api/tests/Feature/PoolCandidateSearchTest.php
@@ -48,8 +48,6 @@ class PoolCandidateSearchTest extends TestCase
         Notify::spy(); // don't send any notifications
         $this->seed([RolePermissionSeeder::class,  DepartmentSeeder::class]);
 
-        $this->bootRefreshesSchemaCache();
-
         $this->community = Community::factory()->create();
         $this->pool = Pool::factory()
             ->withAssessments()

--- a/api/tests/Feature/PoolCandidateTest.php
+++ b/api/tests/Feature/PoolCandidateTest.php
@@ -46,8 +46,6 @@ class PoolCandidateTest extends TestCase
         Notify::spy(); // don't send any notifications
         $this->seed(RolePermissionSeeder::class);
 
-        $this->bootRefreshesSchemaCache();
-
         $this->community = Community::factory()->create();
 
         $this->pool = Pool::factory()->create([

--- a/api/tests/Feature/PoolTest.php
+++ b/api/tests/Feature/PoolTest.php
@@ -52,7 +52,6 @@ class PoolTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->bootRefreshesSchemaCache();
 
         $this->seed(RolePermissionSeeder::class);
 

--- a/api/tests/Feature/ScreeningQuestionsTest.php
+++ b/api/tests/Feature/ScreeningQuestionsTest.php
@@ -96,7 +96,6 @@ class ScreeningQuestionsTest extends TestCase
     {
         parent::setUp();
         $this->seed(RolePermissionSeeder::class);
-        $this->bootRefreshesSchemaCache();
         $this->community = Community::factory()->create([
             'key' => 'test-community']);
         Skill::factory()->count(3)->create();

--- a/api/tests/Feature/SkillFamilyTest.php
+++ b/api/tests/Feature/SkillFamilyTest.php
@@ -44,7 +44,6 @@ class SkillFamilyTest extends TestCase
 
         $this->seed(RolePermissionSeeder::class);
         $this->setUpFaker();
-        $this->bootRefreshesSchemaCache();
 
         $this->community = Community::factory()->create(['name' => 'test-team']);
         $this->teamPool = Pool::factory()->create([

--- a/api/tests/Feature/SkillTest.php
+++ b/api/tests/Feature/SkillTest.php
@@ -49,7 +49,6 @@ class SkillTest extends TestCase
 
         $this->seed(RolePermissionSeeder::class);
         $this->setUpFaker();
-        $this->bootRefreshesSchemaCache();
 
         $this->community = Community::factory()->create(['name' => 'test-team']);
         $this->teamPool = Pool::factory()->create([

--- a/api/tests/Feature/Snapshots/SnapshotTest.php
+++ b/api/tests/Feature/Snapshots/SnapshotTest.php
@@ -40,7 +40,6 @@ class SnapshotTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->bootRefreshesSchemaCache();
         $this->seed(RolePermissionSeeder::class);
     }
 

--- a/api/tests/Feature/TrainingOpportunityTest.php
+++ b/api/tests/Feature/TrainingOpportunityTest.php
@@ -28,7 +28,6 @@ class TrainingOpportunityTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->bootRefreshesSchemaCache();
         $this->withoutExceptionHandling();
         $this->seed(ClassificationSeeder::class);
         $this->seed(RolePermissionSeeder::class);

--- a/api/tests/Feature/UserRoleTest.php
+++ b/api/tests/Feature/UserRoleTest.php
@@ -29,7 +29,6 @@ class UserRoleTest extends TestCase
     {
         parent::setUp();
         $this->seed(RolePermissionSeeder::class);
-        $this->bootRefreshesSchemaCache();
 
         $this->baseUser = User::factory()
             ->asApplicant()

--- a/api/tests/Feature/UserSkillTest.php
+++ b/api/tests/Feature/UserSkillTest.php
@@ -39,7 +39,6 @@ class UserSkillTest extends TestCase
         parent::setUp();
         // Run necessary seeders
         $this->seed(RolePermissionSeeder::class);
-        $this->bootRefreshesSchemaCache();
         $this->user = User::factory()
             ->asApplicant()
             ->create([

--- a/api/tests/Feature/UserTest.php
+++ b/api/tests/Feature/UserTest.php
@@ -50,7 +50,6 @@ class UserTest extends TestCase
     {
         parent::setUp();
         Notify::spy(); // don't send any notifications
-        $this->bootRefreshesSchemaCache();
         // Run necessary seeders
         $this->seed(ClassificationSeeder::class);
         $this->seed(RolePermissionSeeder::class);

--- a/api/tests/Feature/WorkExperienceTest.php
+++ b/api/tests/Feature/WorkExperienceTest.php
@@ -34,7 +34,6 @@ class WorkExperienceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->bootRefreshesSchemaCache();
         $this->withoutExceptionHandling();
         $this->seed(ClassificationSeeder::class);
         $this->seed(RolePermissionSeeder::class);


### PR DESCRIPTION
🤖 Resolves #14997 

## 👋 Introduction

Removes the deprecated method to boot the schema cache refresh trait.

## 🧪 Testing

1. Confirm no calles to `bootRefreshesSchemaCache`
2. Confirm tests still function as expected
