### PR TITLE
[Fix] Import resolver config

### DIFF
--- a/packages/eslint-config-custom/index.mjs
+++ b/packages/eslint-config-custom/index.mjs
@@ -54,7 +54,11 @@ export default tseslint.config(
         "@typescript-eslint/parser": [".ts", ".tsx"],
       },
       "import/resolver": {
-        typescript: {},
+        typescript: {
+          alwaysTryTypes: true,
+          project: ["./apps/*/tsconfig.json", "./packages/*/tsconfig.json"],
+        },
+        node: true,
       },
     },
     rules: {


### PR DESCRIPTION
🤖 Resolves #15177 

## 👋 Introduction

Fixes an issue where path aliases were not properly being resolved by eslint.

## 🧪 Testing

1. Maybe need to run `pnpm i` and restart both Typescript and eslint in your editor
2. Confirm lint check still passes `CI=true pnpm lint --force`
3. Open a file that contains an import from an aliased path
4. Confirm no eslint errors appear
