### PR TITLE
[Fix] Hide revert dialog when candidate is removed

### DIFF
--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/MoreActions.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/MoreActions.tsx
@@ -120,7 +120,7 @@ const MoreActions = ({
 
   const currentStepName =
     // NOTE: Localized can be empty string so || is more suitable
-
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     poolCandidate.assessmentStep?.title?.localized ||
     poolCandidate.assessmentStep?.type?.label?.localized;
 
@@ -178,7 +178,7 @@ const MoreActions = ({
         )}
 
         {isRevertableStatus(status) &&
-          !(poolCandidate.finalDecision.value !== FinalDecision.Removed) && (
+          !(poolCandidate.finalDecision?.value !== FinalDecision.Removed) && (
             <StatusLabel>
               <RevertFinalDecisionDialog
                 revertFinalDecisionQuery={poolCandidate}


### PR DESCRIPTION
🤖 Resolves #15114 

## 👋 Introduction

Prevents the `RevertFinalDecisionDialog` from presenting when they have been removed.

## 🧪 Testing

1. Find a qualified candidate
2. Manually set their `pool_candidate_status` to `EXPIRED` (only way is in DB)
3. Confirm they only see the "Reinstate" dialog trigger and not the "Revert" one

## 📸 Screenshot

<img width="836" height="1065" alt="swappy-20251125_131032" src="https://github.com/user-attachments/assets/e29f070b-6407-4f8d-855d-6799f6029ba7" />
