### PR TITLE
[Fix] Show work streams for all work experience categories

### DIFF
--- a/api/app/Traits/Generator/GeneratesUserDoc.php
+++ b/api/app/Traits/Generator/GeneratesUserDoc.php
@@ -613,30 +613,28 @@ trait GeneratesUserDoc
                 });
             }
 
-            if ($experience->employment_category === EmploymentCategory::GOVERNMENT_OF_CANADA->name || $experience->employment_category === EmploymentCategory::CANADIAN_ARMED_FORCES->name) {
-                $experience->loadMissing(['workStreams']);
-                if ($experience->workStreams && count($experience->workStreams) > 0) {
-                    $workStreamsByCommunity = [];
-                    foreach ($experience->workStreams as $workStream) {
-                        if (isset($workStreamsByCommunity[$workStream->community_id])) {
-                            $workStreamsByCommunity[$workStream->community_id]['workStreams'][] = $workStream->name[$this->lang];
-                        } else {
-                            $community = Community::find($workStream->community_id);
-                            $workStreamsByCommunity[$workStream->community_id] = [
-                                'community' => $community->name[$this->lang],
-                                'workStreams' => [$workStream->name[$this->lang]],
-                            ];
-                        }
+            $experience->loadMissing(['workStreams']);
+            if ($experience->workStreams && count($experience->workStreams) > 0) {
+                $workStreamsByCommunity = [];
+                foreach ($experience->workStreams as $workStream) {
+                    if (isset($workStreamsByCommunity[$workStream->community_id])) {
+                        $workStreamsByCommunity[$workStream->community_id]['workStreams'][] = $workStream->name[$this->lang];
+                    } else {
+                        $community = Community::find($workStream->community_id);
+                        $workStreamsByCommunity[$workStream->community_id] = [
+                            'community' => $community->name[$this->lang],
+                            'workStreams' => [$workStream->name[$this->lang]],
+                        ];
                     }
-
-                    $section->addText($this->localize('common.work_streams'));
-                    collect(Arr::sortRecursive($workStreamsByCommunity))->each(function ($community) use ($section) {
-                        $section->addListItem($community['community'], 0);
-                        foreach ($community['workStreams'] as $workStream) {
-                            $section->addListItem($workStream, 1);
-                        }
-                    });
                 }
+
+                $section->addText($this->localize('common.work_streams'));
+                collect(Arr::sortRecursive($workStreamsByCommunity))->each(function ($community) use ($section) {
+                    $section->addListItem($community['community'], 0);
+                    foreach ($community['workStreams'] as $workStream) {
+                        $section->addListItem($workStream, 1);
+                    }
+                });
             }
         }
     }


### PR DESCRIPTION
🤖 Resolves #15051 

## 👋 Introduction

Updates user profile documens to show work streams for all work experience categories. 

## 🕵️ Details

Seems as though we were only showing these work work experiences where the category was a government or armed forces experience despite the fact any category can add them.

## 🧪 Testing

1. Login as `admin@test.com`
2. Create an external work experience
3. Add at least one work stream
4. Go to download your pfofile
5. Confirm that the work experiences appear

## 📸 Screenshot

[Abagail Considine - Profile - Profil.docx](https://github.com/user-attachments/files/23533036/Abagail.Considine.-.Profile.-.Profil.docx)

<img width="653" height="316" alt="swappy-20251113_141104" src="https://github.com/user-attachments/assets/57423ff2-80ea-47e7-863f-06978f69cadd" />

