### PR TITLE
[Fix] Close pagination page size menu on click

### DIFF
--- a/apps/web/src/components/Pagination/Pagination.tsx
+++ b/apps/web/src/components/Pagination/Pagination.tsx
@@ -168,11 +168,7 @@ const Pagination = ({
                   onValueChange={handlePageSizeChange}
                 >
                   {pageSizes.map((size) => (
-                    <DropdownMenu.RadioItem
-                      closeOnClick
-                      key={size}
-                      value={String(size)}
-                    >
+                    <DropdownMenu.RadioItem key={size} value={String(size)}>
                       {size}
                     </DropdownMenu.RadioItem>
                   ))}

--- a/packages/ui/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/ui/src/components/DropdownMenu/DropdownMenu.tsx
@@ -108,11 +108,13 @@ interface ItemProps extends ItemVariants, Omit<Menu.Item.Props, "className"> {
 const Item = ({
   className,
   color = "primary",
+  closeOnClick = true,
   disabled,
   ...rest
 }: ItemProps) => (
   <Menu.Item
     disabled={disabled}
+    closeOnClick={closeOnClick}
     className={item({ color, disabled, class: className })}
     {...rest}
   />
@@ -130,6 +132,7 @@ interface CheckboxItemProps
 
 const CheckboxItem = ({
   color = "primary",
+  closeOnClick = true,
   disabled,
   className,
   children,
@@ -137,6 +140,7 @@ const CheckboxItem = ({
 }: CheckboxItemProps) => (
   <Menu.CheckboxItem
     className={checkboxItem({ color, disabled, class: className })}
+    closeOnClick={closeOnClick}
     {...rest}
   >
     <Menu.CheckboxItemIndicator className="col-start-1">
@@ -153,6 +157,7 @@ interface RadioItemProps
 
 const RadioItem = ({
   color = "primary",
+  closeOnClick = true,
   disabled,
   className,
   children,
@@ -160,6 +165,7 @@ const RadioItem = ({
 }: RadioItemProps) => (
   <Menu.RadioItem
     className={checkboxItem({ color, disabled, class: className })}
+    closeOnClick={closeOnClick}
     {...rest}
   >
     <Menu.RadioItemIndicator className="col-start-1">


### PR DESCRIPTION
🤖 Resolves #16043 

## 👋 Introduction

Updates the page size dropdown menu to close when an item inside is clicked. This is to avoid confusion when they dropdown gets pushed out of the viewport after a layout shift.

## 🕵️ Details

SEE: https://github.com/GCTC-NTGC/gc-digital-talent/issues/16043#issuecomment-3997352647

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Go to any table
4. Select a different page size
5. Confirm it closes on a single click and you are free to interact with the page