### PR TITLE
[Bug] fix employment category missing from error summary

### DIFF
--- a/apps/web/src/utils/experienceUtils.tsx
+++ b/apps/web/src/utils/experienceUtils.tsx
@@ -157,6 +157,11 @@ export const getExperienceFormLabels = (
       id: "BdpXAF",
       description: "Label for the employment category radio group",
     }),
+    department: intl.formatMessage({
+      defaultMessage: "Department",
+      id: "9aW0M6",
+      description: "Title for department",
+    }),
     role: intl.formatMessage({
       defaultMessage: "My role",
       id: "nyQyqM",
@@ -299,6 +304,11 @@ export const getExperienceFormLabels = (
       defaultMessage: "Rank category",
       id: "4fV+wX",
       description: "Label for the rank category radio group",
+    }),
+    cafForce: intl.formatMessage({
+      defaultMessage: "Military force",
+      id: "kdXBAS",
+      description: "Label for the military force radio group",
     }),
     supervisoryPosition: intl.formatMessage({
       defaultMessage: "Management or supervisory status",


### PR DESCRIPTION
🤖 Resolves #15896

## 👋 Introduction

This PR fixes the issue where the Employment Category field was missing from the error summary when a user submitted a work experience. 
I also found two other labels that were also missing and added them to this PR. 


## 🧪 Testing

1. Build app `pnpm dev:fresh`
2. Login as `applicant@test.com`
3. Navigate to `applicant/career-timeline` and add a new work experience
4. Leave the "Employment Category" unselected 
5. Save form and verify:
    - you are taken to the top of the page with the Error Summary and "Employment Category" is now visible
    - when you click the "employment category" link in the error summary verify the focus moves to the radio group.
6. Refresh page, and add a new work experience, and select the GOC for the Employment Category
7. Leave everything else unselected, save and verify the error summary shows all fields that are required.
8. Refresh page, add a new work experience, select CAF for the employment category
9. Leave everything unselected, save and verify the error summary shows all the fields that are required.

## 📸 Screenshot

<img width="689" height="409" alt="image" src="https://github.com/user-attachments/assets/6da746ca-ddf4-476f-97cb-98cd90edb9b4" />

