### PR TITLE
[Fix] Adjust concurrency group

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,17 +15,9 @@ on:
       - api/**
   merge_group:
     branches: [main]
-# Concurrency is used to cancel other currently-running jobs, to preserve
-# compute resources and cumulative build hours. (ie. If you push twice in a
-# row, this will cancel the previous run.)
-# See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
+
 concurrency:
-  # This scopes the group to:
-  # - the same workflow,
-  # - the same event type, and
-  # - the same branch name
-  # e.g., my-workflow-pull_request-feature/123-my-thing
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}-${{ github.job }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## 👋 Introduction

Should help unblock other jobs from being queued?

## 🕵️ Details

Creates a more unique group for concurrent runs.

## 🧪 Testing

1. CI runs and passes fine.
