### PR TITLE
[Fix] Experience form error summary focus

### DIFF
--- a/apps/web/src/components/ExperienceFormFields/ErrorSummary.tsx
+++ b/apps/web/src/components/ExperienceFormFields/ErrorSummary.tsx
@@ -24,22 +24,23 @@ const ErrorSummary = ({ experienceType }: ErrorSummaryProps) => {
   const derivedType: ExperienceType = type ?? experienceType ?? "personal";
   const labels = getExperienceFormLabels(intl, derivedType);
   const {
-    formState: { errors, isSubmitting },
+    formState: { errors, submitCount },
   } = useFormContext();
   const flatErrors = flattenErrors(errors);
 
   useEffect(() => {
     // After during submit, if there are errors, focus the summary
-    if (errors && isSubmitting) {
+    if (submitCount > 0 && flatErrors) {
       setShowErrorSummary(true);
+      errorSummaryRef.current?.focus();
     }
-  }, [isSubmitting, errors]);
+  }, [submitCount]);
 
   useEffect(() => {
-    if (showErrorSummary && errorSummaryRef.current && flatErrors.length > 0) {
+    if (showErrorSummary && errorSummaryRef.current) {
       errorSummaryRef.current.focus();
     }
-  }, [showErrorSummary, flatErrors, isSubmitting]);
+  }, [showErrorSummary, submitCount]);
 
   return (
     <ErrorSummaryAlert


### PR DESCRIPTION
🤖 Resolves #15567 

## 👋 Introduction

Fixes an issue where the error summary was not being focused when it appeared.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as any user
3. Start creating an experience
4. Attempt to submit the form with errors
5. Confirm that the error summary appears and your focused is moved to it