### PR TITLE
[Debt] Removes important css flag from `DateInput` legend

### DIFF
--- a/packages/forms/src/components/DateInput/DateInput.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.tsx
@@ -27,9 +27,8 @@ import {
 } from "./types";
 import { useRegisterFormLabel } from "../FormLabelsProvider";
 
-// NOTE: Remove important in #13664
 const legendStyles = tv({
-  base: "text-base! font-bold",
+  base: "text-base font-bold",
   variants: { hide: { true: "sr-only" } },
 });
 


### PR DESCRIPTION
🤖 Resolves #16121.

## 👋 Introduction

This PR removes the important css flag and comment from `DateInput` legend.

## 🧪 Testing

1. `pnpm storybook`
2. Navigate to http://localhost:6006/?path=/story/components-dateinput--default
3. Verify legend is styled the same as before (use Chromatic for diff)