### PR TITLE
[Fix] Duplicate value `PoolCandidateSearchRequestReason.UpcomingNeed` in array for `sortPoolCandidateSearchRequestReason`

### DIFF
--- a/packages/i18n/src/utils/enum.ts
+++ b/packages/i18n/src/utils/enum.ts
@@ -138,7 +138,7 @@ export function localizedEnumToInput<T>(
 }
 
 /**
- * Converts an array of localized enums to grpahql input values
+ * Converts an array of localized enums to graphql input values
  *
  * @param localizedEnumArray - Array of localized enums
  * @returns Input values


### PR DESCRIPTION
_This PR applies 2/2 suggestions from code quality [AI findings](https://github.com/GCTC-NTGC/gc-digital-talent/security/quality/ai-findings)._

- Typo: `grpahql` should be `graphql`
- Duplicate value `PoolCandidateSearchRequestReason.UpcomingNeed` in array