### PR TITLE
[Fix] Revalidate profile data on update

### DIFF
--- a/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
+++ b/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
@@ -1,5 +1,6 @@
 import { defineMessage, useIntl } from "react-intl";
 import { useMutation } from "urql";
+import { useRevalidator } from "react-router";
 
 import { Link, Separator, TableOfContents } from "@gc-digital-talent/ui";
 import { navigationMessages } from "@gc-digital-talent/i18n";
@@ -72,6 +73,7 @@ export async function clientLoader({ context }: Route.ClientLoaderArgs) {
 const ProfilePage = ({ loaderData }: Route.ComponentProps) => {
   const intl = useIntl();
   const paths = useRoutes();
+  const revalidator = useRevalidator();
   const { user } = loaderData;
 
   const [{ fetching: isUpdating }, executeUpdateMutation] = useMutation(
@@ -82,7 +84,10 @@ const ProfilePage = ({ loaderData }: Route.ComponentProps) => {
     return executeUpdateMutation({
       id: userId,
       user: userData,
-    }).then((res) => res.data?.updateUserAsUser);
+    }).then(async (res) => {
+      await revalidator.revalidate();
+      return res.data?.updateUserAsUser;
+    });
   };
 
   const sectionProps = {


### PR DESCRIPTION
🤖 Resolves #16309 

## 👋 Introduction

Updates the `ProfilePage` to revalidate data on update.

## 🕵️ Details

We migrated this to loaders but, that makes it so the URQL cache is not affected on changes. This forces `react-router` to revalidate the loader on update causing it to get the fresh data.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as any user
3. Navigate to `/applicant/personal-information`
4. Edit the forms
5. Confirm the display version updates in place