### PR TITLE
[Bug] Fix order by columns

### DIFF
--- a/api/app/Builders/PoolBuilder.php
+++ b/api/app/Builders/PoolBuilder.php
@@ -3,9 +3,10 @@
 namespace App\Builders;
 
 use App\Enums\PoolStatus;
-use App\Models\Team;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Schema;
 
 class PoolBuilder extends Builder
 {
@@ -199,30 +200,34 @@ class PoolBuilder extends Builder
     // A scope for a simple orderBy on a column.  Allows for nulls first or last.
     public function orderByColumn(?array $args): self
     {
-        $column = $args['column'];
-        $order = $args['order'];
-        $nulls = $args['nulls'] ?? null;
+        // user input: DO NOT USE DIRECTLY IN SQL!
+        $inputColumn = $args['column'];
+        $inputOrder = $args['order'];
+        $inputNulls = $args['nulls'] ?? null;
 
         // build column name qualified with table name
         $tableName = $this->model->getTable();
-        $columnSql = "\"$tableName\".\"$column\"";
+        $columnName = Arr::first(Schema::getColumnListing($tableName), fn ($columnName) => strcasecmp($columnName, $inputColumn) == 0);
+        if (empty($columnName)) {
+            throw new \Exception('Invalid column name');
+        }
+        $columnSql = "\"$tableName\".\"$columnName\"";
 
         // build order direction while verifying that option is valid
-        $orderOptionSql = match ($order) {
+        $orderOptionSql = match ($inputOrder) {
             'ASC' => 'ASC',
             'DESC' => 'DESC',
             default => throw new \Exception('Invalid order option'),
         };
 
         // build nulls option while verifying that option is valid
-        $nullsOptionSql = match ($nulls) {
+        $nullsOptionSql = match ($inputNulls) {
             'ORDER_FIRST' => 'NULLS FIRST',
             'ORDER_LAST' => 'NULLS LAST',
             null => '',
             default => throw new \Exception('Invalid nulls option'),
         };
 
-        // SQL execution from user input!  Ensure sufficient sanitization.
         $this->orderByRaw("$columnSql $orderOptionSql $nullsOptionSql");
 
         return $this;


### PR DESCRIPTION
🤖 Resolves #15732 

## 👋 Introduction

Fixes finding #1.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

1. Rebuild the app

- [ ] Admin pool table can still sort by publish date, nulls last
- [ ] [POC query](https://talent-cloud.slack.com/archives/CB424V61J/p1770067657453179?thread_ts=1770042511.690299&cid=CB424V61J) no longer works 

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

## 🚚 Deployment

<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the PR if deployment steps are needed

 -->
