### PR TITLE
[Fix] User role names

### DIFF
--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
@@ -131,8 +131,7 @@ const UsersPaginated_Query = graphql(/* GraphQL */ `
               id
               name
               displayName {
-                en
-                fr
+                localized
               }
             }
           }


### PR DESCRIPTION
🤖 Resolves #16478 

## 👋 Introduction

Addresses an issue where role names were not appearing on the users table.

## 🕵️ Details

We were accessing `localized` field but the query was getting `en` and `fr`.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to `/admin/users`
4. Confirm role names appear for users who have roles above the "Applicant" role (We hide, guest, base user and applicant)

## 📸 Screenshot

<img width="1436" height="503" alt="swappy-20260417_095539" src="https://github.com/user-attachments/assets/49255570-c938-457d-9f03-00288aee718e" />
