### PR TITLE
[Feature] Auth health checks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -122,6 +122,4 @@
   "tailwindCSS.experimental.classRegex": [
     ["tv\\(([^)]*)\\)", "[\"'`]([^\"'`]*)[\"'`]"]
   ]
-  ,
-  "terminal.integrated.scrollback": 20000
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -94,6 +94,14 @@
       ],
       "overrideName": true,
       "icon": "terminal-ubuntu"
+    },
+    "Xdebug": {
+      "path": "/bin/bash",
+      "overrideName": true,
+      "icon": "terminal-linux",
+      "env": {
+        "XDEBUG_SESSION": "1"
+      }
     }
   },
   "terminal.integrated.profiles.osx": {
@@ -114,4 +122,6 @@
   "tailwindCSS.experimental.classRegex": [
     ["tv\\(([^)]*)\\)", "[\"'`]([^\"'`]*)[\"'`]"]
   ]
+  ,
+  "terminal.integrated.scrollback": 20000
 }

--- a/api/app/Console/Commands/AuthPing.php
+++ b/api/app/Console/Commands/AuthPing.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 class AuthPing extends Command
 {
@@ -29,10 +30,8 @@ class AuthPing extends Command
      */
     public function handle()
     {
-        $successCount = 0;
-        $failureCount = 0;
-
         $url = config('oauth.token_uri');
+        // typical payload for requesting a login in the auth callback
         $data = [
             'grant_type' => 'authorization_code',
             'client_id' => config('oauth.client_id'),
@@ -42,9 +41,20 @@ class AuthPing extends Command
         ];
 
         $results = $this->pingTokenUri($url, $data);
-        $this->info('Average transfer time: '.$results->avg('transferTime').' ms');
-        $this->info('Max transfer time: '.$results->max('transferTime').' ms');
-        $this->info('Percent success: '.$results->percentage(fn ($r) => $r['success']).'%');
+        $avgTransferTime = $results->avg('transferTime');
+        $maxTransferTime = $results->max('transferTime');
+        $percentageSuccess = $results->percentage(fn ($r) => $r['success']);
+
+        $this->info('Average transfer time: '.$avgTransferTime.' ms');
+        $this->info('Max transfer time: '.$maxTransferTime.' ms');
+        $this->info('Percentage success: '.$percentageSuccess.'%');
+
+        Log::channel('jobs')->info('Auth ping complete',
+            [
+                'AvgTransferTime' => $avgTransferTime,
+                'MaxTransferTime' => $maxTransferTime,
+                'PercentageSuccess' => $percentageSuccess,
+            ]);
 
         return Command::SUCCESS;
     }
@@ -53,19 +63,22 @@ class AuthPing extends Command
     {
         $results = collect();
         for ($i = 0; $i < 10; $i++) {
-            $response = Http::asForm()->post($url, $data);
+            try {
+                $response = Http::asForm()->post($url, $data);
+                $transferStats = $response->transferStats;
 
-            $transferStats = $response->transferStats;
+                $results->push([
+                    'transferTime' => $transferStats->getTransferTime() * 1000, // s -> ms
+                    // since we don't have a real code we're expecting the invalid_grant error
+                    'success' => $response->status() == 400 && $response->json('error') == 'invalid_grant',
+                ]);
+            } catch (\Throwable $_) {
+                $results->push([
+                    'transferTime' => null,
+                    'success' => false,
+                ]);
+            }
 
-            $transferTime = $transferStats->getTransferTime() * 1000; // s->ms
-
-            $this->info('Transfer time: '.$transferTime.' ms');
-            $this->info('Status: '.$response->status());
-            $this->info('Error message: '.$response->json('error'));
-            $results->push([
-                'transferTime' => $transferTime,
-                'success' => $response->status() == 400 && $response->json('error') == 'invalid_grant',
-            ]);
         }
 
         return $results;

--- a/api/app/Console/Commands/AuthPing.php
+++ b/api/app/Console/Commands/AuthPing.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+
+class AuthPing extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'auth:ping';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Ping the auth server';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $successCount = 0;
+        $failureCount = 0;
+
+        $url = config('oauth.token_uri');
+        $data = [
+            'grant_type' => 'authorization_code',
+            'client_id' => config('oauth.client_id'),
+            'client_secret' => config('oauth.client_secret'),
+            'redirect_uri' => config('oauth.redirect_uri'),
+            'code' => '1', // not a real code, of course
+        ];
+
+        $results = $this->pingTokenUri($url, $data);
+        $this->info('Average transfer time: '.$results->avg('transferTime').' ms');
+        $this->info('Max transfer time: '.$results->max('transferTime').' ms');
+        $this->info('Percent success: '.$results->percentage(fn ($r) => $r['success']).'%');
+
+        return Command::SUCCESS;
+    }
+
+    private function pingTokenUri($url, $data): Collection
+    {
+        $results = collect();
+        for ($i = 0; $i < 10; $i++) {
+            $response = Http::asForm()->post($url, $data);
+
+            $transferStats = $response->transferStats;
+
+            $transferTime = $transferStats->getTransferTime() * 1000; // s->ms
+
+            $this->info('Transfer time: '.$transferTime.' ms');
+            $this->info('Status: '.$response->status());
+            $this->info('Error message: '.$response->json('error'));
+            $results->push([
+                'transferTime' => $transferTime,
+                'success' => $response->status() == 400 && $response->json('error') == 'invalid_grant',
+            ]);
+        }
+
+        return $results;
+    }
+}

--- a/api/app/Console/Kernel.php
+++ b/api/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Console\Commands\AuthPing;
 use App\Console\Commands\PruneUserGeneratedFiles;
 use App\Console\Commands\ResumeReferrals;
 use App\Console\Commands\SendNotificationsApplicationDeadlineApproaching;
@@ -48,6 +49,11 @@ class Kernel extends ConsoleKernel
             ->dailyAt('1:00')
             ->withoutOverlapping()
             ->appendOutputTo(storage_path('logs/resume-referrals.log'));
+
+        // Check the health of the auth provider
+        $schedule->command(AuthPing::class)
+            ->everyFiveMinutes()
+            ->appendOutputTo(storage_path('logs/auth-ping.log'));
     }
 
     /**


### PR DESCRIPTION
🤖 Resolves #16513 

## 👋 Introduction

Adds a health check for the auth connection that runs every few minutes and logs the results.

## 🕵️ Details

A new artisan command sends 10 requests to the auth server's token endpoint that are similar to a regular login request.  The transfer time and whether we get the expected response is recorded and logged to Azure for monitoring.

## 🧪 Testing

Locally:

1. `./artisan auth:ping`

In Azure:

AppLogsDev_CL table in the TalentAppInsights log analytics workspace

## 📸 Screenshot

<img width="711" height="73" alt="image" src="https://github.com/user-attachments/assets/d5422296-767d-48a9-8eb0-6e2cb10804bc" />

<img width="1888" height="984" alt="image" src="https://github.com/user-attachments/assets/726da0e8-4fb3-4725-a89e-22bc9e0db448" />
