### PR TITLE
[Copy] Updates subtitle for the profile page

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2603,6 +2603,10 @@
     "defaultMessage": "Les talents autochtones prêts pour un stage d’apprentissage en TI",
     "description": "Title for the 'Indigenous talent ready for IT apprenticeships' section"
   },
+  "8nWMjm": {
+    "defaultMessage": "Consultez et mettez à jour les renseignements personnels, y compris les préférences de travail et le profil linguistique.",
+    "description": "subtitle for the profile page"
+  },
   "8oFk6S": {
     "defaultMessage": "Mise à jour de la collectivité réussie!",
     "description": "Message displayed after a community is updated"
@@ -10185,10 +10189,6 @@
   "g+tCWe": {
     "defaultMessage": "Commencez par compléter l'information de base de votre compte.",
     "description": "Subtitle for the registration pages"
-  },
-  "g/ReTI": {
-    "defaultMessage": "Consultez et mettez à jour les renseignements personnels, y compris les préférences de travail et le profil linguistique.",
-    "description": "subtitle for the profile page"
   },
   "g1WB3B": {
     "defaultMessage": "Ajouter une expérience",

--- a/apps/web/src/pages/Profile/ProfilePage/messages.ts
+++ b/apps/web/src/pages/Profile/ProfilePage/messages.ts
@@ -8,8 +8,8 @@ const messages = defineMessages({
   },
   subTitle: {
     defaultMessage:
-      "View and update personal information work preferences and language profile.",
-    id: "g/ReTI",
+      "View and update personal information including work preferences and language profile.",
+    id: "8nWMjm",
     description: "subtitle for the profile page",
   },
 });


### PR DESCRIPTION
🤖 Resolves #14985.

## 👋 Introduction

This PR updates the subtitle for the profile page in English and French.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/applicant/personal-information
3. Verify page description updated to reflect linked issue

## 📸 Screenshots

<img width="1459" height="555" alt="Screenshot 2026-01-27 at 11 13 55" src="https://github.com/user-attachments/assets/cadb942b-d5c4-4404-b506-5c3552df2917" />

<img width="1400" height="581" alt="Screenshot 2026-01-27 at 11 14 02" src="https://github.com/user-attachments/assets/31ee5043-8059-42fe-84bf-2f236c0462f6" />