### PR TITLE
[Platform] Increase FPM max children, spare servers

### DIFF
--- a/infrastructure/conf/php-fpm-www.conf
+++ b/infrastructure/conf/php-fpm-www.conf
@@ -124,22 +124,22 @@ pm = dynamic
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = 50
+pm.max_children = 100
 
 ; The number of child processes created on startup.
 ; Note: Used only when pm is set to 'dynamic'
 ; Default Value: (min_spare_servers + max_spare_servers) / 2
-pm.start_servers = 30
+pm.start_servers = 25
 
 ; The desired minimum number of idle server processes.
 ; Note: Used only when pm is set to 'dynamic'
 ; Note: Mandatory when pm is set to 'dynamic'
-pm.min_spare_servers = 3
+pm.min_spare_servers = 25
 
 ; The desired maximum number of idle server processes.
 ; Note: Used only when pm is set to 'dynamic'
 ; Note: Mandatory when pm is set to 'dynamic'
-pm.max_spare_servers = 30
+pm.max_spare_servers = 75
 
 ; The number of rate to spawn child processes at once.
 ; Note: Used only when pm is set to 'dynamic'


### PR DESCRIPTION
🤖 Resolves #16126 

## 👋 Introduction

Increases our PHP-FPM max children and spare servers to better utilize resources.

## 🕵️ Details

We have more resources to spare on the server and while we rarely run out of workers, we have room to add more so it should never happen even under high loads.

## 🧪 Testing

> [!NOTE]
> Likely need to deploy this to truly test it.

1. I guess just reload FPM and run some load tests? 