### PR TITLE
[Copy] Replaces Dissimuler with Masquer

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4872,7 +4872,7 @@
     "description": "Link text for editing a users technical skills to improve"
   },
   "IxngA3": {
-    "defaultMessage": "Dissimuler les détails de cette expérience",
+    "defaultMessage": "Masquer les détails de cette expérience",
     "description": "Button text to hide a miscellaneous experience's details"
   },
   "J+MAUg": {
@@ -12366,7 +12366,7 @@
     "description": "Message displayed when a user fails to updates employee profile information"
   },
   "pLef1V": {
-    "defaultMessage": "Dissimuler les détails de {experienceName}",
+    "defaultMessage": "Masquer les détails de {experienceName}",
     "description": "Button text to hide a specific experience's details"
   },
   "pOazxP": {


### PR DESCRIPTION
🤖 Resolves #15340.

## 👋 Introduction

This PR replaces all references to _Dissimuler_ with _Masquer_ in French.

## 🧪 Testing

1. `pnpm build`
2. Navigate to http://localhost:8000/fr/applicant/career-timeline
3. Verify _Dissimuler_ has been replaced with _Masquer_ in French
4. Verify no references in codebase to _Dissimuler_ or _Dissimulez_

## 📸 Screenshot

<img width="1296" height="842" alt="Screenshot 2025-12-19 at 13 23 22" src="https://github.com/user-attachments/assets/1c343b4f-dd2c-49fe-b8c5-5effd7f2e0ff" />