### PR TITLE
[Debt] Removes `additionalContent` prop from `Hero` component

### DIFF
--- a/apps/web/src/components/Hero/Hero.tsx
+++ b/apps/web/src/components/Hero/Hero.tsx
@@ -69,7 +69,6 @@ interface HeroSharedProps {
   buttonLinks?: ButtonLinkType[];
   children?: ReactNode;
   status?: ReactNode;
-  additionalContent?: ReactNode;
 }
 
 interface HeroNavAndImgProps extends HeroSharedProps {
@@ -108,15 +107,7 @@ const Hero = (
     | HeroOverlapAndCenteredProps,
 ) => {
   // shared props
-  const {
-    title,
-    subtitle,
-    crumbs,
-    buttonLinks,
-    children,
-    status,
-    additionalContent,
-  } = props;
+  const { title, subtitle, crumbs, buttonLinks, children, status } = props;
   // conditional props
   const navTabs = "navTabs" in props ? props.navTabs : null;
   const overlap = "overlap" in props ? props.overlap : false;
@@ -234,13 +225,6 @@ const Hero = (
             {status}
           </div>
         )}
-        {additionalContent ? (
-          <>
-            <Container size="lg" className="relative z-3 pb-12">
-              {additionalContent}
-            </Container>
-          </>
-        ) : null}
       </div>
       {children ? (
         <Container size="lg" className="relative z-3 mx-auto -mt-30 mb-0">


### PR DESCRIPTION
🤖 Resolves #16234.

## 👋 Introduction

This PR removes `additionalContent` prop from `Hero` component.

## 🕵️ Details

Prop was no longer being used and was not even part of any of the `Hero` component storybook stories.

## 🧪 Testing

Verify no references to `additionalContent` in the codebase.