### PR TITLE
[Fix] Updates `ErrorSummary`

### DIFF
--- a/packages/forms/src/components/ErrorSummary.tsx
+++ b/packages/forms/src/components/ErrorSummary.tsx
@@ -105,6 +105,7 @@ const supportLink = (chunks: ReactNode, locale: string) => (
     href={`/${locale}/support`}
     state={{ referrer: window.location.href }}
     newTab
+    color="error"
   >
     {chunks}
   </Link>
@@ -141,10 +142,11 @@ const ErrorSummary = forwardRef<ComponentRef<"div">, ErrorSummaryProps>(
     return invalidFieldNames.length > 0 ? (
       <Notice.Root
         color="error"
-        mode="card"
+        mode="inline"
         role="alert"
         ref={forwardedRef}
         tabIndex={-1}
+        className="mb-6"
       >
         <Notice.Title defaultIcon>
           {intl.formatMessage(errorMessages.summaryTitle)}


### PR DESCRIPTION
🤖 Resolves #15568.

## 👋 Introduction

This PR adds bottom margin to the `ErrorSummary` and changes its style to be more visually apparent.

## 🧪 Testing

> [!NOTE]
> The error can be reproduced on any form that uses the `ErrorSummary` component 

1. Navigate to "Career experience"
2. Add a new experience
3. Leave a required field blank
4. Try and add the experience
5. Observe the bottom margin and style of the `ErrorSummary`

## 📸 Screenshots

<img width="1493" height="828" alt="Screenshot 2026-01-15 at 10 33 20" src="https://github.com/user-attachments/assets/fbe0f08d-3c37-42c3-a942-35d10354e423" />

<img width="1531" height="819" alt="Screenshot 2026-01-15 at 10 33 28" src="https://github.com/user-attachments/assets/23c1cb0e-7ac1-4bf8-b2c1-8ca343b1c2ec" />