### PR TITLE
[Fix] Add placed term to search request candidates table

### DIFF
--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.test.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.test.tsx
@@ -99,6 +99,11 @@ const mockClient = {
           },
           {
             __typename: "LocalizedPlacementType",
+            value: PlacementType.PlacedTerm,
+            label: { localized: "Placed term" },
+          },
+          {
+            __typename: "LocalizedPlacementType",
             value: PlacementType.PlacedActing,
             label: { localized: "Placed acting" },
           },
@@ -136,6 +141,7 @@ describe("Search Request Candidates Table", () => {
     expect(await within(filters).findAllByText(/placed acting/i)).toHaveLength(
       2,
     );
+    expect(await within(filters).findAllByText(/placed term/i)).toHaveLength(2);
     expect(await within(filters).findAllByText(/qualified/i)).toHaveLength(2);
     expect(
       await within(filters).findAllByText(/available for referral/i),

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
@@ -68,6 +68,7 @@ const transformApplicantFilterToPoolCandidateSearchInput = (
     placementTypes: [
       PlacementType.NotPlaced,
       PlacementType.PlacedTentative,
+      PlacementType.PlacedTerm,
       PlacementType.PlacedCasual,
       PlacementType.PlacedActing,
     ],


### PR DESCRIPTION
🤖 Resolves #16369 

## 👋 Introduction

Updates the default filters for the search request candidates table to include "Placed term".

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Submit a search request with some candidates
4. Go to the search request in the admin view
5. Edit one of the candidates to be placed term
6. Navigate back to the search request from step 4
7. Confirm placed term is part of the default filters
8. Confirm the placed term candidate appears in the table