### PR TITLE
[Bug]  Add first render condition to ResponsiveTable to prevent loop

### DIFF
--- a/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
@@ -92,6 +92,7 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
 }: TableProps<TData, TFilters>) => {
   const id = useId();
   const intl = useIntl();
+  const isFirstRender = useRef(true);
   const { announce } = useAnnouncer();
   const hasUpdatedRows = useRef<boolean>(false);
   const [, setSearchParams] = useSearchParams();
@@ -267,6 +268,10 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
           Object.fromEntries(newParams),
         )
       ) {
+        if (isFirstRender.current) {
+          isFirstRender.current = false;
+          return;
+        }
         setSearchParams(newParams, { replace: true });
       }
     }


### PR DESCRIPTION
🤖 Resolves #15799 

## 👋 Introduction

- Adds a first render reference check to the responsive table `useEffect`, to prevent an infinite loop.
- NOTE: Fixed by @esizer :pray: 

## 🧪 Testing

1. Refresh app
2. Go to talent request page 
3. Add filters that provide at least one request
4. View the request in the table. 
5. Then try going back in the browser.
6. Ensure that the table renders.
7. Ensure that other tables aren't effected.
