### PR TITLE
[Copy] Replaces French revenez with revenir

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6080,7 +6080,7 @@
     "description": "Placeholder text for community selection input"
   },
   "OU/MkT": {
-    "defaultMessage": "Annulez et revenez aux possibilités de formation",
+    "defaultMessage": "Annulez et revenir aux possibilités de formation",
     "description": "Button label to return to the opportunities table"
   },
   "OU3MYy": {
@@ -8419,7 +8419,7 @@
     "description": "Message when a claim as yet to be verified"
   },
   "YjDiUu": {
-    "defaultMessage": "Annulez et revenez aux groupes de compétences",
+    "defaultMessage": "Annulez et revenir aux groupes de compétences",
     "description": "Link text to return to skill family table"
   },
   "YjKKrR": {
@@ -11234,7 +11234,7 @@
     "description": "Link text to go report a missing page on the 404"
   },
   "kh9KTx": {
-    "defaultMessage": "Annulez et revenez aux volets de travail",
+    "defaultMessage": "Annulez et revenir aux volets de travail",
     "description": "Link text to cancel updating a work stream"
   },
   "khfdlt": {
@@ -12070,7 +12070,7 @@
     "description": "Heading for the 'create a skill' form"
   },
   "oCL/sl": {
-    "defaultMessage": "Annulez et revenez à l'éditeur de compétence",
+    "defaultMessage": "Annulez et revenir à l'éditeur de compétence",
     "description": "Button label to return to the skills table"
   },
   "oDDr9J": {
@@ -12218,7 +12218,7 @@
     "description": "Label for the submitter's department/agency"
   },
   "om9QYn": {
-    "defaultMessage": "Annulez et revenez aux classifications",
+    "defaultMessage": "Annulez et revenir aux classifications",
     "description": "Link text to return to classification table"
   },
   "opkSia": {
@@ -13542,7 +13542,7 @@
     "description": "Contact email subtitle"
   },
   "uqI3Vf": {
-    "defaultMessage": "Annulez et revenez aux ministères",
+    "defaultMessage": "Annulez et revenir aux ministères",
     "description": "Button label to return to the departments table"
   },
   "usRTou": {

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1168,7 +1168,7 @@
     "description": "Name of the fourth month"
   },
   "fMcKtJ": {
-    "defaultMessage": "Annulez et revenez en arrière",
+    "defaultMessage": "Annulez et revenir en arrière",
     "description": "Text to cancel changes to a form"
   },
   "fO0cRR": {


### PR DESCRIPTION
🤖 Resolves #15341.

## 👋 Introduction

This PR replaces French _revenez_ with _revenir_ on buttons and links only.

## 🧪 Testing

1. `pnpm build:fresh`
2. Search codebase for _revenez_
3. Verify no instances of it used for buttons and links