### PR TITLE
[Fix] Adds padding bottom for `Hero` component additional content

### DIFF
--- a/apps/web/src/components/Hero/Hero.tsx
+++ b/apps/web/src/components/Hero/Hero.tsx
@@ -236,7 +236,7 @@ const Hero = (
         )}
         {additionalContent ? (
           <>
-            <Container size="lg" className="relative z-3">
+            <Container size="lg" className="relative z-3 pb-12">
               {additionalContent}
             </Container>
           </>


### PR DESCRIPTION
🤖 Resolves #15899.

## 👋 Introduction

This PR fixes the bottom spacing of the `Hero` component additional content.

## 🧪 Testing

1. `pnpm build:fresh`
2. Login as admin@test.com
3. Navigate to http://localhost:8000/en/admin/candidates/ and select any user
4. Verify container that contains users details has appropriate bottom spacing

## 📸 Screenshot

<img width="1512" height="834" alt="Screenshot 2026-02-20 at 13 21 41" src="https://github.com/user-attachments/assets/8f2eeee2-3839-4171-b746-28c57351c0de" />