### PR TITLE
[Fix] Add optional technical skills to application review page

### DIFF
--- a/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
@@ -195,6 +195,14 @@ const ApplicationReview = ({ application }: ApplicationPageProps) => {
       PoolSkillType.Essential,
     ),
   );
+
+  const categorizedOptionalSkills = categorizeSkill(
+    filterPoolSkillsByType(
+      application.pool.poolSkills,
+      PoolSkillType.Nonessential,
+    ),
+  );
+
   const allSkills = poolSkillsToSkills(application.pool.poolSkills);
 
   const screeningQuestions =
@@ -406,20 +414,44 @@ const ApplicationReview = ({ application }: ApplicationPageProps) => {
               "Instructional text under the Skill Requirements section",
           })}
         </p>
-        <div>
-          {categorizedEssentialSkills[SkillCategory.Technical]?.map(
-            (requiredTechnicalSkill) => (
-              <SkillTree
-                key={requiredTechnicalSkill.id}
-                skill={requiredTechnicalSkill}
-                experiencesQuery={experiences}
-                showDisclaimer
-                hideConnectButton
-                hideEdit
-              />
-            ),
-          )}
-        </div>
+        <Heading level="h3" size="h4" className="mt-18 mb-6 font-bold">
+          {intl.formatMessage({
+            defaultMessage: "Required technical skills",
+            id: "OCrKtT",
+            description: "Heading for required technical skills section",
+          })}
+        </Heading>
+        {categorizedEssentialSkills[SkillCategory.Technical]?.map(
+          (requiredTechnicalSkill) => (
+            <SkillTree
+              key={requiredTechnicalSkill.id}
+              skill={requiredTechnicalSkill}
+              experiencesQuery={experiences}
+              showDisclaimer
+              hideConnectButton
+              hideEdit
+            />
+          ),
+        )}
+        <Heading level="h3" size="h4" className="mt-18 mb-6 font-bold">
+          {intl.formatMessage({
+            defaultMessage: "Optional technical skills",
+            id: "mm1X02",
+            description: "Title for optional technical skills section",
+          })}
+        </Heading>
+        {categorizedOptionalSkills[SkillCategory.Technical]?.map(
+          (optionalTechnicalSkill) => (
+            <SkillTree
+              key={optionalTechnicalSkill.id}
+              skill={optionalTechnicalSkill}
+              experiencesQuery={experiences}
+              showDisclaimer
+              hideConnectButton
+              hideEdit
+            />
+          ),
+        )}
       </ReviewSection>
       {screeningQuestions.length > 0 && (
         <ReviewSection


### PR DESCRIPTION
🤖 Resolves #15404 

## 👋 Introduction

Adds optional technicall skills to the review page of an application.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Create a process with an optional ("asset") technical skill
4. Start an application for the process created in step 3
5. Make sure to add the optional technical skill to an experience during the skills step
6. Continure to the "Review and submit" step
7. Confirm that both required and optional tehcnical skills appear

## 📸 Screenshot

<img width="1246" height="1080" alt="swappy-20251231_090131" src="https://github.com/user-attachments/assets/8a0e4b71-6d63-4872-bc5b-7dc5fefd3224" />
