### PR TITLE
[Fix] Trims support form `user_agent` value if over `max_user_agent_length`

### DIFF
--- a/api/app/Http/Controllers/SupportController.php
+++ b/api/app/Http/Controllers/SupportController.php
@@ -52,10 +52,11 @@ class SupportController extends Controller
             $parameters['custom_fields']['cf_page_url'] = $path;
         }
         if ($request->input('user_agent')) {
+            $user_agent = (string) $request->input('user_agent');
             if (strlen($request->input('user_agent')) > self::$MAX_USER_AGENT_LENGTH) {
-                $user_agent = substr($path, 0, self::$MAX_USER_AGENT_LENGTH);
+                $user_agent = substr($request->input('user_agent'), 0, self::$MAX_USER_AGENT_LENGTH);
             }
-            $parameters['custom_fields']['cf_user_agent'] = (string) $user_agent;
+            $parameters['custom_fields']['cf_user_agent'] = $user_agent;
         }
         if ($request->cookie('ai_user')) {
             $parameters['custom_fields']['cf_application_insights_user_id'] = (string) $request->cookie('ai_user');


### PR DESCRIPTION
🤖 Resolves #15008.

## 👋 Introduction

This PR trims the support form `user_agent` value if it is over `max_user_agent_length` as the Freshdesk field has a max character limit of 255.

## 🧪 Testing

1. Navigate to http://localhost:8000/en/support
2. Force browser's user agent to be something over 255 characters
3. Support form
4. Verify the form does not error
