### PR TITLE
[Debt] Reduce can root usage

### DIFF
--- a/api/app/Models/AssessmentStep.php
+++ b/api/app/Models/AssessmentStep.php
@@ -224,12 +224,12 @@ class AssessmentStep extends Model
 
             return $query->whereHas('pool', function (Builder $poolQuery) use ($teamIds) {
                 return $poolQuery->where(function (Builder $poolQuery) use ($teamIds) {
-                    $poolQuery->orWhereHas('team', function (Builder $poolQuery) use ($teamIds) {
-                        return $poolQuery->whereIn('id', $teamIds);
-                    })->orWhereHas('community.team', function (Builder $poolQuery) use ($teamIds) {
-                        return $poolQuery->whereIn('id', $teamIds);
-                    })->orWhereHas('department.team', function (Builder $poolQuery) use ($teamIds) {
-                        return $poolQuery->whereIn('id', $teamIds);
+                    $poolQuery->orWhereHas('team', function (Builder $teamQuery) use ($teamIds) {
+                        return $teamQuery->whereIn('id', $teamIds);
+                    })->orWhereHas('community.team', function (Builder $communityQuery) use ($teamIds) {
+                        return $communityQuery->whereIn('id', $teamIds);
+                    })->orWhereHas('department.team', function (Builder $deptQuery) use ($teamIds) {
+                        return $deptQuery->whereIn('id', $teamIds);
                     });
                 });
             });

--- a/api/app/Models/AssessmentStep.php
+++ b/api/app/Models/AssessmentStep.php
@@ -205,7 +205,7 @@ class AssessmentStep extends Model
         });
     }
 
-    public static function withPolicyEagerLoads(Builder $query): Builder
+    public static function scopeWithPolicyEagerLoads(Builder $query): Builder
     {
         return $query->with(['pool.team', 'pool.community.team', 'pool.department.team']);
     }

--- a/api/app/Models/AssessmentStep.php
+++ b/api/app/Models/AssessmentStep.php
@@ -7,6 +7,7 @@ use App\Enums\ActivityEvent;
 use App\Enums\ActivityLog;
 use App\Enums\AssessmentStepType;
 use App\Traits\LogsCustomActivity;
+use Database\Helpers\TeamHelpers;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -15,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
@@ -206,5 +208,33 @@ class AssessmentStep extends Model
     public static function withPolicyEagerLoads(Builder $query): Builder
     {
         return $query->with(['pool.team', 'pool.community.team', 'pool.department.team']);
+    }
+
+    public function scopeWhereAuthorizedToView(Builder $query)
+    {
+        /** @var User | null */
+        $user = Auth::user();
+
+        if ($user?->isAbleTo('view-any-assessmentPlan')) {
+            return $query;
+        }
+
+        if ($user?->isAbleTo('view-team-assessmentPlan')) {
+            $teamIds = TeamHelpers::getTeamIdsForPermission($user, 'view-team-assessmentPlan');
+
+            return $query->whereHas('pool', function (Builder $poolQuery) use ($teamIds) {
+                return $poolQuery->where(function (Builder $poolQuery) use ($teamIds) {
+                    $poolQuery->orWhereHas('team', function (Builder $poolQuery) use ($teamIds) {
+                        return $poolQuery->whereIn('id', $teamIds);
+                    })->orWhereHas('community.team', function (Builder $poolQuery) use ($teamIds) {
+                        return $poolQuery->whereIn('id', $teamIds);
+                    })->orWhereHas('department.team', function (Builder $poolQuery) use ($teamIds) {
+                        return $poolQuery->whereIn('id', $teamIds);
+                    });
+                });
+            });
+        }
+
+        return $query->whereRaw('0 = 1');
     }
 }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -828,9 +828,6 @@ type Community implements HasRoleAssignments {
     @with(relation: "team")
     @canRoot(ability: "viewTeamMembers")
   teamIdForRoleAssignment: ID @with(relation: "team")
-  pools: [Pool]
-    @hasMany(scopes: ["authorizedToView"])
-    @canResolved(ability: "view")
   workStreams: [WorkStream!] @hasMany
   communityDevelopmentPrograms: [CommunityDevelopmentProgram!] @hasMany
   associatedDevelopmentPrograms: [DevelopmentProgram!]

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -569,16 +569,6 @@ type AssessmentStep {
   sortOrder: Int @rename(attribute: "sort_order")
   title: LocalizedString
   poolSkills: [PoolSkill] @belongsToMany
-  assessmentResults: [AssessmentResult]
-    @hasMany
-    @with(
-      relations: [
-        "assessmentResult.pool.team"
-        "assessmentResult.pool.community.team"
-        "assessmentResult.department.team"
-      ]
-    )
-    @canRoot(ability: "viewAssessmentResults")
   screeningQuestions: [ScreeningQuestion] @with(relation: "screeningQuestions")
 }
 

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -603,8 +603,7 @@ type PoolSkill {
   requiredLevel: SkillLevel @rename(attribute: "required_skill_level")
   skill: Skill @belongsTo
   assessmentSteps: [AssessmentStep]
-    @belongsToMany
-    @canRoot(ability: "viewAssessmentSteps", scopes: ["withPolicyEagerLoads"])
+    @belongsToMany(scopes: ["whereAuthorizedToView"])
 }
 
 type PoolCandidateCategory {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -520,8 +520,7 @@ type Pool implements HasRoleAssignments {
   isComplete: Boolean @rename(attribute: "is_complete")
   assessmentPlanIsComplete: Boolean
   assessmentSteps: [AssessmentStep]
-    @hasMany
-    @canRoot(ability: "viewAssessmentPlan", scopes: ["withPolicyEagerLoads"])
+    @hasMany(scopes: ["withPolicyEagerLoads", "whereAuthorizedToView"])
   poolSkills(type: PoolSkillType @where): [PoolSkill]
     @hasMany(scopes: ["withPolicyEagerLoads"])
   roleAssignments: [RoleAssignment!]

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1126,7 +1126,6 @@ type AssessmentStep {
   sortOrder: Int
   title: LocalizedString
   poolSkills: [PoolSkill]
-  assessmentResults: [AssessmentResult]
   screeningQuestions: [ScreeningQuestion]
 }
 

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1307,7 +1307,6 @@ type Community implements HasRoleAssignments {
   contactEmail: String
   roleAssignments: [RoleAssignment!]
   teamIdForRoleAssignment: ID
-  pools: [Pool]
   workStreams: [WorkStream!]
   communityDevelopmentPrograms: [CommunityDevelopmentProgram!]
   associatedDevelopmentPrograms: [DevelopmentProgram!]

--- a/api/tests/Feature/PoolSkillAssessmentStepAuthorizationTest.php
+++ b/api/tests/Feature/PoolSkillAssessmentStepAuthorizationTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\Pool;
+use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
+use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
+
+class PoolSkillAssessmentStepAuthorizationTest extends TestCase
+{
+    use MakesGraphQLRequests;
+    use RefreshDatabase;
+    use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
+
+    protected $deptA;
+
+    protected $deptB;
+
+    protected $poolA;
+
+    protected $poolB;
+
+    protected string $query = <<<'GRAPHQL'
+        query GetPoolSkillSteps($id: UUID!) {
+            pool(id: $id) {
+                id
+                poolSkills {
+                    id
+                    assessmentSteps {
+                        id
+                    }
+                }
+            }
+        }
+    GRAPHQL;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolePermissionSeeder::class);
+
+        $this->deptA = Department::factory()->create();
+        $this->poolA = Pool::factory()->published()->create([
+            'department_id' => $this->deptA->id,
+        ]);
+
+        $this->deptB = Department::factory()->create();
+        $this->poolB = Pool::factory()->published()->create([
+            'department_id' => $this->deptB->id,
+        ]);
+    }
+
+    public function testDepartmentAdvisorNestedStepBoundaries(): void
+    {
+        $advisorA = User::factory()
+            ->asDepartmentHRAdvisor($this->deptA->id)
+            ->create();
+
+        $skillA = $this->poolA->poolSkills->first();
+        $stepIdA = $skillA->assessmentSteps->first()->id;
+
+        $skillB = $this->poolB->poolSkills->first();
+        $stepIdB = $skillB->assessmentSteps->first()->id;
+
+        $this->actingAs($advisorA, 'api')
+            ->graphQL($this->query, ['id' => $this->poolA->id])
+            ->assertJsonFragment(['id' => $stepIdA]);
+
+        $this->actingAs($advisorA, 'api')
+            ->graphQL($this->query, ['id' => $this->poolB->id])
+            ->assertJsonMissing(['id' => $stepIdB])
+            ->assertJson([
+                'data' => [
+                    'pool' => [
+                        'poolSkills' => [
+                            [
+                                'id' => $skillB->id,
+                                'assessmentSteps' => [],
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+    }
+
+    public function testPlatformAdminCanViewDeeplyNestedSteps(): void
+    {
+        $admin = User::factory()->asAdmin()->create();
+        $stepIdB = $this->poolB->poolSkills->first()->assessmentSteps->first()->id;
+
+        $this->actingAs($admin, 'api')
+            ->graphQL($this->query, ['id' => $this->poolB->id])
+            ->assertJsonFragment(['id' => $stepIdB]);
+    }
+
+    public function testApplicantCannotViewNestedSteps(): void
+    {
+        $applicant = User::factory()->asApplicant()->create();
+        $skillIdA = $this->poolA->poolSkills->first()->id;
+
+        $this->actingAs($applicant, 'api')
+            ->graphQL($this->query, ['id' => $this->poolA->id])
+            ->assertJson([
+                'data' => [
+                    'pool' => [
+                        'poolSkills' => [
+                            [
+                                'id' => $skillIdA,
+                                'assessmentSteps' => [],
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+    }
+}

--- a/api/tests/Unit/AssessmentStepAuthorizationScopeTest.php
+++ b/api/tests/Unit/AssessmentStepAuthorizationScopeTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\AssessmentStep;
+use App\Models\Community;
+use App\Models\Department;
+use App\Models\Pool;
+use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+use Tests\TestCase;
+
+class AssessmentStepAuthorizationScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $poolA;
+
+    protected $poolB;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(RolePermissionSeeder::class);
+
+        // Setup Pool A with Assessment Steps
+        $this->poolA = Pool::factory()->published()->create();
+
+        // Setup Pool B with Assessment Steps
+        $this->poolB = Pool::factory()->published()->create();
+    }
+
+    /**
+     * Platform Admin should see all steps across all pools.
+     * Permission: view-any-assessmentPlan
+     */
+    public function testScopeAuthorizedToViewAsPlatformAdmin(): void
+    {
+        Auth::shouldReceive('user')
+            ->andReturn(User::factory()->asAdmin()->create());
+
+        $viewableIds = AssessmentStep::whereAuthorizedToView()->pluck('id')->toArray();
+        $allIds = AssessmentStep::pluck('id')->toArray();
+
+        $this->assertEqualsCanonicalizing($allIds, $viewableIds);
+    }
+
+    /**
+     * Process Operator should see steps for their pool,
+     * but MUST NOT see steps from other pools.
+     * Permission: view-team-assessmentPlan
+     */
+    public function testScopeAuthorizedToViewAsProcessOperatorBoundary(): void
+    {
+        // User is operator for Pool A only
+        $operator = User::factory()->asProcessOperator($this->poolA->id)->create();
+        Auth::shouldReceive('user')->andReturn($operator);
+
+        $viewableIds = AssessmentStep::whereAuthorizedToView()->pluck('id')->toArray();
+
+        $expectedIds = $this->poolA->assessmentSteps->pluck('id')->toArray();
+        $forbiddenIds = $this->poolB->assessmentSteps->pluck('id')->toArray();
+
+        // Affirmative: They see theirs
+        foreach ($expectedIds as $id) {
+            $this->assertContains($id, $viewableIds);
+        }
+
+        // Negative: They DO NOT see others (Boundary check)
+        foreach ($forbiddenIds as $id) {
+            $this->assertNotContains($id, $viewableIds, 'Process Operator leaked data from a pool they do not manage.');
+        }
+    }
+
+    /**
+     * Department HR Advisor should see steps for pools in their department,
+     * but MUST NOT see steps for pools in other departments.
+     * Permission: view-team-assessmentPlan
+     */
+    public function testScopeAuthorizedToViewAsDepartmentAdvisorBoundary(): void
+    {
+        $deptA = Department::factory()->create();
+        $this->poolA->department_id = $deptA->id;
+        $this->poolA->save();
+
+        $deptB = Department::factory()->create();
+        $this->poolB->department_id = $deptB->id;
+        $this->poolB->save();
+
+        // Advisor belongs to Dept A
+        $advisor = User::factory()->asDepartmentHRAdvisor($deptA->id)->create();
+        Auth::shouldReceive('user')->andReturn($advisor);
+
+        $viewableIds = AssessmentStep::whereAuthorizedToView()->pluck('id')->toArray();
+
+        $expectedId = $this->poolA->assessmentSteps->first()->id;
+        $forbiddenId = $this->poolB->assessmentSteps->first()->id;
+
+        $this->assertContains($expectedId, $viewableIds);
+        $this->assertNotContains($forbiddenId, $viewableIds, 'HR Advisor leaked data from a different department.');
+    }
+
+    /**
+     * Community Admin should see steps for pools in their community,
+     * but MUST NOT see steps for pools in other communities.
+     * Permission: view-team-assessmentPlan
+     */
+    public function testScopeAuthorizedToViewAsCommunityAdminBoundary(): void
+    {
+        $commA = Community::factory()->create();
+        $this->poolA->community_id = $commA->id;
+        $this->poolA->save();
+
+        $commB = Community::factory()->create();
+        $this->poolB->community_id = $commB->id;
+        $this->poolB->save();
+
+        $admin = User::factory()->asCommunityAdmin($commA->id)->create();
+        Auth::shouldReceive('user')->andReturn($admin);
+
+        $viewableIds = AssessmentStep::whereAuthorizedToView()->pluck('id')->toArray();
+
+        $this->assertContains($this->poolA->assessmentSteps->first()->id, $viewableIds);
+        $this->assertNotContains($this->poolB->assessmentSteps->first()->id, $viewableIds, 'Community Admin leaked data from another community.');
+    }
+
+    /**
+     * Negative Case: Applicant role.
+     * Applicants have NO view permissions for assessmentPlan in rolepermission.php.
+     */
+    public function testScopeAuthorizedToViewAsApplicant(): void
+    {
+        $applicant = User::factory()->asApplicant()->create();
+        Auth::shouldReceive('user')->andReturn($applicant);
+
+        $viewableIds = AssessmentStep::whereAuthorizedToView()->pluck('id')->toArray();
+
+        $this->assertEmpty($viewableIds, 'Applicants should have no access to internal assessment steps.');
+    }
+
+    /**
+     * Negative Case: Guest (Unauthenticated).
+     */
+    public function testScopeAuthorizedToViewAsGuest(): void
+    {
+        Auth::shouldReceive('user')->andReturn(null);
+
+        $viewableIds = AssessmentStep::whereAuthorizedToView()->pluck('id')->toArray();
+
+        $this->assertEmpty($viewableIds, 'Guests should see zero assessment steps.');
+    }
+}

--- a/apps/web/src/components/AssessmentResultsTable/testData.ts
+++ b/apps/web/src/components/AssessmentResultsTable/testData.ts
@@ -192,19 +192,15 @@ export const testPoolCandidate: PoolCandidate = {
       // set assessment steps out of order
       {
         ...interviewGroupStep,
-        assessmentResults: interviewGroupResults,
       },
       {
         ...applicationScreeningStep,
-        assessmentResults: applicationScreeningResults,
       },
       {
         ...referenceCheckStep,
-        assessmentResults: referenceCheckResults,
       },
       {
         ...screeningQuestionsStep,
-        assessmentResults: screeningQuestionsResults,
       },
     ],
   },


### PR DESCRIPTION
🤖 Resolves #16132 

## 👋 Introduction

This removes some instances of `@canRoot` and `@canResolved`.

## 🕵️ Details

These permission checks can hide n+1 queries which is detrimental when used in nested types. This PR removes 3 instances:

 - Removes `assessmentResults` from the `AssessmentStep` type since it was not being used
 - Removed `pools` from the `Community` type since it was not being used
 - Replaced `@canRoot` with a `whereAuthorizedToView` scope and tests

> [!IMPORTANT]
> The ticket comment mentions `PoolCandidate`. That was not done here due to how disruptive it would be. Separate scope for that refactor created in https://github.com/GCTC-NTGC/gc-digital-talent/issues/16534 

## 🧪 Testing

1. Confirm no instances where we query `AssessmentStep.assessmentResults`
2. Confirm no instances where we query `Community.pools`
3. Confirm `Pool.PoolSkill.assessmentSteps` can be queried
    a. Confirm tests check all happy and non-happy paths 