### PR TITLE
[Bug] Make taken emails valid for API

### DIFF
--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -172,26 +172,28 @@ class AuthController extends Controller
         if ($idToken->claims()->has('email')) {
             $incomingEmailAddress = $idToken->claims()->get('email');
 
-            // if existing users have this email address then take it from them
-            try {
-                $existingUser = User::where('sub', '!=', $sub)
-                    ->where(fn ($subquery) => $subquery
-                        ->where('email', 'ilike', $incomingEmailAddress)
-                        ->orWhere('work_email', 'ilike', $incomingEmailAddress)
-                    )->first();
-                if (strcasecmp($existingUser->email, $incomingEmailAddress) == 0) {
-                    $existingUser->email = $existingUser->email.'-taken-at-'.Carbon::now()->timestamp;
+            // if email is not null, check if existing users have this email and take it from them
+            if (! empty($incomingEmailAddress)) {
+                try {
+                    $existingUser = User::where('sub', '!=', $sub)
+                        ->where(fn ($subquery) => $subquery
+                            ->where('email', 'ilike', $incomingEmailAddress)
+                            ->orWhere('work_email', 'ilike', $incomingEmailAddress)
+                        )->first();
+                    if (strcasecmp($existingUser->email, $incomingEmailAddress) == 0) {
+                        $existingUser->email = $existingUser->email.'-taken-at-'.Carbon::now()->timestamp;
+                    }
+                    if (strcasecmp($existingUser->work_email, $incomingEmailAddress) == 0) {
+                        $existingUser->work_email = $existingUser->work_email.'-taken-at-'.Carbon::now()->timestamp;
+                    }
+                    $existingUser->save();
+                } catch (\Throwable $e) {
+                    // log and continue - don't break log in for failure to take address
+                    Log::error('Failed to take email address on log in.'.$e->getMessage(), [
+                        'sub' => $sub,
+                        'email address' => $incomingEmailAddress,
+                    ]);
                 }
-                if (strcasecmp($existingUser->work_email, $incomingEmailAddress) == 0) {
-                    $existingUser->work_email = $existingUser->work_email.'-taken-at-'.Carbon::now()->timestamp;
-                }
-                $existingUser->save();
-            } catch (\Throwable $e) {
-                // log and continue - don't break log in for failure to take address
-                Log::error('Failed to take email address on log in.'.$e->getMessage(), [
-                    'sub' => $sub,
-                    'email address' => $incomingEmailAddress,
-                ]);
             }
 
             // email should be clear now so save if possible

--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -180,10 +180,10 @@ class AuthController extends Controller
                         ->orWhere('work_email', 'ilike', $incomingEmailAddress)
                     )->first();
                 if (strcasecmp($existingUser->email, $incomingEmailAddress) == 0) {
-                    $existingUser->email = $existingUser->email.'_taken_'.Carbon::now()->timestamp;
+                    $existingUser->email = $existingUser->email.'-taken-at-'.Carbon::now()->timestamp;
                 }
                 if (strcasecmp($existingUser->work_email, $incomingEmailAddress) == 0) {
-                    $existingUser->work_email = $existingUser->work_email.'_taken_'.Carbon::now()->timestamp;
+                    $existingUser->work_email = $existingUser->work_email.'-taken-at-'.Carbon::now()->timestamp;
                 }
                 $existingUser->save();
             } catch (\Throwable $e) {

--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -175,7 +175,7 @@ class AuthController extends Controller
             // if email is not null, check if existing users have this email and take it from them
             if (! empty($incomingEmailAddress)) {
                 try {
-                    $existingUser = User::where('sub', '!=', $sub)
+                    $existingUser = User::where('id', '!=', $userMatch->id)
                         ->where(fn ($subquery) => $subquery
                             ->where('email', 'ilike', $incomingEmailAddress)
                             ->orWhere('work_email', 'ilike', $incomingEmailAddress)

--- a/api/tests/Unit/AuthControllerTest.php
+++ b/api/tests/Unit/AuthControllerTest.php
@@ -157,8 +157,8 @@ class AuthControllerTest extends TestCase
 
         // The existing user's email should be updated
         $existingUser->refresh();
-        $this->assertStringContainsString('_taken_', $existingUser->email);
-        $this->assertStringContainsString('_taken_', $existingUser->work_email);
+        $this->assertStringContainsString('-taken-at-', $existingUser->email);
+        $this->assertStringContainsString('-taken-at-', $existingUser->work_email);
 
         // The new user should have the duplicate email
         $newUser = User::where('sub', 'newsub')->sole();


### PR DESCRIPTION
🤖 Resolves #16428 

## 👋 Introduction

Mangles the taken email addresses in a way that still allows them to pass through the API.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

1. Configure your environment for CanadaLogin
2. Manually update some other user with the same email address you use with CL
3. Log in with your CL user
4. Grant your CL user admin privileges, maybe with Tinker :point_down: 
```php
$user = User::where('email', 'username@domain.tld')->sole();
$user->addRoles(['base_user', 'applicant', 'platform_admin']); 
```
5. Try to load the other user using the admin pages
- [ ] Your CL user has the email address properly set
- [ ] The other user can be loaded in the app without an error
- [ ] The email address is mangled with at "taken-at" timestamp


## 📸 Screenshot

<img width="871" height="291" alt="image" src="https://github.com/user-attachments/assets/864085cb-2c63-4d3c-8428-3f5043d47774" />
