### PR TITLE
[Platform] Upload coverage report to Codecov

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -132,3 +132,12 @@ jobs:
           name: html-report--attempt-${{ github.run_attempt }}
           path: playwright-report
           retention-days: 14
+
+      - name: Upload coverage report to Codecov
+        if: github.actor != 'dependabot[bot]'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: e2e
+          fail_ci_if_error: false
+          directory: coverage


### PR DESCRIPTION
🤖 Resolves #15726.

## 👋 Introduction

This PR adds a step to the Playwright GitHub workflow to upload the coverage report to Codecov.

## 🧪 Testing

1. Verify Playwright GitHub workflow runs without error
2. Verify coverage report with flag e2e is uploaded to Codecov