### PR TITLE
[Bug] Enable cache invalidation for flags and bookmarks

### DIFF
--- a/api/app/GraphQL/Mutations/TogglePoolCandidateFlag.php
+++ b/api/app/GraphQL/Mutations/TogglePoolCandidateFlag.php
@@ -15,6 +15,6 @@ final class TogglePoolCandidateFlag
         $candidate->is_flagged = ! $candidate->is_flagged;
         $candidate->save();
 
-        return $candidate->is_flagged;
+        return $candidate;
     }
 }

--- a/api/app/GraphQL/Mutations/TogglePoolCandidateUserBookmark.php
+++ b/api/app/GraphQL/Mutations/TogglePoolCandidateUserBookmark.php
@@ -19,10 +19,7 @@ final class TogglePoolCandidateUserBookmark
         /** @var PoolCandidate */
         $poolCandidate = PoolCandidate::find($args['pool_candidate_id']);
 
-        $executeToggle = $user->poolCandidateBookmarks()->toggle($poolCandidate->id);
-
-        $isNowBookmarked = $executeToggle && $executeToggle['attached'] && count($executeToggle['attached']) > 0;
-
-        return $isNowBookmarked;
+        $user->poolCandidateBookmarks()->toggle($poolCandidate->id);
+        return $poolCandidate;
     }
 }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -3144,7 +3144,7 @@ type Mutation {
     @guard
     @canFind(ability: "updateStatus", find: "id", injectArgs: true)
   # Return a boolean to prevent automatically updating the client's cache
-  togglePoolCandidateFlag(id: ID!): Boolean
+  togglePoolCandidateFlag(id: ID!): PoolCandidate
     @guard
     @canFind(
       ability: "updateFlag"
@@ -3154,7 +3154,7 @@ type Mutation {
     )
   togglePoolCandidateUserBookmark(
     poolCandidateId: UUID! @rename(attribute: "pool_candidate_id")
-  ): Boolean
+  ): PoolCandidate
     @guard
     @canFind(
       ability: "view"

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -576,8 +576,8 @@ type Mutation {
   removeUserWorkEmail(id: UUID!): User
   createPoolCandidateAsAdmin(poolCandidate: CreatePoolCandidateAsAdminInput!): PoolCandidate
   updatePoolCandidateStatus(id: UUID!, poolCandidate: UpdatePoolCandidateStatusInput!): PoolCandidate @deprecated(reason: "Replaced by specific mutations")
-  togglePoolCandidateFlag(id: ID!): Boolean
-  togglePoolCandidateUserBookmark(poolCandidateId: UUID!): Boolean
+  togglePoolCandidateFlag(id: ID!): PoolCandidate
+  togglePoolCandidateUserBookmark(poolCandidateId: UUID!): PoolCandidate
   updatePoolCandidateClaimVerification(id: UUID!, poolCandidate: UpdatePoolCandidateClaimVerificationInput!): PoolCandidate
   updatePoolCandidateNotes(id: UUID!, notes: String): PoolCandidate
   updatePoolCandidateScreeningStage(poolCandidate: UpdatePoolCandidateScreeningStageInput!): PoolCandidate

--- a/apps/web/src/hooks/useCandidateBookmarkToggle.ts
+++ b/apps/web/src/hooks/useCandidateBookmarkToggle.ts
@@ -7,7 +7,11 @@ import { useControllableState } from "@gc-digital-talent/ui";
 
 const TogglePoolCandidateUserBookmark_Mutation = graphql(/* GraphQL */ `
   mutation TogglePoolCandidateUserBookmark_Mutation($id: UUID!) {
-    togglePoolCandidateUserBookmark(poolCandidateId: $id)
+    togglePoolCandidateUserBookmark(poolCandidateId: $id) {
+      id
+      isBookmarked
+      __typename
+    }
   }
 `);
 
@@ -49,7 +53,7 @@ const useCandidateBookmarkToggle = ({
         .then((res) => {
           if (!res.error) {
             const newIsBookmarked =
-              res.data?.togglePoolCandidateUserBookmark === true;
+              res.data?.togglePoolCandidateUserBookmark?.isBookmarked === true;
             if (showToast) {
               if (newIsBookmarked) {
                 toast.success(

--- a/apps/web/src/hooks/useCandidateFlagToggle.ts
+++ b/apps/web/src/hooks/useCandidateFlagToggle.ts
@@ -7,7 +7,11 @@ import { useControllableState } from "@gc-digital-talent/ui";
 
 const PoolCandidate_ToggleFlagMutation = graphql(/* GraphQL */ `
   mutation ToggleFlag_Mutation($id: ID!) {
-    togglePoolCandidateFlag(id: $id)
+    togglePoolCandidateFlag(id: $id) {
+      id
+      isFlagged
+      __typename
+    }
   }
 `);
 
@@ -58,7 +62,8 @@ const useCandidateFlagToggle = ({
       })
         .then((res) => {
           if (!res.error) {
-            const newIsFlagged = res.data?.togglePoolCandidateFlag === true;
+            const newIsFlagged =
+              res.data?.togglePoolCandidateFlag?.isFlagged === true;
             if (showToast) {
               if (newIsFlagged) {
                 toast.success(


### PR DESCRIPTION
🤖 Resolves #16166 

## 👋 Introduction

Fixes the issue of keeping a stale view of flags and bookmarks by returning a pool candidate from the API instead of a simple boolean.

:+1: Doesn't allow the flag and bookmark state to go stale
:-1: Causes rows to jump around the table

> [!CAUTION]
> If we go with this solution we should probably simplify the optimistic UI logic in useCandidateFlagToggle and useCandidateBookmarkToggle since it might become unnecessary. 

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

<!--
1. ...
2. ...
 -->

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

## 🚚 Deployment

<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the PR if deployment steps are needed

 -->
