### PR TITLE
[Bug] Fix flaky `UserTest`

### DIFF
--- a/api/tests/Feature/UserTest.php
+++ b/api/tests/Feature/UserTest.php
@@ -1729,7 +1729,7 @@ class UserTest extends TestCase
         ]);
         User::factory()->create([
             'first_name' => 'dan',
-            'last_name' => 'man',
+            'last_name' => 'manny',
             'email' => 'dan@user.com',
             'telephone' => '99999',
         ]);
@@ -1791,7 +1791,7 @@ class UserTest extends TestCase
             ], 1],
             'assert email filter with partial email returns correct count' => [['email' => 'user.com'], 4],
             'assert more than one search term results in AND filtering' => [['generalSearch' => 'sam 67890'], 1],
-            'assert filtering for last name in general search returns correct count' => [['generalSearch' => 'man'], 1],
+            'assert filtering for last name in general search returns correct count' => [['generalSearch' => 'manny'], 1],
             'assert filtering general search and name search (both subqueries) filter as AND' => [[
                 'generalSearch' => '@user.com',
                 'name' => 'zak',


### PR DESCRIPTION
🤖 Resolves #16002

## 👋 Introduction

Fix the flaky test.
I suspect "man" was matching with seeded values in other fields. Rather than try and hardcode every possibility, I just made the name a little more unique

## 🧪 Testing

1. Run `UserTest`

## 📸 Screenshot

<img width="347" height="354" alt="image" src="https://github.com/user-attachments/assets/d4f3ad79-72f8-47a7-9b95-2c700dc0de33" />


