### PR TITLE
[Fix] Add missing `user_id` index on experience tables

### DIFF
--- a/api/database/migrations/2025_12_30_161222_add_user_id_index_experience_tables.php
+++ b/api/database/migrations/2025_12_30_161222_add_user_id_index_experience_tables.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('award_experiences', function (Blueprint $table) {
+            $table->index('user_id', 'award_experiences_user_id_index');
+        });
+
+        Schema::table('community_experiences', function (Blueprint $table) {
+            $table->index('user_id', 'community_experiences_user_id_index');
+        });
+
+        Schema::table('education_experiences', function (Blueprint $table) {
+            $table->index('user_id', 'education_experiences_user_id_index');
+        });
+
+        Schema::table('personal_experiences', function (Blueprint $table) {
+            $table->index('user_id', 'personal_experiences_user_id_index');
+        });
+
+        Schema::table('work_experiences', function (Blueprint $table) {
+            $table->index('user_id', 'work_experiences_user_id_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('award_experiences', function (Blueprint $table) {
+            $table->dropIndex('award_experiences_user_id_index');
+        });
+
+        Schema::table('community_experiences', function (Blueprint $table) {
+            $table->dropIndex('community_experiences_user_id_index');
+        });
+
+        Schema::table('education_experiences', function (Blueprint $table) {
+            $table->dropIndex('education_experiences_user_id_index');
+        });
+
+        Schema::table('personal_experiences', function (Blueprint $table) {
+            $table->dropIndex('personal_experiences_user_id_index');
+        });
+
+        Schema::table('work_experiences', function (Blueprint $table) {
+            $table->dropIndex('work_experiences_user_id_index');
+        });
+    }
+};


### PR DESCRIPTION
🤖 Resolves #15424

## 👋 Introduction

Adds an index to the `user_id` column on the experience tables to avoid sequence scans.

## 🕵️ Details

```
QUERY PLAN
Index Scan using work_experiences_user_id_index on work_experiences  (cost=0.28..8.30 rows=1 width=544) (actual time=0.017..0.017 rows=1 loops=1)
  Index Cond: (user_id = 'd47419db-52c5-480f-ab91-d4cfd7f58878'::uuid)
  Filter: (deleted_at IS NULL)
Planning Time: 0.308 ms
Execution Time: 0.029 ms
```

## 🧪 Testing

> [!IMPORTANT]
> IKf you have a small table size, a sequence scan might actually be chosen instead of index so you will need to seed quite a few experiences (5000 should be enough).

```sql
EXPLAIN ANALYZE
SELECT * FROM work_experiences
WHERE user_id = '{UUID}'
  AND deleted_at IS NULL;
``` 

1. Run a qurey to an experience
2. Obersve the sequence scan
3. Run migration `make artisan CMD="migrate"`
4. re-run the query from step 1
5. Confirm it now runs an index scan