### PR TITLE
[Refactor] Remove numbers from steps in candidate filter dialog input

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
@@ -350,6 +350,7 @@ const PoolCandidateFilterDialog = ({
             name="assessmentSteps"
             isMulti
             label={intl.formatMessage(applicationMessages.assessmentStage)}
+            doNotSort
             options={assessmentSteps.map((step) => ({
               value: String(step.sortOrder ?? 0),
               label:


### PR DESCRIPTION
🤖 Resolves #15509 

## 👋 Introduction

Removes the numbers from steps in the candidate filter dialog input while maintaining sort order.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to a processes candidates table `/admin/pools/{id}/pool-candidates`
4. Open the filter dialog
5. Confirm the "Assessment stage" options do not include numbers
6. Confirm they maintain the proper order from the assessment plan