### PR TITLE
[Feat] Add job application app insights event tracking

### DIFF
--- a/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
@@ -151,6 +151,19 @@ const ApplicationReview = ({ application }: ApplicationPageProps) => {
         }
       })
       .catch(() => {
+        if (appInsights) {
+          const aiUserId = appInsights?.context?.user?.id || "unknown";
+          appInsights.trackEvent?.(
+            { name: "Job application submission error" },
+            {
+              aiUserId,
+              pageUrl: window.location.href,
+              timestamp: new Date().toISOString(),
+              referrer: document.referrer || "none",
+              source: "ApplicationReviewPage",
+            },
+          );
+        }
         toast.error(
           intl.formatMessage({
             defaultMessage: "Error: submitting application failed",


### PR DESCRIPTION
🤖 Resolves #13601 

## 👋 Introduction

Adds two new events to app insights tracking,

- Job application creation
- Job application submission

## 🕵️ Details

These only fire on success which seemed to make sense to me. Though, I can change that if we need to.

## 🧪 Testing

> [!NOTE]
> I'm not sure if this can be tested locally? :thinking:  

1. Build `pnpm dev:fresh`
2. Login as a user
3. Start and complete a job application
4. Confirm the events are logged in app insights