### PR TITLE
[Fix] Candidates table flag state

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -207,6 +207,7 @@ const CandidatesTableCandidatesPaginated_Query = graphql(/* GraphQL */ `
           ...JobPlacementDialogCandidateTable
           id
           notes
+          isFlagged
           status {
             value
             label {


### PR DESCRIPTION
🤖 Resolves #16154 

## 👋 Introduction

Fixes an issue where the flag state was not showing as active when a candidate was flagged.

## 🕵️ Details

This was caused by the type mismatch since we have a special type for the table, we could not use fragments and were simply casting it which masked the fact that we were not even querying for the required field to make this work.

Unfortunatly, this is just another bug related to the DX tools we built up to avoid this exact issue falling apart due to the need for a special type to handle this table :sob: 

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Go to a process candidates page
4. Click a candidate
5. Toggle the flag on their detials page
6. Go back to the candidates table in step 3
7. Confirm the candidate you flagged shows as activley flagged

## 📸 Screenshot

<img width="846" height="523" alt="swappy-20260317_132158" src="https://github.com/user-attachments/assets/04829bc7-076f-48a3-a85a-1108dcb9ec84" />
