### PR TITLE
[Debt] Adds `TbsSecurityLoggingEventId` to programmatic-types file

### DIFF
--- a/api/programmatic-types.graphql
+++ b/api/programmatic-types.graphql
@@ -1705,6 +1705,10 @@ enum TargetRole {
   OTHER
 }
 
+enum TbsSecurityLoggingEventId {
+  EMAIL_SENT
+}
+
 enum TimeFrame {
   THIS_YEAR
   ONE_TO_TWO_YEARS


### PR DESCRIPTION
## 👋 Introduction

This PR adds `TbsSecurityLoggingEventId` to `api/programmatic-types.graphql` that was added in https://github.com/GCTC-NTGC/gc-digital-talent/issues/15940.

## ❓ Question

Why is `api/programmatic-types.graphql` not in the `.gitignore` file?

https://github.com/GCTC-NTGC/gc-digital-talent/blob/c744795eccaf1c4c23d59f233dec8c3499129941/api/programmatic-types.graphql#L3