### PR TITLE
[Fix] Reinstate dialog display

### DIFF
--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/MoreActions.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/MoreActions/MoreActions.tsx
@@ -210,7 +210,7 @@ const MoreActions = ({
         )}
 
         {isRevertableStatus(status) &&
-          !(poolCandidate.finalDecision?.value !== FinalDecision.Removed) && (
+          !(poolCandidate.finalDecision?.value === FinalDecision.Removed) && (
             <StatusLabel>
               <RevertFinalDecisionDialog
                 revertFinalDecisionQuery={poolCandidate}


### PR DESCRIPTION
🤖 Resolves #15288 

## 👋 Introduction

Fixes an issue where the dialog to reinstate a candidate was no longer being displayed when the candidate was disqualifed.

## 🧪 Testing

1. Find a new application
2. Record final decision
3. Disqualified
4. Screened out at application
5. Confirm the reinstate dialog appears