### PR TITLE
[Fix] Remove `@canRoot` from `PoolCandidatesAdminView`

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -702,8 +702,8 @@ type PoolCandidateAdminView {
   submittedAt: DateTime @rename(attribute: "submitted_at")
   suspendedAt: DateTime @rename(attribute: "suspended_at")
   status: LocalizedApplicationStatus @rename(attribute: "application_status")
-  candidateStatus: LocalizedCandidateStatus @canRoot(ability: "viewStatus")
-  candidateInterest: LocalizedCandidateInterest @canRoot(ability: "viewStatus")
+  candidateStatus: LocalizedCandidateStatus
+  candidateInterest: LocalizedCandidateInterest
   screeningStage: LocalizedScreeningStage @rename(attribute: "screening_stage")
   notes: String
   isFlagged: Boolean @rename(attribute: "is_flagged")


### PR DESCRIPTION
🤖 Resolves #16068 

## 👋 Introduction

These were errantly added in the status migration and part of the reason we saw performance degredation on the pool candidates table.

## 🕵️ Details

This is not something that I expect will have a huge effect on the overal performance but it is an easy first fix in the process.

## 🧪 Testing

1. Login as `admin@test.com`
2. Navigate to `/admin/pool-candidates`
3. Confirm it still loads as expected