### PR TITLE
[Feature] Training fund message

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -9162,6 +9162,10 @@
     "defaultMessage": "Une femme autochtone porte un manteau de jeans qui est orné de plusieurs épinglettes.",
     "description": "Indigenous Apprenticeship woman smiling image text alternative"
   },
+  "cF0+Id": {
+    "defaultMessage": "À l'approche de la fin de l'exercice financier, nous gérons avec soin les fonds restants disponibles pour les formations. En raison du volume important de demandes de formation, nous fermons l'offre « Choisissez votre cours » aux nouvelles candidatures. Les demandes restantes seront évaluées dans l'ordre dans lequel elles ont été reçues, en fonction des fonds disponibles. Le budget sera réinitialisé avec le nouvel exercice financier le 1er avril 2026 et nous vous encourageons à postuler à ce moment-là.",
+    "description": "Body for a notice about no more choose your own course options for the year."
+  },
   "cF8idC": {
     "defaultMessage": "Candidature",
     "description": "Label for the application link column"
@@ -10656,6 +10660,10 @@
   "i9ovz7": {
     "defaultMessage": "Postes bilingues",
     "description": "Sub-heading for language requirements dialog"
+  },
+  "i9skPs": {
+    "defaultMessage": "Avis important : fermeture de l'option « Choisissez votre cours » pour l'exercice financier 2025/2026",
+    "description": "Title for a notice about no more choose your own course options for the year."
   },
   "iA1Q8d": {
     "defaultMessage": "Ainsi, ce processus n'apparaîtra plus automatiquement dans les recherches de requêtes et les tableaux de bord partout.",

--- a/apps/web/src/pages/InstructorLedTrainingPage/InstructorLedTrainingPage.tsx
+++ b/apps/web/src/pages/InstructorLedTrainingPage/InstructorLedTrainingPage.tsx
@@ -412,18 +412,16 @@ export const Component = () => {
           <Notice.Root color="warning" className="mt-18">
             <Notice.Title icon={BellAlertIcon}>
               {intl.formatMessage({
-                defaultMessage:
-                  "Important notice: Closing of the “Choose your own course” option for the fiscal year 2025/2026",
-                id: "JXlKez",
+                defaultMessage: `Important Notice: Closing of the "Choose your own course" option for the fiscal year 2025/2026`,
+                id: "i9skPs",
                 description:
                   "Title for a notice about no more choose your own course options for the year.",
               })}
             </Notice.Title>
             <Notice.Content>
               {intl.formatMessage({
-                defaultMessage:
-                  "As we approach the end of the fiscal year, we are carefully managing the remaining funds available for training opportunities. Due to the volume of training requests, we are closing the “Choose your own course” offer to new applications. Remaining requests will be evaluated in the order they were received, based on available funds. The budget will reset with the new fiscal year on April 1, 2026, and we encourage you to apply at that time.",
-                id: "CLw1nT",
+                defaultMessage: `As we approach the end of the fiscal year, we are carefully managing the remaining funds available for training opportunities. Due to the volume of training requests, we are closing the "Choose your own course" offer to new applications. Remaining requests will be evaluated in the order they were received, based on available funds. The budget will reset with the new fiscal year on April 1, 2026 and we encourage you to apply at that time.`,
+                id: "cF0+Id",
                 description:
                   "Body for a notice about no more choose your own course options for the year.",
               })}


### PR DESCRIPTION
🤖 Resolves #15437 

## 👋 Introduction

Adds a notice to the training fund page about the "choose your own course" program.

## 🧪 Testing

1. Rebuild app
2. Visit `http://localhost:8000/en/it-training-fund/instructor-led-training`

- [ ] Notice is visible
- [ ] If you change the autohide date to something in the past, the notice is hidden

## 📸 Screenshot

<img width="1156" height="761" alt="image" src="https://github.com/user-attachments/assets/27d2e117-5f4d-468f-9fd0-09071d29d1ea" />
