### PR TITLE
[Fix] TermsAndConditions.tsx breadcrumb

### DIFF
--- a/apps/web/src/pages/TermsAndConditions/TermsAndConditions.tsx
+++ b/apps/web/src/pages/TermsAndConditions/TermsAndConditions.tsx
@@ -229,7 +229,7 @@ export const Component = () => {
     crumbs: [
       {
         label: pageTitle,
-        url: paths.termsConditions(),
+        url: paths.termsAndConditions(),
       },
     ],
   });


### PR DESCRIPTION
## 👋 Introduction

This PR fixes an incorrect breadcrumb on the terms and conditions page.

## 🧪 Testing

1. `pnpm build`
2. Navigate to http://localhost:8000/en/terms-and-conditions
3. Verify breadcrumb points to correct URL