### PR TITLE
[Feature] Longer skill family names

### DIFF
--- a/apps/web/src/pages/Skills/components/tableHelpers.tsx
+++ b/apps/web/src/pages/Skills/components/tableHelpers.tsx
@@ -8,7 +8,6 @@ import {
   Skill,
   SkillFamily,
 } from "@gc-digital-talent/graphql";
-import { UNICODE_CHAR } from "@gc-digital-talent/ui";
 
 export function categoryAccessor(
   category: Maybe<LocalizedSkillCategory>,
@@ -21,7 +20,6 @@ export function skillFamiliesCell(
   skillFamilies: Maybe<Maybe<SkillFamily>[]> | undefined,
   intl: IntlShape,
 ) {
-  const maxCharacterCount = 50;
   const familyNames = skillFamilies
     ?.filter(notEmpty)
     .sort()
@@ -30,16 +28,7 @@ export function skillFamiliesCell(
   familyNames?.sort((a, b) => a.localeCompare(b));
 
   const familyItems = familyNames?.map((familyName) => (
-    <li key={familyName}>
-      {familyName.length < maxCharacterCount ? (
-        familyName
-      ) : (
-        <>
-          {familyName.slice(0, maxCharacterCount)}
-          <span>{UNICODE_CHAR.ELLIPSE}</span>
-        </>
-      )}
-    </li>
+    <li key={familyName}>{familyName}</li>
   ));
 
   return familyItems ? <ul>{familyItems}</ul> : null;


### PR DESCRIPTION
🤖 Resolves #15143 

## 👋 Introduction

- Removes the max character count for skill family names in the Skill library table.

## 🧪 Testing

1. Build app
2. Create a skill family with a large character count (over 50 should do)
3. Go to skill library
4. Ensure full skill family name is visible

## 📸 Screenshot

Before:
<img width="3046" height="1454" alt="Screenshot from 2025-12-02 15-45-47" src="https://github.com/user-attachments/assets/0dede274-1cd2-41cc-ac7d-dff90a6baf3a" />

After:
<img width="3046" height="1454" alt="image" src="https://github.com/user-attachments/assets/366785a9-e3a4-42ae-be34-c5b9572d1f40" />
