### PR TITLE
Fix community assignment to talent requests

### DIFF
--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -194,6 +194,10 @@ const RequestOptions_Query = graphql(/* GraphQL */ `
         en
         fr
       }
+      community {
+        id
+        key
+      }
     }
   }
 `);
@@ -267,16 +271,12 @@ export const RequestForm = ({
       values?.positionType === true
         ? PoolCandidateSearchPositionType.TeamLead
         : PoolCandidateSearchPositionType.IndividualContributor;
-    const qualifiedStreams = applicantFilter?.qualifiedInWorkStreams;
-    let community = communities?.find((c) => c.key === "digital");
-    const ATIPStream = optionsData?.workStreams?.find(
-      (workStream) => workStream?.key === "ACCESS_INFORMATION_PRIVACY",
+    // We should always receive exactly one stream and only its ID
+    const selectedStreamId = applicantFilter?.qualifiedInWorkStreams?.[0]?.id;
+    const selectedStream = optionsData?.workStreams?.find(
+      (s) => s?.id === selectedStreamId,
     );
-    if (
-      qualifiedStreams?.some((workStream) => workStream?.id === ATIPStream?.id)
-    ) {
-      community = communities?.find((c) => c.key === "atip");
-    }
+    const community = selectedStream?.community;
 
     // always append ONSITE to the flexible locations region
     const adjustedFlexibleWorkLocations = [
@@ -295,7 +295,7 @@ export const RequestForm = ({
       hrAdvisorEmail: values.hrAdvisorEmail ?? "",
       wasEmpty: candidateCount === 0 && !state.allPools,
       community: {
-        connect: community?.id ?? communities[0].id,
+        connect: community?.id,
       },
       applicantFilter: {
         create: {
@@ -314,7 +314,7 @@ export const RequestForm = ({
               : [],
           },
           community: {
-            connect: community?.id ?? communities[0].id,
+            connect: community?.id,
           },
           pools: {
             sync: applicantFilter?.pools


### PR DESCRIPTION
🤖 Resolves #14989.

## 👋 Introduction

Fixes logic around which community gets assigned to new talent requests to ensure the right people can see them.

> [!NOTE]
> This only applies to new talent requests - existing requests will remain unchanged.

## 🧪 Testing

1. Submit a talent request for a Digital Community stream ex.`Business Line Advisory Services`.
2. Submit a talent request for an ATIP Community stream ex. `Access to Information`.
3. Sign in as a Community Administrator for the Digital Community but no other community roles.
4. Navigate to view talent requests `admin/talent-requests`.
5. Confirm you can see the request from step 1 but not from step 2.
6. Sign in as a Community Administrator for the ATIP Community but no other community roles.
7. Navigate to view talent requests `admin/talent-requests`.
8. Confirm you can see the request from step 2 but not from step 1.