### PR TITLE
Community admins can view the edit community page

### DIFF
--- a/apps/web/src/pages/Communities/UpdateCommunityPage/UpdateCommunityPage.tsx
+++ b/apps/web/src/pages/Communities/UpdateCommunityPage/UpdateCommunityPage.tsx
@@ -412,7 +412,7 @@ export const UpdateCommunity = () => {
 };
 
 export const Component = () => (
-  <RequireAuth roles={[ROLE_NAME.PlatformAdmin]}>
+  <RequireAuth roles={[ROLE_NAME.PlatformAdmin, ROLE_NAME.CommunityAdmin]}>
     <UpdateCommunity />
   </RequireAuth>
 );


### PR DESCRIPTION
🤖 Resolves #16458 

## 👋 Introduction

Add the missing role to the roles array


## 🧪 Testing



1. As a community admin only
2. Can edit your community 




