### PR TITLE
[Platform] Updates TypeScript target compiler option to `es6`

### DIFF
--- a/packages/tsconfig/e2e.json
+++ b/packages/tsconfig/e2e.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "types": ["node"],
     "module": "ES2020",
     "moduleResolution": "Bundler"

--- a/packages/tsconfig/lib.json
+++ b/packages/tsconfig/lib.json
@@ -2,6 +2,6 @@
   "extends": "./base.json",
   "compilerOptions": {
     "module": "ES2015",
-    "target": "ES2015"
+    "target": "es6"
   }
 }


### PR DESCRIPTION
🤖 Resolves #15839.

## 👋 Introduction

This PR updates the TypeScript target compiler option to be consistently `es6`.

## 🧪 Testing

Verify everything using TypeScript works the same as before