### PR TITLE
[Feature] Sector identifier endpoint

### DIFF
--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -191,4 +191,17 @@ class AuthController extends Controller
 
         return response($response)->header('Content-Type', 'application/json');
     }
+
+    public function sectorIdentifier(Request $request)
+    {
+        return response()->json([
+            // our actual auth callback
+            config('oauth.redirect_uri'),
+
+            // auth callbacks for the Sign In Canada to GC Sign In migration tool
+            'https://api.migration.signin-connexion.cdssandbox.xyz/v1/auth/callback',
+            'https://api.migration.signin-connexion.cdssandbox.xyz/v1/auth/legacy/callback',
+
+        ]);
+    }
 }

--- a/api/routes/web.php
+++ b/api/routes/web.php
@@ -18,6 +18,7 @@ Route::prefix(config('app.app_dir'))->group(function () {
     Route::get('/register', [AuthController::class, 'login']);
     Route::get('/auth-callback', [AuthController::class, 'authCallback']);
     Route::get('/refresh', [AuthController::class, 'refresh']);
+    Route::get('/sector-identifier', [AuthController::class, 'sectorIdentifier']);
 });
 
 Route::prefix('')->group(function () {
@@ -25,4 +26,5 @@ Route::prefix('')->group(function () {
     Route::get('/register', [AuthController::class, 'login']);
     Route::get('/auth-callback', [AuthController::class, 'authCallback']);
     Route::get('/refresh', [AuthController::class, 'refresh']);
+    Route::get('/sector-identifier', [AuthController::class, 'sectorIdentifier']);
 });

--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -178,6 +178,11 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
     }
+     location = /sector-identifier {
+        fastcgi_pass 127.0.0.1:9000;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME /home/site/wwwroot/api/public/index.php;
+    }
 
     location ^~ /api/ {
         fastcgi_pass 127.0.0.1:9000;

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -224,6 +224,11 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root/api/public/index.php;
     }
+    location = /sector-identifier {
+        fastcgi_pass 127.0.0.1:9000;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root/api/public/index.php;
+    }
 
     location ^~ /api/ {
         fastcgi_pass 127.0.0.1:9000;


### PR DESCRIPTION
🤖 Resolves #15804 

## 👋 Introduction

The GC Sign in team has asked us to add a new endpoint to our app to support the migration tool they're providing us with.

## 🕵️ Details

I've already asked Kevan to review this on the dev vertical and he said it looks good.

## 🧪 Testing

1. Rebuild the app
2. Visit /sector-identifier
3. Verify that it matches https://rp-sim.migration.signin-connexion.cdssandbox.xyz/sector-identifier except that our auth callback is swapped into the first position.
