### PR TITLE
[Feat] Use cursor pagination for candidate navigations links

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1625,6 +1625,49 @@ type Query {
       scopes: ["whereSkillCount", "whereAuthorizedToViewPoolCandidateAdminView"]
       model: "App\\Models\\PoolCandidate"
     )
+  poolCandidatesCursor(
+    where: PoolCandidateSearchInput
+      @scope(name: "wherePoolCandidateSearchInputToSpecialLocationMatching")
+    orderByBase: PoolCandidatesBaseSort @scope
+    orderByPoolName: PoolCandidatePoolNameOrderByInput @scope
+    orderByClaimVerification: ClaimVerificationSort @scope
+    orderByEmployeeDepartment: SortOrder @scope
+    orderByScreeningStage: SortOrder @scope
+    orderBy: _
+      @orderBy(
+        relations: [
+          {
+            relation: "user"
+            columns: [
+              "priority_weight"
+              "first_name"
+              "email"
+              "preferred_lang"
+              "preferred_language_for_interview"
+              "preferred_language_for_exam"
+              "current_city"
+            ]
+          }
+          { relation: "pool", columns: ["process_number"] }
+          { relation: "assessmentStep", columns: ["sort_order"] }
+        ]
+      )
+      @with(
+        relations: [
+          "user:id,first_name,last_name,email,preferred_lang,computed_department"
+          "user.poolCandidates.pool.team"
+          "user.poolCandidates.pool.community.team"
+          "user.communityInterests.community.team"
+          "pool:id,process_number"
+          "skills:id,name"
+        ]
+      ) # Limit fields for eager loading
+  ): [PoolCandidateAdminView]!
+    @guard
+    @cursorPaginate(
+      model: "PoolCandidate"
+      scopes: ["whereAuthorizedToViewPoolCandidateAdminView"]
+    )
   # This query lives at api/app/GraphQL/Queries/CountPoolCandidatesByPool.php.
   # Returns the number of candidates by filtering their parent applicant, grouped by pool.
   countPoolCandidatesByPool(

--- a/api/programmatic-types.graphql
+++ b/api/programmatic-types.graphql
@@ -518,6 +518,39 @@ type PoolCandidateAdminViewWithSkillCountPaginator {
   data: [PoolCandidateAdminViewWithSkillCount!]!
 }
 
+"Information about pagination using a Relay style cursor connection."
+type PageInfo {
+  "When paginating forwards, are there more items?"
+  hasNextPage: Boolean!
+
+  "When paginating backwards, are there more items?"
+  hasPreviousPage: Boolean!
+
+  "The cursor to continue paginating backwards."
+  startCursor: String
+
+  "The cursor to continue paginating forwards."
+  endCursor: String
+}
+
+"A paginated list of PoolCandidateAdminView edges."
+type PoolCandidateAdminViewConnection {
+  "Pagination information about the list of edges."
+  pageInfo: PageInfo!
+
+  "A list of PoolCandidateAdminView edges."
+  edges: [PoolCandidateAdminViewEdge!]!
+}
+
+"An edge that contains a node of type PoolCandidateAdminView and a cursor."
+type PoolCandidateAdminViewEdge {
+  "The PoolCandidateAdminView node."
+  node: PoolCandidateAdminView!
+
+  "A unique cursor that can be used for pagination."
+  cursor: String!
+}
+
 "A paginated list of PoolCandidateSearchRequest items."
 type PoolCandidateSearchRequestPaginator {
   "Pagination information about the list of items."
@@ -729,6 +762,72 @@ input QueryPoolCandidatesPaginatedAdminViewOrderByRelationOrderByClause {
 
   "Aggregate specification."
   assessmentStep: QueryPoolCandidatesPaginatedAdminViewOrderByAssessmentStep
+}
+
+"Allowed column names for Query.poolCandidatesCursor.orderBy."
+enum QueryPoolCandidatesCursorOrderByUserColumn {
+  PRIORITY_WEIGHT
+  FIRST_NAME
+  EMAIL
+  PREFERRED_LANG
+  PREFERRED_LANGUAGE_FOR_INTERVIEW
+  PREFERRED_LANGUAGE_FOR_EXAM
+  CURRENT_CITY
+}
+
+"Aggregate specification for Query.poolCandidatesCursor.orderBy.user."
+input QueryPoolCandidatesCursorOrderByUser {
+  "The aggregate function to apply to the column."
+  aggregate: OrderByRelationWithColumnAggregateFunction!
+
+  "Name of the column to use."
+  column: QueryPoolCandidatesCursorOrderByUserColumn
+}
+
+"Allowed column names for Query.poolCandidatesCursor.orderBy."
+enum QueryPoolCandidatesCursorOrderByPoolColumn {
+  PROCESS_NUMBER
+}
+
+"Aggregate specification for Query.poolCandidatesCursor.orderBy.pool."
+input QueryPoolCandidatesCursorOrderByPool {
+  "The aggregate function to apply to the column."
+  aggregate: OrderByRelationWithColumnAggregateFunction!
+
+  "Name of the column to use."
+  column: QueryPoolCandidatesCursorOrderByPoolColumn
+}
+
+"Allowed column names for Query.poolCandidatesCursor.orderBy."
+enum QueryPoolCandidatesCursorOrderByAssessmentStepColumn {
+  SORT_ORDER
+}
+
+"Aggregate specification for Query.poolCandidatesCursor.orderBy.assessmentStep."
+input QueryPoolCandidatesCursorOrderByAssessmentStep {
+  "The aggregate function to apply to the column."
+  aggregate: OrderByRelationWithColumnAggregateFunction!
+
+  "Name of the column to use."
+  column: QueryPoolCandidatesCursorOrderByAssessmentStepColumn
+}
+
+"Order by clause for Query.poolCandidatesCursor.orderBy."
+input QueryPoolCandidatesCursorOrderByRelationOrderByClause {
+  "The column that is used for ordering."
+  column: String
+
+  "The direction that is used for ordering."
+  order: SortOrder!
+
+  "Aggregate specification."
+  user: QueryPoolCandidatesCursorOrderByUser
+
+  "Aggregate specification."
+  pool: QueryPoolCandidatesCursorOrderByPool
+
+  "Aggregate specification."
+  assessmentStep: QueryPoolCandidatesCursorOrderByAssessmentStep
 }
 
 "Allowed column names for Query.communityInterestsPaginated.orderBy."

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -513,6 +513,27 @@ type Query {
     "The offset from which items are returned."
     page: Int
   ): PoolCandidateAdminViewWithSkillCountPaginator!
+  poolCandidatesCursor(
+    where: PoolCandidateSearchInput
+    orderByBase: PoolCandidatesBaseSort
+    orderByPoolName: PoolCandidatePoolNameOrderByInput
+    orderByClaimVerification: ClaimVerificationSort
+    orderByEmployeeDepartment: SortOrder
+    orderByScreeningStage: SortOrder
+    orderBy: [QueryPoolCandidatesCursorOrderByRelationOrderByClause!]
+
+    "Limits number of fetched items for forward pagination."
+    first: Int
+
+    "Limits number of fetched items for reverse pagination."
+    last: Int
+
+    "A cursor after which elements are returned."
+    after: String
+
+    "A cursor before which elements are returned."
+    before: String
+  ): PoolCandidateAdminViewConnection!
   poolCandidateSearchRequestsPaginated(
     where: PoolCandidateSearchRequestInput
     orderBy: [OrderByClause!]
@@ -2964,6 +2985,39 @@ type PoolCandidateAdminViewWithSkillCountPaginator {
   data: [PoolCandidateAdminViewWithSkillCount!]!
 }
 
+"Information about pagination using a Relay style cursor connection."
+type PageInfo {
+  "When paginating forwards, are there more items?"
+  hasNextPage: Boolean!
+
+  "When paginating backwards, are there more items?"
+  hasPreviousPage: Boolean!
+
+  "The cursor to continue paginating backwards."
+  startCursor: String
+
+  "The cursor to continue paginating forwards."
+  endCursor: String
+}
+
+"A paginated list of PoolCandidateAdminView edges."
+type PoolCandidateAdminViewConnection {
+  "Pagination information about the list of edges."
+  pageInfo: PageInfo!
+
+  "A list of PoolCandidateAdminView edges."
+  edges: [PoolCandidateAdminViewEdge!]!
+}
+
+"An edge that contains a node of type PoolCandidateAdminView and a cursor."
+type PoolCandidateAdminViewEdge {
+  "The PoolCandidateAdminView node."
+  node: PoolCandidateAdminView!
+
+  "A unique cursor that can be used for pagination."
+  cursor: String!
+}
+
 "A paginated list of PoolCandidateSearchRequest items."
 type PoolCandidateSearchRequestPaginator {
   "Pagination information about the list of items."
@@ -3175,6 +3229,72 @@ input QueryPoolCandidatesPaginatedAdminViewOrderByRelationOrderByClause {
 
   "Aggregate specification."
   assessmentStep: QueryPoolCandidatesPaginatedAdminViewOrderByAssessmentStep
+}
+
+"Allowed column names for Query.poolCandidatesCursor.orderBy."
+enum QueryPoolCandidatesCursorOrderByUserColumn {
+  PRIORITY_WEIGHT
+  FIRST_NAME
+  EMAIL
+  PREFERRED_LANG
+  PREFERRED_LANGUAGE_FOR_INTERVIEW
+  PREFERRED_LANGUAGE_FOR_EXAM
+  CURRENT_CITY
+}
+
+"Aggregate specification for Query.poolCandidatesCursor.orderBy.user."
+input QueryPoolCandidatesCursorOrderByUser {
+  "The aggregate function to apply to the column."
+  aggregate: OrderByRelationWithColumnAggregateFunction!
+
+  "Name of the column to use."
+  column: QueryPoolCandidatesCursorOrderByUserColumn
+}
+
+"Allowed column names for Query.poolCandidatesCursor.orderBy."
+enum QueryPoolCandidatesCursorOrderByPoolColumn {
+  PROCESS_NUMBER
+}
+
+"Aggregate specification for Query.poolCandidatesCursor.orderBy.pool."
+input QueryPoolCandidatesCursorOrderByPool {
+  "The aggregate function to apply to the column."
+  aggregate: OrderByRelationWithColumnAggregateFunction!
+
+  "Name of the column to use."
+  column: QueryPoolCandidatesCursorOrderByPoolColumn
+}
+
+"Allowed column names for Query.poolCandidatesCursor.orderBy."
+enum QueryPoolCandidatesCursorOrderByAssessmentStepColumn {
+  SORT_ORDER
+}
+
+"Aggregate specification for Query.poolCandidatesCursor.orderBy.assessmentStep."
+input QueryPoolCandidatesCursorOrderByAssessmentStep {
+  "The aggregate function to apply to the column."
+  aggregate: OrderByRelationWithColumnAggregateFunction!
+
+  "Name of the column to use."
+  column: QueryPoolCandidatesCursorOrderByAssessmentStepColumn
+}
+
+"Order by clause for Query.poolCandidatesCursor.orderBy."
+input QueryPoolCandidatesCursorOrderByRelationOrderByClause {
+  "The column that is used for ordering."
+  column: String
+
+  "The direction that is used for ordering."
+  order: SortOrder!
+
+  "Aggregate specification."
+  user: QueryPoolCandidatesCursorOrderByUser
+
+  "Aggregate specification."
+  pool: QueryPoolCandidatesCursorOrderByPool
+
+  "Aggregate specification."
+  assessmentStep: QueryPoolCandidatesCursorOrderByAssessmentStep
 }
 
 "Allowed column names for Query.communityInterestsPaginated.orderBy."

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -65,19 +65,14 @@ import {
   priorityCell,
   transformFormValuesToFilterState,
   transformPoolCandidateSearchInputToFormValues,
-  getSortOrder,
   processCell,
-  getPoolNameSort,
-  getClaimVerificationSort,
   addSearchToPoolCandidateFilterInput,
-  getDepartmentSort,
-  getScreeningStageSort,
   candidateStatusCell,
-  getBaseSort,
   poolCandidateBookmarkHeader,
   poolCandidateBookmarkCell,
   applicationStatusCell,
   screeningResultCell,
+  getQueryVariables,
 } from "./helpers";
 import { rowSelectCell } from "../Table/ResponsiveTable/RowSelection";
 import { normalizedText } from "../Table/sortingFns";
@@ -560,22 +555,21 @@ const PoolCandidatesTable = ({
     }
   };
 
+  const queryVariables = getQueryVariables({
+    filterState,
+    searchState,
+    sortState,
+    doNotUseFlag,
+    doNotUseBookmark,
+    locale,
+  });
+
   const [{ data, fetching }] = useQuery({
     query: CandidatesTableCandidatesPaginated_Query,
     variables: {
-      where: addSearchToPoolCandidateFilterInput(
-        filterState,
-        searchState?.term,
-        searchState?.type,
-      ),
       page: paginationState.pageIndex,
       first: paginationState.pageSize,
-      orderByBaseInput: getBaseSort(doNotUseBookmark, doNotUseFlag),
-      poolNameSortingInput: getPoolNameSort(sortState, locale),
-      sortingInput: getSortOrder(sortState, filterState),
-      orderByEmployeeDepartment: getDepartmentSort(sortState),
-      orderByScreeningStage: getScreeningStageSort(sortState),
-      orderByClaimVerification: getClaimVerificationSort(sortState),
+      ...queryVariables,
     },
   });
 
@@ -584,10 +578,6 @@ const PoolCandidatesTable = ({
       const poolCandidates = data?.poolCandidatesPaginatedAdminView.data ?? [];
       return poolCandidates.filter(notEmpty);
     }, [data?.poolCandidatesPaginatedAdminView.data]);
-
-  const candidateIdsFromFilterData = filteredData.map(
-    (iterator) => iterator.poolCandidate.id,
-  );
 
   const [{ data: tableData, fetching: fetchingTableData }] = useQuery({
     query: CandidatesTable_Query,
@@ -790,7 +780,7 @@ const PoolCandidatesTable = ({
             poolCandidate.id,
             paths,
             intl,
-            candidateIdsFromFilterData,
+            queryVariables,
             poolCandidate.user.firstName,
             poolCandidate.user.lastName,
           ),

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -61,6 +61,7 @@ import CandidateFlag, {
 import PoolCandidateBookmark, {
   PoolCandidateBookmark_Fragment,
 } from "./PoolCandidateBookmark";
+import { SearchState } from "../Table/ResponsiveTable/types";
 
 export const priorityCell = (
   weight: number,
@@ -79,29 +80,6 @@ export const priorityCell = (
     >
       {getLocalizedName(label, intl)}
     </span>
-  );
-};
-
-export const candidateNameCell = (
-  candidateId: string,
-  paths: ReturnType<typeof useRoutes>,
-  intl: IntlShape,
-  tableCandidateIds?: string[],
-  candidateFirstName?: Maybe<string>,
-  candidateLastName?: Maybe<string>,
-) => {
-  const candidateName = getFullNameLabel(
-    candidateFirstName,
-    candidateLastName,
-    intl,
-  );
-  return (
-    <Link
-      href={paths.poolCandidateApplication(candidateId)}
-      state={{ candidateIds: tableCandidateIds, stepName: null }}
-    >
-      {candidateName}
-    </Link>
   );
 };
 
@@ -690,5 +668,60 @@ export const poolCandidateBookmarkCell = (
       firstName={firstName}
       lastName={lastName}
     />
+  );
+};
+
+interface GetQueryVariablesArgs {
+  filterState?: PoolCandidateSearchInput;
+  searchState?: SearchState;
+  sortState?: SortingState;
+  doNotUseFlag: boolean;
+  doNotUseBookmark: boolean;
+  locale: Locales;
+}
+
+export const getQueryVariables = ({
+  filterState,
+  searchState,
+  sortState,
+  doNotUseBookmark,
+  doNotUseFlag,
+  locale,
+}: GetQueryVariablesArgs) => ({
+  where: addSearchToPoolCandidateFilterInput(
+    filterState,
+    searchState?.term,
+    searchState?.type,
+  ),
+  orderByBaseInput: getBaseSort(doNotUseBookmark, doNotUseFlag),
+  poolNameSortingInput: getPoolNameSort(sortState, locale),
+  sortingInput: getSortOrder(sortState, filterState),
+  orderByEmployeeDepartment: getDepartmentSort(sortState),
+  orderByScreeningStage: getScreeningStageSort(sortState),
+  orderByClaimVerification: getClaimVerificationSort(sortState),
+});
+
+export type CandidateQueryVariables = ReturnType<typeof getQueryVariables>;
+
+export const candidateNameCell = (
+  candidateId: string,
+  paths: ReturnType<typeof useRoutes>,
+  intl: IntlShape,
+  queryVariables: CandidateQueryVariables,
+  candidateFirstName?: Maybe<string>,
+  candidateLastName?: Maybe<string>,
+) => {
+  const candidateName = getFullNameLabel(
+    candidateFirstName,
+    candidateLastName,
+    intl,
+  );
+  return (
+    <Link
+      href={paths.poolCandidateApplication(candidateId)}
+      state={{ queryVariables }}
+    >
+      {candidateName}
+    </Link>
   );
 };

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CandidateNavigation/CandidateNavigation.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CandidateNavigation/CandidateNavigation.tsx
@@ -1,12 +1,21 @@
 import { defineMessages, useIntl } from "react-intl";
 import ChevronDoubleRightIcon from "@heroicons/react/16/solid/ChevronDoubleRightIcon";
 import ChevronDoubleLeftIcon from "@heroicons/react/16/solid/ChevronDoubleLeftIcon";
+import { useLocation } from "react-router";
 
-import { Card, LinkProps, Link, Separator } from "@gc-digital-talent/ui";
+import {
+  Card,
+  LinkProps,
+  Link,
+  Separator,
+  Loading,
+} from "@gc-digital-talent/ui";
 
 import useRoutes from "~/hooks/useRoutes";
 
-import usePoolCandidateNavigation from "./usePoolCandidateNavigation";
+import usePoolCandidateNavigation, {
+  NavigationState,
+} from "./usePoolCandidateNavigation";
 
 const messages = defineMessages({
   nextCandidate: {
@@ -28,25 +37,25 @@ const messages = defineMessages({
   },
 });
 
-interface CandidateNavigationProps {
-  candidateId: string;
+const commonLinkProps: Partial<LinkProps> = {
+  color: "primary",
+  mode: "inline",
+  block: true,
+};
+
+interface LocationState {
+  state?: NavigationState;
 }
 
-const CandidateNavigation = ({ candidateId }: CandidateNavigationProps) => {
+const CandidateNavigation = () => {
   const intl = useIntl();
   const paths = useRoutes();
-  const candidateNavigation = usePoolCandidateNavigation(candidateId);
-  if (!candidateNavigation?.candidateIds) return null;
-  const { nextCandidate, previousCandidate, candidateIds, stepName } =
-    candidateNavigation;
-  if (!nextCandidate && !previousCandidate) return null;
+  const { state } = useLocation() as LocationState;
+  const { next, prev, fetching } = usePoolCandidateNavigation(state);
 
-  const commonLinkProps: Partial<LinkProps> = {
-    color: "primary",
-    mode: "inline",
-    state: { candidateIds, stepName },
-    block: true,
-  };
+  if (fetching) return <Loading inline />;
+
+  if (!next && !prev) return null;
 
   return (
     <Card
@@ -54,9 +63,10 @@ const CandidateNavigation = ({ candidateId }: CandidateNavigationProps) => {
       className="relative grid grid-cols-2 items-center justify-between gap-x-3"
     >
       <div>
-        {previousCandidate && (
+        {prev && (
           <Link
-            href={paths.poolCandidateApplication(previousCandidate)}
+            href={paths.poolCandidateApplication(prev.id)}
+            state={{ ...state, currentCursor: prev.cursor }}
             icon={ChevronDoubleLeftIcon}
             {...commonLinkProps}
           >
@@ -71,9 +81,10 @@ const CandidateNavigation = ({ candidateId }: CandidateNavigationProps) => {
         className="absolute top-0 bottom-0 left-1/2 -translate-x-1/2"
       />
       <div>
-        {nextCandidate && (
+        {next && (
           <Link
-            href={paths.poolCandidateApplication(nextCandidate)}
+            href={paths.poolCandidateApplication(next.id)}
+            state={{ ...state, currentCursor: next.cursor }}
             utilityIcon={ChevronDoubleRightIcon}
             {...commonLinkProps}
           >

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CandidateNavigation/usePoolCandidateNavigation.ts
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/CandidateNavigation/usePoolCandidateNavigation.ts
@@ -1,47 +1,132 @@
-import { useLocation } from "react-router";
+import { useMemo } from "react";
+import { useQuery } from "urql";
 
-interface CandidateLocation {
-  state?: {
-    candidateIds?: string[];
-    stepName?: string;
-  };
+import {
+  graphql,
+  PoolCandidatesBaseSort,
+  QueryPoolCandidatesCursorOrderByRelationOrderByClause,
+} from "@gc-digital-talent/graphql";
+
+import { CandidateQueryVariables } from "~/components/PoolCandidatesTable/helpers";
+
+// Must match what exists in PoolCandidatesTable
+const CandidateNavigation_Query = graphql(/** GraphQL */ `
+  query CandidateNavigation(
+    $where: PoolCandidateSearchInput
+    $orderByBaseInput: PoolCandidatesBaseSort!
+    $poolNameSortingInput: PoolCandidatePoolNameOrderByInput
+    $sortingInput: [QueryPoolCandidatesCursorOrderByRelationOrderByClause!]
+    $orderByClaimVerification: ClaimVerificationSort
+    $orderByEmployeeDepartment: SortOrder
+    $orderByScreeningStage: SortOrder
+    $after: String
+    $before: String
+    $first: Int
+    $last: Int
+  ) {
+    next: poolCandidatesCursor(
+      where: $where
+      orderByBase: $orderByBaseInput
+      orderByPoolName: $poolNameSortingInput
+      orderBy: $sortingInput
+      orderByClaimVerification: $orderByClaimVerification
+      orderByEmployeeDepartment: $orderByEmployeeDepartment
+      orderByScreeningStage: $orderByScreeningStage
+      after: $after
+      first: $first
+    ) {
+      edges {
+        node {
+          id
+        }
+      }
+      pageInfo {
+        endCursor
+      }
+    }
+    prev: poolCandidatesCursor(
+      where: $where
+      orderByBase: $orderByBaseInput
+      orderByPoolName: $poolNameSortingInput
+      orderBy: $sortingInput
+      orderByClaimVerification: $orderByClaimVerification
+      orderByEmployeeDepartment: $orderByEmployeeDepartment
+      orderByScreeningStage: $orderByScreeningStage
+      before: $before
+      last: $last
+    ) {
+      edges {
+        node {
+          id
+        }
+      }
+      pageInfo {
+        startCursor
+      }
+    }
+  }
+`);
+
+export interface NavigationState {
+  queryVariables: CandidateQueryVariables;
+  currentCursor?: string;
 }
 
-type UsePoolCandidateNavigationReturn = {
-  candidateIds?: string[];
-  stepName?: string;
-  previousCandidate?: string;
-  nextCandidate?: string;
-  lastCandidate?: boolean;
-} | null;
+const usePoolCandidateNavigation = (state?: NavigationState) => {
+  // If we have no cursor in state, we are on the first candidate
+  const isInitial = !state?.currentCursor;
 
-const usePoolCandidateNavigation = (
-  candidateId: string,
-): UsePoolCandidateNavigationReturn => {
-  const { state } = useLocation() as CandidateLocation;
-  if (!state?.candidateIds || !candidateId) return null;
-  const { candidateIds, stepName } = state;
+  const [{ data, fetching, error }] = useQuery({
+    query: CandidateNavigation_Query,
+    variables: {
+      ...state?.queryVariables,
+      sortingInput: state?.queryVariables
+        .sortingInput as QueryPoolCandidatesCursorOrderByRelationOrderByClause[],
+      orderByBaseInput:
+        state?.queryVariables?.orderByBaseInput ??
+        ({
+          column: "submitted_at",
+          order: "DESC",
+        } as PoolCandidatesBaseSort),
+      after: state?.currentCursor ?? null,
+      before: state?.currentCursor ?? null,
+      first: isInitial ? 2 : 1,
+      last: 1,
+    },
+    pause: !state?.queryVariables,
+  });
 
-  const currentIndex = candidateIds.findIndex((id) => id === candidateId);
-  if (currentIndex < 0) return null;
+  return useMemo(() => {
+    if (fetching || error || !data) {
+      return { fetching, next: null, prev: null };
+    }
 
-  const nextCandidate = candidateIds[currentIndex + 1];
-  const previousCandidate = candidateIds[currentIndex - 1];
+    const nextEdges = data.next?.edges ?? [];
+    const prevEdges = data.prev?.edges ?? [];
 
-  if (currentIndex === 0) {
-    return { nextCandidate, candidateIds, stepName };
-  }
+    // NEXT: If initial, target is index 1. If we have a cursor, target is index 0.
+    const nextNode = isInitial ? nextEdges[1] : nextEdges[0];
 
-  if (currentIndex === candidateIds.length - 1) {
+    // PREV: Only exists if we aren't at the very start.
+    // NOTE: Not working, first click seems to go to next
+    const prevNode = isInitial ? null : prevEdges[0];
+
     return {
-      previousCandidate,
-      candidateIds,
-      lastCandidate: true,
-      stepName,
+      fetching: false,
+      next: nextNode
+        ? {
+            id: nextNode.node.id,
+            cursor: data.next?.pageInfo?.endCursor,
+          }
+        : null,
+      prev: prevNode
+        ? {
+            id: prevNode.node.id,
+            cursor: data.prev?.pageInfo?.startCursor,
+          }
+        : null,
     };
-  }
-
-  return { previousCandidate, nextCandidate, candidateIds, stepName };
+  }, [data, fetching, error, isInitial]);
 };
 
 export default usePoolCandidateNavigation;

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/Sidebar/ApplicationSidebar.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/Sidebar/ApplicationSidebar.tsx
@@ -73,7 +73,7 @@ const ApplicationSidebar = ({ query }: ApplicationSidebarProps) => {
         <Card.Separator />
         <ApplicationNotes query={application} />
       </Card>
-      <CandidateNavigation candidateId={application.id} />
+      <CandidateNavigation />
     </>
   );
 };


### PR DESCRIPTION
🤖 Resolves #10286 

## 👋 Introduction

Updates the `CandidateNavigation` to use cursor pagination and no longer rely on the table IDs.

## 🕵️ Details

> [!IMPORTANT]
> This is not working as is. Changing directions is acting odd. You can go in a single direction fine but when changing directions, it intially goes in the wrong direction but after that first issue, it works fine until you try and change directions again. 

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to `/admin/pool-candidates`
4. Take note of the order
5. Cklick on a candidate
6. Use next and previous buttons
7. Confirm it matches the table order and can go past the page size