### PR TITLE
[Fix] Show read notifications in dialog

### DIFF
--- a/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
+++ b/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
@@ -31,7 +31,7 @@ const Overlay = m.create(DialogPrimitive.Overlay);
 
 const NotificationDialog_Query = graphql(/* GraphQL */ `
   query NotificationDialog {
-    notifications(where: { onlyUnread: true }, first: 30) {
+    notifications(first: 30) {
       data {
         id
         ...NotificationDialogItem


### PR DESCRIPTION
## 👋 Introduction

Updates the nofification dialog to show both read and unread notifications.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as any user
3. Create some notificaitons
4. Mark at least one as read
5. Open the notification dialog
6. Confirm to read notifications appear

## 📸 Screenshot

<img width="491" height="537" alt="swappy-20251117_113956" src="https://github.com/user-attachments/assets/b639aae2-2f11-42b0-8c94-ae8fa2e0c8b4" />
