### PR TITLE
[Fix] Email verification icon accName

### DIFF
--- a/apps/web/src/components/ContactEmailCard/ContactEmailCard.tsx
+++ b/apps/web/src/components/ContactEmailCard/ContactEmailCard.tsx
@@ -47,6 +47,7 @@ const ContactEmailCard = ({ query }: ContactEmailCardProps) => {
               {contactEmail.isEmailVerified && (
                 <CheckCircleIcon
                   className="size-6 text-success"
+                  aria-hidden="false"
                   aria-label={intl.formatMessage({
                     defaultMessage: "Verified",
                     id: "GMglI5",

--- a/apps/web/src/components/WorkEmailCard.tsx/WorkEmailCard.tsx
+++ b/apps/web/src/components/WorkEmailCard.tsx/WorkEmailCard.tsx
@@ -97,6 +97,7 @@ const WorkEmailCard = ({ query }: WorkEmailCardProps) => {
               {workEmailFragment.isWorkEmailVerified && (
                 <CheckCircleIcon
                   className="size-6 text-success"
+                  aria-hidden="false"
                   aria-label={intl.formatMessage({
                     defaultMessage: "Verified",
                     id: "GMglI5",


### PR DESCRIPTION
🤖 Resolves #15171 

## 👋 Introduction

Make the email verified icon visible to ATs.

## 🧪 Testing

> [!TIP]
> You can login as any user, just make sure both emails (contact and email) exist with a verified date. 

1. Build `pnpm dev:fresh`
2. Login as `applicant-employee@test.com`
3. Navigate to account settings
4. Open the accessibility tree
5. Confirm both verified icons have an accName (Verified)