### PR TITLE
[Feature] Store last sign in ISS

### DIFF
--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -163,6 +163,7 @@ class AuthController extends Controller
 
         // update the user with values from logging in
         $userMatch->last_sign_in_at = Carbon::now();
+        $userMatch->last_sign_in_iss = $idToken->claims()->get('iss', null);
         if ($idToken->claims()->has('given_name')) {
             $userMatch->first_name = $idToken->claims()->get('given_name');
         }

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -108,6 +108,7 @@ use Staudenmeir\EloquentHasManyDeep\HasRelationships;
  * @property array $flexible_work_locations
  * @property OffPlatformRecruitmentProcess $offPlatformRecruitmentProcesses
  * @property ?EmployeeProfile $employeeProfile
+ * @property ?string $last_sign_in_iss
  */
 class User extends Model implements Authenticatable, HasLocalePreference, LaratrustUser
 {

--- a/api/database/migrations/2026_04_10_171836_add_last_sign_in_iss.php
+++ b/api/database/migrations/2026_04_10_171836_add_last_sign_in_iss.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('last_sign_in_iss')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('contact_email');
+        });
+    }
+};

--- a/api/tests/Feature/Snapshots/SnapshotShapeTest.php
+++ b/api/tests/Feature/Snapshots/SnapshotShapeTest.php
@@ -123,6 +123,7 @@ class SnapshotShapeTest extends TestCase
             'nextRoleCSuiteRoleTitle',
             'careerObjectiveCSuiteRoleTitle',
             'careerPlanningLearningOpportunitiesInterest',
+            'lastSignInIss',
         ],
         UserSkill::class => [
             'userId',


### PR DESCRIPTION
🤖 Resolves #16426 

## 👋 Introduction

Stores the iss (issuer) values for the last sign in to help us know whether someone has used CanadaLogin yet or not.

## 🕵️ Details

This is for future use, like a possible in-app migration tool or targeted emails.  For now, it is not exposed in the API at all.

I did check the tokens of a migrated account on UAT and the iss is `https://auth.login-connexion.alpha.canada.ca/oauth2`.

## 🧪 Testing


1. Run the migration
- [ ] Logging in with SIC stores a SIC value
- [ ] Logging in with CL stores a CL values


## 📸 Screenshot

<img width="352" height="133" alt="image" src="https://github.com/user-attachments/assets/87ff7392-b831-4a93-aeef-2da4cf0adab4" />
