### PR TITLE
[Copy] Updates Sign up text

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1595,6 +1595,10 @@
     "defaultMessage": "Actif",
     "description": "Status message if the application is not suspended"
   },
+  "4LMyAD": {
+    "defaultMessage": "S'inscrire avec CléGC",
+    "description": "GCKey sign up link text on the sign up page"
+  },
   "4LN+P9": {
     "defaultMessage": "Niveau de classification visé",
     "description": "Label for a employee profile target classification level field"
@@ -5935,10 +5939,6 @@
     "defaultMessage": "Les compétences techniques essentielles ont été mises à jour avec succès.",
     "description": "Message displayed when a user successfully updates the essential technical skills"
   },
-  "Nd1bIG": {
-    "defaultMessage": "Continuez vers CléGC et inscrivez-vous",
-    "description": "GCKey sign up link text on the sign up page"
-  },
   "NeR+6V": {
     "defaultMessage": "<strong>Contributeur individuel</strong> : Les conseillers principaux en <abbreviation>TI</abbreviation> (<abbreviation>IT-04</abbreviation>) fournissent des conseils techniques et une orientation stratégique d'experts dans leur domaine d'expertise en matière de fourniture de solutions et de services à des clients internes ou externes et à des intervenants.",
     "description": "IT-04 senior advisor description precursor to work stream list"
@@ -6178,10 +6178,6 @@
   "OvL68O": {
     "defaultMessage": "Conçu par la communauté autochtone, avec elle et pour elle, le programme recrute des candidats des Premières Nations, inuits et métis qui se passionnent pour les TI, pour des emplois de niveau débutant, ainsi que pour des possibilités d’apprentissage et de perfectionnement.",
     "description": "Summary for Indigenous community job opportunities on Browse IT jobs page"
-  },
-  "Ovlh3a": {
-    "defaultMessage": "Inscrivez-vous plutôt",
-    "description": "Sign in link text on the registration page."
   },
   "OvusdX": {
     "defaultMessage": "Confirmer une adresse courriel professionnelle",

--- a/apps/web/src/pages/Auth/SignUpPage/SignUpPage.tsx
+++ b/apps/web/src/pages/Auth/SignUpPage/SignUpPage.tsx
@@ -38,6 +38,7 @@ import mfaStep3ImageDark from "~/assets/img/mfa-step-3-dark.webp";
 import mfaStep4ImageDark from "~/assets/img/mfa-step-4-dark.webp";
 import Instructions from "~/components/Instructions";
 import gckeyMessages from "~/messages/gckeyMessages";
+import authMessages from "~/messages/authMessages";
 
 const helpLink = (chunks: ReactNode, path: string) => (
   <Link href={path} state={{ referrer: window.location.href }}>
@@ -150,8 +151,8 @@ export const Component = () => {
             </Ul>
             <Link href={loginPath} mode="solid" color="primary" external>
               {intl.formatMessage({
-                defaultMessage: "Continue to GCKey and sign up",
-                id: "Nd1bIG",
+                defaultMessage: "Sign up with GCKey",
+                id: "4LMyAD",
                 description: "GCKey sign up link text on the sign up page",
               })}
             </Link>
@@ -556,17 +557,13 @@ export const Component = () => {
         <div className="flex flex-col items-center gap-6 sm:flex-row">
           <Link href={loginPath} mode="solid" color="primary" external>
             {intl.formatMessage({
-              defaultMessage: "Continue to GCKey and sign up",
-              id: "Nd1bIG",
+              defaultMessage: "Sign up with GCKey",
+              id: "4LMyAD",
               description: "GCKey sign up link text on the sign up page",
             })}
           </Link>
           <Link href={loginPath} mode="inline" external>
-            {intl.formatMessage({
-              defaultMessage: "Sign in instead",
-              id: "Ovlh3a",
-              description: "Sign in link text on the registration page.",
-            })}
+            {intl.formatMessage(authMessages.signIn)}
           </Link>
         </div>
       </Container>


### PR DESCRIPTION
🤖 Resolves #15515.

## 👋 Introduction

This PR updates the Sign up text on the sign in page.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/register-info
3. Verify two buttons have text "Sign up with GCKey"
4. Verify button has text "Sign in"
5. Switch to French
6. Verify two buttons have text "S'inscrire avec CléGC"
7. Verify button has text "Se connecter"

## 📸 Screenshots

### English

<img width="1486" height="3071" alt="localhost_8000_en_register-info" src="https://github.com/user-attachments/assets/2ab18609-0bb2-43d5-9bac-0c7c97d7a33f" />

### French

<img width="1486" height="3191" alt="localhost_8000_fr_register-info" src="https://github.com/user-attachments/assets/7eaca0cd-6c5d-40c4-bde8-d5adbb382f4d" />
