### PR TITLE
[Refactor] Add rule to `DisqualifyCandidateValidator`

### DIFF
--- a/api/app/GraphQL/Validators/DisqualifyCandidateValidator.php
+++ b/api/app/GraphQL/Validators/DisqualifyCandidateValidator.php
@@ -7,6 +7,7 @@ namespace App\GraphQL\Validators;
 use App\Enums\ErrorCode;
 use App\Enums\PoolCandidateStatus;
 use App\Models\PoolCandidate;
+use Illuminate\Validation\Rule;
 use Nuwave\Lighthouse\Exceptions\ValidationException;
 use Nuwave\Lighthouse\Validation\Validator;
 
@@ -32,7 +33,12 @@ final class DisqualifyCandidateValidator extends Validator
             throw ValidationException::withMessages(['status' => ErrorCode::INVALID_STATUS_DISQUALIFICATION->name]);
         }
 
-        return [];
+        return [
+            'reason' => [
+                'required',
+                Rule::in(array_column(PoolCandidateStatus::cases(), 'name')),
+            ],
+        ];
     }
 
     public function messages(): array


### PR DESCRIPTION
🤖 Resolves #15375

## 👋 Introduction

This is a minor addition, temporary, gone after the status changes are done.
It just asserts that the input reason `DisqualificationReason` can be assigned to a column with expected shape `PoolCandidateStatus`

The more we have methods in different places called from varying places, the more important I think overcautious validation is

## 🧪 Testing

1. Can disqualify a candidate normally



