### PR TITLE
[Refactor] Notification dialog

### DIFF
--- a/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
+++ b/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
@@ -4,7 +4,7 @@ import { AnimatePresence, m, usePresence } from "motion/react";
 import BellAlertIcon from "@heroicons/react/24/outline/BellAlertIcon";
 import BellAlertIconSm from "@heroicons/react/20/solid/BellAlertIcon";
 import XMarkIcon from "@heroicons/react/20/solid/XMarkIcon";
-import { UseQueryExecute } from "urql";
+import { useQuery, UseQueryExecute } from "urql";
 
 import { unpackMaybes, useIsSmallScreen } from "@gc-digital-talent/helpers";
 import { graphql } from "@gc-digital-talent/graphql";
@@ -24,17 +24,17 @@ import notificationMessages from "~/messages/notificationMessages";
 import { NOTIFICATION_POLLING_INTERVAL } from "~/constants/notifications";
 
 import UnreadAlertBellIcon from "./UnreadAlertBellIcon";
-import NotificationList from "../NotificationList/NotificationList";
+import NotificationActions from "../NotificationList/NotificationActions";
+import NotificationDialogList from "./NotificationDialogList";
 
 const Overlay = m.create(DialogPrimitive.Overlay);
 
-// For the sake of the bell icon, we only care if the user has at least 1 unread notification
-// This is to query to minimal amount of data to display the badge
-const NotificationCount_Query = graphql(/* GraphQL */ `
-  query NotificationCount {
-    notifications(where: { onlyUnread: true }, first: 1) {
+const NotificationDialog_Query = graphql(/* GraphQL */ `
+  query NotificationDialog {
+    notifications(where: { onlyUnread: true }, first: 30) {
       data {
         id
+        ...NotificationDialogItem
       }
     }
   }
@@ -42,18 +42,22 @@ const NotificationCount_Query = graphql(/* GraphQL */ `
 
 interface DialogPortalWithPresenceProps {
   onClose: () => void;
-  executeQuery: UseQueryExecute;
+  onRead: UseQueryExecute;
 }
 
 const DialogPortalWithPresence = ({
   onClose,
-  executeQuery,
+  onRead,
 }: DialogPortalWithPresenceProps) => {
   const intl = useIntl();
   const paths = useRoutes();
   const [isPresent] = usePresence();
   const [render, setRender] = useState<boolean>(isPresent);
   const containerRef = useRef<HTMLDivElement>(null);
+  const [{ data, fetching }, executeQuery] = useQuery({
+    query: NotificationDialog_Query,
+    pause: !render,
+  });
 
   useEffect(() => {
     let timerId: ReturnType<typeof setTimeout>;
@@ -77,7 +81,7 @@ const DialogPortalWithPresence = ({
 
   const handleRead = () => {
     onClose();
-    executeQuery();
+    onRead();
   };
 
   return render ? (
@@ -88,7 +92,7 @@ const DialogPortalWithPresence = ({
         animate={{ opacity: 0.85 }}
         exit={{ opacity: 0.85 }}
         transition={{ duration: 0.2 }}
-        className="fixed inset-0 z-[97] bg-gray-700/90"
+        className="fixed inset-0 z-48 bg-gray-700/90"
       />
       <DialogPrimitive.Content forceMount asChild>
         <m.div
@@ -97,7 +101,7 @@ const DialogPortalWithPresence = ({
           animate={{ x: 0, scale: 1 }}
           exit={{ x: "100%", scale: 0.95 }}
           transition={{ duration: 0.2, ease: "easeInOut" }}
-          className="fixed inset-y-0 right-0 z-[98] m-3 ml-auto w-110 max-w-[95vw] overflow-y-auto rounded bg-white font-sans text-black shadow-lg dark:bg-gray-600 dark:text-white"
+          className="fixed inset-y-0 right-0 z-49 m-3 ml-auto w-110 max-w-[95vw] overflow-y-auto rounded bg-white font-sans text-black shadow-lg dark:bg-gray-600 dark:text-white"
         >
           <div className="p-6">
             <div className="mb-3 flex items-center justify-between gap-y-1.5">
@@ -137,7 +141,17 @@ const DialogPortalWithPresence = ({
               })}
             </DialogPrimitive.Description>
           </div>
-          <NotificationList inDialog limit={30} onRead={handleRead} />
+          <NotificationActions
+            onRead={onRead}
+            onlyUnread
+            inDialog
+            onRefresh={executeQuery}
+            fetching={fetching}
+          />
+          <NotificationDialogList
+            query={unpackMaybes(data?.notifications?.data)}
+            onRead={handleRead}
+          />
           <p className="m-6">
             <DialogPrimitive.Close asChild>
               <Link href={paths.notifications()} mode="solid" color="primary">
@@ -155,6 +169,18 @@ const DialogPortalWithPresence = ({
   ) : null;
 };
 
+// For the sake of the bell icon, we only care if the user has at least 1 unread notification
+// This is to query to minimal amount of data to display the badge
+const NotificationCount_Query = graphql(/* GraphQL */ `
+  query NotificationCount {
+    notifications(where: { onlyUnread: true }, first: 1) {
+      data {
+        id
+      }
+    }
+  }
+`);
+
 interface NotificationDialog {
   /** Controllable open state */
   open?: boolean;
@@ -163,6 +189,7 @@ interface NotificationDialog {
   /** Trigger color */
   color?: ButtonProps["color"];
 }
+
 const NotificationDialog = ({
   open,
   onOpenChange,
@@ -261,8 +288,8 @@ const NotificationDialog = ({
       <AnimatePresence initial={false}>
         {open && (
           <DialogPortalWithPresence
-            executeQuery={executeQuery}
             onClose={() => onOpenChange?.(false)}
+            onRead={executeQuery}
           />
         )}
       </AnimatePresence>

--- a/apps/web/src/components/NotificationDialog/NotificationDialogList.tsx
+++ b/apps/web/src/components/NotificationDialog/NotificationDialogList.tsx
@@ -1,0 +1,59 @@
+import { useIntl } from "react-intl";
+
+import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
+import { Well } from "@gc-digital-talent/ui";
+
+import NotificationItem from "../NotificationList/NotificationItem";
+
+const NotificationDialogItem_Fragment = graphql(/** GraphQL */ `
+  fragment NotificationDialogItem on Notification {
+    id
+    ...NotificationItem
+  }
+`);
+
+interface NotificationDialogListProps {
+  query: FragmentType<typeof NotificationDialogItem_Fragment>[];
+  onRead?: () => void;
+}
+
+const NotificationDialogList = ({
+  query,
+  onRead,
+}: NotificationDialogListProps) => {
+  const intl = useIntl();
+  const notifications = getFragment(NotificationDialogItem_Fragment, query);
+
+  return notifications.length > 0 ? (
+    <ul className="flex list-none flex-col p-0">
+      {notifications.map((notification) => (
+        <NotificationItem
+          key={notification.id}
+          notification={notification}
+          inDialog
+          onRead={onRead}
+        />
+      ))}
+    </ul>
+  ) : (
+    <Well className="mx-6">
+      <p className="mb-6 font-bold">
+        {intl.formatMessage({
+          defaultMessage: "You don't have any new notifications.",
+          id: "6cr+Qy",
+          description: "Title for the no notifications message",
+        })}
+      </p>
+      <p>
+        {intl.formatMessage({
+          defaultMessage:
+            "Check back here for alerts about a variety of activities on the platform, including job opportunities, new features, and more.",
+          id: "d4aLWc",
+          description: "Explanation of how the list of notifications work",
+        })}
+      </p>
+    </Well>
+  );
+};
+
+export default NotificationDialogList;


### PR DESCRIPTION
## 👋 Introduction

This is a a small refactor (hopefully) to the notification dialog as an attempt to stabilize it.

## 🕵️ Details

The idea here is that we reduce our need for the pagining which was added as a common component between the dialog and all notifications page.

We lose a small amount of functionality (paging and polling) in favour of reducing out query count to avoid SiC rate-limiting us.

Refreshing will only show the latest 30, you can no lonver see more than 30.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as any user
3. Trigger some notifications
4. Open the dialog
5. Confirm notifications appear
6. While the dialog is open, Trigger some more notifications (probably in a different tab)
7. Click refresh
8. Confirm new notification appears