### PR TITLE
[Debt] Renames `KeywordSearchTest` class to match filename

### DIFF
--- a/api/tests/Feature/KeywordSearchTest.php
+++ b/api/tests/Feature/KeywordSearchTest.php
@@ -15,7 +15,7 @@ use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
 use Tests\UsesProtectedGraphqlEndpoint;
 
-class KeywordSearchBetaTest extends TestCase
+class KeywordSearchTest extends TestCase
 {
     use MakesGraphQLRequests;
     use RefreshDatabase;


### PR DESCRIPTION
🤖 Resolves #15972.

## 👋 Introduction

This PR renames a test to comply with psr-4 standards.

## 🧪 Testing

1. `make refresh-api`
2. Verify no warnings related to psr-4 standards