### PR TITLE
[Fix] Replaces `lodash/unionBy` with `lodash/uniqBy`

### DIFF
--- a/apps/web/src/components/NavMenu/useMainNavLinks.tsx
+++ b/apps/web/src/components/NavMenu/useMainNavLinks.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-deprecated */
 import { useIntl } from "react-intl";
-import uniqBy from "lodash/unionBy";
+import uniqBy from "lodash/uniqBy";
 import { useLocation } from "react-router";
 
 import { commonMessages, navigationMessages } from "@gc-digital-talent/i18n";


### PR DESCRIPTION
🤖 Resolves #16063.

## 👋 Introduction

This PR replaces `lodash/unionBy` with `lodash/uniqBy` so that module matches the imported function.

## 🧪 Testing

1. Search codebase for `unionBy`
2. Verify no modules for `unionBy` are importing other functions

> [!TIP]
>  Spoiler: there are no instances of `unionBy` anymore.