### PR TITLE
[Fix] Localized subfields in error summary

### DIFF
--- a/api/app/GraphQL/Validators/Mutation/CreateCommunityValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/CreateCommunityValidator.php
@@ -20,6 +20,12 @@ final class CreateCommunityValidator extends Validator
                 'sometimes',
                 Rule::unique('communities', 'key')->ignore($this->arg('id'), 'id'),
             ],
+            'community.name.en' => ['required_with:community.name.fr', 'string'],
+            'community.name.fr' => ['required_with:community.name.en', 'string'],
+            'community.description.en' => ['required_with:community.description.fr', 'string'],
+            'community.description.fr' => ['required_with:community.description.en', 'string'],
+            'community.mandateAuthority.en' => ['required_with:community.mandateAuthority.fr', 'string'],
+            'community.mandateAuthority.fr' => ['required_with:community.mandateAuthority.en', 'string'],
             'community.informationUrl.en' => ['required_with:community.informationUrl.fr', 'string', 'nullable', 'url:http,https'],
             'community.informationUrl.fr' => ['required_with:community.informationUrl.en', 'string', 'nullable', 'url:http,https'],
         ];

--- a/api/app/GraphQL/Validators/Mutation/UpdateCommunityValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/UpdateCommunityValidator.php
@@ -20,6 +20,12 @@ final class UpdateCommunityValidator extends Validator
                 'sometimes',
                 Rule::unique('communities', 'key')->ignore($this->arg('id'), 'id'),
             ],
+            'community.name.en' => ['required_with:community.name.fr', 'string'],
+            'community.name.fr' => ['required_with:community.name.en', 'string'],
+            'community.description.en' => ['required_with:community.description.fr', 'string'],
+            'community.description.fr' => ['required_with:community.description.en', 'string'],
+            'community.mandateAuthority.en' => ['required_with:community.mandateAuthority.fr', 'string'],
+            'community.mandateAuthority.fr' => ['required_with:community.mandateAuthority.en', 'string'],
             'community.informationUrl.en' => ['required_with:community.informationUrl.fr', 'string', 'nullable', 'url:http,https'],
             'community.informationUrl.fr' => ['required_with:community.informationUrl.en', 'string', 'nullable', 'url:http,https'],
         ];

--- a/packages/forms/src/components/ErrorSummary.tsx
+++ b/packages/forms/src/components/ErrorSummary.tsx
@@ -81,7 +81,6 @@ const addLabelsToErrors = (
 ): FieldNameWithLabel[] => {
   const invalidFieldNames = flattenErrors(errors);
   let fieldNamesWithLabels: FieldNameWithLabel[] = [];
-
   invalidFieldNames.forEach((fieldName) => {
     const fieldNameWithLabel = getFieldLabel(fieldName, labels);
     if (fieldNameWithLabel) {
@@ -160,8 +159,14 @@ const ErrorSummary = forwardRef<ComponentRef<"div">, ErrorSummaryProps>(
                     mode="text"
                     color="error"
                   >
-                    {field.label}
-                    {field.index ?? <span className="ml-1">{field.index}</span>}
+                    <>
+                      {field.label}
+                      {field.name.endsWith(".en") &&
+                        ` ${intl.formatMessage(commonMessages.englishLabel)}`}
+                      {field.name.endsWith(".fr") &&
+                        ` ${intl.formatMessage(commonMessages.frenchLabel)}`}
+                      {field.index && ` ${field.index}`}
+                    </>
                   </ScrollToLink>
                   {intl.formatMessage(commonMessages.dividingColon)}
                   <ErrorMessage name={field.name} />

--- a/packages/forms/src/utils.ts
+++ b/packages/forms/src/utils.ts
@@ -265,6 +265,13 @@ export function flattenErrors(
             },
           );
         }
+        // check for localized subfields
+        if ("en" in fieldError) {
+          errorNames = [...errorNames, `${fieldName}.en`];
+        }
+        if ("fr" in fieldError) {
+          errorNames = [...errorNames, `${fieldName}.fr`];
+        }
         // We have an error message so add it to the array (we don't want errors with no message)
         if ("message" in fieldError) {
           errorNames = [...errorNames, `${parentKey}${fieldName}`];


### PR DESCRIPTION
🤖 Resolves #16470.

## 👋 Introduction

This PR fixes the error summary component to account for localized subfields. It also adds fields to the Laravel validators for create and update community for localized fields (cannot have one locale without the other).

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/admin/communities/create
3. Submit form with empty field values
4. Verify error summary contains all required fields

## 📸 Screenshots

<img width="1256" height="749" alt="Screenshot 2026-04-22 at 12 31 40" src="https://github.com/user-attachments/assets/50435691-ffdf-482a-a561-64789f9fd43c" />
<img width="1315" height="754" alt="Screenshot 2026-04-22 at 12 31 51" src="https://github.com/user-attachments/assets/7e1636c5-b189-4e0c-88cc-b9e932ddcd9e" />
