### PR TITLE
[Fix]] Suppress hydration error

### DIFF
--- a/apps/web/src/root.tsx
+++ b/apps/web/src/root.tsx
@@ -132,6 +132,7 @@ interface LayoutProps {
 
 export function Layout({ children }: LayoutProps) {
   return (
+    // Suppress hydration warning coming from `initTheme.js` when running watch mode
     <html lang="en" suppressHydrationWarning>
       <head>
         <script


### PR DESCRIPTION
🤖 Resolves #16214 

## 👋 Introduction

Supresses a noisy error that isn't breaking.

## 🕵️ Details

HMR is mad because we run a scropt while its trying to hydrarte. We don't care, so lets suppress that!

## 🧪 Testing

1. Run `pnpm watch`
2. Confirm no hydration errors appear in the console