### PR TITLE
[Fix] Update screening dialog to use headings

### DIFF
--- a/apps/web/src/components/ScreeningDecisions/AssessmentType.tsx
+++ b/apps/web/src/components/ScreeningDecisions/AssessmentType.tsx
@@ -1,7 +1,7 @@
 import { useIntl } from "react-intl";
 
 import { FragmentType, getFragment, graphql } from "@gc-digital-talent/graphql";
-import { Accordion, Notice } from "@gc-digital-talent/ui";
+import { Accordion, Heading, Notice } from "@gc-digital-talent/ui";
 import {
   commonMessages,
   getSkillLevelDefinition,
@@ -78,14 +78,14 @@ const AssessmentType = ({
   if (dialogType === DIALOG_TYPE.Education) {
     return (
       <>
-        <p className="mb-3">
+        <Heading level="h3" size="h6" className="mt-0 mb-3">
           {intl.formatMessage({
             defaultMessage: "Selected requirement option:",
             id: "FS4Dg5",
             description:
               "Header for selected requirement option in education requirement screening decision dialog.",
           })}
-        </p>
+        </Heading>
         {educationRequirementOption ? (
           <Notice.Root className="mb-6 text-left">
             <Notice.Content>{educationRequirementOption}</Notice.Content>

--- a/apps/web/src/components/ScreeningDecisions/SupportingEvidence.tsx
+++ b/apps/web/src/components/ScreeningDecisions/SupportingEvidence.tsx
@@ -10,6 +10,7 @@ import {
 } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 import { commonMessages } from "@gc-digital-talent/i18n";
+import { Heading } from "@gc-digital-talent/ui";
 
 import ExperienceCard, {
   ExperienceCard_Fragment,
@@ -54,14 +55,14 @@ const SupportingEvidence = ({
 
   return (
     <>
-      <p className="mb-3">
+      <Heading level="h3" size="h6" className="mb-3">
         {intl.formatMessage({
           defaultMessage: "Supporting evidence:",
           id: "w59dPh",
           description:
             "Header for supporting evidence section in screening decision dialog.",
         })}
-      </p>
+      </Heading>
       {experiencesFiltered.length > 0 ? (
         experiencesFiltered.map((experience) => (
           <div className="mb-3" key={experience.id}>


### PR DESCRIPTION
🤖 Resolves #14510 

## 👋 Introduction

Updates the existing `<p>` tags in the screening dialog to us the appropriate heading elements.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to an application in the admin view
4. Open both an education, screening question and skill asessment in the table
5. Confirm the dialog contains headings where appropriate and they have the correct level

## 📸 Screenshot

<img width="887" height="1090" alt="swappy-20260409_115930" src="https://github.com/user-attachments/assets/68656ba0-9538-44f7-99e2-f901204696b0" />
