### PR TITLE
[Copy] Replaces French Ajoutez with Ajouter

### DIFF
--- a/apps/web/src/lang/__snapshots__/lang.test.ts.snap
+++ b/apps/web/src/lang/__snapshots__/lang.test.ts.snap
@@ -109,13 +109,6 @@ exports[`message files > should have no changes to duplicate strings 1`] = `
     ]
   },
   {
-    "en": "Add individual role",
-    "fr": [
-      "Ajouter un rôle individuel",
-      "Ajouter un rôle individue"
-    ]
-  },
-  {
     "en": "Submit",
     "fr": [
       "Soumettre",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6484,7 +6484,7 @@
     "description": "Text describing accessibility commissioner"
   },
   "QCesvO": {
-    "defaultMessage": "Ajouter un rôle individue",
+    "defaultMessage": "Ajouter un rôle individuel",
     "description": "Header for the form to add a role to a user"
   },
   "QDDnVO": {


### PR DESCRIPTION
🤖 Resolves #15338.

## 👋 Introduction

This PR replaces French _Ajoutez_ with _Ajouter_ on buttons and links only. It also fixes a typo that I caught during the lang test snapshot update: https://github.com/GCTC-NTGC/gc-digital-talent/commit/3d6655ce172840ea77d677c231e6cf11c7b1833e.

## 🧪 Testing

1. `pnpm build:fresh`
2. Search codebase for _Ajoutez_
3. Verify no instances of it used for buttons and links