### PR TITLE
[Bug] Fix TypeError in Nominations Excel Download

### DIFF
--- a/api/app/Traits/Generator/GeneratesFile.php
+++ b/api/app/Traits/Generator/GeneratesFile.php
@@ -141,7 +141,7 @@ trait GeneratesFile
      * @param  bool  $condition  The condition
      * @param  string  $data  The data shown if condition met
      */
-    public function canShare(bool $condition, string $data)
+    public function canShare(bool $condition, ?string $data = null)
     {
         if ($condition) {
             return $data;


### PR DESCRIPTION
🤖 Resolves #15651

## 👋 Introduction

This pr fixes a TypeError that was occurring when downloading a talent nomination excel file. 

## 🕵️ Details

Updated the canShare() method to accept nullable strings: `?string $data = null`

You will need to locally modify a user's data to test this fix.

## 🧪 Testing


1. Build app
2. Log in as talent-coordinator@test.com
3. In a second terminal run make queue-work
4. Navigate to admin/talent-events and select a talent event with nomination
5. Download the excel file
6. Confirm the file downloads without errors


## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

