### PR TITLE
[Fix] Skip flaky excel download test

### DIFF
--- a/apps/playwright/tests/admin/user-excel.spec.ts
+++ b/apps/playwright/tests/admin/user-excel.spec.ts
@@ -4,7 +4,14 @@ import UserPage from "~/fixtures/UserPage";
 import { loginBySub } from "~/utils/auth";
 
 test.describe("User Excel", () => {
-  test("Download user as Excel", async ({ appPage }) => {
+  // NOTE: Skipping until subscriptions are added so we know when the file has been generated
+  // This was broken when we removed the polling query
+  // Remember, you will need to modify the downloadExcel function for subscriptions likely
+  //
+  // REF: https://github.com/GCTC-NTGC/gc-digital-talent/issues/15038
+  //
+  // eslint-disable-next-line playwright/no-skipped-test
+  test.skip("Download user as Excel", async ({ appPage }) => {
     const userPage = new UserPage(appPage.page);
     await loginBySub(userPage.page, "admin@test.com", false);
     await userPage.goToIndex();


### PR DESCRIPTION
🤖 Resolves #15139 

## 👋 Introduction

Skips a flaky async download until we get subscriptions implemented,

## 🕵️ Details

This is flaky for the same reason as the other one where the fix was to temporarily skip.

https://github.com/GCTC-NTGC/gc-digital-talent/pull/15096

## 🧪 Testing

1. Confirm test skipped
2. Confirm documentation provided is clear