### PR TITLE
Fix for Unused import

### DIFF
--- a/apps/locust/testSearchPage.py
+++ b/apps/locust/testSearchPage.py
@@ -1,6 +1,5 @@
 import string
 import random
-import time
 from locust import HttpUser, task, between
 
 class TestSearchPage(HttpUser):


### PR DESCRIPTION
To fix an unused-import issue, the general approach is to remove the import statement for any module that is not referenced in the file. This reduces clutter and avoids misleading readers into thinking the module is used.

For this specific case, the best fix is to delete the `import time` line from `apps/locust/testSearchPage.py`. No other changes are needed because `time` is not referenced anywhere in the snippet. Functionality will remain the same: the `TestSearchPage` class, the `candidate_count` task, and all logic using `random` and `string` remain unchanged.

Concretely:
- In `apps/locust/testSearchPage.py`, locate line 3: `import time`.
- Remove this line, keeping the other imports (`string`, `random`, and `from locust import HttpUser, task, between`) intact.
- No new methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._