### PR TITLE
[Bug] Fix null handling in table sorting

### DIFF
--- a/apps/web/src/components/Table/sortingFns.ts
+++ b/apps/web/src/components/Table/sortingFns.ts
@@ -20,7 +20,9 @@ const compareNormalized = (strA: string, strB: string): number => {
   return a > b ? 1 : -1;
 };
 
-export const normalizedText: SortingFn<unknown> = (rowA, rowB, columnId) => {
+// Note: any required for react-table
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const normalizedText: SortingFn<any> = (rowA, rowB, columnId) => {
   const unknownValueA = rowA.getValue<unknown>(columnId);
   const strValueA = typeof unknownValueA === "string" ? unknownValueA : "";
   const unknownValueB = rowB.getValue<unknown>(columnId);
@@ -44,7 +46,9 @@ const compareNumeric = (a: number, b: number): number => {
   return a > b ? 1 : -1;
 };
 
-export const numeric: SortingFn<unknown> = (rowA, rowB, columnId) => {
+// Note: any required for react-table
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const numeric: SortingFn<any> = (rowA, rowB, columnId) => {
   const unknownValueA = rowA.getValue<unknown>(columnId);
   const numericValueA = Number(unknownValueA);
   const unknownValueB = rowB.getValue<unknown>(columnId);


### PR DESCRIPTION
🤖 Resolves #15245

## 👋 Introduction

Allows sorting in tables with nulls.

## 🕵️ Details

Our default value for classification->display_name is `{"en": "", "fr": ""}` but it is possible to set them to `{"en": null, "fr": null}` and we have that in production.  Unfortunately, our table thinks nulls are not possible and allowed us to skip the checks.  I fixed this for `normalizedText` and also `numeric` sorting, just in case.

## 🧪 Testing

1. Manually set a display_name in the classifications table to `{"en": null, "fr": null}`
2. Manually set a min_salary value in the classifications table to null
3. Log in as admin@test.com
4. Visit /en/admin/settings/classifications
5. Sort by display name
6. Sort by min salary