### PR TITLE
[Bug] Hide Empty Candidate Navigation Card

### DIFF
--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CandidateNavigation/CandidateNavigation.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CandidateNavigation/CandidateNavigation.tsx
@@ -36,9 +36,10 @@ const CandidateNavigation = ({ candidateId }: CandidateNavigationProps) => {
   const intl = useIntl();
   const paths = useRoutes();
   const candidateNavigation = usePoolCandidateNavigation(candidateId);
-  if (!candidateNavigation) return null;
+  if (!candidateNavigation?.candidateIds) return null;
   const { nextCandidate, previousCandidate, candidateIds, stepName } =
     candidateNavigation;
+  if (!nextCandidate && !previousCandidate) return null;
 
   const commonLinkProps: Partial<IconLinkProps> = {
     color: "primary",


### PR DESCRIPTION
🤖 Resolves  #15757

## 👋 Introduction

This pr fixes a bug where the candidate navigation card would appear empty when there are no previous/next candidates to display. I think the issue was introduced when the navigation component was refactored to use a `<Card>` component, it was rendering even when empty. 

## 🕵️ Details

I added two simple checks to make sure the navigation card only appears when there's actually something to navigate to. 
The first check is to make sure we have the list of candidates (candidateIds)
```
  if (!candidateNavigation?.candidateIds) return null;
```

Check is to make sure we have at least one link to show (previous/next)
```
  if (!nextCandidate && !previousCandidate) return null;
```

If either one fails the the component will return null and no card is rendered.


## 🧪 Testing

1. Build app `pnpm run dev`
2. Log in as `admin@test.com`
3. Navigate to `admin/pool-candidates` and select the first candidate in the list
    -  Verify "previous candidate" does not appear
    -  Verify "next candidate" appear
  -  Select "next candidate"
    - Verify "previous candidate" appears
    - Verify "next candidate" appears.
4. Navigate back to `admin/pool-candidates` and use the filter to get one candidate
    -  Verify "previous candidate" and "next candidate" as well as the `<Card>` do not appear


## 📸 Screenshot

<img width="428" height="387" alt="image" src="https://github.com/user-attachments/assets/c808c609-305c-429e-ac85-d4fb95437756" />

## 🚚 Deployment

<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the PR if deployment steps are needed

 -->
