### PR TITLE
[Bug] Ensure build pipeline fails for PHP

### DIFF
--- a/infrastructure/azure-pipelines.yml
+++ b/infrastructure/azure-pipelines.yml
@@ -22,7 +22,7 @@ resources:
       type: git
       ref: refs/heads/main
 variables:
-  phpVersion: "9.9"
+  phpVersion: "8.4"
 
 jobs:
   - job: build_artifact


### PR DESCRIPTION
🤖 Resolves #15634

## 👋 Introduction

Ensures that the build pipeline will fail if the PHP install fails.

## 🕵️ Details

The last step in the script was to echo out the installed PHP version.  If apt fails to install the packages it returns a "100" error code but then the last step runs successfully and the pipeline completes.  I simply removed that last echo line.

## 🧪 Testing

1. Log into Azure DevOps and try to build this branch at commit 4ff3dd458a73b4179a7495653e849e09124986ed.
2. Observe the that Setup PHP step fails as expected.

## 📸 Screenshot

<img width="1550" height="1451" alt="image" src="https://github.com/user-attachments/assets/9948e6ea-d12a-44c6-89cd-477f8065c7ab" />
