### PR TITLE
[Copy] Fixes spelling of create in French

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6192,7 +6192,7 @@
     "description": "Description of a decorative image of a hummingbird"
   },
   "P4BgMG": {
-    "defaultMessage": "Creer",
+    "defaultMessage": "Créer",
     "description": "Short title for the create job poster template page"
   },
   "P8DJDV": {


### PR DESCRIPTION
🤖 Resolves #15443.

## 👋 Introduction

This PR fixes a missing an acute accent in the word create in French.

## 🧪 Testing

1. `pnpm build:fresh`
2. Nvaigate to http://localhost:8000/fr/admin/settings/job-templates/create
3. Verify last breadcrumb is _Créer_ and not _Creer_
4. Verify no instances of _Creer_ without _é_ in codebase

## 📸 Screenshot

<img width="1465" height="512" alt="Screenshot 2025-12-23 at 12 25 27" src="https://github.com/user-attachments/assets/4f685be2-646c-4219-8bb8-b114f267ae1d" />