### PR TITLE
[Fix] `ResponsiveTable` search param race condition

### DIFF
--- a/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
@@ -95,7 +95,6 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
 }: TableProps<TData, TFilters>) => {
   const id = useId();
   const intl = useIntl();
-  const isFirstRender = useRef(true);
   const lastWrittenTableParamsRef = useRef<Record<string, string | null>>({});
   const { announce } = useAnnouncer();
   const hasUpdatedRows = useRef<boolean>(false);
@@ -278,11 +277,6 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
         Object.fromEntries(managedKeys.map((key) => [key, newParams.get(key)]));
 
       if (!isEqual(desiredTableParams, lastWrittenTableParamsRef.current)) {
-        if (isFirstRender.current) {
-          isFirstRender.current = false;
-          lastWrittenTableParamsRef.current = desiredTableParams;
-          return;
-        }
         setSearchParams(newParams, { replace: true });
         lastWrittenTableParamsRef.current = desiredTableParams;
       }

--- a/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
@@ -95,6 +95,9 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
 }: TableProps<TData, TFilters>) => {
   const id = useId();
   const intl = useIntl();
+  // Tracks the URL params this table last wrote. Compared against desired state before
+  // each write so back-button navigation (which changes URL but not table state) doesn't
+  // trigger a competing setSearchParams call during the route transition.
   const lastWrittenTableParamsRef = useRef<Record<string, string | null>>({});
   const { announce } = useAnnouncer();
   const hasUpdatedRows = useRef<boolean>(false);
@@ -264,6 +267,7 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
         newParams.set(filterParamKey, JSON.stringify(filter?.state));
       }
 
+      // Only write if the table's desired params changed — not if unrelated URL state changed.
       const managedKeys = [
         SEARCH_PARAM_KEY.SORT_RULE,
         SEARCH_PARAM_KEY.HIDDEN_COLUMNS,

--- a/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
@@ -96,6 +96,7 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
   const id = useId();
   const intl = useIntl();
   const isFirstRender = useRef(true);
+  const lastWrittenTableParamsRef = useRef<Record<string, string | null>>({});
   const { announce } = useAnnouncer();
   const hasUpdatedRows = useRef<boolean>(false);
   const [, setSearchParams] = useSearchParams();
@@ -171,7 +172,6 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
 
   useEffect(() => {
     if (urlSync) {
-      const currentParams = new URLSearchParams(window.location.search);
       const newParams = new URLSearchParams(window.location.search);
 
       let searchState: SearchState = {
@@ -265,17 +265,26 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
         newParams.set(filterParamKey, JSON.stringify(filter?.state));
       }
 
-      if (
-        !isEqual(
-          Object.fromEntries(currentParams),
-          Object.fromEntries(newParams),
-        )
-      ) {
+      const managedKeys = [
+        SEARCH_PARAM_KEY.SORT_RULE,
+        SEARCH_PARAM_KEY.HIDDEN_COLUMNS,
+        SEARCH_PARAM_KEY.PAGE_SIZE,
+        SEARCH_PARAM_KEY.PAGE,
+        SEARCH_PARAM_KEY.SEARCH_COLUMN,
+        SEARCH_PARAM_KEY.SEARCH_TERM,
+        filterParamKey,
+      ];
+      const desiredTableParams: Record<string, string | null> =
+        Object.fromEntries(managedKeys.map((key) => [key, newParams.get(key)]));
+
+      if (!isEqual(desiredTableParams, lastWrittenTableParamsRef.current)) {
         if (isFirstRender.current) {
           isFirstRender.current = false;
+          lastWrittenTableParamsRef.current = desiredTableParams;
           return;
         }
         setSearchParams(newParams, { replace: true });
+        lastWrittenTableParamsRef.current = desiredTableParams;
       }
     }
   }, [


### PR DESCRIPTION
🤖 Resolves #15883 

## 👋 Introduction

Addresses an issue in the `ResponsiveTable` when navigating using the browser back button.

## 🕵️ Details

When you have search params in the browser history and the current page and navigated back, react was comparing the current URL params (which were changing) to determine if it should re-render.  The issue was, during navigatioin we had two separate search params (before and after navigaiton). They were racing eachother to replace thge URL state.

The losing one would see nothing to replace (old params were gone) hence the `removeChild` error.



## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to `/admin/talent-requests`
4. Add some filters to updarte thr URLSearchParams
5. Click on a request
6. Scroll to the candidates table
7. Modify the filters tol up the URLSearchParams
8. Press the back button in the browser
9. Confirm no console errors for `removeChild`
10. Confirm the loading spinner does not hang