### PR TITLE
[Feature] CanadaLogin Account Settings Page

### DIFF
--- a/apps/playwright/tests/applicant/applicant-settings.spec.ts
+++ b/apps/playwright/tests/applicant/applicant-settings.spec.ts
@@ -43,7 +43,7 @@ test.describe("Applicant settings page", () => {
     const settingsPage = new AccountSettings(appPage.page);
     await loginBySub(appPage.page, sub);
     await settingsPage.goToSettings();
-    await appPage.waitForGraphqlResponse("AccountSettings");
+    await appPage.waitForGraphqlResponse("AccountSettingsDeprecated");
     await settingsPage.removeWorkEmail();
     // check changes
     await expect(
@@ -84,7 +84,7 @@ test.describe("Applicant settings page", () => {
     const settingsPage = new AccountSettings(appPage.page);
     await loginBySub(appPage.page, sub);
     await settingsPage.goToSettings();
-    await appPage.waitForGraphqlResponse("AccountSettings");
+    await appPage.waitForGraphqlResponse("AccountSettingsDeprecated");
     await expect(
       settingsPage.page.getByRole("img", { name: /verified/i }).last(),
     ).toBeVisible({ timeout: 30000 });

--- a/apps/web/src/components/PersonalInfoBox/PersonalInfoBox.tsx
+++ b/apps/web/src/components/PersonalInfoBox/PersonalInfoBox.tsx
@@ -30,7 +30,7 @@ const PersonalInfoBox_Fragment = graphql(/** GraphQL */ `
 
 interface AccountAndContactInformationProps {
   query: FragmentType<typeof PersonalInfoBox_Fragment>;
-  footer?: "does-it-look-incorrect";
+  footer?: boolean;
 }
 
 const PersonalInfoBox = ({
@@ -67,7 +67,7 @@ const PersonalInfoBox = ({
             personalInfo.preferredLang?.label.localized}
         </p>
       </Notice.Content>
-      {footer === "does-it-look-incorrect" ? (
+      {footer ? (
         <Notice.Footer>
           {intl.formatMessage(
             {

--- a/apps/web/src/components/PersonalInfoBox/PersonalInfoBox.tsx
+++ b/apps/web/src/components/PersonalInfoBox/PersonalInfoBox.tsx
@@ -1,0 +1,97 @@
+import type { ReactNode } from "react";
+import { useIntl } from "react-intl";
+
+import { getRuntimeVariable } from "@gc-digital-talent/env";
+import {
+  getFragment,
+  graphql,
+  type FragmentType,
+} from "@gc-digital-talent/graphql";
+import { Link, Notice } from "@gc-digital-talent/ui";
+import { commonMessages } from "@gc-digital-talent/i18n";
+
+import { getFullNameLabel } from "~/utils/nameUtils";
+
+const PersonalInfoBox_Fragment = graphql(/** GraphQL */ `
+  fragment PersonalInfoBox on User {
+    id
+    firstName
+    lastName
+    telephone
+    email
+    preferredLang {
+      value
+      label {
+        localized
+      }
+    }
+  }
+`);
+
+interface AccountAndContactInformationProps {
+  query: FragmentType<typeof PersonalInfoBox_Fragment>;
+  footer?: "does-it-look-incorrect";
+}
+
+const PersonalInfoBox = ({
+  query: personalInfoQuery,
+  footer,
+}: AccountAndContactInformationProps) => {
+  const intl = useIntl();
+
+  const personalInfo = getFragment(PersonalInfoBox_Fragment, personalInfoQuery);
+
+  return (
+    <Notice.Root>
+      <Notice.Title>
+        {getFullNameLabel(personalInfo.firstName, personalInfo.lastName, intl)}
+      </Notice.Title>
+      <Notice.Content>
+        {personalInfo.email ? (
+          <p>
+            <Link href={`mailto:${personalInfo.email}`} color="black">
+              {personalInfo.email}
+            </Link>
+          </p>
+        ) : null}
+
+        {personalInfo.telephone ? <p>{personalInfo.telephone}</p> : null}
+        <p>
+          {intl.formatMessage({
+            defaultMessage: "Preferred contact language",
+            id: "AumMAr",
+            description:
+              "Legend text for required language preference in getting started form",
+          }) +
+            intl.formatMessage(commonMessages.dividingColon) +
+            personalInfo.preferredLang?.label.localized}
+        </p>
+      </Notice.Content>
+      {footer === "does-it-look-incorrect" ? (
+        <Notice.Footer>
+          {intl.formatMessage(
+            {
+              defaultMessage:
+                "Does this information look incorrect? You can update it by <a>visiting your profile on CanadaLogin</a>.",
+              id: "hbbeY8",
+              description: "Footer for create account page",
+            },
+            {
+              a: (chunks: ReactNode) => {
+                const uri = getRuntimeVariable("OAUTH_MANAGE_ACCOUNT_URI");
+                return uri ? (
+                  <Link href={uri} color="black" size="sm">
+                    {chunks}
+                  </Link>
+                ) : (
+                  <span>{chunks}</span>
+                );
+              },
+            },
+          )}
+        </Notice.Footer>
+      ) : null}
+    </Notice.Root>
+  );
+};
+export default PersonalInfoBox;

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7187,6 +7187,10 @@
     "defaultMessage": "Vous avez répondu aux questions suivantes :",
     "description": "Message in screening questions section of the application review page."
   },
+  "SdglrJ": {
+    "defaultMessage": "Mettre à jour vos renseignements personnels et ceux liés à l’emploi, gérer vos notifications et vos disponibilités.",
+    "description": "Subtitle for the account settings page."
+  },
   "Se2I7I": {
     "defaultMessage": "Échec de la mise à jour de la date d’expiration",
     "description": "Error message for updating expiry date"
@@ -13430,6 +13434,10 @@
     "defaultMessage": "Détails sur le candidat",
     "description": "Heading for filters directly related to the candidates"
   },
+  "sx79Vq": {
+    "defaultMessage": "Renseignements sur le compte et coordonnées",
+    "description": "Title for the account and contact information information section"
+  },
   "sxCR5N": {
     "defaultMessage": "Seuls les membres du personnel admissibles seront pris en considération pour les possibilités de coaching des cadres. L'admissibilité dépend de votre classification et de votre structure organisationnelle.",
     "description": "Context for an employee profile career development preference field"
@@ -14073,6 +14081,10 @@
   "vd8CrA": {
     "defaultMessage": "{applicantsCount, plural, =0 {0 candidature} one {# candidature} other {# candidatures}}",
     "description": "Applications count for process"
+  },
+  "vdPlPP": {
+    "defaultMessage": "Mettre à jour les renseignements de ConnexionCanada",
+    "description": "Link to update your CanadaLogin information"
   },
   "veZI+j": {
     "defaultMessage": "<strong>{name}</strong> a soumis",
@@ -14981,6 +14993,10 @@
   "zLTray": {
     "defaultMessage": "Comment lancer un processus de recrutement sur Talents numériques du GC?",
     "description": "Question about recruitment processes"
+  },
+  "zLaAer": {
+    "defaultMessage": "Talents numériques du GC utilise ConnexionCanada, un service d’authentification du gouvernement du Canada, afin de vous donner accès à votre compte à l’aide d’un seul nom d’utilisateur et d’un seul mot de passe. Vous pouvez <a>modifier vos renseignements sur le site web de ConnexionCanada</a>, et les changements s’appliqueront automatiquement ici lorsque vous accéderez à votre compte.",
+    "description": "Description for the account and information section"
   },
   "zLnqLc": {
     "defaultMessage": "Options de mutation latérale",

--- a/apps/web/src/pages/Auth/RegistrationPages/GettingStartedPage/GettingStartedForm.tsx
+++ b/apps/web/src/pages/Auth/RegistrationPages/GettingStartedPage/GettingStartedForm.tsx
@@ -1,19 +1,16 @@
 import { defineMessage, useIntl } from "react-intl";
 import FlagIcon from "@heroicons/react/24/outline/FlagIcon";
 import { FormProvider, useForm } from "react-hook-form";
-import type { ReactNode } from "react";
 
-import { Heading, Link, Notice } from "@gc-digital-talent/ui";
+import { Heading } from "@gc-digital-talent/ui";
 import { RadioGroup } from "@gc-digital-talent/forms";
-import { commonMessages, errorMessages } from "@gc-digital-talent/i18n";
+import { errorMessages } from "@gc-digital-talent/i18n";
 import type { FragmentType } from "@gc-digital-talent/graphql";
 import { graphql, getFragment } from "@gc-digital-talent/graphql";
-import { getRuntimeVariable } from "@gc-digital-talent/env";
 
-import { getFullNameLabel } from "~/utils/nameUtils";
 import EmailVerification from "~/components/EmailVerification/EmailVerification";
+import PersonalInfoBox from "~/components/PersonalInfoBox/PersonalInfoBox";
 
-import labels from "./labels";
 import BottomHalfNotEmployee from "./components/BottomHalfNotEmployee";
 import BottomHalfEmployeeWithEmail from "./components/BottomHalfEmployeeWithEmail";
 import BottomHalfEmployeeNoEmail from "./components/BottomHalfEmployeeNoEmail";
@@ -26,17 +23,9 @@ export const sectionTitle = defineMessage({
 
 export const GettingStartedInitialValues_Query = graphql(/** GraphQL */ `
   fragment GettingStartedInitialValues on User {
-    firstName
-    lastName
-    preferredLang {
-      label {
-        localized
-      }
-    }
-    email
     workEmail
     isWorkEmailVerified
-    telephone
+    ...PersonalInfoBox
   }
 `);
 
@@ -112,54 +101,12 @@ const GettingStartedForm = ({
           description: "Message after main heading in create account page.",
         })}
       </p>
-      <Notice.Root className="mb-6">
-        <Notice.Title>
-          {getFullNameLabel(
-            initialValues.firstName,
-            initialValues.lastName,
-            intl,
-          )}
-        </Notice.Title>
-        <Notice.Content>
-          {initialValues.email ? (
-            <p>
-              <Link href={`mailto:${initialValues.email}`} color="black">
-                {initialValues.email}
-              </Link>
-            </p>
-          ) : null}
-
-          {initialValues.telephone ? <p>{initialValues.telephone}</p> : null}
-          <p>
-            {intl.formatMessage(labels.preferredLang) +
-              intl.formatMessage(commonMessages.dividingColon) +
-              initialValues.preferredLang?.label.localized}
-          </p>
-        </Notice.Content>
-        <Notice.Footer>
-          {intl.formatMessage(
-            {
-              defaultMessage:
-                "Does this information look incorrect? You can update it by <a>visiting your profile on CanadaLogin</a>.",
-              id: "hbbeY8",
-              description: "Footer for create account page",
-            },
-            {
-              a: (chunks: ReactNode) => {
-                const uri = getRuntimeVariable("OAUTH_MANAGE_ACCOUNT_URI");
-                return uri ? (
-                  <Link href={uri} color="black" size="sm">
-                    {chunks}
-                  </Link>
-                ) : (
-                  <span>{chunks}</span>
-                );
-              },
-            },
-          )}
-        </Notice.Footer>
-      </Notice.Root>
-
+      <div className="mb-6">
+        <PersonalInfoBox
+          query={initialValues}
+          footer="does-it-look-incorrect"
+        />
+      </div>
       <div className="mb-6">
         <FormProvider {...formMethods}>
           <form>

--- a/apps/web/src/pages/Auth/RegistrationPages/GettingStartedPage/GettingStartedForm.tsx
+++ b/apps/web/src/pages/Auth/RegistrationPages/GettingStartedPage/GettingStartedForm.tsx
@@ -102,10 +102,7 @@ const GettingStartedForm = ({
         })}
       </p>
       <div className="mb-6">
-        <PersonalInfoBox
-          query={initialValues}
-          footer="does-it-look-incorrect"
-        />
+        <PersonalInfoBox query={initialValues} footer />
       </div>
       <div className="mb-6">
         <FormProvider {...formMethods}>

--- a/apps/web/src/pages/Profile/AccountSettings/AccountAndContactInformation.tsx
+++ b/apps/web/src/pages/Profile/AccountSettings/AccountAndContactInformation.tsx
@@ -1,0 +1,134 @@
+import { useIntl } from "react-intl";
+import UserCircleIcon from "@heroicons/react/24/outline/UserCircleIcon";
+import type { ReactNode } from "react";
+
+import {
+  Card,
+  CardSeparator,
+  Link,
+  Notice,
+  TableOfContents,
+} from "@gc-digital-talent/ui";
+import type { FragmentType } from "@gc-digital-talent/graphql";
+import { getFragment, graphql } from "@gc-digital-talent/graphql";
+import { commonMessages } from "@gc-digital-talent/i18n";
+import { getRuntimeVariable } from "@gc-digital-talent/env";
+
+import { getFullNameLabel } from "~/utils/nameUtils";
+
+const AccountAndContactInformation_Fragment = graphql(/** GraphQL */ `
+  fragment AccountAndContactInformation on User {
+    id
+    firstName
+    lastName
+    telephone
+    email
+    preferredLang {
+      value
+      label {
+        localized
+      }
+    }
+  }
+`);
+
+interface AccountAndContactInformationProps {
+  personalInfoQuery: FragmentType<typeof AccountAndContactInformation_Fragment>;
+}
+
+const AccountAndContactInformation = ({
+  personalInfoQuery,
+}: AccountAndContactInformationProps) => {
+  const intl = useIntl();
+  const manageAccountUri = getRuntimeVariable("OAUTH_MANAGE_ACCOUNT_URI");
+
+  const personalInfo = getFragment(
+    AccountAndContactInformation_Fragment,
+    personalInfoQuery,
+  );
+
+  return (
+    <Card space="lg">
+      <TableOfContents.Heading
+        size="h3"
+        icon={UserCircleIcon}
+        color="primary"
+        className="mt-0 mb-6"
+      >
+        {intl.formatMessage({
+          defaultMessage: "Account and contact information",
+          id: "sx79Vq",
+          description:
+            "Title for the account and contact information information section",
+        })}
+      </TableOfContents.Heading>
+      <div className="mb-6">
+        {intl.formatMessage(
+          {
+            defaultMessage:
+              "GC Digital Talent partners with the Government of Canada’s credential service, CanadaLogin, to provide you with account access using a single username and password. You can <a>manage related data on the CanadaLogin website</a> and it will automatically reflect here when you access your account.",
+            id: "zLaAer",
+            description: "Description for the account and information section",
+          },
+          {
+            a: (chunks: ReactNode) => {
+              return manageAccountUri ? (
+                <Link href={manageAccountUri} color="black">
+                  {chunks}
+                </Link>
+              ) : (
+                <span>{chunks}</span>
+              );
+            },
+          },
+        )}
+      </div>
+      <Notice.Root className="mb-9">
+        <Notice.Title>
+          {getFullNameLabel(
+            personalInfo.firstName,
+            personalInfo.lastName,
+            intl,
+          )}
+        </Notice.Title>
+        <Notice.Content>
+          {personalInfo.email ? (
+            <p>
+              <Link href={`mailto:${personalInfo.email}`} color="black">
+                {personalInfo.email}
+              </Link>
+            </p>
+          ) : null}
+
+          {personalInfo.telephone ? <p>{personalInfo.telephone}</p> : null}
+          <p>
+            {intl.formatMessage({
+              defaultMessage: "Preferred contact language",
+              id: "AumMAr",
+              description:
+                "Legend text for required language preference in getting started form",
+            }) +
+              intl.formatMessage(commonMessages.dividingColon) +
+              personalInfo.preferredLang?.label.localized}
+          </p>
+        </Notice.Content>
+      </Notice.Root>
+      {manageAccountUri ? (
+        <>
+          <CardSeparator space="lg" orientation="horizontal" className="my-0" />
+          <div className="mt-6">
+            <Link href={manageAccountUri} external newTab className="font-bold">
+              {intl.formatMessage({
+                defaultMessage: "Update CanadaLogin information",
+                id: "vdPlPP",
+                description: "Link to update your CanadaLogin information",
+              })}
+            </Link>
+          </div>
+        </>
+      ) : null}
+    </Card>
+  );
+};
+
+export default AccountAndContactInformation;

--- a/apps/web/src/pages/Profile/AccountSettings/AccountAndContactInformation.tsx
+++ b/apps/web/src/pages/Profile/AccountSettings/AccountAndContactInformation.tsx
@@ -23,7 +23,8 @@ const AccountAndContactInformation = ({
   query,
 }: AccountAndContactInformationProps) => {
   const intl = useIntl();
-  const manageAccountUri = getRuntimeVariable("OAUTH_MANAGE_ACCOUNT_URI");
+  const manageAccountUri =
+    getRuntimeVariable("OAUTH_MANAGE_ACCOUNT_URI") ?? "#";
 
   const data = getFragment(AccountAndContactInformation_Fragment, query);
 
@@ -51,37 +52,29 @@ const AccountAndContactInformation = ({
             description: "Description for the account and information section",
           },
           {
-            a: (chunks: ReactNode) => {
-              return manageAccountUri ? (
-                <Link href={manageAccountUri} color="black">
-                  {chunks}
-                </Link>
-              ) : (
-                <span>{chunks}</span>
-              );
-            },
+            a: (chunks: ReactNode) => (
+              <Link href={manageAccountUri} color="black">
+                {chunks}
+              </Link>
+            ),
           },
         )}
       </div>
       <div className="mb-9">
         <PersonalInfoBox query={data} />
       </div>
-      {manageAccountUri ? (
-        <>
-          <div className="-x-6 sm:-mx-9" /*Match card padding*/>
-            <Separator space="none" orientation="horizontal" decorative />
-          </div>
-          <div className="mt-6">
-            <Link href={manageAccountUri} external newTab className="font-bold">
-              {intl.formatMessage({
-                defaultMessage: "Update CanadaLogin information",
-                id: "vdPlPP",
-                description: "Link to update your CanadaLogin information",
-              })}
-            </Link>
-          </div>
-        </>
-      ) : null}
+      <div className="-x-6 sm:-mx-9" /*Match card padding*/>
+        <Separator space="none" orientation="horizontal" decorative />
+      </div>
+      <div className="mt-6">
+        <Link href={manageAccountUri} external newTab className="font-bold">
+          {intl.formatMessage({
+            defaultMessage: "Update CanadaLogin information",
+            id: "vdPlPP",
+            description: "Link to update your CanadaLogin information",
+          })}
+        </Link>
+      </div>
     </Card>
   );
 };

--- a/apps/web/src/pages/Profile/AccountSettings/AccountAndContactInformation.tsx
+++ b/apps/web/src/pages/Profile/AccountSettings/AccountAndContactInformation.tsx
@@ -2,50 +2,30 @@ import { useIntl } from "react-intl";
 import UserCircleIcon from "@heroicons/react/24/outline/UserCircleIcon";
 import type { ReactNode } from "react";
 
-import {
-  Card,
-  Link,
-  Notice,
-  Separator,
-  TableOfContents,
-} from "@gc-digital-talent/ui";
+import { Card, Link, Separator, TableOfContents } from "@gc-digital-talent/ui";
 import type { FragmentType } from "@gc-digital-talent/graphql";
 import { getFragment, graphql } from "@gc-digital-talent/graphql";
-import { commonMessages } from "@gc-digital-talent/i18n";
 import { getRuntimeVariable } from "@gc-digital-talent/env";
 
-import { getFullNameLabel } from "~/utils/nameUtils";
+import PersonalInfoBox from "~/components/PersonalInfoBox/PersonalInfoBox";
 
 const AccountAndContactInformation_Fragment = graphql(/** GraphQL */ `
   fragment AccountAndContactInformation on User {
-    id
-    firstName
-    lastName
-    telephone
-    email
-    preferredLang {
-      value
-      label {
-        localized
-      }
-    }
+    ...PersonalInfoBox
   }
 `);
 
 interface AccountAndContactInformationProps {
-  personalInfoQuery: FragmentType<typeof AccountAndContactInformation_Fragment>;
+  query: FragmentType<typeof AccountAndContactInformation_Fragment>;
 }
 
 const AccountAndContactInformation = ({
-  personalInfoQuery,
+  query,
 }: AccountAndContactInformationProps) => {
   const intl = useIntl();
   const manageAccountUri = getRuntimeVariable("OAUTH_MANAGE_ACCOUNT_URI");
 
-  const personalInfo = getFragment(
-    AccountAndContactInformation_Fragment,
-    personalInfoQuery,
-  );
+  const data = getFragment(AccountAndContactInformation_Fragment, query);
 
   return (
     <Card space="lg">
@@ -83,36 +63,9 @@ const AccountAndContactInformation = ({
           },
         )}
       </div>
-      <Notice.Root className="mb-9">
-        <Notice.Title>
-          {getFullNameLabel(
-            personalInfo.firstName,
-            personalInfo.lastName,
-            intl,
-          )}
-        </Notice.Title>
-        <Notice.Content>
-          {personalInfo.email ? (
-            <p>
-              <Link href={`mailto:${personalInfo.email}`} color="black">
-                {personalInfo.email}
-              </Link>
-            </p>
-          ) : null}
-
-          {personalInfo.telephone ? <p>{personalInfo.telephone}</p> : null}
-          <p>
-            {intl.formatMessage({
-              defaultMessage: "Preferred contact language",
-              id: "AumMAr",
-              description:
-                "Legend text for required language preference in getting started form",
-            }) +
-              intl.formatMessage(commonMessages.dividingColon) +
-              personalInfo.preferredLang?.label.localized}
-          </p>
-        </Notice.Content>
-      </Notice.Root>
+      <div className="mb-9">
+        <PersonalInfoBox query={data} />
+      </div>
       {manageAccountUri ? (
         <>
           <div className="-x-6 sm:-mx-9" /*Match card padding*/>

--- a/apps/web/src/pages/Profile/AccountSettings/AccountAndContactInformation.tsx
+++ b/apps/web/src/pages/Profile/AccountSettings/AccountAndContactInformation.tsx
@@ -4,9 +4,9 @@ import type { ReactNode } from "react";
 
 import {
   Card,
-  CardSeparator,
   Link,
   Notice,
+  Separator,
   TableOfContents,
 } from "@gc-digital-talent/ui";
 import type { FragmentType } from "@gc-digital-talent/graphql";
@@ -115,7 +115,9 @@ const AccountAndContactInformation = ({
       </Notice.Root>
       {manageAccountUri ? (
         <>
-          <CardSeparator space="lg" orientation="horizontal" className="my-0" />
+          <div className="-x-6 sm:-mx-9" /*Match card padding*/>
+            <Separator space="none" orientation="horizontal" decorative />
+          </div>
           <div className="mt-6">
             <Link href={manageAccountUri} external newTab className="font-bold">
               {intl.formatMessage({

--- a/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPage.stories.tsx
+++ b/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPage.stories.tsx
@@ -1,0 +1,50 @@
+import { faker } from "@faker-js/faker/locale/en";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Container } from "@gc-digital-talent/ui";
+import { makeFragmentData } from "@gc-digital-talent/graphql";
+import { fakeUsers } from "@gc-digital-talent/fake-data";
+
+import {
+  AccountSettings,
+  PersonalInformation_Fragment,
+} from "./AccountSettingsPage";
+
+faker.seed(0);
+
+const user = fakeUsers(1)[0];
+
+const meta = {
+  component: AccountSettings,
+  decorators: [
+    (Comp) => (
+      <Container className="mt-18">
+        <Comp />
+      </Container>
+    ),
+  ],
+} satisfies Meta<typeof AccountSettings>;
+
+export default meta;
+
+type Story = StoryObj<typeof AccountSettings>;
+
+export const Default: Story = {
+  args: {
+    personalInfoQuery: makeFragmentData(
+      {
+        id: "00000000-0000-0000-0000-000000000000",
+        enabledEmailNotifications: user.enabledEmailNotifications,
+        enabledInAppNotifications: user.enabledInAppNotifications,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        telephone: user.telephone,
+        email: user.email,
+        preferredLang: {
+          label: { localized: "English" },
+        },
+      },
+      PersonalInformation_Fragment,
+    ),
+  },
+};

--- a/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPage.tsx
+++ b/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPage.tsx
@@ -156,7 +156,7 @@ const AccountSettings = ({ personalInfoQuery }: AccountSettingsProps) => {
           </TableOfContents.Navigation>
           <TableOfContents.Content>
             <TableOfContents.Section id={sections.accountAndContact.id}>
-              <AccountAndContactInformation personalInfoQuery={personalInfo} />
+              <AccountAndContactInformation query={personalInfo} />
             </TableOfContents.Section>
             <TableOfContents.Section
               id={sections.notificationSettings.id}

--- a/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPage.tsx
+++ b/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPage.tsx
@@ -1,16 +1,11 @@
 import { useIntl, defineMessage } from "react-intl";
 import Cog8ToothIcon from "@heroicons/react/24/outline/Cog8ToothIcon";
 import { useQuery } from "urql";
-import UserCircleIcon from "@heroicons/react/24/outline/UserCircleIcon";
-import type { ReactNode } from "react";
 
 import {
-  Card,
-  CardSeparator,
   Container,
   Link,
   NotFound,
-  Notice,
   Pending,
   Separator,
   TableOfContents,
@@ -20,7 +15,6 @@ import { getFragment, graphql } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 import { ROLE_NAME } from "@gc-digital-talent/auth";
 import { commonMessages, navigationMessages } from "@gc-digital-talent/i18n";
-import { getRuntimeVariable } from "@gc-digital-talent/env";
 
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import useRoutes from "~/hooks/useRoutes";
@@ -30,26 +24,17 @@ import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import type { Status } from "~/components/StatusItem/StatusItem";
 import StatusItem from "~/components/StatusItem/StatusItem";
 import messages from "~/messages/profileMessages";
-import { getFullNameLabel } from "~/utils/nameUtils";
 
 import AccountManagement from "./AccountManagement";
 import NotificationSettings from "./NotificationSettings";
+import AccountAndContactInformation from "./AccountAndContactInformation";
 
 const PersonalInformation_Fragment = graphql(/** GraphQL */ `
   fragment PersonalInformation on User {
     id
-    firstName
-    lastName
-    telephone
-    email
-    preferredLang {
-      value
-      label {
-        localized
-      }
-    }
     enabledEmailNotifications
     enabledInAppNotifications
+    ...AccountAndContactInformation
   }
 `);
 
@@ -137,8 +122,6 @@ const AccountSettings = ({ personalInfoQuery }: AccountSettingsProps) => {
     ],
   });
 
-  const manageAccountUri = getRuntimeVariable("OAUTH_MANAGE_ACCOUNT_URI");
-
   return (
     <>
       <SEO title={formattedPageTitle} description={formattedSubTitle} />
@@ -185,96 +168,7 @@ const AccountSettings = ({ personalInfoQuery }: AccountSettingsProps) => {
           </TableOfContents.Navigation>
           <TableOfContents.Content>
             <TableOfContents.Section id={sections.accountAndContact.id}>
-              <Card space="lg">
-                <TableOfContents.Heading
-                  size="h3"
-                  icon={UserCircleIcon}
-                  color="primary"
-                  className="mt-0 mb-6"
-                >
-                  {sections.accountAndContact.title}
-                </TableOfContents.Heading>
-                <div className="mb-6">
-                  {intl.formatMessage(
-                    {
-                      defaultMessage:
-                        "GC Digital Talent partners with the Government of Canada’s credential service, CanadaLogin, to provide you with account access using a single username and password. You can <a>manage related data on the CanadaLogin website</a> and it will automatically reflect here when you access your account.",
-                      id: "zLaAer",
-                      description:
-                        "Description for the account and information section",
-                    },
-                    {
-                      a: (chunks: ReactNode) => {
-                        return manageAccountUri ? (
-                          <Link href={manageAccountUri} color="black">
-                            {chunks}
-                          </Link>
-                        ) : (
-                          <span>{chunks}</span>
-                        );
-                      },
-                    },
-                  )}
-                </div>
-                <Notice.Root className="mb-9">
-                  <Notice.Title>
-                    {getFullNameLabel(
-                      personalInfo.firstName,
-                      personalInfo.lastName,
-                      intl,
-                    )}
-                  </Notice.Title>
-                  <Notice.Content>
-                    {personalInfo.email ? (
-                      <p>
-                        <Link
-                          href={`mailto:${personalInfo.email}`}
-                          color="black"
-                        >
-                          {personalInfo.email}
-                        </Link>
-                      </p>
-                    ) : null}
-
-                    {personalInfo.telephone ? (
-                      <p>{personalInfo.telephone}</p>
-                    ) : null}
-                    <p>
-                      {intl.formatMessage({
-                        defaultMessage: "Preferred contact language",
-                        id: "AumMAr",
-                        description:
-                          "Legend text for required language preference in getting started form",
-                      }) +
-                        intl.formatMessage(commonMessages.dividingColon) +
-                        personalInfo.preferredLang?.label.localized}
-                    </p>
-                  </Notice.Content>
-                </Notice.Root>
-                {manageAccountUri ? (
-                  <>
-                    <CardSeparator
-                      space="lg"
-                      orientation="horizontal"
-                      className="my-0"
-                    />
-                    <div className="mt-6">
-                      <Link
-                        href={manageAccountUri}
-                        external
-                        className="font-bold"
-                      >
-                        {intl.formatMessage({
-                          defaultMessage: "Update CanadaLogin information",
-                          id: "vdPlPP",
-                          description:
-                            "Link to update your CanadaLogin information",
-                        })}
-                      </Link>
-                    </div>
-                  </>
-                ) : null}
-              </Card>
+              <AccountAndContactInformation personalInfoQuery={personalInfo} />
             </TableOfContents.Section>
             <TableOfContents.Section
               id={sections.notificationSettings.id}

--- a/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPage.tsx
+++ b/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPage.tsx
@@ -28,7 +28,7 @@ import messages from "~/messages/profileMessages";
 import NotificationSettings from "./NotificationSettings";
 import AccountAndContactInformation from "./AccountAndContactInformation";
 
-const PersonalInformation_Fragment = graphql(/** GraphQL */ `
+export const PersonalInformation_Fragment = graphql(/** GraphQL */ `
   fragment PersonalInformation on User {
     id
     enabledEmailNotifications
@@ -62,7 +62,9 @@ interface AccountSettingsProps {
   personalInfoQuery: FragmentType<typeof PersonalInformation_Fragment>;
 }
 
-const AccountSettings = ({ personalInfoQuery }: AccountSettingsProps) => {
+export const AccountSettings = ({
+  personalInfoQuery,
+}: AccountSettingsProps) => {
   const intl = useIntl();
   const paths = useRoutes();
 

--- a/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPage.tsx
+++ b/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPage.tsx
@@ -1,11 +1,16 @@
 import { useIntl, defineMessage } from "react-intl";
 import Cog8ToothIcon from "@heroicons/react/24/outline/Cog8ToothIcon";
-import { useMutation, useQuery } from "urql";
+import { useQuery } from "urql";
+import UserCircleIcon from "@heroicons/react/24/outline/UserCircleIcon";
+import type { ReactNode } from "react";
 
 import {
+  Card,
+  CardSeparator,
   Container,
   Link,
   NotFound,
+  Notice,
   Pending,
   Separator,
   TableOfContents,
@@ -15,20 +20,17 @@ import { getFragment, graphql } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 import { ROLE_NAME } from "@gc-digital-talent/auth";
 import { commonMessages, navigationMessages } from "@gc-digital-talent/i18n";
+import { getRuntimeVariable } from "@gc-digital-talent/env";
 
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import useRoutes from "~/hooks/useRoutes";
 import SEO from "~/components/SEO/SEO";
 import Hero from "~/components/Hero";
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
-import PersonalInformation from "~/components/Profile/components/PersonalInformation/PersonalInformation";
-import type { SectionProps } from "~/components/Profile/types";
 import type { Status } from "~/components/StatusItem/StatusItem";
 import StatusItem from "~/components/StatusItem/StatusItem";
-import { aboutSectionHasEmptyRequiredFields } from "~/validators/profile";
 import messages from "~/messages/profileMessages";
-import ContactEmailCard from "~/components/ContactEmailCard/ContactEmailCard";
-import WorkEmailCard from "~/components/WorkEmailCard.tsx/WorkEmailCard";
+import { getFullNameLabel } from "~/utils/nameUtils";
 
 import AccountManagement from "./AccountManagement";
 import NotificationSettings from "./NotificationSettings";
@@ -40,43 +42,19 @@ const PersonalInformation_Fragment = graphql(/** GraphQL */ `
     lastName
     telephone
     email
-    isEmailVerified
-    workEmail
-    isWorkEmailVerified
-    isVerifiedGovEmployee
     preferredLang {
       value
-    }
-    preferredLanguageForInterview {
-      value
-    }
-    preferredLanguageForExam {
-      value
-    }
-    citizenship {
-      value
-    }
-    armedForcesStatus {
-      value
+      label {
+        localized
+      }
     }
     enabledEmailNotifications
     enabledInAppNotifications
-    ...ProfilePersonalInformation
-    ...ContactEmailCard
-    ...WorkEmailCard
-  }
-`);
-
-const ProfileUpdateUser_Mutation = graphql(/* GraphQL */ `
-  mutation UpdateUserAsUser($id: ID!, $user: UpdateUserAsUserInput!) {
-    updateUserAsUser(id: $id, user: $user) {
-      id
-    }
   }
 `);
 
 export type SectionKey =
-  | "personalInfo"
+  | "accountAndContact"
   | "notificationSettings"
   | "accountManagement";
 
@@ -93,8 +71,9 @@ const pageTitle = defineMessage({
 });
 
 const subTitle = defineMessage({
-  defaultMessage: "Learn about GCKey and manage your notifications.",
-  id: "HR2ouB",
+  defaultMessage:
+    "Update your personal and employee information, manage notifications, and update your availability.",
+  id: "SdglrJ",
   description: "Subtitle for the account settings page.",
 });
 
@@ -122,16 +101,14 @@ const AccountSettings = ({ personalInfoQuery }: AccountSettingsProps) => {
   const formattedSubTitle = intl.formatMessage(subTitle);
 
   const sections: Record<SectionKey, Section> = {
-    personalInfo: {
-      id: "personal-info",
+    accountAndContact: {
+      id: "account-and-contact",
       title: intl.formatMessage({
-        defaultMessage: "Personal and contact information",
-        id: "BWh6S1",
-        description: "Title for the personal and contact information section",
+        defaultMessage: "Account and contact information",
+        id: "sx79Vq",
+        description:
+          "Title for the account and contact information information section",
       }),
-      status: aboutSectionHasEmptyRequiredFields(personalInfo)
-        ? "error"
-        : "success",
     },
     notificationSettings: {
       id: "notification-settings",
@@ -160,23 +137,7 @@ const AccountSettings = ({ personalInfoQuery }: AccountSettingsProps) => {
     ],
   });
 
-  const [{ fetching: isUpdating }, executeUpdateMutation] = useMutation(
-    ProfileUpdateUser_Mutation,
-  );
-
-  const handleUpdate: SectionProps["onUpdate"] = async (userId, userData) => {
-    return executeUpdateMutation({
-      id: userId,
-      user: userData,
-    }).then((res) => res.data?.updateUserAsUser);
-  };
-
-  const sectionProps = {
-    query: personalInfo,
-    isUpdating,
-    onUpdate: handleUpdate,
-    pool: null,
-  };
+  const manageAccountUri = getRuntimeVariable("OAUTH_MANAGE_ACCOUNT_URI");
 
   return (
     <>
@@ -193,10 +154,7 @@ const AccountSettings = ({ personalInfoQuery }: AccountSettingsProps) => {
               {Object.values(sections).map((section) => {
                 if (section.status) {
                   return (
-                    <TableOfContents.ListItem
-                      key={section.id}
-                      className="-ml-7px list-none"
-                    >
+                    <TableOfContents.ListItem key={section.id}>
                       <StatusItem
                         asListItem={false}
                         title={section.title}
@@ -226,14 +184,97 @@ const AccountSettings = ({ personalInfoQuery }: AccountSettingsProps) => {
             </div>
           </TableOfContents.Navigation>
           <TableOfContents.Content>
-            <TableOfContents.Section id={sections.personalInfo.id}>
-              <div className="grid grid-cols-1 gap-1.5 xs:grid-cols-2">
-                <div className="col-span-2">
-                  <PersonalInformation {...sectionProps} />
+            <TableOfContents.Section id={sections.accountAndContact.id}>
+              <Card space="lg">
+                <TableOfContents.Heading
+                  size="h3"
+                  icon={UserCircleIcon}
+                  color="primary"
+                  className="mt-0 mb-6"
+                >
+                  {sections.accountAndContact.title}
+                </TableOfContents.Heading>
+                <div className="mb-6">
+                  {intl.formatMessage(
+                    {
+                      defaultMessage:
+                        "GC Digital Talent partners with the Government of Canada’s credential service, CanadaLogin, to provide you with account access using a single username and password. You can <a>manage related data on the CanadaLogin website</a> and it will automatically reflect here when you access your account.",
+                      id: "zLaAer",
+                      description:
+                        "Description for the account and information section",
+                    },
+                    {
+                      a: (chunks: ReactNode) => {
+                        return manageAccountUri ? (
+                          <Link href={manageAccountUri} color="black">
+                            {chunks}
+                          </Link>
+                        ) : (
+                          <span>{chunks}</span>
+                        );
+                      },
+                    },
+                  )}
                 </div>
-                <ContactEmailCard query={personalInfo} />
-                <WorkEmailCard query={personalInfo} />
-              </div>
+                <Notice.Root className="mb-9">
+                  <Notice.Title>
+                    {getFullNameLabel(
+                      personalInfo.firstName,
+                      personalInfo.lastName,
+                      intl,
+                    )}
+                  </Notice.Title>
+                  <Notice.Content>
+                    {personalInfo.email ? (
+                      <p>
+                        <Link
+                          href={`mailto:${personalInfo.email}`}
+                          color="black"
+                        >
+                          {personalInfo.email}
+                        </Link>
+                      </p>
+                    ) : null}
+
+                    {personalInfo.telephone ? (
+                      <p>{personalInfo.telephone}</p>
+                    ) : null}
+                    <p>
+                      {intl.formatMessage({
+                        defaultMessage: "Preferred contact language",
+                        id: "AumMAr",
+                        description:
+                          "Legend text for required language preference in getting started form",
+                      }) +
+                        intl.formatMessage(commonMessages.dividingColon) +
+                        personalInfo.preferredLang?.label.localized}
+                    </p>
+                  </Notice.Content>
+                </Notice.Root>
+                {manageAccountUri ? (
+                  <>
+                    <CardSeparator
+                      space="lg"
+                      orientation="horizontal"
+                      className="my-0"
+                    />
+                    <div className="mt-6">
+                      <Link
+                        href={manageAccountUri}
+                        external
+                        className="font-bold"
+                      >
+                        {intl.formatMessage({
+                          defaultMessage: "Update CanadaLogin information",
+                          id: "vdPlPP",
+                          description:
+                            "Link to update your CanadaLogin information",
+                        })}
+                      </Link>
+                    </div>
+                  </>
+                ) : null}
+              </Card>
             </TableOfContents.Section>
             <TableOfContents.Section
               id={sections.notificationSettings.id}

--- a/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPage.tsx
+++ b/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPage.tsx
@@ -25,7 +25,6 @@ import type { Status } from "~/components/StatusItem/StatusItem";
 import StatusItem from "~/components/StatusItem/StatusItem";
 import messages from "~/messages/profileMessages";
 
-import AccountManagement from "./AccountManagement";
 import NotificationSettings from "./NotificationSettings";
 import AccountAndContactInformation from "./AccountAndContactInformation";
 
@@ -38,10 +37,7 @@ const PersonalInformation_Fragment = graphql(/** GraphQL */ `
   }
 `);
 
-export type SectionKey =
-  | "accountAndContact"
-  | "notificationSettings"
-  | "accountManagement";
+export type SectionKey = "accountAndContact" | "notificationSettings";
 
 interface Section {
   id: string;
@@ -101,14 +97,6 @@ const AccountSettings = ({ personalInfoQuery }: AccountSettingsProps) => {
         defaultMessage: "Notification settings",
         id: "mZ1C/0",
         description: "Title for the notification settings.",
-      }),
-    },
-    accountManagement: {
-      id: "account-management",
-      title: intl.formatMessage({
-        defaultMessage: "Account management",
-        id: "efBMD2",
-        description: "Title for the account management.",
       }),
     },
   };
@@ -195,29 +183,6 @@ const AccountSettings = ({ personalInfoQuery }: AccountSettingsProps) => {
                 enabledEmailNotifications={enabledEmailNotifications}
                 enabledInAppNotifications={enabledInAppNotifications}
               />
-            </TableOfContents.Section>
-            <TableOfContents.Section
-              id={sections.accountManagement.id}
-              className="mt-12 xs:mt-18"
-            >
-              <TableOfContents.Heading
-                size="h3"
-                icon={Cog8ToothIcon}
-                color="primary"
-                className="mt-0 mb-6"
-              >
-                {sections.accountManagement.title}
-              </TableOfContents.Heading>
-              <p className="mb-6">
-                {intl.formatMessage({
-                  defaultMessage:
-                    "This section focuses on general account management and information related to how we link to your GCKey.",
-                  id: "G6PxDn",
-                  description:
-                    "Subtitle for account management section on account settings page.",
-                })}
-              </p>
-              <AccountManagement />
             </TableOfContents.Section>
           </TableOfContents.Content>
         </TableOfContents.Wrapper>

--- a/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPageDeprecated.tsx
+++ b/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPageDeprecated.tsx
@@ -1,0 +1,329 @@
+import { useIntl, defineMessage } from "react-intl";
+import Cog8ToothIcon from "@heroicons/react/24/outline/Cog8ToothIcon";
+import { useMutation, useQuery } from "urql";
+
+import {
+  Container,
+  Link,
+  NotFound,
+  Pending,
+  Separator,
+  TableOfContents,
+} from "@gc-digital-talent/ui";
+import type { FragmentType } from "@gc-digital-talent/graphql";
+import { getFragment, graphql } from "@gc-digital-talent/graphql";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+import { commonMessages, navigationMessages } from "@gc-digital-talent/i18n";
+
+import useBreadcrumbs from "~/hooks/useBreadcrumbs";
+import useRoutes from "~/hooks/useRoutes";
+import SEO from "~/components/SEO/SEO";
+import Hero from "~/components/Hero";
+import RequireAuth from "~/components/RequireAuth/RequireAuth";
+import PersonalInformation from "~/components/Profile/components/PersonalInformation/PersonalInformation";
+import type { SectionProps } from "~/components/Profile/types";
+import type { Status } from "~/components/StatusItem/StatusItem";
+import StatusItem from "~/components/StatusItem/StatusItem";
+import { aboutSectionHasEmptyRequiredFields } from "~/validators/profile";
+import messages from "~/messages/profileMessages";
+import ContactEmailCard from "~/components/ContactEmailCard/ContactEmailCard";
+import WorkEmailCard from "~/components/WorkEmailCard.tsx/WorkEmailCard";
+
+import AccountManagement from "./AccountManagement";
+import NotificationSettings from "./NotificationSettings";
+
+const PersonalInformation_Fragment = graphql(/** GraphQL */ `
+  fragment PersonalInformationDeprecated on User {
+    id
+    firstName
+    lastName
+    telephone
+    email
+    isEmailVerified
+    workEmail
+    isWorkEmailVerified
+    isVerifiedGovEmployee
+    preferredLang {
+      value
+    }
+    preferredLanguageForInterview {
+      value
+    }
+    preferredLanguageForExam {
+      value
+    }
+    citizenship {
+      value
+    }
+    armedForcesStatus {
+      value
+    }
+    enabledEmailNotifications
+    enabledInAppNotifications
+    ...ProfilePersonalInformation
+    ...ContactEmailCard
+    ...WorkEmailCard
+  }
+`);
+
+const ProfileUpdateUser_Mutation = graphql(/* GraphQL */ `
+  mutation UpdateUserAsUser($id: ID!, $user: UpdateUserAsUserInput!) {
+    updateUserAsUser(id: $id, user: $user) {
+      id
+    }
+  }
+`);
+
+export type SectionKey =
+  | "personalInfo"
+  | "notificationSettings"
+  | "accountManagement";
+
+interface Section {
+  id: string;
+  title: string;
+  status?: Status;
+}
+
+const pageTitle = defineMessage({
+  defaultMessage: "Account settings",
+  id: "2r9tuE",
+  description: "Title for the account settings page",
+});
+
+const subTitle = defineMessage({
+  defaultMessage: "Learn about GCKey and manage your notifications.",
+  id: "HR2ouB",
+  description: "Subtitle for the account settings page.",
+});
+
+interface AccountSettingsProps {
+  personalInfoQuery: FragmentType<typeof PersonalInformation_Fragment>;
+}
+
+const AccountSettings = ({ personalInfoQuery }: AccountSettingsProps) => {
+  const intl = useIntl();
+  const paths = useRoutes();
+
+  const personalInfo = getFragment(
+    PersonalInformation_Fragment,
+    personalInfoQuery,
+  );
+
+  const enabledEmailNotifications = unpackMaybes(
+    personalInfo.enabledEmailNotifications,
+  );
+  const enabledInAppNotifications = unpackMaybes(
+    personalInfo.enabledInAppNotifications,
+  );
+
+  const formattedPageTitle = intl.formatMessage(pageTitle);
+  const formattedSubTitle = intl.formatMessage(subTitle);
+
+  const sections: Record<SectionKey, Section> = {
+    personalInfo: {
+      id: "personal-info",
+      title: intl.formatMessage({
+        defaultMessage: "Personal and contact information",
+        id: "BWh6S1",
+        description: "Title for the personal and contact information section",
+      }),
+      status: aboutSectionHasEmptyRequiredFields(personalInfo)
+        ? "error"
+        : "success",
+    },
+    notificationSettings: {
+      id: "notification-settings",
+      title: intl.formatMessage({
+        defaultMessage: "Notification settings",
+        id: "mZ1C/0",
+        description: "Title for the notification settings.",
+      }),
+    },
+    accountManagement: {
+      id: "account-management",
+      title: intl.formatMessage({
+        defaultMessage: "Account management",
+        id: "efBMD2",
+        description: "Title for the account management.",
+      }),
+    },
+  };
+
+  const crumbs = useBreadcrumbs({
+    crumbs: [
+      {
+        label: formattedPageTitle,
+        url: paths.accountSettings(),
+      },
+    ],
+  });
+
+  const [{ fetching: isUpdating }, executeUpdateMutation] = useMutation(
+    ProfileUpdateUser_Mutation,
+  );
+
+  const handleUpdate: SectionProps["onUpdate"] = async (userId, userData) => {
+    return executeUpdateMutation({
+      id: userId,
+      user: userData,
+    }).then((res) => res.data?.updateUserAsUser);
+  };
+
+  const sectionProps = {
+    query: personalInfo,
+    isUpdating,
+    onUpdate: handleUpdate,
+    pool: null,
+  };
+
+  return (
+    <>
+      <SEO title={formattedPageTitle} description={formattedSubTitle} />
+      <Hero
+        title={formattedPageTitle}
+        subtitle={formattedSubTitle}
+        crumbs={crumbs}
+      />
+      <Container className="my-18">
+        <TableOfContents.Wrapper>
+          <TableOfContents.Navigation>
+            <TableOfContents.List>
+              {Object.values(sections).map((section) => {
+                if (section.status) {
+                  return (
+                    <TableOfContents.ListItem
+                      key={section.id}
+                      className="-ml-7px list-none"
+                    >
+                      <StatusItem
+                        asListItem={false}
+                        title={section.title}
+                        status={section.status}
+                        scrollTo={section.id}
+                      />
+                    </TableOfContents.ListItem>
+                  );
+                }
+                return (
+                  <TableOfContents.ListItem key={section.id}>
+                    <TableOfContents.AnchorLink id={section.id}>
+                      {section.title}
+                    </TableOfContents.AnchorLink>
+                  </TableOfContents.ListItem>
+                );
+              })}
+            </TableOfContents.List>
+            <Separator space="sm" />
+            <div className="flex flex-col gap-y-3">
+              <Link href={paths.profile()}>
+                {intl.formatMessage(navigationMessages.applicantProfile)}
+              </Link>
+              <Link href={paths.employeeProfile()}>
+                {intl.formatMessage(navigationMessages.employeeProfileGC)}
+              </Link>
+            </div>
+          </TableOfContents.Navigation>
+          <TableOfContents.Content>
+            <TableOfContents.Section id={sections.personalInfo.id}>
+              <div className="grid grid-cols-1 gap-1.5 xs:grid-cols-2">
+                <div className="col-span-2">
+                  <PersonalInformation {...sectionProps} />
+                </div>
+                <ContactEmailCard query={personalInfo} />
+                <WorkEmailCard query={personalInfo} />
+              </div>
+            </TableOfContents.Section>
+            <TableOfContents.Section
+              id={sections.notificationSettings.id}
+              className="mt-12 xs:mt-18"
+            >
+              <TableOfContents.Heading
+                size="h3"
+                icon={Cog8ToothIcon}
+                color="secondary"
+                className="mt-0 mb-6"
+              >
+                {sections.notificationSettings.title}
+              </TableOfContents.Heading>
+              <p className="mb-6">
+                {intl.formatMessage({
+                  defaultMessage:
+                    "The settings provided in this section allow you to control the types of notifications you receive and where they are delivered. Email notifications are delivered to the contact email provided on your profile, while in-app notifications are delivered to the notification pane found in the main menu.",
+                  id: "J/gp3y",
+                  description:
+                    "Subtitle for notification settings section on account settings page.",
+                })}
+              </p>
+              <NotificationSettings
+                enabledEmailNotifications={enabledEmailNotifications}
+                enabledInAppNotifications={enabledInAppNotifications}
+              />
+            </TableOfContents.Section>
+            <TableOfContents.Section
+              id={sections.accountManagement.id}
+              className="mt-12 xs:mt-18"
+            >
+              <TableOfContents.Heading
+                size="h3"
+                icon={Cog8ToothIcon}
+                color="primary"
+                className="mt-0 mb-6"
+              >
+                {sections.accountManagement.title}
+              </TableOfContents.Heading>
+              <p className="mb-6">
+                {intl.formatMessage({
+                  defaultMessage:
+                    "This section focuses on general account management and information related to how we link to your GCKey.",
+                  id: "G6PxDn",
+                  description:
+                    "Subtitle for account management section on account settings page.",
+                })}
+              </p>
+              <AccountManagement />
+            </TableOfContents.Section>
+          </TableOfContents.Content>
+        </TableOfContents.Wrapper>
+      </Container>
+    </>
+  );
+};
+
+const AccountSettings_Query = graphql(/* GraphQL */ `
+  query AccountSettingsDeprecated {
+    me {
+      ...PersonalInformationDeprecated
+    }
+  }
+`);
+
+export const AccountSettingsPageDeprecated = () => {
+  const intl = useIntl();
+  const [{ data, fetching, error }] = useQuery({
+    query: AccountSettings_Query,
+  });
+
+  return (
+    <Pending fetching={fetching} error={error}>
+      {data?.me ? (
+        <AccountSettings personalInfoQuery={data?.me} />
+      ) : (
+        <NotFound headingMessage={intl.formatMessage(commonMessages.notFound)}>
+          <p>{intl.formatMessage(messages.userNotFound)}</p>
+        </NotFound>
+      )}
+    </Pending>
+  );
+};
+
+export const Component = () => (
+  <RequireAuth roles={[ROLE_NAME.Applicant]}>
+    <AccountSettingsPageDeprecated />
+  </RequireAuth>
+);
+
+Component.displayName = "AccountSettingsPageDeprecated";
+
+export default Component;

--- a/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPageWrapper.tsx
+++ b/apps/web/src/pages/Profile/AccountSettings/AccountSettingsPageWrapper.tsx
@@ -1,0 +1,24 @@
+import { useFeatureFlags } from "@gc-digital-talent/env";
+
+import { AccountSettingsPage } from "./AccountSettingsPage";
+import { AccountSettingsPageDeprecated } from "./AccountSettingsPageDeprecated";
+
+/**
+ * A wrapper to conditionally render the actual account page
+ * depending on feature flags.  This component can be
+ * entirely removed along with the deprecated page
+ * when the flag is.
+ */
+export const Component = () => {
+  const featureFlags = useFeatureFlags();
+
+  return featureFlags.canadaLogin ? (
+    <AccountSettingsPage />
+  ) : (
+    <AccountSettingsPageDeprecated />
+  );
+};
+
+Component.displayName = "AccountSettingsPageWrapper";
+
+export default Component;

--- a/apps/web/src/routes.ts
+++ b/apps/web/src/routes.ts
@@ -148,7 +148,7 @@ export default [
                 ),
                 route(
                   "settings",
-                  "./pages/Profile/AccountSettings/AccountSettingsPage.tsx",
+                  "./pages/Profile/AccountSettings/AccountSettingsPageWrapper.tsx",
                 ),
                 route(
                   "notifications",

--- a/packages/ui/src/components/CardSeparator/CardSeparator.tsx
+++ b/packages/ui/src/components/CardSeparator/CardSeparator.tsx
@@ -1,6 +1,20 @@
 import type { ComponentProps } from "react";
+import { tv } from "tailwind-variants";
 
 import Separator from "../Separator";
+
+const cardSeparator = tv({
+  variants: {
+    // should match the spaces from Card.tsx
+    space: {
+      none: "",
+      xs: "-mx-3",
+      sm: "-mx-4",
+      md: "-mx-6",
+      lg: "-mx-6 sm:-mx-9",
+    },
+  },
+});
 
 const CardSeparator = ({
   orientation = "horizontal",
@@ -8,7 +22,7 @@ const CardSeparator = ({
   ...rest
 }: ComponentProps<typeof Separator>) => {
   return (
-    <div className="-mx-6">
+    <div className={cardSeparator({ space })}>
       <Separator decorative orientation={orientation} space={space} {...rest} />
     </div>
   );

--- a/packages/ui/src/components/CardSeparator/CardSeparator.tsx
+++ b/packages/ui/src/components/CardSeparator/CardSeparator.tsx
@@ -1,20 +1,6 @@
 import type { ComponentProps } from "react";
-import { tv } from "tailwind-variants";
 
 import Separator from "../Separator";
-
-const cardSeparator = tv({
-  variants: {
-    // should match the spaces from Card.tsx
-    space: {
-      none: "",
-      xs: "-mx-3",
-      sm: "-mx-4",
-      md: "-mx-6",
-      lg: "-mx-6 sm:-mx-9",
-    },
-  },
-});
 
 const CardSeparator = ({
   orientation = "horizontal",
@@ -22,7 +8,7 @@ const CardSeparator = ({
   ...rest
 }: ComponentProps<typeof Separator>) => {
   return (
-    <div className={cardSeparator({ space })}>
+    <div className="-mx-6">
       <Separator decorative orientation={orientation} space={space} {...rest} />
     </div>
   );


### PR DESCRIPTION
🤖 Resolves #16195 

## 👋 Introduction

Adds an alternative version of the Account Settings page for CanadaLogin.

## 🕵️ Details

At a high level:
- renames the existing accounts page to "deprecated"
- adds a wrapper to switch between the old and new versions
- factors out the personal info box from registration so it can be reused in accounts

## 🧪 Testing

1. Set FEATURE_CANADALOGIN=true in apps/web/.env
2. Rebuild
3. Log in as any user
4. Navigate to `/applicant/settings`
- [ ] Alternate version of page appears
- [ ] Page meets the issues AC
- [ ] Turning the feature flag off reverts to the previous account settings page

## 📸 Screenshot

<img width="911" height="642" alt="image" src="https://github.com/user-attachments/assets/352c1b33-f046-4b4a-9dab-57b89f67cf23" />
