### PR TITLE
[Bug] Add contractor to GovEmployeeType

### DIFF
--- a/api/app/Enums/GovEmployeeType.php
+++ b/api/app/Enums/GovEmployeeType.php
@@ -12,6 +12,7 @@ enum GovEmployeeType
     case CASUAL;
     case TERM;
     case INDETERMINATE;
+    case CONTRACTOR;
 
     public static function getLangFilename(): string
     {

--- a/api/lang/en/gov_employee_type.php
+++ b/api/lang/en/gov_employee_type.php
@@ -5,4 +5,5 @@ return [
     'casual' => 'Casual',
     'term' => 'Term',
     'indeterminate' => 'Indeterminate',
+    'contractor' => 'Contractor',
 ];

--- a/api/lang/fr/gov_employee_type.php
+++ b/api/lang/fr/gov_employee_type.php
@@ -5,4 +5,5 @@ return [
     'casual' => 'Occasionnel',
     'term' => 'Durée déterminée',
     'indeterminate' => 'Durée indéterminée',
+    'contractor' => 'Entrepreneur ou entrepreneuse',
 ];

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -3908,6 +3908,7 @@ enum GovEmployeeType {
   CASUAL
   TERM
   INDETERMINATE
+  CONTRACTOR
 }
 
 enum GovPositionType {


### PR DESCRIPTION
🤖 Resolves #15511

## 👋 Introduction

Adds contractor to the list of GovEmployeetype.

## 🕵️ Details

The suggested fix was to switch the Excel generator to use WorkExperienceGovEmployeeType but I found that having CONTRACTOR in the computed_gov_employee_type caused GraphQL queries to crash out in the app, too.  We're planning on merging the two enums soon, anyway.

I don't think it's actually possible for the app to get into this state.  CONTRACTOR can't bet automatically set from a work experience.  I'm guessing we're seeing janky seeded data.  Nonetheless, this should should harden things a bit.
<img width="750" height="403" alt="image" src="https://github.com/user-attachments/assets/7a87e261-46cc-4719-9b50-1c752274b5b8" />


## 🧪 Testing

1. Rebuild the app
2. Manually change the `computed_gov_employee_type` for a user to "CONTRACTOR" in the database.
3. The app works:
    - [ ] Applicant personal information page
    - [ ] Admin applicant profile page
    - [ ] Applicant profile download

## 📸 Screenshot

<img width="948" height="724" alt="image" src="https://github.com/user-attachments/assets/b0bcc560-084a-4da3-a3af-7807ff999258" />
