### PR TITLE
[Fix] Improve pool candidate authorized to view permission checks

### DIFF
--- a/api/app/Builders/PoolCandidateBuilder.php
+++ b/api/app/Builders/PoolCandidateBuilder.php
@@ -720,6 +720,7 @@ class PoolCandidateBuilder extends Builder
             ->toArray();
     }
 
+    // main authorization scope for viewing PoolCandidateAdminView
     public function whereAuthorizedToViewPoolCandidateAdminView(): self
     {
         /** @var \App\Models\User | null */


### PR DESCRIPTION
🤖 Resolves #14414 

## 👋 Introduction

This pre-computes the team IDs to avoid looping in every scope which was the most signifcant contributor to slow down.

## 🕵️ Details

I don't know if this is even possible. @petertgiles pointed out, we have a custom user checker to handle protected requests. Since this skips over the `isAbleTo` for performance, we might be losing critical securiry.

Putting it up anyway to see what people thinkg. Maybe it will spark an idea? :woman_shrugging: 

---

The reason that the query got increasingly slow when having more team based roles was due to the laratrust `isAbleTo` method being slow when not cached (first run ever ~1min). Within the scope for the paginated pool candidates query, we were looping over the users team for each permission check calling `isAbleTo` in order to get the team ids. 

This was leading to a lot of calls to `isAbleTo` which was adding time per role (if you did not have platform admin).

This removes those calls and makes a direct database call to get the IDs to avoid some of the extra code/hydration in the `isAbleTo` call.

We still have some guards where we check a singular `isAbleTo` before using the team IDs so this should have the same security. But, extra documentation was added to try to emphasize why this exists.

Ideally, we do not avoid `isAbleTo` calls, unless it is causing performance issues due to many calls.

> [!NOTE]
> More information on this can be found in both this PR and the ticket dicusccion. 

## :question: Question

This only targets the pool candidates scope since we have had issues with it in the past. However, this pattern of looping over team based roles exists in other scopes.

Should we:

1. Apply this pattern to those now?
2. Create a new ticket to apply this pattern more broadly
3. Handle it on an as-needed basis?

## 🧪 Testing

1. Seed a lot of pool candidates (5000+)
4. Give a user a lot of team based roles (100+ process operator is good) 
5. Check bopth main and this branch
6. Compare the overall time
7. Confirm there is a noticable difference

## 📸 Screenshot

### Before

<img width="776" height="361" alt="before" src="https://github.com/user-attachments/assets/f6159ad8-c39e-4540-ae2a-322c09ffcd58" />

### After

<img width="1094" height="228" alt="after" src="https://github.com/user-attachments/assets/6bc8529b-543e-4282-b0e0-443c791b5827" />
