### PR TITLE
[Fix] Set max height on dropdown menu

### DIFF
--- a/packages/ui/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/ui/src/components/DropdownMenu/DropdownMenu.tsx
@@ -39,7 +39,7 @@ function ArrowSvg(props: React.ComponentProps<"svg">) {
 }
 
 const popup = tv({
-  base: `max-w-screen overflow-y-auto rounded-md bg-white py-3 font-sans text-black shadow-md outline-1 outline-gray-200 dark:bg-gray-600 dark:text-white dark:-outline-offset-1 dark:outline-gray-300`,
+  base: `max-h-[var(--available-height)] max-w-screen overflow-y-auto rounded-md bg-white py-3 font-sans text-black shadow-md outline-1 outline-gray-200 dark:bg-gray-600 dark:text-white dark:-outline-offset-1 dark:outline-gray-300`,
 });
 
 interface PopupProps extends Omit<Menu.Popup.Props, "className"> {


### PR DESCRIPTION
🤖 Resolves #15948 

## 👋 Introduction

Uses the `--available-height` css variable from Base UI to set a max height and show a scroll bar on the dropdown menu to prevernt it from going outside the current viewport.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to `/admin/pool-candidates`
4. Open the "Filter by" dropdown
5. Adjust screen height
6. Confirm that the dropdown always stays within the bounds of the viewport

## 📸 Screenshot

<img width="454" height="602" alt="swappy-20260226_152255" src="https://github.com/user-attachments/assets/f0012a07-9a3b-47df-96dc-c539bf020b2f" />
<img width="468" height="790" alt="swappy-20260226_152308" src="https://github.com/user-attachments/assets/26d1239f-f902-47dd-a626-48cd8f97a4ce" />
