### PR TITLE
[Feature] Preset language options

### DIFF
--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -124,6 +124,7 @@ class AuthController extends Controller
         );
 
         // preferred language
+        $idTokenLocaleCode = null;
         if ($idToken->claims()->has('locale')) {
             $normalizedValue = strtolower(substr($idToken->claims()->get('locale'), 0, 2));
             if ($normalizedValue == 'en' || $normalizedValue == 'fr') {

--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -123,15 +123,33 @@ class AuthController extends Controller
             new InvalidArgumentException('Invalid session nonce')
         );
 
+        // preferred language
+        if ($idToken->claims()->has('locale')) {
+            $normalizedValue = strtolower(substr($idToken->claims()->get('locale'), 0, 2));
+            if ($normalizedValue == 'en' || $normalizedValue == 'fr') {
+                $idTokenLocaleCode = $normalizedValue;
+            }
+        }
+
         // track whether a new user was created
         $newUserCreated = false;
 
         // find the corresponding User
         $sub = $idToken->claims()->get('sub');
-        $userMatch = User::where('sub', $sub)->withTrashed()->firstOr(function () use ($sub, &$newUserCreated) {
+        $userMatch = User::where('sub', $sub)->withTrashed()->firstOr(function () use ($sub, &$newUserCreated, $idTokenLocaleCode) {
             // No user found for given subscriber - lets auto-register them
             $newUser = new User;
             $newUser->sub = $sub;
+            if ($idTokenLocaleCode == 'en') {
+                $newUser->looking_for_english = true;
+            }
+            if ($idTokenLocaleCode == 'fr') {
+                $newUser->looking_for_french = true;
+            }
+            if (! empty($idTokenLocaleCode)) {
+                $newUser->preferred_language_for_interview = $idTokenLocaleCode;
+                $newUser->preferred_language_for_exam = $idTokenLocaleCode;
+            }
             $newUser->save();
             $newUser->syncRoles([  // every new user is automatically an base_user and an applicant
                 Role::where('name', 'base_user')->sole(),
@@ -191,11 +209,8 @@ class AuthController extends Controller
         if ($idToken->claims()->has('phone_number')) {
             $userMatch->telephone = $idToken->claims()->get('phone_number');
         }
-        if ($idToken->claims()->has('locale')) {
-            $normalizedValue = strtolower(substr($idToken->claims()->get('locale'), 0, 2));
-            if ($normalizedValue == 'en' || $normalizedValue == 'fr') {
-                $userMatch->preferred_lang = $normalizedValue;
-            }
+        if (! empty($idTokenLocaleCode)) {
+            $userMatch->preferred_lang = $idTokenLocaleCode;
         }
         $userMatch->save();
 

--- a/apps/web/src/components/Profile/components/LanguageProfile/Display.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/Display.tsx
@@ -69,10 +69,11 @@ interface DisplayProps {
 
 const Display = ({ query, context }: DisplayProps) => {
   const intl = useIntl();
-  const showHelperMessage = getFromLocalStorage<boolean>(
+  const newUserFlagIsSet = getFromLocalStorage<boolean>(
     KEY_NEW_USER_LANGUAGE_PRESET,
     false,
   );
+  const showHelperMessage = newUserFlagIsSet && context == "applicant-view";
   const notProvided = intl.formatMessage(commonMessages.notProvided);
   const labels = getLabels(intl);
   const user = getFragment(LanguageProfileDisplay_Fragment, query);

--- a/apps/web/src/components/Profile/components/LanguageProfile/Display.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/Display.tsx
@@ -1,11 +1,12 @@
 import { useIntl } from "react-intl";
 
 import { commonMessages } from "@gc-digital-talent/i18n";
-import { CardSeparator, Separator, Ul } from "@gc-digital-talent/ui";
+import { CardSeparator, Notice, Separator, Ul } from "@gc-digital-talent/ui";
 import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
 
 import FieldDisplay from "~/components/FieldDisplay/FieldDisplay";
 import { getExamValidityOptions, getLabels } from "~/utils/languageUtils";
+import ToggleForm from "~/components/ToggleForm/ToggleForm";
 
 const LanguageProfileDisplay_Fragment = graphql(/** GraphQL */ `
   fragment LanguageProfileDisplay on User {
@@ -110,6 +111,33 @@ const Display = ({ query, context }: DisplayProps) => {
           description: "Introduction for the language profile form",
         })}
       </p>
+      <Notice.Root color="error">
+        <Notice.Content>
+          {intl.formatMessage(
+            {
+              defaultMessage: `The current information was inferred based on your choice of contact language during registration. Please use the "{buttonLabel}" button to review these settings.`,
+              id: "ADUuJh",
+              description:
+                "Helper message that the language settings were preset",
+            },
+            {
+              buttonLabel: (
+                <ToggleForm.Trigger
+                  aria-label={intl.formatMessage({
+                    defaultMessage: "Edit language profile",
+                    id: "fxPLAl",
+                    description:
+                      "Button text to start editing language profile",
+                  })}
+                  color="error"
+                >
+                  {intl.formatMessage(commonMessages.editThisSection)}
+                </ToggleForm.Trigger>
+              ),
+            },
+          )}
+        </Notice.Content>
+      </Notice.Root>
       <FieldDisplay
         hasError={
           !lookingForEnglish && !lookingForFrench && !lookingForBilingual

--- a/apps/web/src/components/Profile/components/LanguageProfile/Display.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/Display.tsx
@@ -3,10 +3,12 @@ import { useIntl } from "react-intl";
 import { commonMessages } from "@gc-digital-talent/i18n";
 import { CardSeparator, Notice, Separator, Ul } from "@gc-digital-talent/ui";
 import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
+import { getFromLocalStorage } from "@gc-digital-talent/storage";
 
 import FieldDisplay from "~/components/FieldDisplay/FieldDisplay";
 import { getExamValidityOptions, getLabels } from "~/utils/languageUtils";
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
+import { KEY_NEW_USER_LANGUAGE_PRESET } from "~/constants/storageKeys";
 
 const LanguageProfileDisplay_Fragment = graphql(/** GraphQL */ `
   fragment LanguageProfileDisplay on User {
@@ -67,6 +69,10 @@ interface DisplayProps {
 
 const Display = ({ query, context }: DisplayProps) => {
   const intl = useIntl();
+  const showHelperMessage = getFromLocalStorage<boolean>(
+    KEY_NEW_USER_LANGUAGE_PRESET,
+    false,
+  );
   const notProvided = intl.formatMessage(commonMessages.notProvided);
   const labels = getLabels(intl);
   const user = getFragment(LanguageProfileDisplay_Fragment, query);
@@ -111,33 +117,35 @@ const Display = ({ query, context }: DisplayProps) => {
           description: "Introduction for the language profile form",
         })}
       </p>
-      <Notice.Root color="error">
-        <Notice.Content>
-          {intl.formatMessage(
-            {
-              defaultMessage: `The current information was inferred based on your choice of contact language during registration. Please use the "{buttonLabel}" button to review these settings.`,
-              id: "ADUuJh",
-              description:
-                "Helper message that the language settings were preset",
-            },
-            {
-              buttonLabel: (
-                <ToggleForm.Trigger
-                  aria-label={intl.formatMessage({
-                    defaultMessage: "Edit language profile",
-                    id: "fxPLAl",
-                    description:
-                      "Button text to start editing language profile",
-                  })}
-                  color="error"
-                >
-                  {intl.formatMessage(commonMessages.editThisSection)}
-                </ToggleForm.Trigger>
-              ),
-            },
-          )}
-        </Notice.Content>
-      </Notice.Root>
+      {showHelperMessage ? (
+        <Notice.Root color="error">
+          <Notice.Content>
+            {intl.formatMessage(
+              {
+                defaultMessage: `The current information was inferred based on your choice of contact language during registration. Please use the "{buttonLabel}" button to review these settings.`,
+                id: "ADUuJh",
+                description:
+                  "Helper message that the language settings were preset",
+              },
+              {
+                buttonLabel: (
+                  <ToggleForm.Trigger
+                    aria-label={intl.formatMessage({
+                      defaultMessage: "Edit language profile",
+                      id: "fxPLAl",
+                      description:
+                        "Button text to start editing language profile",
+                    })}
+                    color="error"
+                  >
+                    {intl.formatMessage(commonMessages.editThisSection)}
+                  </ToggleForm.Trigger>
+                ),
+              },
+            )}
+          </Notice.Content>
+        </Notice.Root>
+      ) : null}
       <FieldDisplay
         hasError={
           !lookingForEnglish && !lookingForFrench && !lookingForBilingual

--- a/apps/web/src/components/Profile/components/LanguageProfile/Display.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/Display.tsx
@@ -138,6 +138,7 @@ const Display = ({ query, context }: DisplayProps) => {
                         "Button text to start editing language profile",
                     })}
                     color="error"
+                    className="font-normal"
                   >
                     {intl.formatMessage(commonMessages.editThisSection)}
                   </ToggleForm.Trigger>

--- a/apps/web/src/components/Profile/components/LanguageProfile/FormFields.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/FormFields.tsx
@@ -9,8 +9,10 @@ import {
 import { errorMessages } from "@gc-digital-talent/i18n";
 import { FragmentType, getFragment } from "@gc-digital-talent/graphql";
 import { CardSeparator } from "@gc-digital-talent/ui";
+import { removeFromLocalStorage } from "@gc-digital-talent/storage";
 
 import { getConsideredLangItems } from "~/utils/languageUtils";
+import { KEY_NEW_USER_LANGUAGE_PRESET } from "~/constants/storageKeys";
 
 import useDirtyFields from "../../hooks/useDirtyFields";
 import ConsideredLanguages, {
@@ -30,6 +32,9 @@ const FormFields = ({ labels, optionsQuery }: FormFieldProps) => {
   const options = getFragment(LanguageProfileOptions_Fragment, optionsQuery);
 
   const languageOptions = localizedEnumToOptions(options?.languages, intl);
+
+  // once they open the form we can remove the helper message
+  removeFromLocalStorage(KEY_NEW_USER_LANGUAGE_PRESET);
 
   return (
     <div className="flex flex-col gap-6">

--- a/apps/web/src/components/Profile/components/LanguageProfile/FormFields.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/FormFields.tsx
@@ -9,10 +9,8 @@ import {
 import { errorMessages } from "@gc-digital-talent/i18n";
 import { FragmentType, getFragment } from "@gc-digital-talent/graphql";
 import { CardSeparator } from "@gc-digital-talent/ui";
-import { removeFromLocalStorage } from "@gc-digital-talent/storage";
 
 import { getConsideredLangItems } from "~/utils/languageUtils";
-import { KEY_NEW_USER_LANGUAGE_PRESET } from "~/constants/storageKeys";
 
 import useDirtyFields from "../../hooks/useDirtyFields";
 import ConsideredLanguages, {
@@ -22,9 +20,14 @@ import ConsideredLanguages, {
 interface FormFieldProps {
   labels: FieldLabels;
   optionsQuery?: FragmentType<typeof LanguageProfileOptions_Fragment>;
+  setLanguagePresetNoticeIsVisible: (isVisible: boolean) => void;
 }
 
-const FormFields = ({ labels, optionsQuery }: FormFieldProps) => {
+const FormFields = ({
+  labels,
+  optionsQuery,
+  setLanguagePresetNoticeIsVisible,
+}: FormFieldProps) => {
   const intl = useIntl();
   const consideredLangOptions = getConsideredLangItems(intl);
   useDirtyFields("language");
@@ -34,7 +37,7 @@ const FormFields = ({ labels, optionsQuery }: FormFieldProps) => {
   const languageOptions = localizedEnumToOptions(options?.languages, intl);
 
   // once they open the form we can remove the helper message
-  removeFromLocalStorage(KEY_NEW_USER_LANGUAGE_PRESET);
+  setLanguagePresetNoticeIsVisible(false);
 
   return (
     <div className="flex flex-col gap-6">

--- a/apps/web/src/components/Profile/components/LanguageProfile/LanguageProfile.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/LanguageProfile.tsx
@@ -13,6 +13,7 @@ import {
   graphql,
   Pool,
 } from "@gc-digital-talent/graphql";
+import { getFromLocalStorage } from "@gc-digital-talent/storage";
 
 import MissingLanguageRequirements from "~/components/MissingLanguageRequirements";
 import profileMessages from "~/messages/profileMessages";
@@ -22,6 +23,7 @@ import {
 } from "~/validators/profile/languageInformation";
 import { getMissingLanguageRequirements } from "~/utils/languageUtils";
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
+import { KEY_NEW_USER_LANGUAGE_PRESET } from "~/constants/storageKeys";
 
 import { SectionProps } from "../../types";
 import FormActions from "../FormActions";
@@ -91,7 +93,12 @@ const LanguageProfile = ({
   const intl = useIntl();
   const user = getFragment(ProfileLanguageProfile_Fragment, query);
   const isNull = hasAllEmptyFields(user);
-  const emptyRequired = hasEmptyRequiredFields(user);
+  const hasUnacknowledgedNotices = getFromLocalStorage<boolean>(
+    KEY_NEW_USER_LANGUAGE_PRESET,
+    false,
+  );
+  const emptyRequired =
+    hasEmptyRequiredFields(user) || hasUnacknowledgedNotices;
   const { labels, isEditing, setIsEditing, icon, title } = useSectionInfo({
     section: "language",
     isNull,

--- a/apps/web/src/components/Profile/components/LanguageProfile/LanguageProfile.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/LanguageProfile.tsx
@@ -13,7 +13,6 @@ import {
   graphql,
   Pool,
 } from "@gc-digital-talent/graphql";
-import { getFromLocalStorage } from "@gc-digital-talent/storage";
 
 import MissingLanguageRequirements from "~/components/MissingLanguageRequirements";
 import profileMessages from "~/messages/profileMessages";
@@ -23,7 +22,6 @@ import {
 } from "~/validators/profile/languageInformation";
 import { getMissingLanguageRequirements } from "~/utils/languageUtils";
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
-import { KEY_NEW_USER_LANGUAGE_PRESET } from "~/constants/storageKeys";
 
 import { SectionProps } from "../../types";
 import FormActions from "../FormActions";
@@ -81,6 +79,8 @@ const ProfileLanguageProfile_Fragment = graphql(/** GraphQL */ `
 
 interface LanguageProfileProps extends SectionProps<Pick<Pool, "id">> {
   query: FragmentType<typeof ProfileLanguageProfile_Fragment>;
+  languagePresetNoticeIsVisible: boolean;
+  setLanguagePresetNoticeIsVisible: (isVisible: boolean) => void;
 }
 
 const LanguageProfile = ({
@@ -89,14 +89,13 @@ const LanguageProfile = ({
   onUpdate,
   isUpdating,
   pool,
+  languagePresetNoticeIsVisible,
+  setLanguagePresetNoticeIsVisible,
 }: LanguageProfileProps) => {
   const intl = useIntl();
   const user = getFragment(ProfileLanguageProfile_Fragment, query);
   const isNull = hasAllEmptyFields(user);
-  const hasUnacknowledgedNotices = getFromLocalStorage<boolean>(
-    KEY_NEW_USER_LANGUAGE_PRESET,
-    false,
-  );
+  const hasUnacknowledgedNotices = languagePresetNoticeIsVisible;
   const emptyRequired =
     hasEmptyRequiredFields(user) || hasUnacknowledgedNotices;
   const { labels, isEditing, setIsEditing, icon, title } = useSectionInfo({
@@ -199,7 +198,13 @@ const LanguageProfile = ({
                 defaultValues: dataToFormValues(user),
               }}
             >
-              <FormFields labels={labels} optionsQuery={data} />
+              <FormFields
+                labels={labels}
+                optionsQuery={data}
+                setLanguagePresetNoticeIsVisible={
+                  setLanguagePresetNoticeIsVisible
+                }
+              />
               <FormActions isUpdating={isUpdating} />
             </BasicForm>
           )}

--- a/apps/web/src/components/ToggleForm/LabelledTrigger.tsx
+++ b/apps/web/src/components/ToggleForm/LabelledTrigger.tsx
@@ -1,5 +1,4 @@
 import { useIntl } from "react-intl";
-import { ReactNode } from "react";
 
 import { commonMessages } from "@gc-digital-talent/i18n";
 
@@ -7,7 +6,7 @@ import SectionTrigger from "./Trigger";
 
 interface LabelledTriggerProps {
   disabled?: boolean;
-  sectionTitle: ReactNode;
+  sectionTitle: string;
 }
 
 const LabelledTrigger = ({ disabled, sectionTitle }: LabelledTriggerProps) => {

--- a/apps/web/src/components/ToggleForm/Trigger.tsx
+++ b/apps/web/src/components/ToggleForm/Trigger.tsx
@@ -1,11 +1,11 @@
 import { useIntl } from "react-intl";
 import { ReactNode } from "react";
 
-import { Button, ToggleSection } from "@gc-digital-talent/ui";
+import { Button, ButtonProps, ToggleSection } from "@gc-digital-talent/ui";
 
 const { useContext } = ToggleSection;
 
-interface TriggerProps {
+interface TriggerProps extends ButtonProps {
   children: ReactNode;
   className?: string;
 }

--- a/apps/web/src/constants/storageKeys.ts
+++ b/apps/web/src/constants/storageKeys.ts
@@ -1,0 +1,2 @@
+// new user help messages
+export const KEY_NEW_USER_LANGUAGE_PRESET = "new_user_language_preset";

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2979,6 +2979,10 @@
     "defaultMessage": "Confirmer maintenant",
     "description": "Button to start the email address verification process"
   },
+  "ADUuJh": {
+    "defaultMessage": "Les renseignements actuels ont été établis en fonction de la langue de communication choisie lors de votre inscription. Utilisez le bouton \"{buttonLabel}\" pour revoir ces paramètres.",
+    "description": "Helper message that the language settings were preset"
+  },
   "ADk6dX": {
     "defaultMessage": "Filtrer les demandes et consigner les résultats de l’évaluation",
     "description": "Permissions related to assessing candidates"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2980,7 +2980,7 @@
     "description": "Button to start the email address verification process"
   },
   "ADUuJh": {
-    "defaultMessage": "Les renseignements actuels ont été établis en fonction de la langue de communication choisie lors de votre inscription. Utilisez le bouton \"{buttonLabel}\" pour revoir ces paramètres.",
+    "defaultMessage": "Les renseignements actuels ont été établis en fonction de la langue de communication choisie lors de votre inscription. Utilisez le bouton « {buttonLabel} » pour revoir ces paramètres.",
     "description": "Helper message that the language settings were preset"
   },
   "ADk6dX": {

--- a/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.tsx
+++ b/apps/web/src/pages/ApplicantDashboardPage/ApplicantDashboardPage.tsx
@@ -17,6 +17,7 @@ import {
 } from "@gc-digital-talent/graphql";
 import { commonMessages, navigationMessages } from "@gc-digital-talent/i18n";
 import { NotFoundError } from "@gc-digital-talent/helpers";
+import { getFromLocalStorage } from "@gc-digital-talent/storage";
 
 import useRoutes from "~/hooks/useRoutes";
 import SEO from "~/components/SEO/SEO";
@@ -33,6 +34,7 @@ import { hasEmptyRequiredFields as careerDevelopmentHasEmptyRequiredFields } fro
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import UnlockEmployeeToolsDialog from "~/components/UnlockEmployeeToolsDialog/UnlockEmployeeToolsDialog";
 import StatusItem from "~/components/StatusItem/StatusItem";
+import { KEY_NEW_USER_LANGUAGE_PRESET } from "~/constants/storageKeys";
 
 import CareerDevelopmentTaskCard from "./components/CareerDevelopmentTaskCard";
 import ApplicationsProcessesTaskCard from "./components/ApplicationsProcessesTaskCard";
@@ -209,6 +211,11 @@ export const DashboardPage = ({
     ],
   });
 
+  const newUserLanguagePresetFlagIsSet = getFromLocalStorage<boolean>(
+    KEY_NEW_USER_LANGUAGE_PRESET,
+    false,
+  );
+
   const currentUser = getFragment(
     ApplicantDashboardPage_Fragment,
     applicantDashboardQuery.me,
@@ -225,6 +232,7 @@ export const DashboardPage = ({
   const personalInformationState =
     workPreferencesSectionHasEmptyRequiredFields(currentUser) ||
     languageInformationSectionHasEmptyRequiredFields(currentUser) ||
+    newUserLanguagePresetFlagIsSet ||
     priorityEntitlementsHasEmptyRequiredFields(currentUser)
       ? "error"
       : "success";

--- a/apps/web/src/pages/Applications/ApplicationLayout.tsx
+++ b/apps/web/src/pages/Applications/ApplicationLayout.tsx
@@ -63,7 +63,7 @@ const ApplicationPageWrapper = ({ query }: ApplicationPageWrapperProps) => {
     experienceId,
   });
   const browserState = {
-    newUserLanguagePresetFlagIsSet: getFromLocalStorage<boolean>(
+    languagePresetNoticeIsVisible: getFromLocalStorage<boolean>(
       KEY_NEW_USER_LANGUAGE_PRESET,
       false,
     ),

--- a/apps/web/src/pages/Applications/ApplicationLayout.tsx
+++ b/apps/web/src/pages/Applications/ApplicationLayout.tsx
@@ -18,6 +18,7 @@ import {
 import { navigationMessages } from "@gc-digital-talent/i18n";
 import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
 import { ROLE_NAME } from "@gc-digital-talent/auth";
+import { getFromLocalStorage } from "@gc-digital-talent/storage";
 
 import SEO from "~/components/SEO/SEO";
 import Hero from "~/components/Hero";
@@ -32,6 +33,7 @@ import {
   isOnDisabledPage,
 } from "~/utils/applicationUtils";
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
+import { KEY_NEW_USER_LANGUAGE_PRESET } from "~/constants/storageKeys";
 
 import StepDisabledPage from "./StepDisabledPage/StepDisabledPage";
 import ApplicationContextProvider from "./ApplicationContext";
@@ -60,6 +62,12 @@ const ApplicationPageWrapper = ({ query }: ApplicationPageWrapperProps) => {
     application,
     experienceId,
   });
+  const browserState = {
+    newUserLanguagePresetFlagIsSet: getFromLocalStorage<boolean>(
+      KEY_NEW_USER_LANGUAGE_PRESET,
+      false,
+    ),
+  };
   const title = poolTitle(intl, application.pool);
   const isIAP = isIAPPool(application.pool.publishingGroup?.value);
 
@@ -153,7 +161,11 @@ const ApplicationPageWrapper = ({ query }: ApplicationPageWrapperProps) => {
                 description: "Label for the application stepper navigation",
               })}
               currentIndex={currentStepIndex}
-              steps={applicationStepsToStepperArgs(steps, application)}
+              steps={applicationStepsToStepperArgs(
+                steps,
+                application,
+                browserState,
+              )}
             />
             {isIAP && (
               <div className="my-6">

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
@@ -8,7 +8,7 @@ import {
   ThrowNotFound,
 } from "@gc-digital-talent/ui";
 import { graphql, PoolAreaOfSelection } from "@gc-digital-talent/graphql";
-import { getFromLocalStorage } from "@gc-digital-talent/storage";
+import { useLocalStorage } from "@gc-digital-talent/storage";
 
 import useRoutes from "~/hooks/useRoutes";
 import { GetPageNavInfo } from "~/types/applicationStep";
@@ -82,12 +82,9 @@ export const ApplicationProfile = ({ application }: ApplicationPageProps) => {
     application,
     stepOrdinal: currentStepOrdinal,
   });
-  const browserState = {
-    newUserLanguagePresetFlagIsSet: getFromLocalStorage<boolean>(
-      KEY_NEW_USER_LANGUAGE_PRESET,
-      false,
-    ),
-  };
+
+  const [languagePresetNoticeIsVisible, setLanguagePresetNoticeIsVisible] =
+    useLocalStorage<boolean>(KEY_NEW_USER_LANGUAGE_PRESET, false);
 
   const [{ fetching: isUpdating }, executeUpdateMutation] = useMutation(
     Application_UpdateProfileMutation,
@@ -178,6 +175,8 @@ export const ApplicationProfile = ({ application }: ApplicationPageProps) => {
             pool: application.pool,
             user: application.user,
           }}
+          languagePresetNoticeIsVisible={languagePresetNoticeIsVisible}
+          setLanguagePresetNoticeIsVisible={setLanguagePresetNoticeIsVisible}
         />
       </div>
       <Separator />
@@ -185,7 +184,9 @@ export const ApplicationProfile = ({ application }: ApplicationPageProps) => {
         application={application}
         user={application.user}
         isValid={
-          !stepHasError(application.user, application.pool, null, browserState)
+          !stepHasError(application.user, application.pool, null, {
+            newUserLanguagePresetFlagIsSet: languagePresetNoticeIsVisible,
+          })
         }
       />
     </ProfileFormProvider>

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
@@ -8,6 +8,7 @@ import {
   ThrowNotFound,
 } from "@gc-digital-talent/ui";
 import { graphql, PoolAreaOfSelection } from "@gc-digital-talent/graphql";
+import { getFromLocalStorage } from "@gc-digital-talent/storage";
 
 import useRoutes from "~/hooks/useRoutes";
 import { GetPageNavInfo } from "~/types/applicationStep";
@@ -22,6 +23,7 @@ import poolCandidateMessages from "~/messages/poolCandidateMessages";
 import ContactEmailCard from "~/components/ContactEmailCard/ContactEmailCard";
 import WorkEmailCard from "~/components/WorkEmailCard.tsx/WorkEmailCard";
 import CitizenVeteranPriority from "~/components/Profile/components/CitizenVeteranPriority/CitizenVeteranPriority";
+import { KEY_NEW_USER_LANGUAGE_PRESET } from "~/constants/storageKeys";
 
 import StepNavigation from "./components/StepNavigation";
 import { ApplicationPageProps } from "../ApplicationApi";
@@ -80,6 +82,12 @@ export const ApplicationProfile = ({ application }: ApplicationPageProps) => {
     application,
     stepOrdinal: currentStepOrdinal,
   });
+  const browserState = {
+    newUserLanguagePresetFlagIsSet: getFromLocalStorage<boolean>(
+      KEY_NEW_USER_LANGUAGE_PRESET,
+      false,
+    ),
+  };
 
   const [{ fetching: isUpdating }, executeUpdateMutation] = useMutation(
     Application_UpdateProfileMutation,
@@ -176,7 +184,9 @@ export const ApplicationProfile = ({ application }: ApplicationPageProps) => {
       <StepNavigation
         application={application}
         user={application.user}
-        isValid={!stepHasError(application.user, application.pool)}
+        isValid={
+          !stepHasError(application.user, application.pool, null, browserState)
+        }
       />
     </ProfileFormProvider>
   );

--- a/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationProfilePage/ApplicationProfilePage.tsx
@@ -185,7 +185,7 @@ export const ApplicationProfile = ({ application }: ApplicationPageProps) => {
         user={application.user}
         isValid={
           !stepHasError(application.user, application.pool, null, {
-            newUserLanguagePresetFlagIsSet: languagePresetNoticeIsVisible,
+            languagePresetNoticeIsVisible,
           })
         }
       />

--- a/apps/web/src/pages/Applications/profileStep/profileStepValidation.tsx
+++ b/apps/web/src/pages/Applications/profileStep/profileStepValidation.tsx
@@ -1,5 +1,9 @@
-import { Pool } from "@gc-digital-talent/graphql";
+import {
+  Application_PoolCandidateFragment,
+  Pool,
+} from "@gc-digital-talent/graphql";
 
+import { ApplicationBrowserState } from "~/types/applicationStep";
 import {
   aboutSectionHasEmptyRequiredFields,
   diversityEquityInclusionSectionHasEmptyRequiredFields,
@@ -25,6 +29,8 @@ interface PartialUser
 const stepHasError = (
   user: PartialUser,
   pool: Omit<Pool, "activities" | "teamId">,
+  _application: Application_PoolCandidateFragment | null | undefined,
+  browserState: ApplicationBrowserState | null | undefined,
 ) => {
   const hasEmptyRequiredFields =
     aboutSectionHasEmptyRequiredFields(user, pool) ||
@@ -33,7 +39,9 @@ const stepHasError = (
     languageInformationSectionHasEmptyRequiredFields(user) ||
     workPreferencesSectionHasEmptyRequiredFields(user) ||
     languageInformationSectionHasUnsatisfiedRequirements(user, pool);
-  return hasEmptyRequiredFields;
+  const hasUnacknowledgedNotices =
+    !!browserState?.newUserLanguagePresetFlagIsSet;
+  return hasEmptyRequiredFields || hasUnacknowledgedNotices;
 };
 
 export default stepHasError;

--- a/apps/web/src/pages/Applications/profileStep/profileStepValidation.tsx
+++ b/apps/web/src/pages/Applications/profileStep/profileStepValidation.tsx
@@ -40,7 +40,7 @@ const stepHasError = (
     workPreferencesSectionHasEmptyRequiredFields(user) ||
     languageInformationSectionHasUnsatisfiedRequirements(user, pool);
   const hasUnacknowledgedNotices =
-    !!browserState?.newUserLanguagePresetFlagIsSet;
+    !!browserState?.languagePresetNoticeIsVisible;
   return hasEmptyRequiredFields || hasUnacknowledgedNotices;
 };
 

--- a/apps/web/src/pages/Auth/RegistrationPages/GettingStartedPage/GettingStartedPage.tsx
+++ b/apps/web/src/pages/Auth/RegistrationPages/GettingStartedPage/GettingStartedPage.tsx
@@ -3,12 +3,14 @@ import { useQuery } from "urql";
 
 import { Card, Pending, ThrowNotFound } from "@gc-digital-talent/ui";
 import { graphql } from "@gc-digital-talent/graphql";
+import { setInLocalStorage } from "@gc-digital-talent/storage";
 
 import Hero from "~/components/Hero";
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import profileMessages from "~/messages/profileMessages";
+import { KEY_NEW_USER_LANGUAGE_PRESET } from "~/constants/storageKeys";
 
 import messages from "../messages";
 import GettingStartedForm, {
@@ -30,6 +32,9 @@ export const GettingStartedPage = () => {
   const [{ data, fetching, error }] = useQuery({
     query: GettingStarted_Query,
   });
+
+  // someone on this page is probably a new user so enable the new user flags
+  setInLocalStorage<boolean>(KEY_NEW_USER_LANGUAGE_PRESET, true);
 
   const crumbs = useBreadcrumbs({
     crumbs: [

--- a/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
+++ b/apps/web/src/pages/Profile/ProfilePage/ProfilePage.tsx
@@ -7,6 +7,7 @@ import { navigationMessages } from "@gc-digital-talent/i18n";
 import { graphql } from "@gc-digital-talent/graphql";
 import { ROLE_NAME } from "@gc-digital-talent/auth";
 import { NotFoundError } from "@gc-digital-talent/helpers";
+import { useLocalStorage } from "@gc-digital-talent/storage";
 
 import profileMessages from "~/messages/profileMessages";
 import { SectionProps } from "~/components/Profile/types";
@@ -20,6 +21,7 @@ import CitizenVeteranPriority from "~/components/Profile/components/CitizenVeter
 import { requireUser } from "~/routing/auth";
 import { graphqlClientContext, intlContext } from "~/routing/context";
 import useRoutes from "~/hooks/useRoutes";
+import { KEY_NEW_USER_LANGUAGE_PRESET } from "~/constants/storageKeys";
 
 import type { Route } from "./+types/ProfilePage";
 
@@ -75,6 +77,9 @@ const ProfilePage = ({ loaderData }: Route.ComponentProps) => {
   const paths = useRoutes();
   const revalidator = useRevalidator();
   const { user } = loaderData;
+
+  const [languagePresetNoticeIsVisible, setLanguagePresetNoticeIsVisible] =
+    useLocalStorage<boolean>(KEY_NEW_USER_LANGUAGE_PRESET, false);
 
   const [{ fetching: isUpdating }, executeUpdateMutation] = useMutation(
     ProfileUpdateUser_Mutation,
@@ -158,7 +163,13 @@ const ProfilePage = ({ loaderData }: Route.ComponentProps) => {
             <GovernmentInformation query={user} />
           </TableOfContents.Section>
           <TableOfContents.Section id={PAGE_SECTION_ID.LANGUAGE}>
-            <LanguageProfile {...sectionProps} />
+            <LanguageProfile
+              languagePresetNoticeIsVisible={languagePresetNoticeIsVisible}
+              setLanguagePresetNoticeIsVisible={
+                setLanguagePresetNoticeIsVisible
+              }
+              {...sectionProps}
+            />
           </TableOfContents.Section>
         </div>
       </TableOfContents.Content>

--- a/apps/web/src/types/applicationStep.ts
+++ b/apps/web/src/types/applicationStep.ts
@@ -19,6 +19,10 @@ interface GetApplicationStepInfoArgs {
   stepOrdinal?: number;
 }
 
+export interface ApplicationBrowserState {
+  newUserLanguagePresetFlagIsSet: boolean;
+}
+
 export interface ApplicationStepInfo {
   // the enum in the API that represents this step
   applicationStep?: ApplicationStep;
@@ -37,6 +41,11 @@ export interface ApplicationStepInfo {
     user: ApplicationPoolCandidateFragmentType["user"],
     pool: Omit<Pool, "activities" | "teamId">,
     application: ApplicationPoolCandidateFragmentType,
+    browserState:
+      | {
+          newUserLanguagePresetFlagIsSet: boolean;
+        }
+      | undefined,
   ) => boolean;
 }
 

--- a/apps/web/src/types/applicationStep.ts
+++ b/apps/web/src/types/applicationStep.ts
@@ -20,7 +20,7 @@ interface GetApplicationStepInfoArgs {
 }
 
 export interface ApplicationBrowserState {
-  newUserLanguagePresetFlagIsSet: boolean;
+  languagePresetNoticeIsVisible: boolean;
 }
 
 export interface ApplicationStepInfo {
@@ -41,11 +41,7 @@ export interface ApplicationStepInfo {
     user: ApplicationPoolCandidateFragmentType["user"],
     pool: Omit<Pool, "activities" | "teamId">,
     application: ApplicationPoolCandidateFragmentType,
-    browserState:
-      | {
-          newUserLanguagePresetFlagIsSet: boolean;
-        }
-      | undefined,
+    browserState: ApplicationBrowserState | undefined,
   ) => boolean;
 }
 

--- a/apps/web/src/utils/applicationUtils.ts
+++ b/apps/web/src/utils/applicationUtils.ts
@@ -13,7 +13,10 @@ import {
   Application_PoolCandidateFragment,
 } from "@gc-digital-talent/graphql";
 
-import { ApplicationStepInfo } from "~/types/applicationStep";
+import {
+  ApplicationBrowserState,
+  ApplicationStepInfo,
+} from "~/types/applicationStep";
 
 // Filter the prerequisite list by steps present in this application and then figure out if any are missing from the submitted steps
 const missingPrerequisitesFromThisApplication = (
@@ -89,6 +92,7 @@ export function isOnDisabledPage(
 export function applicationStepsToStepperArgs(
   applicationSteps: ApplicationStepInfo[],
   application: Application_PoolCandidateFragment,
+  browserState: ApplicationBrowserState,
 ): StepType[] {
   return applicationSteps
     .filter((step) => step.showInStepper)
@@ -104,7 +108,12 @@ export function applicationStepsToStepperArgs(
           step.prerequisites,
           application.submittedSteps,
         )?.length,
-        error: step.hasError?.(application.user, application.pool, application),
+        error: step.hasError?.(
+          application.user,
+          application.pool,
+          application,
+          browserState,
+        ),
       };
     });
 }


### PR DESCRIPTION
🤖 Resolves #16333 

## 👋 Introduction

Presets extra language options for new users and a new notice to highlight it.

## 🕵️ Details

The notice gets enabled when visiting the "getting started" page and is cleared when opening the language form.

## 🧪 Testing

1. Ensure the CanadaLogin env variables and feature flag are set and rebuild
2. Log in as a new user

> [!TIP]
> Once the language options have been preset you can easily reset the notice by manually visiting /en/registration/account .

- [ ] The position language, preferred interview language, and preferred written language are automatically set
- [ ] A notice is showing that says they're preset
- [ ] Opening the form once clears the notice
- [ ] Changing the preset values and logging in again does not change them
- [ ] The notice is not shown in the admin view
- [ ] Notice causes validation to be in error state 
    - [ ] on dashboard
    - [ ] in personal information page
    - [ ] in application process


## 📸 Screenshot

<img width="837" height="649" alt="image" src="https://github.com/user-attachments/assets/84f47b05-5dcb-4248-83f1-e7b2fd2240f1" />


