### PR TITLE
[Fix] Useless conditional `seniorManagementStatus `

### DIFF
--- a/apps/web/src/components/ExperienceCard/WorkContent/SupervisoryContent.tsx
+++ b/apps/web/src/components/ExperienceCard/WorkContent/SupervisoryContent.tsx
@@ -143,19 +143,18 @@ const SupervisoryContent = ({
                   ? cSuiteRoleTitle?.label.localized
                   : intl.formatMessage(commonMessages.notApplicable)}
               </ContentSection>
-              {seniorManagementStatus &&
-                cSuiteRoleTitle?.value === CSuiteRoleTitle.Other && (
-                  <>
-                    <Separator space="sm" decorative />
-                    <ContentSection
-                      title={experienceFormLabels.otherCSuiteRoleTitle}
-                      headingLevel={headingLevel}
-                    >
-                      {otherCSuiteRoleTitle ??
-                        intl.formatMessage(commonMessages.notApplicable)}
-                    </ContentSection>
-                  </>
-                )}
+              {cSuiteRoleTitle?.value === CSuiteRoleTitle.Other && (
+                <>
+                  <Separator space="sm" decorative />
+                  <ContentSection
+                    title={experienceFormLabels.otherCSuiteRoleTitle}
+                    headingLevel={headingLevel}
+                  >
+                    {otherCSuiteRoleTitle ??
+                      intl.formatMessage(commonMessages.notApplicable)}
+                  </ContentSection>
+                </>
+              )}
             </>
           )}
         </>


### PR DESCRIPTION
In general, to fix a condition that always evaluates to true (or false) inside a block already guarded by the same condition, remove the redundant part and keep only the additional, meaningful predicates. This simplifies the logic, improves readability, and satisfies the static analysis rule without changing runtime behavior.

Here, the JSX fragment rendering the “other C-suite role title” section is already nested inside `{seniorManagementStatus && (...)}` at line 135. Therefore the inner condition at line 146, `{seniorManagementStatus && cSuiteRoleTitle?.value === CSuiteRoleTitle.Other && (...)}`, can safely be simplified to `{cSuiteRoleTitle?.value === CSuiteRoleTitle.Other && (...)}`. No imports or additional helpers are necessary.

Specifically, in `apps/web/src/components/ExperienceCard/WorkContent/SupervisoryContent.tsx`, replace the conditional expression starting at line 146 so that `seniorManagementStatus &&` is removed, leaving the rest of the JSX intact.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._