### PR TITLE
[Fix] Remove gov employee check for profile completness

### DIFF
--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -620,7 +620,6 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
                 is_null($this->attributes['looking_for_french']) &&
                 is_null($this->attributes['looking_for_bilingual'])
             ) or
-            is_null($this->attributes['computed_is_gov_employee']) or
             is_null($this->attributes['has_priority_entitlement']) or
             ($this->attributes['has_priority_entitlement'] && is_null($this->attributes['priority_number'])) or
             is_null($this->attributes['flexible_work_locations']) or


### PR DESCRIPTION
🤖 Resolves #16537 

## 👋 Introduction

Removes the check for government employee status from profile completeness.

## 🕵️ Details

This is automatically set when work experiences are modified. However, since we don't require any work experience to appy, this check doesn't make much sense and can remain `null`.

## 🧪 Testing

1. Login as a brand new user
2. Complete your profile without creating any work experiences
3. Confirm you can submit an application while `computed_is_gov_employee` is `null`
