### PR TITLE
[Refactor] Move other recruitment section

### DIFF
--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/ViewPoolCandidatePage.tsx
@@ -6,7 +6,6 @@ import ClipboardIcon from "@heroicons/react/24/outline/ClipboardIcon";
 import {
   NotFound,
   Pending,
-  Accordion,
   Heading,
   Sidebar,
   Chip,


### PR DESCRIPTION
🤖 Resolves #15699 

## 👋 Introduction

Moves the section displaying a candidates other recruitments to the bottom of the page.

## 🕵️ Details

I will be looking for confirmation from @Jerryescandon but I bneleive the heading change and addition of the lead-in descriptive text is out of scope for this?

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to the view candidate page
4. Confirm the "Other processes" sectioon is at the bottom with no accordion

## 📸 Screenshot

<img width="1432" height="930" alt="swappy-20260130_082619" src="https://github.com/user-attachments/assets/97e262c2-58e0-40a8-a4d9-661869e8567f" />
