### PR TITLE
[Fix] Remove duplicate translation artifacts

### DIFF
--- a/apps/web/src/pages/Home/HomePage/HomePage.tsx
+++ b/apps/web/src/pages/Home/HomePage/HomePage.tsx
@@ -28,11 +28,6 @@ export const Component = ({ defaultImage }: HeroProps) => {
         })}
       />
       <Hero defaultImage={defaultImage} />
-      {intl.formatMessage({
-        defaultMessage: "test web string",
-        description: "Testing",
-        id: 'uHMeqf',
-      })}
       <Opportunities />
       <Profile />
       <Featured />

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -1,11 +1,6 @@
 import { defineMessages } from "react-intl";
 
 const commonMessages = defineMessages({
-  test: {
-    defaultMessage: "test i18n string",
-    id: "cah4Cr",
-    description: "testing",
-  },
   projectTitle: {
     defaultMessage: "GC Digital Talent",
     id: "1i0PsT",


### PR DESCRIPTION
🤖 Resolves #16018 

## 👋 Introduction

Updates the artifact path so `node_modules` are actually ignored.

## 🕵️ Details

We had a rule to exclude it but it was not working. This should make it actually work :laughing: 

## 🧪 Testing

1. Force an untranslated string in both web and i18n
2. Confirm no `node_modules` or duplicates appear in the failed translation job artifact

## 📸 Screenshot

<img width="370" height="302" alt="swappy-20260306_142447" src="https://github.com/user-attachments/assets/2ec0ccaa-3a83-4eb8-8c7c-63a0b4bb5769" />

