### PR TITLE
[Fix] Not being referred scope

### DIFF
--- a/api/app/Builders/PoolCandidateBuilder.php
+++ b/api/app/Builders/PoolCandidateBuilder.php
@@ -359,9 +359,9 @@ class PoolCandidateBuilder extends Builder
                 ->where(function ($query) use ($now) {
                     $query->whereNull('resume_referrals_at')
                         ->orWhere('resume_referrals_at', '>', $now);
-                });
-        })
-            ->orWhere('application_status', '!=', ApplicationStatus::QUALIFIED->name);
+                })
+                ->orWhere('application_status', '!=', ApplicationStatus::QUALIFIED->name);
+        });
     }
 
     public function whereSuspendedStatus(?string $suspendedStatus): self


### PR DESCRIPTION
🤖 Resolves https://github.com/GCTC-NTGC/gc-digital-talent/issues/16388

## 👋 Introduction

Fixes an issue where the `whereNotBeingReferred` scope was expanding the spec to be too wide.

## 🕵️ Details

The `orWhere` clause for the status was misplaced outside of the parent `where` ecapsulation. This lead to a query like:

```sql
SELECT * FROM "pool_candidates" 
WHERE "pool_id" = 5 
  AND (
    "pause_referrals_at" <= '2026-04-08 12:00:00' 
    AND ("resume_referrals_at" IS NULL OR "resume_referrals_at" > '2026-04-08 12:00:00')
  )
  OR "application_status" != 'QUALIFIED'; 
```

As you can see, the `OR` was outside so it was asking for `pool_id = 5 OR application_status != QUALIFIED`.

now it should be:

```sql
SELECT * FROM "pool_candidates" 
WHERE "pool_id" = 5 
  AND (
    "pause_referrals_at" <= '2026-04-08 12:00:00' 
    AND ("resume_referrals_at" IS NULL OR "resume_referrals_at" > '2026-04-08 12:00:00')
    OR "application_status" != 'QUALIFIED'
  );
```


## 🧪 Testing

1. Go to a processs or search request candidates table
2. Filter by "Not referred"
3. Confirm candidates outside of the current scope to not appea