### PR TITLE
[Fix] vitest workflow space

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -86,6 +86,3 @@ jobs:
           flags: unittests
           fail_ci_if_error: false
           directory: coverage
-
-      - name: Clean up Playwright Browsers
-        run: npx playwright uninstall chromium


### PR DESCRIPTION
🤖 Resolves #15204 

## 👋 Introduction

Attempts to do some more aggressive cleanup in the vitest workflow to save space.

## 🕵️ Details

This does two things:

1. Skips the build step which produces files we don't use
2. Runs some cleanup in the image to hopefully remove files we don't need

Seems like the main offender were some preinstalled packages that come with the container we use 😬 

https://github.com/GCTC-NTGC/gc-digital-talent/actions/runs/19738027693/job/56554600888#step:4:9

## 🧪 Testing

1. Confirm the vitest workflow runs all the way through consistently