### PR TITLE
[Bug] Fix job poster template keywords

### DIFF
--- a/apps/web/src/pages/JobPosterTemplateAdminPages/CreateJobPosterTemplatePage/CreateJobPosterTemplatePage.tsx
+++ b/apps/web/src/pages/JobPosterTemplateAdminPages/CreateJobPosterTemplatePage/CreateJobPosterTemplatePage.tsx
@@ -23,7 +23,11 @@ import {
 } from "@gc-digital-talent/ui";
 import { Submit } from "@gc-digital-talent/forms";
 import { toast } from "@gc-digital-talent/toast";
-import { unpackMaybes } from "@gc-digital-talent/helpers";
+import {
+  emptyToNull,
+  notEmpty,
+  unpackMaybes,
+} from "@gc-digital-talent/helpers";
 
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
@@ -148,8 +152,14 @@ const formValuesToMutationInput = ({
       fr: workDescriptionFr,
     },
     keywords: {
-      en: keywordsEn?.split(",").map((s) => s.trim()),
-      fr: keywordsFr?.split(",").map((s) => s.trim()),
+      en: keywordsEn
+        ?.split(",")
+        .map((s) => emptyToNull(s.trim()))
+        .filter(notEmpty),
+      fr: keywordsFr
+        ?.split(",")
+        .map((s) => emptyToNull(s.trim()))
+        .filter(notEmpty),
     },
     classification: {
       connect: classification,

--- a/apps/web/src/pages/JobPosterTemplateAdminPages/UpdateJobPosterTemplatePage/components/JobDetailsSection/JobDetailsSection.tsx
+++ b/apps/web/src/pages/JobPosterTemplateAdminPages/UpdateJobPosterTemplatePage/components/JobDetailsSection/JobDetailsSection.tsx
@@ -16,6 +16,7 @@ import {
   Scalars,
 } from "@gc-digital-talent/graphql";
 import { toast } from "@gc-digital-talent/toast";
+import { emptyToNull, notEmpty } from "@gc-digital-talent/helpers";
 
 import useToggleSectionInfo from "~/hooks/useToggleSectionInfo";
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
@@ -150,8 +151,14 @@ const formValuesToMutationInput = (
     fr: workDescriptionFr,
   },
   keywords: {
-    en: keywordsEn?.split(",").map((s) => s.trim()),
-    fr: keywordsFr?.split(",").map((s) => s.trim()),
+    en: keywordsEn
+      ?.split(",")
+      .map((s) => emptyToNull(s.trim()))
+      .filter(notEmpty),
+    fr: keywordsFr
+      ?.split(",")
+      .map((s) => emptyToNull(s.trim()))
+      .filter(notEmpty),
   },
   classification: {
     connect: classification,


### PR DESCRIPTION
🤖 Resolves #15752 

## 👋 Introduction

Fixes the form-to-input handling in the job poster template pages.

## 🕵️ Details

The problem was that the form was trying to submit an array with empty strings in it.  I added `emptyToNull` to turn the empty strings to nulls and then `filter(notEmpty)` to remove nulls.

## 🧪 Testing

1. Log in as admin@test.com
2. Navigate to http://localhost:3000/en/admin/settings/job-templates/create
3. Create a template with no keywords
4. Create a template with keywords
5. Edit a template with no keywords
6. Edit a template with keywords
