### PR TITLE
[Fix] Screening stage sync for under assessment

### DIFF
--- a/api/app/Console/Commands/SyncScreeningStage.php
+++ b/api/app/Console/Commands/SyncScreeningStage.php
@@ -33,7 +33,7 @@ class SyncScreeningStage extends Command
                     WHEN pool_candidate_status = 'APPLICATION_REVIEW' THEN 'APPLICATION_REVIEW'
                     WHEN pool_candidate_status = 'SCREENED_IN' THEN 'SCREENED_IN'
                     WHEN pool_candidate_status = 'UNDER_ASSESSMENT' THEN 'UNDER_ASSESSMENT'
-                    WHEN pool_candidate_status NOT IN ('NEW_APPLICATION', 'APPLICATION_REVIEW', 'SCREENED_IN', 'DRAFT', 'DRAFT_EXPIRED')
+                    WHEN pool_candidate_status NOT IN ('NEW_APPLICATION', 'APPLICATION_REVIEW', 'SCREENED_IN', 'DRAFT', 'DRAFT_EXPIRED', 'UNDER_ASSESSMENT')
                         AND (computed_final_decision IS NULL OR computed_final_decision = 'TO_ASSESS')
                         AND removed_at IS NULL THEN 'UNDER_ASSESSMENT'
                     ELSE NULL


### PR DESCRIPTION
🤖 Resolves #15537 

## 👋 Introduction

Fixes an issue where some candidates did not have their screening stage properly set to `UNDER_ASSESSMENT`.

## 🕵️ Details

There were two cases that were missed here.

1. If the candidate status is `UNDER_ASSESSMENT` it should always mirror the screening stage
2. If it is not but the final decision is `TO_ASSESS` it should still be set to `UNDER_ASSESSMENT`

## 🧪 Testing

> [!NOTE]
> This is going to be difficult to test since you neeed to put at least three candidates in a legacy state

Requirements:

- Screening stage is null for all
- One candidate with
    -  `pool_candidate_status` = `UNDER_ASSESSMENT`
- Another candidate with
    - any status other than draft or those that overlap with `ScreeningStage`
    - `removed_at` = `null`
    - A final decision of `TO_ASSESS`
- A third candidate with
    - any status other than draft or those that overlap with `ScreeningStage`
    - `removed_at` = `null`
    - A final decision of `null`

1. Create candidates with the state mentioned
2. Run `artisan app:sync-screening-stage`
3. Confirm all three candidates have a `screening_stage` of `UNDER_ASSESSMENT`