### PR TITLE
[Fix] Avoid pasing `null` to `json_decode` in `ProfileSnapshot`

### DIFF
--- a/api/app/ValueObjects/ProfileSnapshot.php
+++ b/api/app/ValueObjects/ProfileSnapshot.php
@@ -40,6 +40,13 @@ class ProfileSnapshot implements Castable
 
     public function __construct(mixed $snapshot)
     {
+
+        if (! $snapshot) {
+            $this->profile = null;
+
+            return;
+        }
+
         $snapshot = json_decode($snapshot, true) ?? null;
 
         if (! $snapshot) {


### PR DESCRIPTION
🤖 Resolves #15044 

## 👋 Introduction

Checks that a snapshot exists before attempting to decoded it.

## 🧪 Testing

1. Open tinker `make artisan CMD="tinker"`
2. Seed multiple candidates `PoolCandidate::factory(20)->create()`
3. Confirm no `jscon_decode` deprecation warnings appear