### PR TITLE
[Debt] Removes `pool.owner` from frontend, GraphQL schema

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -457,7 +457,6 @@ interface HasRoleAssignments {
 
 type Pool implements HasRoleAssignments {
   id: ID!
-  owner: UserPublicProfile @belongsTo(relation: "user")
   community: Community @belongsTo(relation: "community")
   teamId: UUID! @rename(attribute: "team.id") @with(relation: "team")
   name: LocalizedString

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1044,7 +1044,6 @@ interface HasRoleAssignments {
 
 type Pool implements HasRoleAssignments {
   id: ID!
-  owner: UserPublicProfile
   community: Community
   teamId: UUID!
   name: LocalizedString

--- a/api/tests/Feature/PoolTest.php
+++ b/api/tests/Feature/PoolTest.php
@@ -1684,9 +1684,6 @@ class PoolTest extends TestCase
             mutation CreatePool($userId: ID!, $communityId: ID, $pool: CreatePoolInput!) {
                 createPool(userId: $userId, communityId: $communityId, pool: $pool) {
                     id
-                    owner {
-                        id
-                    }
                     community {
                         id
                     }
@@ -1713,8 +1710,6 @@ class PoolTest extends TestCase
             );
 
         $response->assertJsonFragment([
-            'owner' => ['id' => $this->communityRecruiter->id],
-        ])->assertJsonFragment([
             'community' => ['id' => $this->community->id],
         ])->assertJsonFragment([
             'classification' => ['id' => $classification->id],
@@ -1740,9 +1735,6 @@ class PoolTest extends TestCase
             mutation CreatePool($userId: ID!, $communityId: ID, $pool: CreatePoolInput!) {
                 createPool(userId: $userId, communityId: $communityId, pool: $pool) {
                     id
-                    owner {
-                        id
-                    }
                     community {
                         id
                     }
@@ -1768,8 +1760,6 @@ class PoolTest extends TestCase
             );
 
         $response->assertJsonFragment([
-            'owner' => ['id' => $departmentAdmin->id],
-        ])->assertJsonFragment([
             'community' => null,
         ])->assertJsonFragment([
             'classification' => ['id' => $classification->id],
@@ -1798,9 +1788,6 @@ class PoolTest extends TestCase
             mutation CreatePool($userId: ID!, $communityId: ID, $pool: CreatePoolInput!) {
                 createPool(userId: $userId, communityId: $communityId, pool: $pool) {
                     id
-                    owner {
-                        id
-                    }
                     community {
                         id
                     }

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3039,10 +3039,6 @@
     "defaultMessage": "{count, plural, =0 {0 élément sélectionné} one {# élément sélectionné} other {# éléments sélectionnés}}",
     "description": "Message displayed for the number of rows selected in a table"
   },
-  "AWk4BX": {
-    "defaultMessage": "Nom du propriétaire",
-    "description": "Title displayed for the Pool table Owner Name column"
-  },
   "AXJKYq": {
     "defaultMessage": "Filtres de profils d'employé(e)",
     "description": "Heading for filters associated with employee profiles"
@@ -12449,10 +12445,6 @@
   "pcAgJh": {
     "defaultMessage": "Nous choisirons les personnes participantes en fonction de leur admissibilité, de leurs compétences ou de leur expérience, et de la représentation des groupes visés par l’équité en matière d’emploi au sein de l’effectif de la TI du gouvernement du Canada. Nous communiquerons avec vous dans les huit jours ouvrables suivant la date limite de présentation des demandes. Si vous faites partie des personnes choisies, vous aurez trois jours ouvrables pour confirmer votre participation.",
     "description": "Second paragraph of apply and share section"
-  },
-  "pe5WkF": {
-    "defaultMessage": "Courriel du propriétaire",
-    "description": "Title displayed for the Pool table Owner Email column"
   },
   "peTSHR": {
     "defaultMessage": "Notes sur cette demande",

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -45,10 +45,6 @@ import permissionConstants from "~/constants/permissionConstants";
 import {
   classificationAccessor,
   classificationCell,
-  emailLinkAccessor,
-  fullNameCell,
-  ownerEmailAccessor,
-  ownerNameAccessor,
   poolNameAccessor,
   viewCell,
   transformPoolInput,
@@ -107,12 +103,6 @@ const PoolTable_PoolFragment = graphql(/* GraphQL */ `
       id
       group
       level
-    }
-    owner {
-      id
-      firstName
-      lastName
-      email
     }
   }
 `);
@@ -345,45 +335,6 @@ const PoolTable = ({ title, initialFilterInput }: PoolTableProps) => {
       id: "processNumber",
       header: intl.formatMessage(processMessages.processNumber),
     }),
-    columnHelper.accessor((row) => ownerNameAccessor(row), {
-      id: "ownerName",
-      // Note: Being removed with communities
-      enableColumnFilter: false,
-      header: intl.formatMessage({
-        defaultMessage: "Owner Name",
-        id: "AWk4BX",
-        description: "Title displayed for the Pool table Owner Name column",
-      }),
-      cell: ({ row: { original: pool } }) =>
-        fullNameCell(
-          {
-            owner: {
-              firstName: pool.owner?.firstName,
-              lastName: pool.owner?.lastName,
-            },
-          },
-          intl,
-        ),
-    }),
-    columnHelper.accessor((row) => ownerEmailAccessor(row), {
-      id: "ownerEmail",
-      // Note: Being removed with communities
-      enableColumnFilter: false,
-      header: intl.formatMessage({
-        defaultMessage: "Owner Email",
-        id: "pe5WkF",
-        description: "Title displayed for the Pool table Owner Email column",
-      }),
-      cell: ({ row: { original: pool } }) =>
-        emailLinkAccessor(
-          {
-            owner: {
-              email: pool.owner?.email,
-            },
-          },
-          intl,
-        ),
-    }),
     columnHelper.accessor(({ publishedAt }) => accessors.date(publishedAt), {
       id: "publishedAt",
       enableColumnFilter: false,
@@ -423,13 +374,7 @@ const PoolTable = ({ title, initialFilterInput }: PoolTableProps) => {
       columns={columns}
       isLoading={fetching}
       filterParamKey={SEARCH_PARAM_KEY.POOL_FILTERS}
-      hiddenColumnIds={[
-        "id",
-        "publishedAt",
-        "createdDate",
-        "ownerEmail",
-        "ownerName",
-      ]}
+      hiddenColumnIds={["id", "publishedAt", "createdDate"]}
       search={{
         internal: false,
         label: intl.formatMessage({

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
@@ -18,13 +18,10 @@ import {
   PoolWorkStreamNameOrderByInput,
   QueryPoolsPaginatedOrderByClassificationColumn,
   QueryPoolsPaginatedOrderByRelationOrderByClause,
-  QueryPoolsPaginatedOrderByUserColumn,
   SortOrder,
-  User,
 } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 
-import { getFullNameHtml } from "~/utils/nameUtils";
 import { SearchState } from "~/components/Table/ResponsiveTable/types";
 import tableMessages from "~/components/PoolCandidatesTable/tableMessages";
 
@@ -51,17 +48,6 @@ export function viewCell(
   );
 }
 
-export function fullNameCell(
-  pool: { owner: Pick<User, "firstName" | "lastName"> },
-  intl: IntlShape,
-) {
-  return (
-    <span>
-      {getFullNameHtml(pool.owner?.firstName, pool.owner?.lastName, intl)}
-    </span>
-  );
-}
-
 export function classificationAccessor(
   classification: Maybe<Pick<Classification, "group" | "level">> | undefined,
 ) {
@@ -85,42 +71,6 @@ export function classificationCell(
       </>
     </Chip>
   );
-}
-
-export function emailLinkAccessor(
-  pool: { owner: Pick<User, "email"> },
-  intl: IntlShape,
-) {
-  if (pool.owner?.email) {
-    return (
-      <Link color="black" external href={`mailto:${pool.owner.email}`}>
-        {pool.owner.email}
-      </Link>
-    );
-  }
-  return (
-    <span className="italic">
-      {intl.formatMessage({
-        defaultMessage: "No email provided",
-        id: "1JCjTP",
-        description: "Fallback for email value",
-      })}
-    </span>
-  );
-}
-
-export function ownerNameAccessor(pool: Pick<Pool, "owner">) {
-  const firstName = pool.owner?.firstName
-    ? pool.owner.firstName.toLowerCase()
-    : "";
-  const lastName = pool.owner?.lastName
-    ? pool.owner.lastName.toLowerCase()
-    : "";
-  return `${firstName} ${lastName}`;
-}
-
-export function ownerEmailAccessor(pool: Pick<Pool, "owner">) {
-  return pool.owner?.email ? pool.owner.email.toLowerCase() : "";
 }
 
 interface TransformPoolInputArgs {
@@ -158,8 +108,6 @@ export function getOrderByClause(
     ["name", "name"],
     ["publishingGroup", "publishing_group"],
     ["processNumber", "process_number"],
-    ["ownerName", "FIRST_NAME"],
-    ["ownerEmail", "EMAIL"],
     // ["publishedAt", "published_at"], // moved to getOrderByColumnSort to handle nulls
     ["createdDate", "created_at"],
     ["updatedDate", "updated_at"],
@@ -195,20 +143,6 @@ export function getOrderByClause(
         classification: {
           aggregate: OrderByRelationWithColumnAggregateFunction.Max,
           column: "LEVEL" as QueryPoolsPaginatedOrderByClassificationColumn,
-        },
-      },
-    ];
-  }
-
-  if (sortingRule && ["ownerName", "ownerEmail"].includes(sortingRule.id)) {
-    const columnName = columnMap.get(sortingRule.id);
-    return [
-      {
-        column: undefined,
-        order: sortingRule.desc ? SortOrder.Desc : SortOrder.Asc,
-        user: {
-          aggregate: OrderByRelationWithColumnAggregateFunction.Max,
-          column: columnName as QueryPoolsPaginatedOrderByUserColumn,
         },
       },
     ];

--- a/packages/fake-data/src/fakePools.ts
+++ b/packages/fake-data/src/fakePools.ts
@@ -1,5 +1,4 @@
 import { faker } from "@faker-js/faker/locale/en";
-import pick from "lodash/pick";
 
 import {
   FAR_FUTURE_DATE,
@@ -11,8 +10,6 @@ import {
   Classification,
   Pool,
   PoolLanguage,
-  User,
-  UserPublicProfile,
   PublishingGroup,
   SecurityStatus,
   Skill,
@@ -32,7 +29,6 @@ import {
 import fakePaginatorInfo, { fakePaginateData } from "./fakePaginatorInfo";
 import fakeScreeningQuestions from "./fakeScreeningQuestions";
 import fakeGeneralQuestions from "./fakeGeneralQuestions";
-import fakeUsers from "./fakeUsers";
 import fakeClassifications from "./fakeClassifications";
 import fakeSkillFamilies from "./fakeSkillFamilies";
 import fakeSkills from "./fakeSkills";
@@ -43,7 +39,6 @@ import toLocalizedEnum from "./fakeLocalizedEnum";
 import fakeWorkStreams from "./fakeWorkStreams";
 
 const generatePool = (
-  users: User[],
   skills: Skill[],
   classifications: Classification[],
   departments: Department[],
@@ -55,7 +50,6 @@ const generatePool = (
 ): Pool => {
   faker.seed(index); // repeatable results
 
-  const ownerUser: User = faker.helpers.arrayElement<User>(users);
   const essentialSkills = faker.helpers.arrayElements(
     skills,
     essentialSkillCount > 0
@@ -97,12 +91,6 @@ const generatePool = (
   );
   return {
     id: faker.string.uuid(),
-    owner: pick(ownerUser, [
-      "id",
-      "email",
-      "firstName",
-      "lastName",
-    ]) as UserPublicProfile,
     name: {
       en: englishName || `${faker.company.catchPhrase()} EN`,
       fr: frenchName || `${faker.company.catchPhrase()} FR`,
@@ -179,13 +167,10 @@ export default (
   workStreams = fakeWorkStreams(),
   essentialSkillCount = -1,
 ): Pool[] => {
-  const users = fakeUsers();
-
   return Array.from({ length: numToGenerate }, (_, index) => {
     switch (index) {
       case 0:
         return generatePool(
-          users,
           skills,
           classifications,
           departments,
@@ -197,7 +182,6 @@ export default (
         );
       case 1:
         return generatePool(
-          users,
           skills,
           classifications,
           departments,
@@ -209,7 +193,6 @@ export default (
         );
       default:
         return generatePool(
-          users,
           skills,
           classifications,
           departments,


### PR DESCRIPTION
🤖 Resolves #16168.

## 👋 Introduction

This PR removes `pool.owner` from the frontend and from the GraphQL schema.

## 🧪 Testing

1. `make refresh-api; make seed-fresh; pnpm i; pnpm run build:fresh`
2. Verify no references to `pool.owner` or any of its nested fields in the codebase