### PR TITLE
[Fix] Skill breadcrumb text

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5731,6 +5731,10 @@
     "defaultMessage": "Afficher tous<hidden> les renseignements liés à l’expérience</hidden>",
     "description": "Button label to expand all experiences"
   },
+  "M2LfhH": {
+    "defaultMessage": "Modifier<hidden> une compétence</hidden>",
+    "description": "Breadcrumb title for the edit skill page link."
+  },
   "M2MQu7": {
     "defaultMessage": "Aidez le Bureau du contrôleur général à recueillir des renseignements importants sur l'effectif des cadres de la gestion financière afin d'élaborer des programmes stratégiques, d'appuyer la planification de la relève et de renforcer notre collectivité.",
     "description": "Page subtitle for the comptrollership executives talent management page"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -483,10 +483,6 @@
     "defaultMessage": "Collectivité des cadres",
     "description": "Heading for executive jobs in government"
   },
-  "/zsCRf": {
-    "defaultMessage": "Modifier<hidden> la collectivité</hidden>",
-    "description": "Breadcrumb title for the edit skill page link."
-  },
   "0/jj1v": {
     "defaultMessage": "Réinitialisez tous les filtres",
     "description": "Button text to reset a filter form"
@@ -14513,6 +14509,10 @@
   "xjdD1/": {
     "defaultMessage": "Retirer de la collectivité",
     "description": "Header for the form to remove a community role from a user"
+  },
+  "xk9i5D": {
+    "defaultMessage": "Modifier<hidden> la collectivité</hidden>",
+    "description": "Breadcrumb title for the edit community page link."
   },
   "xkJAuq": {
     "defaultMessage": "Ajouter cette compétence",

--- a/apps/web/src/pages/Communities/UpdateCommunityPage/UpdateCommunityPage.tsx
+++ b/apps/web/src/pages/Communities/UpdateCommunityPage/UpdateCommunityPage.tsx
@@ -362,8 +362,8 @@ export const UpdateCommunity = () => {
     {
       label: intl.formatMessage({
         defaultMessage: "Edit<hidden> community</hidden>",
-        id: "/zsCRf",
-        description: "Breadcrumb title for the edit skill page link.",
+        id: "xk9i5D",
+        description: "Breadcrumb title for the edit community page link.",
       }),
       url: paths.communityUpdate(communityId),
     },

--- a/apps/web/src/pages/Skills/UpdateSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateSkillPage.tsx
@@ -445,8 +445,8 @@ export const UpdateSkill = () => {
         ? [
             {
               label: intl.formatMessage({
-                defaultMessage: "Edit<hidden> community</hidden>",
-                id: "/zsCRf",
+                defaultMessage: "Edit<hidden> skill</hidden>",
+                id: "M2LfhH",
                 description: "Breadcrumb title for the edit skill page link.",
               }),
               url: routes.skillUpdate(skillId),


### PR DESCRIPTION
🤖 Resolves #16486.

## 👋 Introduction

This PR fixes a hidden string that was incorrect and a description of a `intl` string.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/admin/settings/skills
3. Edit a skill
4. Observe the hidden text on the Edit breadcumb is Edit a skill and not Edit a community

## 📸 Screenshot
<img width="1242" height="803" alt="Screenshot 2026-04-15 at 16 46 53" src="https://github.com/user-attachments/assets/bbc1a73e-640f-4320-8668-98d3a86be50d" />
