### PR TITLE
[Fix] Locale redirect logging users out

### DIFF
--- a/packages/i18n/src/components/LocaleProvider.tsx
+++ b/packages/i18n/src/components/LocaleProvider.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable formatjs/no-literal-string-in-jsx */
 import { createContext, ReactNode, useState, useEffect, useMemo } from "react";
 
 import { Locales } from "../types";
@@ -24,6 +25,22 @@ const guessLocale = (): Locales => {
 
   return "en";
 };
+
+interface LinkProps {
+  href: string;
+  children: ReactNode;
+}
+
+const Link = ({ href, children }: LinkProps) => (
+  // NOTE: Cannot use react-router here
+  // eslint-disable-next-line react/forbid-elements
+  <a
+    href={href}
+    className="text-primary-600 underline hover:text-primary-700 dark:text-primary-200 dark:hover:text-primary-100"
+  >
+    {children}
+  </a>
+);
 
 export interface LocaleState {
   locale: Locales;
@@ -73,7 +90,39 @@ const LocaleProvider = ({ children }: LocaleProviderProps) => {
     };
   }, [locale, setLocale]);
 
-  if (needsRedirect && !localeReady) return null;
+  if (needsRedirect && !localeReady) {
+    return (
+      <div className="grid h-screen w-screen place-items-center text-center">
+        <div className="max-w-5xl">
+          <div className="mb-6">
+            <p className="mb-.5">
+              We’re redirecting you to the version of the site that matches your
+              browser settings.
+            </p>
+            <p>
+              Nous vous redirigeons vers la version du site qui correspond aux
+              paramètres de votre navigateur.
+            </p>
+          </div>
+          <div>
+            <p className="mb-.5">
+              If this doesn’t happen automatically, visit{" "}
+              <Link href="/en">talent.canada.ca/en</Link> for the English
+              version or <Link href="/fr">talent.canada.ca/fr</Link> for the
+              French version.
+            </p>
+            <p>
+              Si cette opération ne s’effectue pas automatiquement, consultez le{" "}
+              <Link href="/fr">talent.canada.ca/fr</Link> pour obtenir la
+              version en français ou le{" "}
+              <Link href="/en">talent.canada.ca/en</Link> pour obtenir la
+              version en anglais.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <LocaleContext.Provider value={state}>{children}</LocaleContext.Provider>


### PR DESCRIPTION
🤖 Resolves #15343 

## 👋 Introduction

Fixes an issue where the locale redirect could interrupt a token refresh and cause a forced logout.

## 🧪 Testing

> [!TIP]
> Set mock oauth expire time to a lower number so you diont need to sit idle for 10mins. Not too low because of the 20s skew allowed. 45s is probably decent.

1. Build `pnpm dev:fresh`
2. Login as any user
3. Wait for token to expire
4. Open a new blank window
5. Navigate to root route with no locale `/`
6. Confirm that only one refresh occurs not two
7. Confirm that it succeeds and you are not logged out