### PR TITLE
[Fix] UUID v7 support

### DIFF
--- a/apps/web/src/hooks/useRequiredParams.ts
+++ b/apps/web/src/hooks/useRequiredParams.ts
@@ -12,7 +12,7 @@ import { commonMessages } from "@gc-digital-talent/i18n";
 import invariant from "~/utils/invariant";
 
 const uuidRegEx =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-7][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  /^[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}$/;
 
 const isUUID = (str: string): boolean => {
   return !!uuidRegEx.exec(str);


### PR DESCRIPTION
🤖 Resolves #15428 

## 👋 Introduction

Updates the url param validation to enforce UUIDs to support v7.

## 🕵️ Details

We have a backend check as well but it uses internal laravel helpers that were updated in the upgrade to v12 so did not need to be fixed.

## 🧪 Testing

> [!NOTE]
> The created resource must have a page that uses the `useRequiredParams` without `enforceUUID` disabled 

1. Build `pnpm dev:fresh`
2. Create some resource with a ID that is a UUIDv7
3. Navigate to that specific resource on the frontend
4. Confirm the pages does not crash with a UUID error