### PR TITLE
[Bug] Resolve flaky `testScopePlacementTypesIn`

### DIFF
--- a/api/tests/Feature/PoolCandidateSearchTest.php
+++ b/api/tests/Feature/PoolCandidateSearchTest.php
@@ -897,6 +897,7 @@ class PoolCandidateSearchTest extends TestCase
             ]);
 
         $expectedCandidate = PoolCandidate::factory()
+            ->availableInSearch()
             ->create([
                 'pool_id' => $this->pool->id,
                 'placement_type' => PlacementType::UNDER_CONSIDERATION->name,


### PR DESCRIPTION
🤖 Resolves #15848

## 👋 Introduction

Fix the flaky test.
Seems the test candidate was just missing some fields that our state function provides

## 🧪 Testing

1. Test workflow passes
2. Test passes locally

To run the one test locally if you need help

`make test CMD='--filter testScopePlacementTypesIn'`




