### PR TITLE
[Bug] Deduplicate department options

### DIFF
--- a/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
+++ b/apps/web/src/pages/Pools/CreatePoolPage/CreatePoolPage.tsx
@@ -181,13 +181,14 @@ export const CreatePoolForm = ({
     },
   );
 
-  const departmentOptions: Option[] = departments.map(
-    ({ id, departmentName }) => ({
+  const departmentOptions: Option[] = uniqBy(
+    departments.map(({ id, departmentName }) => ({
       value: id,
       label:
         departmentName?.localized ??
         intl.formatMessage(commonMessages.notAvailable),
-    }),
+    })),
+    "value",
   );
 
   return (


### PR DESCRIPTION
🤖 Resolves #16158

## 👋 Introduction

In the case of multiple roles with one department, a department is then returned multiple times in teamables. Dedupe the options before rendering 

## 🧪 Testing

1. Assign both department roles to yourself
2. Go to create a process, department dropdown

## 📸 Screenshot

<img width="1320" height="722" alt="image" src="https://github.com/user-attachments/assets/6b6953ec-c6b2-484c-8666-d5a98ca3b821" />




