### PR TITLE
[Refactor] Force index use on notifications queries

### DIFF
--- a/api/app/Models/Notification.php
+++ b/api/app/Models/Notification.php
@@ -47,7 +47,10 @@ class Notification extends DatabaseNotification
         $user = Auth::user();
 
         if (! is_null($user?->id)) {
-            $query->where('notifiable_id', $user->id);
+            $query
+                // Added to enforce index in query
+                ->where('notifiable_type', get_class($user))
+                ->where('notifiable_id', $user->id);
 
             return;
         }


### PR DESCRIPTION
🤖 Resolves #15425 

## 👋 Introduction

Adds the `notifiable_type` to the authorization scope for notifications so that it is always used in the query.

## 🕵️ Details

Ensuring an existing index exists in the query should help polstgres plan better queries.

```
QUERY PLAN
Limit  (cost=8.17..8.18 rows=1 width=1128) (actual time=0.045..0.046 rows=1 loops=1)
  ->  Sort  (cost=8.17..8.18 rows=1 width=1128) (actual time=0.045..0.045 rows=1 loops=1)
        Sort Key: created_at DESC
        Sort Method: quicksort  Memory: 25kB
        ->  Index Scan using notifications_notifiable_type_notifiable_id_index on notifications  (cost=0.14..8.16 rows=1 width=1128) (actual time=0.016..0.016 rows=1 loops=1)
              Index Cond: (((notifiable_type)::text = 'App\Models\User'::text) AND (notifiable_id = '4886180a-930d-4224-a951-0a022429aaae'::uuid))
              Filter: (deleted_at IS NULL)
Planning Time: 0.247 ms
Execution Time: 0.057 ms
```

## 🧪 Testing

1. Seed a lot of notifications
2. Uncomment the DB listener in `AppServiceProvider`
3. Login as a user with notifications
4. Force a notification query
5. Get that query out of the logs
6. Run it in postgres with the `EXPLAIN ANALYZE` prefix
7. Confirm it uses the index in the query plan