### PR TITLE
[Fix] Disable link in read only skill portfolio table

### DIFF
--- a/apps/web/src/components/SkillsPortfolioTable/SkillPortfolioTable.tsx
+++ b/apps/web/src/components/SkillsPortfolioTable/SkillPortfolioTable.tsx
@@ -1,10 +1,5 @@
-import { useIntl, IntlShape } from "react-intl";
-import {
-  ColumnDef,
-  createColumnHelper,
-  CellContext,
-  Row,
-} from "@tanstack/react-table";
+import { useIntl } from "react-intl";
+import { ColumnDef, createColumnHelper, Row } from "@tanstack/react-table";
 import { useMutation } from "urql";
 
 import {
@@ -121,11 +116,6 @@ export const SkillPortfolioTable_SkillFragment = graphql(/* GraphQL */ `
   }
 `);
 
-type UserSkillCell = CellContext<
-  SkillPortfolioTableUserSkillFragmentType,
-  unknown
->;
-
 const columnHelper =
   createColumnHelper<SkillPortfolioTableUserSkillFragmentType>();
 
@@ -152,16 +142,6 @@ const skillLevelSort = (
     order.indexOf(a.original.skillLevel) - order.indexOf(b.original.skillLevel)
   );
 };
-
-const skillNameCell = (
-  cell: UserSkillCell,
-  intl: IntlShape,
-  paths: ReturnType<typeof useRoutes>,
-) => (
-  <Link href={paths.editUserSkill(cell.row.original.skill.id)}>
-    {getLocalizedName(cell.row.original.skill.name, intl)}
-  </Link>
-);
 
 interface SkillPortfolioTableProps {
   caption?: string;
@@ -204,7 +184,17 @@ const SkillPortfolioTable = ({
         description: "Skill name column header for the skill library table",
       }),
       sortingFn: normalizedText,
-      cell: (cell: UserSkillCell) => skillNameCell(cell, intl, paths),
+      cell: ({
+        getValue,
+        row: {
+          original: { skill },
+        },
+      }) =>
+        readOnly ? (
+          getValue()
+        ) : (
+          <Link href={paths.editUserSkill(skill.id)}>{getValue()}</Link>
+        ),
       enableHiding: false,
       enableColumnFilter: false,
       meta: {
@@ -214,7 +204,7 @@ const SkillPortfolioTable = ({
     columnHelper.accessor((row) => row.experiences?.length ?? 0, {
       id: "experiences",
       header: intl.formatMessage(navigationMessages.careerExperience),
-      cell: (cell: UserSkillCell) =>
+      cell: (cell) =>
         intl.formatMessage(
           {
             defaultMessage:
@@ -243,7 +233,7 @@ const SkillPortfolioTable = ({
             skill: { category },
           },
         },
-      }: UserSkillCell) =>
+      }) =>
         skillLevel
           ? intl.formatMessage(
               getSkillLevelName(


### PR DESCRIPTION
🤖 Resolves #15037 

## 👋 Introduction

Addresses an issue where a skill was still being linked to in the portfolio table when it was read only.

## 🧪 Testing

1. Build `pnmp dev:fresh`
2. Login as `admin@test.com`
3. Navigate to a users skill portfolio in the admin interface
4. Confirm skills are not linked
5. Navigate to your own application skill portfolio
6. Confirm skills are still linked to the edit page

## 📸 Screenshot

<img width="1363" height="948" alt="swappy-20251112_112204" src="https://github.com/user-attachments/assets/dd5415e0-f24e-4b43-ba34-6e0acbca9627" />
