### PR TITLE
[Copy] Replaces French Enregistrez with Enregistrer

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -12486,7 +12486,7 @@
     "description": "Label for the search request table search input"
   },
   "po01Az": {
-    "defaultMessage": "Enregistrer la décision concernant l'approbation de cette nomination pour la gestion des talents.",
+    "defaultMessage": "Enregistrez la décision concernant l'approbation de cette nomination pour la gestion des talents.",
     "description": "Subtitle for dialog to evaluate a nomination group"
   },
   "pp+b1H": {


### PR DESCRIPTION
🤖 Resolves #15339.

## 👋 Introduction

This PR replaces French _Enregistrez_ with _Enregistrer_ on buttons and links only.

## 🧪 Testing

1. `pnpm build:fresh`
2. Search codebase for _Enregistrez_
3. Verify no instances of it used for buttons and links