### PR TITLE
[Refactor] Only run webkit tests on main branch

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: [chromium, webkit]
+        project: ${{ github.ref_name == 'main' && fromJSON('["chromium", "webkit"]') || fromJSON('["chromium"]') }}
         shardIndex: [1, 2, 3, 4]
         shardTotal: [4]
     env:


### PR DESCRIPTION
🤖 Resolves #16527 

## 👋 Introduction

Updates the playwright workflow to only run the webkit project on the main branch.

## 🧪 Testing

> [!NOTE]
> Hard to test since we would need to merge this into main to confirm that webkit infact runs :sweat_smile:  

1. Confirm that only chromium e2e tests run on this PR