### PR TITLE
[Debt] Remove redundant candidate location scope

### DIFF
--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -651,16 +651,6 @@ class PoolCandidate extends Model
         return null;
     }
 
-    /**
-     * Flexible Work Locations filtering
-     */
-    public function scopeWhereFlexibleWorkLocationsIn($query, array $locations)
-    {
-        return $query->whereHas('user', function ($userQuery) use ($locations) {
-            $userQuery->whereFlexibleWorkLocationsIn($locations);
-        });
-    }
-
     public function submit(?string $signature)
     {
         $this->signature = $signature;


### PR DESCRIPTION
🤖 Resolves #15316 

## 👋 Introduction

Removes a scope that was duplicated across model and builder for pool candidates.

## 🧪 Testing

1. Confirm scope was removed
2. Confirm identical scope belongs on `PoolCandidateBuilder`
3. Confirm functionality of the scope is unchanged