### PR TITLE
[Platform] Adds tailwind, react-router groups for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,14 @@ updates:
           - "major"
           - "minor"
           - "patch"
+      react-router:
+        patterns:
+          - "@react-router/node"
+          - "@react-router/dev"
+          - "react-router"
+        update-types:
+          - "minor"
+          - "patch"
       storybook:
         patterns:
           - "@storybook*"


### PR DESCRIPTION
🤖 Resolves #16003.

## 👋 Introduction

This PR adds tailwind, react-router groups for dependabot.

## 🧪 Testing

Verify dependabot group syntax is correct.