### PR TITLE
[Fix]  Dialog.Footer is nested inside Dialog.Body

### DIFF
--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/SecurityClearanceDialog.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/SecurityClearanceDialog.tsx
@@ -207,18 +207,18 @@ const SecurityClearanceDialog = () => {
               )}
             </p>
           </div>
-          <Dialog.Footer>
-            <Dialog.Close>
-              <Button color="primary">
-                {intl.formatMessage({
-                  defaultMessage: "Close",
-                  id: "4p0QdF",
-                  description: "Button text used to close an open modal",
-                })}
-              </Button>
-            </Dialog.Close>
-          </Dialog.Footer>
         </Dialog.Body>
+        <Dialog.Footer>
+          <Dialog.Close>
+            <Button color="primary">
+              {intl.formatMessage({
+                defaultMessage: "Close",
+                id: "4p0QdF",
+                description: "Button text used to close an open modal",
+              })}
+            </Button>
+          </Dialog.Close>
+        </Dialog.Footer>
       </Dialog.Content>
     </Dialog.Root>
   );


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/GCTC-NTGC/gc-digital-talent/security/quality/ai-findings)._

> The Dialog.Footer is nested inside Dialog.Body, but based on common UI patterns and the structure seen in similar components, it should likely be a sibling of Dialog.Body at the same level within Dialog.Content for proper semantic structure.