### PR TITLE
[Fix] Turborepo `dev` and `build` inputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,11 +1,25 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": ["package.json", "**/.env", "pnpm-workspace.yaml"],
+  "globalDependencies": [
+    "package.json",
+    "**/.env",
+    "pnpm-workspace.yaml"
+  ],
   "tasks": {
     "build": {
-      "dependsOn": ["^intl-compile", "intl-compile", "^codegen"],
-      "inputs": ["src/**", "package.json"],
-      "outputs": ["dist/**"],
+      "dependsOn": [
+        "^intl-compile",
+        "intl-compile",
+        "^codegen"
+      ],
+      "inputs": [
+        "src/**",
+        "index.html",
+        "package.json"
+      ],
+      "outputs": [
+        "dist/**"
+      ],
       "outputLogs": "new-only"
     },
     "codegen": {
@@ -16,29 +30,54 @@
         "src/**/*.ts",
         "src/**/*.tsx"
       ],
-      "outputs": ["src/index.ts"],
+      "outputs": [
+        "src/index.ts"
+      ],
       "cache": false,
       "outputLogs": "new-only"
     },
     "dev": {
-      "dependsOn": ["intl-compile", "^intl-compile", "^codegen"],
-      "inputs": ["src/**/*.ts", "src/**/*.tsx", "package.json"],
-      "outputs": ["dist/**"],
+      "dependsOn": [
+        "intl-compile",
+        "^intl-compile",
+        "^codegen"
+      ],
+      "inputs": [
+        "src/**/*.ts",
+        "src/**/*.tsx",
+        "package.json",
+        "index.html"
+      ],
+      "outputs": [
+        "dist/**"
+      ],
       "outputLogs": "new-only"
     },
     "watch": {
-      "dependsOn": ["intl-compile", "^intl-compile"],
+      "dependsOn": [
+        "intl-compile",
+        "^intl-compile"
+      ],
       "cache": false,
       "persistent": true
     },
     "build:intl-cli": {
-      "inputs": ["src/cli.ts"],
-      "outputs": ["dist/cli.js"],
+      "inputs": [
+        "src/cli.ts"
+      ],
+      "outputs": [
+        "dist/cli.js"
+      ],
       "outputLogs": "new-only"
     },
     "intl-extract": {
-      "inputs": ["src/**/*.ts", "src/**/*.tsx"],
-      "outputs": ["src/lang/en.json"],
+      "inputs": [
+        "src/**/*.ts",
+        "src/**/*.tsx"
+      ],
+      "outputs": [
+        "src/lang/en.json"
+      ],
       "outputLogs": "new-only"
     },
     "intl-compile": {
@@ -50,8 +89,13 @@
         "src/lang/ojw.json",
         "src/lang/mic.json"
       ],
-      "dependsOn": ["intl-extract", "^intl-extract"],
-      "outputs": ["src/lang/*{Compiled}.json"],
+      "dependsOn": [
+        "intl-extract",
+        "^intl-extract"
+      ],
+      "outputs": [
+        "src/lang/*{Compiled}.json"
+      ],
       "cache": false,
       "outputLogs": "new-only"
     },
@@ -66,16 +110,26 @@
         "src/lang/ojw.json",
         "src/lang/mic.json"
       ],
-      "dependsOn": ["intl-compile", "^intl-compile"],
+      "dependsOn": [
+        "intl-compile",
+        "^intl-compile"
+      ],
       "cache": false,
       "outputLogs": "new-only"
     },
     "storybook": {
-      "dependsOn": ["^codegen", "^intl-compile", "intl-compile"],
+      "dependsOn": [
+        "^codegen",
+        "^intl-compile",
+        "intl-compile"
+      ],
       "outputs": []
     },
     "build-storybook": {
-      "outputs": ["dist/**", "storybook-static/**"]
+      "outputs": [
+        "dist/**",
+        "storybook-static/**"
+      ]
     },
     "test": {
       "outputLogs": "new-only"
@@ -107,10 +161,18 @@
       ]
     },
     "prettier": {
-      "inputs": ["./.prettierrc", "**/*.{ts,tsx}", "!node_modules"]
+      "inputs": [
+        "./.prettierrc",
+        "**/*.{ts,tsx}",
+        "!node_modules"
+      ]
     },
     "prettier:fix": {
-      "inputs": ["./.prettierrc", "**/*.{ts,tsx}", "!node_modules"]
+      "inputs": [
+        "./.prettierrc",
+        "**/*.{ts,tsx}",
+        "!node_modules"
+      ]
     },
     "tsc": {}
   }


### PR DESCRIPTION
🤖 Resolves #15307 

## 👋 Introduction

Added `index.html` to the `build` and `dev` inputs for turborepo config so that changes to it bust the cache.

## 🧪 Testing

1. Run `pnpm dev`
2. Run again and ensure it uses cached version
3. Modify `apps/web/index.html`
4. Run `pnpm dev` again
5. Confirm it does not use cache