### PR TITLE
[Fix] Changes `Notice` mode to card in `ErrorSummary`

### DIFF
--- a/packages/forms/src/components/ErrorSummary.tsx
+++ b/packages/forms/src/components/ErrorSummary.tsx
@@ -139,7 +139,7 @@ const ErrorSummary = forwardRef<ComponentRef<"div">, ErrorSummaryProps>(
     return invalidFieldNames.length > 0 ? (
       <Notice.Root
         color="error"
-        mode="inline"
+        mode="card"
         role="alert"
         ref={forwardedRef}
         tabIndex={-1}


### PR DESCRIPTION
🤖 Resolves #15806.

## 👋 Introduction

This PR changes `Notice` mode to card in `ErrorSummary`.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to any where the `ErrorSummary` component is used
3. Verify it uses looks "ok"