### PR TITLE
[Debt] Replaces deprecated `setValidationConstraints` with `withValidationConstraints`

### DIFF
--- a/api/app/Services/OpenIdBearerTokenService.php
+++ b/api/app/Services/OpenIdBearerTokenService.php
@@ -196,7 +196,7 @@ class OpenIdBearerTokenService
         $token = $config->parser()->parse($bearerToken);
 
         assert($token instanceof UnencryptedToken);
-        $config->withValidationConstraints(
+        $config = $config->withValidationConstraints(
             new IssuedBy($this->getConfigProperty('issuer')),
             new RelatedTo($token->claims()->get('sub')),
             new LooseValidAt($this->clock, $this->allowableClockSkew),


### PR DESCRIPTION
🤖 Resolves #15043.

## 👋 Introduction

This PR replaces the deprecated `setValidationConstraints` with `withValidationConstraints` for lcobucci/jwt (REF: https://github.com/lcobucci/jwt/pull/1092)

## 🧪 Testing

1. `make artisan CMD="test --filter=OpenIdBearerTokenTest"`
2. Confirm it passes 10 times