### PR TITLE
[Fix] Don't crash nomination when missing template IDs

### DIFF
--- a/api/app/Listeners/SendTalentNominationSubmittedNotifications.php
+++ b/api/app/Listeners/SendTalentNominationSubmittedNotifications.php
@@ -19,7 +19,14 @@ class SendTalentNominationSubmittedNotifications
      */
     public function __construct()
     {
-        $this->canSendNotifications = ! empty(config('notify.client.apiKey'));
+        $this->canSendNotifications = collect([
+            config('notify.client.apiKey'),
+            config('notify.templates.nomination_received_submitter_en'),
+            config('notify.templates.nomination_received_submitter_fr'),
+            config('notify.templates.nomination_received_nominator_en'),
+            config('notify.templates.nomination_received_nominator_fr'),
+        ])
+            ->every(fn ($val) => ! empty($val));
     }
 
     /**


### PR DESCRIPTION
🤖 Resolves #15013 

## 👋 Introduction

Checks that all config values are present before attempting to send the nomination notification.

## 🕵️ Details

## 🧪 Testing

1. Populate GCNOTIFY_API_KEY
2. Leave the GCNOTIFY_TEMPLATE_NOMINATION_* values empty
3. `composer install --prefer-dist`
4. ` ./artisan test tests/Feature/TalentNominationTest.php`

- [ ] All tests pass
- [ ] A debug message is logged that the notification was not sent

5. Populate the GCNOTIFY_TEMPLATE_NOMINATION_* values
6. `composer install --prefer-dist`
7. ` ./artisan test tests/Feature/TalentNominationTest.php`

- [ ] All tests pass
- [ ] No debug messages
