### PR TITLE
[Feature] Remove customized IAP signin/signup pages (2nd attempt)

### DIFF
--- a/apps/web/src/components/NavMenu/IAPNavMenu.tsx
+++ b/apps/web/src/components/NavMenu/IAPNavMenu.tsx
@@ -16,7 +16,7 @@ const IAPNavMenu = () => {
   const paths = useRoutes();
   const { pathname } = useLocation();
   const { loggedIn } = useAuthentication();
-  const searchParams = `?from=${paths.iap()}&personality=iap`;
+  const searchParams = `?from=${paths.iap()}`;
 
   const homeLinkProps = {
     href: paths.iap(),

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2095,10 +2095,6 @@
     "defaultMessage": "Si vous avez des questions au sujet de CléGC, veuillez contacter l'équipe de CléGC à l'adresse",
     "description": "GCKey answer for who to contact about GCKey, introduction sentence"
   },
-  "6SfJEp": {
-    "defaultMessage": "Vous pouvez vous connecter à votre profil de Programme d'apprentissage en TI pour les personnes autochtones à l'aide de votre CléGC actuelle, même si vous n'avez jamais utilisé cette plateforme auparavant.",
-    "description": "Instructions on how to sign in with GCKey - IAP variant"
-  },
   "6UVZOY": {
     "defaultMessage": "Laissez notre équipe vous épargner du temps et de l’énergie en associant vos besoins à des professionnels des <abbreviation>TI</abbreviation> préalablement sélectionnés et possédant les compétences requises pour le poste. Tous les talents de nos bassins de dotation ont été sélectionnés à l’issue d’un processus concurrentiel. Vous pouvez donc passer directement à l’entrevue et décider s’ils conviennent à votre équipe.",
     "description": "Summary for to go to the search page on Browse IT jobs page"
@@ -6895,10 +6891,6 @@
     "defaultMessage": "Les mises en candidature doivent être parrainées par un cadre dirigeant travaillant dans le domaine de la personne candidate et seront triées par l'équipe de la collectivité fonctionnelle associée. Une fois la mise en candidature confirmée, la personne candidate sera inscrit dans le système de gestion des talents de cette collectivité pour l'année en cours.",
     "description": "Paragraph two, instructions on how to submit a nomination"
   },
-  "QsWizb": {
-    "defaultMessage": "<strong>Vous n’avez pas de compte CléGC?</strong> <a>Créer un compte</a>.",
-    "description": "Instruction on what to do if user does not have a GCKey"
-  },
   "Qt9Q8k": {
     "defaultMessage": "Le programme dure combien de temps?",
     "description": "Learn more dialog question two heading"
@@ -8749,10 +8741,6 @@
   "YzUhwE": {
     "defaultMessage": "Modifier l’ébauche d’un processus et d’un plan d’évaluation",
     "description": "Permissions related to creating/deleting draft processes assessment plan"
-  },
-  "Z+gi2d": {
-    "defaultMessage": "Si vous n’êtes pas certain(e) d’avoir un compte CléGC, veuillez continuer au site Web et tentez d’y accéder. Si vous ne pouvez pas vous rappeler de votre mot de passe, vous pourrez également le rétablir.",
-    "description": "Instructions on what to do if user doesn't know if they have a GCKey - IAP variant"
   },
   "Z+n7lE": {
     "defaultMessage": "Saisissez une adresse de courriel professionnelle et utilisez le bouton de recherche pour trouver un utilisateur.",
@@ -12629,10 +12617,6 @@
   "ow4z7W": {
     "defaultMessage": "Modifier<hidden> la classification</hidden>",
     "description": "Breadcrumb title for the edit classification page link."
-  },
-  "ow71P8": {
-    "defaultMessage": "<strong>Préavis!</strong> Avant de vous demander d’aller établir vos justificatifs CléGC, nous vous demandons d’examiner de nouveau les critères d’admissibilité du programme afin de veiller à ce que vous répondiez aux exigences.",
-    "description": "A request for the user to review the IAP eligibility criteria"
   },
   "ox2by6": {
     "defaultMessage": "En savoir plus<hidden> : {topic}</hidden>",

--- a/apps/web/src/pages/Auth/SignInPage/SignInPage.tsx
+++ b/apps/web/src/pages/Auth/SignInPage/SignInPage.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from "react";
-import { useEffect } from "react";
 import { useIntl } from "react-intl";
 import { useSearchParams } from "react-router";
 import SparklesIcon from "@heroicons/react/24/outline/SparklesIcon";
@@ -21,7 +20,6 @@ import {
 } from "@gc-digital-talent/ui";
 import { useApiRoutes } from "@gc-digital-talent/auth";
 import { getLocale } from "@gc-digital-talent/i18n";
-import { useTheme } from "@gc-digital-talent/theme";
 import { useFeatureFlags } from "@gc-digital-talent/env";
 import { RadioGroup } from "@gc-digital-talent/forms";
 
@@ -78,21 +76,12 @@ const helpLink = (chunks: ReactNode, path: string) => (
   </Link>
 );
 
-const buildExternalLink = (path: string, chunks: ReactNode) => (
-  <Link external href={path}>
-    {chunks}
-  </Link>
-);
-
 export const Component = () => {
   const intl = useIntl();
   const paths = useRoutes();
   const apiPaths = useApiRoutes();
   const [searchParams] = useSearchParams();
-  const { key: themeKey, setKey: setThemeKey } = useTheme();
   const fromPath = searchParams.get("from");
-  const iapMode =
-    fromPath === paths.iap() || searchParams.get("personality") === "iap";
   const fallbackPath = paths.applicantDashboard();
   const loginPath = apiPaths.login(fromPath ?? fallbackPath, getLocale(intl));
 
@@ -138,12 +127,6 @@ export const Component = () => {
 
   const skipMigration =
     selectedMethod === "canadaLogin" ? "&skipmigration=true" : "";
-
-  useEffect(() => {
-    if (iapMode && themeKey !== "iap") {
-      setThemeKey("iap");
-    }
-  }, [iapMode, themeKey, setThemeKey]);
 
   const InstructionCards = () => {
     if (selectedMethod === "canadaLogin") {
@@ -647,124 +630,120 @@ export const Component = () => {
         <SEO title={pageTitle} />
         <Hero title={pageTitle} crumbs={crumbs} overlap={true} centered={true}>
           <div className="mt-0 rounded-md bg-white px-6 py-12 shadow-sm sm:mt-10 dark:bg-gray-600">
-            {!iapMode && (
-              <div className="px-2">
-                <Heading
-                  level="h2"
-                  color="primary"
-                  icon={SparklesIcon}
-                  className="mt-0 font-normal"
-                >
-                  {intl.formatMessage({
-                    defaultMessage: "Welcome back",
-                    id: "nmBkRg",
-                    description:
-                      "Welcome heading at the top of the sign in page",
-                  })}
-                </Heading>
-                <p className="pt-2 pl-2 font-normal">
-                  {intl.formatMessage({
-                    defaultMessage:
-                      "We're upgrading from GCKey sign in experience to the government's new central account system called CanadaLogin.",
-                    id: "OgTBmm",
-                    description:
-                      "Copy under welcome heading at the top of the sign in page",
-                  })}
-                </p>
-                <p className="pt-4 pl-2 font-normal">
-                  {intl.formatMessage({
-                    defaultMessage:
-                      "You'll be leaving our site to sign in with CanadaLogin. If anything goes wrong, we have prepared additional guidance for you.",
-                    id: "vC8yrC",
-                    description:
-                      "Copy under welcome heading at the top of the sign in page",
-                  })}
-                </p>
+            <div className="px-2">
+              <Heading
+                level="h2"
+                color="primary"
+                icon={SparklesIcon}
+                className="mt-0 font-normal"
+              >
+                {intl.formatMessage({
+                  defaultMessage: "Welcome back",
+                  id: "nmBkRg",
+                  description: "Welcome heading at the top of the sign in page",
+                })}
+              </Heading>
+              <p className="pt-2 pl-2 font-normal">
+                {intl.formatMessage({
+                  defaultMessage:
+                    "We're upgrading from GCKey sign in experience to the government's new central account system called CanadaLogin.",
+                  id: "OgTBmm",
+                  description:
+                    "Copy under welcome heading at the top of the sign in page",
+                })}
+              </p>
+              <p className="pt-4 pl-2 font-normal">
+                {intl.formatMessage({
+                  defaultMessage:
+                    "You'll be leaving our site to sign in with CanadaLogin. If anything goes wrong, we have prepared additional guidance for you.",
+                  id: "vC8yrC",
+                  description:
+                    "Copy under welcome heading at the top of the sign in page",
+                })}
+              </p>
 
-                <p className="pt-6 pl-2 font-normal">
-                  {intl.formatMessage({
-                    defaultMessage: "How did you last sign in?",
-                    id: "CIDrn4",
-                    description:
-                      "Heading for the section asking users how they last signed in on the sign in page",
-                  })}
-                </p>
+              <p className="pt-6 pl-2 font-normal">
+                {intl.formatMessage({
+                  defaultMessage: "How did you last sign in?",
+                  id: "CIDrn4",
+                  description:
+                    "Heading for the section asking users how they last signed in on the sign in page",
+                })}
+              </p>
 
-                <div className="p-2">
-                  <FormProvider {...methods}>
-                    <RadioGroup
-                      idPrefix="signin-method"
-                      name="signInMethod"
-                      legend=""
-                      columns={1}
-                      trackUnsaved={false}
-                      items={[
-                        {
-                          value: "canadaLogin",
-                          label: (
-                            <div className="flex-col gap-2 xxs:flex-row xxs:items-center">
-                              <span className="mr-2">
-                                {intl.formatMessage({
-                                  defaultMessage: "CanadaLogin",
-                                  id: "t0iSsj",
-                                  description:
-                                    "CanadaLogin sign in method label",
-                                })}
-                              </span>
-                              <Chip color="primary" icon={SparklesIcon}>
-                                <span>
-                                  {intl.formatMessage({
-                                    defaultMessage: "New",
-                                    id: "N0zaCd",
-                                    description:
-                                      "Chip label for CanadaLogin option",
-                                  })}
-                                </span>
-                              </Chip>
-                            </div>
-                          ),
-
-                          contentBelow: (
-                            <p className="font-normal text-gray-500 dark:text-gray-100">
-                              {intl.formatMessage({
-                                defaultMessage:
-                                  "You have signed in recently and created a CanadaLogin account using your email",
-                                id: "wxXlyJ",
-                                description:
-                                  "Message shown under CanadaLogin option on sign in page",
-                              })}
-                            </p>
-                          ),
-                        },
-                        {
-                          value: "gckey",
-                          label: (
+              <div className="p-2">
+                <FormProvider {...methods}>
+                  <RadioGroup
+                    idPrefix="signin-method"
+                    name="signInMethod"
+                    legend=""
+                    columns={1}
+                    trackUnsaved={false}
+                    items={[
+                      {
+                        value: "canadaLogin",
+                        label: (
+                          <div className="flex-col gap-2 xxs:flex-row xxs:items-center">
                             <span className="mr-2">
                               {intl.formatMessage({
-                                defaultMessage: "GCKey",
-                                id: "o6FC2W",
-                                description: "GCKey sign in method label",
+                                defaultMessage: "CanadaLogin",
+                                id: "t0iSsj",
+                                description: "CanadaLogin sign in method label",
                               })}
                             </span>
-                          ),
-                          contentBelow: (
-                            <p className="font-normal text-gray-500 dark:text-gray-100">
-                              {intl.formatMessage({
-                                defaultMessage:
-                                  "Your last sign in was before April 2026 and used a GCKey username",
-                                id: "5V6IMt",
-                                description:
-                                  "Message shown under GCKey option on sign in page",
-                              })}
-                            </p>
-                          ),
-                        },
-                      ]}
-                    />
-                  </FormProvider>
-                </div>
+                            <Chip color="primary" icon={SparklesIcon}>
+                              <span>
+                                {intl.formatMessage({
+                                  defaultMessage: "New",
+                                  id: "N0zaCd",
+                                  description:
+                                    "Chip label for CanadaLogin option",
+                                })}
+                              </span>
+                            </Chip>
+                          </div>
+                        ),
+
+                        contentBelow: (
+                          <p className="font-normal text-gray-500 dark:text-gray-100">
+                            {intl.formatMessage({
+                              defaultMessage:
+                                "You have signed in recently and created a CanadaLogin account using your email",
+                              id: "wxXlyJ",
+                              description:
+                                "Message shown under CanadaLogin option on sign in page",
+                            })}
+                          </p>
+                        ),
+                      },
+                      {
+                        value: "gckey",
+                        label: (
+                          <span className="mr-2">
+                            {intl.formatMessage({
+                              defaultMessage: "GCKey",
+                              id: "o6FC2W",
+                              description: "GCKey sign in method label",
+                            })}
+                          </span>
+                        ),
+                        contentBelow: (
+                          <p className="font-normal text-gray-500 dark:text-gray-100">
+                            {intl.formatMessage({
+                              defaultMessage:
+                                "Your last sign in was before April 2026 and used a GCKey username",
+                              id: "5V6IMt",
+                              description:
+                                "Message shown under GCKey option on sign in page",
+                            })}
+                          </p>
+                        ),
+                      },
+                    ]}
+                  />
+                </FormProvider>
               </div>
-            )}
+            </div>
             {selectedMethod && (
               <div className="px-4">
                 <Notice.Root
@@ -875,395 +854,15 @@ export const Component = () => {
         </Hero>
 
         <Container className="my-10">
-          {!iapMode ? (
-            <>
-              <div id="registrationInstructions" className="scroll-mt-20">
-                <InstructionCards />
+          <div id="registrationInstructions" className="scroll-mt-20">
+            <InstructionCards />
 
-                <Heading
-                  icon={InformationCircleIcon}
-                  color="primary"
-                  level="h3"
-                  size="h4"
-                  className="mt-20 mb-5 justify-center font-normal xs:justify-start"
-                >
-                  {intl.formatMessage({
-                    defaultMessage: "Frequently Asked Questions (FAQs)",
-                    id: "AUtIo9",
-                    description:
-                      "Heading for Frequently Asked Questions section on sign in page",
-                  })}
-                </Heading>
-                <Accordion.Root
-                  type="single"
-                  size="sm"
-                  mode="card"
-                  collapsible
-                  className="my-5 mt-4"
-                >
-                  <Accordion.Item value="one">
-                    <Accordion.Trigger as="h4">
-                      {intl.formatMessage(
-                        canadaLoginMessages.signInWithCanadaLogin,
-                      )}
-                    </Accordion.Trigger>
-                    <Accordion.Content>
-                      <p className="mb-3">
-                        {intl.formatMessage(
-                          canadaLoginMessages.answerSignInWithCanadaLogin1,
-                        )}
-                      </p>
-                      <p className="mb-3">
-                        {intl.formatMessage(
-                          canadaLoginMessages.answerSignInWithCanadaLogin2,
-                        )}
-                      </p>
-                      <p className="mb-3">
-                        {intl.formatMessage(
-                          canadaLoginMessages.answerSignInWithCanadaLogin3,
-                        )}
-                      </p>
-                    </Accordion.Content>
-                  </Accordion.Item>
-                  <Accordion.Item value="two">
-                    <Accordion.Trigger as="h4">
-                      {intl.formatMessage(gckeyMessages.questionContactGCkey)}
-                    </Accordion.Trigger>
-                    <Accordion.Content>
-                      <p className="mb-3">
-                        {intl.formatMessage(gckeyMessages.answerContactGCkey1)}
-                      </p>
-                      <p className="mb-3">
-                        {intl.formatMessage(gckeyMessages.answerContactGCkey2)}
-                      </p>
-                      <p className="mb-3">
-                        <Link
-                          color="black"
-                          external
-                          href="tel:1-855-438-1102"
-                          // eslint-disable-next-line formatjs/no-literal-string-in-jsx
-                          aria-label="1 8 5 5 4 3 8 1 1 0 2"
-                          // eslint-disable-next-line formatjs/no-literal-string-in-jsx
-                        >
-                          1-855-438-1102
-                        </Link>
-                      </p>
-                      <p className="mb-3">
-                        {intl.formatMessage(gckeyMessages.answerContactGCkey3)}
-                      </p>
-                      <p className="mb-3">
-                        <Link
-                          color="black"
-                          external
-                          href="tel:1-855-438-1103"
-                          // eslint-disable-next-line formatjs/no-literal-string-in-jsx
-                          aria-label="1 8 5 5 4 3 8 1 1 0 3"
-                          // eslint-disable-next-line formatjs/no-literal-string-in-jsx
-                        >
-                          1-855-438-1103
-                        </Link>
-                      </p>
-                      <p className="mb-3">
-                        {intl.formatMessage(gckeyMessages.answerContactGCkey4)}
-                      </p>
-                      <p className="mb-3">
-                        <Link
-                          color="black"
-                          external
-                          href="tel:1-800-2318-6290"
-                          // eslint-disable-next-line formatjs/no-literal-string-in-jsx
-                          aria-label="1 8 0 0 2 3 1 8 6 2 9 0"
-                          // eslint-disable-next-line formatjs/no-literal-string-in-jsx
-                        >
-                          1-800-2318-6290
-                        </Link>
-                      </p>
-                      <p>
-                        {intl.formatMessage(gckeyMessages.answerContactGCkey5)}
-                      </p>
-                    </Accordion.Content>
-                  </Accordion.Item>
-
-                  <Accordion.Item value="three">
-                    <Accordion.Trigger as="h4">
-                      {intl.formatMessage(canadaLoginMessages.haveCanadaLogin)}
-                    </Accordion.Trigger>
-                    <Accordion.Content>
-                      <p>
-                        {intl.formatMessage(
-                          canadaLoginMessages.haveCanadaLoginAnswer,
-                        )}
-                      </p>
-                    </Accordion.Content>
-                  </Accordion.Item>
-                  <Accordion.Item value="four">
-                    <Accordion.Trigger as="h4">
-                      {intl.formatMessage(
-                        canadaLoginMessages.whatIsCanadaLogin,
-                      )}
-                    </Accordion.Trigger>
-                    <Accordion.Content>
-                      <p>
-                        {intl.formatMessage(
-                          canadaLoginMessages.whatIsCanadaLoginAnswer,
-                        )}
-                      </p>
-                    </Accordion.Content>
-                  </Accordion.Item>
-                  <Accordion.Item value="five">
-                    <Accordion.Trigger as="h4">
-                      {intl.formatMessage(
-                        canadaLoginMessages.contactCanadaLogin,
-                      )}
-                    </Accordion.Trigger>
-                    <Accordion.Content>
-                      <p>
-                        {intl.formatMessage(
-                          canadaLoginMessages.answerContactCanadaLogin1,
-                        )}
-                      </p>
-                      <p className="mt-4 mb-3">
-                        <Link
-                          color="black"
-                          external
-                          aria-label={intl.formatMessage(
-                            canadaLoginMessages.answerContactCanadaLogin2,
-                          )}
-                          href={
-                            intl.locale === "fr"
-                              ? "https://connexion.canada.ca/fr/utilisateurs/nous-contacter/"
-                              : "https://login.canada.ca/en/users/contact-us/"
-                          }
-                        >
-                          {intl.formatMessage(
-                            canadaLoginMessages.answerContactCanadaLogin2,
-                          )}
-                        </Link>
-                      </p>
-                    </Accordion.Content>
-                  </Accordion.Item>
-                </Accordion.Root>
-                <p className="mt-6">
-                  {intl.formatMessage(gckeyMessages.moreQuestions, {
-                    helpLink: (chunks: ReactNode) =>
-                      helpLink(chunks, paths.support()),
-                  })}
-                </p>
-              </div>
-            </>
-          ) : (
-            <>
-              {/* IAP copy */}
-              <p className="mb-3">
-                {intl.formatMessage({
-                  defaultMessage:
-                    "You can sign in to your IT Apprenticeship Program for Indigenous Peoples profile using your existing GCKey, even if you've never used this platform before.",
-                  id: "6SfJEp",
-                  description:
-                    "Instructions on how to sign in with GCKey - IAP variant",
-                })}
-              </p>
-              <p className="mb-3">
-                {intl.formatMessage({
-                  defaultMessage:
-                    "If you're unsure of whether you have an existing GCKey account, continue to the website and try signing in. If you can't remember your password, you can also reset it there.",
-                  id: "Z+gi2d",
-                  description:
-                    "Instructions on what to do if user doesn't know if they have a GCKey - IAP variant",
-                })}
-              </p>
-              <p className="mb-6">
-                {intl.formatMessage(
-                  {
-                    defaultMessage:
-                      "<strong>Don't have a GCKey account?</strong> <a>Sign up for one</a>.",
-                    id: "QsWizb",
-                    description:
-                      "Instruction on what to do if user does not have a GCKey",
-                  },
-                  {
-                    a: (chunks: ReactNode) =>
-                      buildExternalLink(loginPath, chunks),
-                  },
-                )}
-              </p>
-              <p className="mb-12">
-                {intl.formatMessage({
-                  defaultMessage:
-                    "<strong>Heads up!</strong> Before we send you off to set up your GCKey credentials, we ask that you take another look at the program's eligibility criteria to ensure that you meet the requirements.",
-                  id: "ow71P8",
-                  description:
-                    "A request for the user to review the IAP eligibility criteria",
-                })}
-              </p>
-              <p>
-                {intl.formatMessage(
-                  {
-                    defaultMessage:
-                      "If you have questions concerning this step, or if you are unsure about how to proceed, please feel free to reach out to our support team at <a>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</a>.",
-                    id: "ltzA7w",
-                    description:
-                      "How to get help from the support team - IAP variant",
-                  },
-                  {
-                    a: (chunks: ReactNode) =>
-                      buildExternalLink(
-                        "mailto:edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca",
-                        chunks,
-                      ),
-                  },
-                )}
-              </p>
-            </>
-          )}
-        </Container>
-      </>
-    );
-  }
-
-  return (
-    <>
-      <SEO title={pageTitle} />
-      <Hero title={pageTitle} crumbs={crumbs} />
-      <Container className="my-18">
-        {!iapMode ? (
-          <>
-            {/* Standard copy */}
-            <Heading
-              icon={SparklesIcon}
-              color="warning"
-              level="h2"
-              size="h3"
-              className="mt-0 mb-6 font-normal"
-            >
-              {intl.formatMessage({
-                defaultMessage: "Welcome back",
-                id: "db3ZDX",
-                description:
-                  "Heading at the top of the sign in page for applicant profiles",
-              })}
-            </Heading>
-            <p className="my-6">
-              {intl.formatMessage({
-                defaultMessage:
-                  "Just a reminder you'll be leaving our site to sign in with GCKey. If anything goes wrong, we have prepared additional guidance for you.",
-                id: "ci1JMn",
-                description:
-                  "Instructions on what to do if user doesn't know if they have a GCKey",
-              })}
-            </p>
-            <Link
-              href={loginPath}
-              mode="solid"
-              color="primary"
-              external
-              onClick={() => {
-                if (appInsights) {
-                  const userId = appInsights.context?.user?.id;
-                  appInsights.trackEvent(
-                    { name: "GCKey Login Initiated" },
-                    {
-                      aiUserId: userId,
-                      pageUrl: window.location.href,
-                      path: window.location.pathname,
-                      timestamp: new Date().toISOString(),
-                      userAgent: navigator.userAgent,
-                      referrer: document.referrer || "none",
-                      gcKeyStatus: "initiated",
-                    },
-                  );
-                }
-              }}
-            >
-              {intl.formatMessage({
-                defaultMessage: "Sign in with GCKey",
-                id: "oQNunm",
-                description: "GCKey sign in link text on the sign in page",
-              })}
-            </Link>
-            <Heading
-              icon={ArrowLeftEndOnRectangleIcon}
-              color="secondary"
-              level="h2"
-              size="h3"
-              className="mt-18 mb-6 font-normal"
-            >
-              {intl.formatMessage({
-                defaultMessage: "Signing in to your account",
-                id: "Wnid+N",
-                description:
-                  "Heading for section of the sign in page showing the sign in steps",
-              })}
-            </Heading>
-            <Heading level="h3" size="h6" className="mt-12 mb-6 font-bold">
-              {intl.formatMessage({
-                defaultMessage:
-                  "Steps to signing in with GCKey and completing two-factor authentication",
-                id: "QNMqSh",
-                description: "Subtitle for a section explaining sign in steps",
-              })}
-            </Heading>
-            <Instructions.List>
-              <Instructions.Step
-                img={{
-                  src: step1Image,
-                  darkSrc: step1ImageDark,
-                }}
-              >
-                {intl.formatMessage({
-                  defaultMessage:
-                    "1. Sign in with your username and password. Remember, <strong>your username is separate from your email address</strong>.",
-                  id: "oR+6vE",
-                  description: "Text for first sign in step.",
-                })}
-              </Instructions.Step>
-              <Instructions.Step
-                img={{
-                  src: step2Image,
-                  darkSrc: step2ImageDark,
-                }}
-              >
-                {intl.formatMessage({
-                  defaultMessage:
-                    "2. <strong>Open the authenticator app</strong> on your device.",
-                  id: "QuHfUJ",
-                  description: "Text for second sign in step.",
-                })}
-              </Instructions.Step>
-              <Instructions.Step
-                img={{
-                  src: step3Image,
-                  darkSrc: step3ImageDark,
-                }}
-              >
-                {intl.formatMessage({
-                  defaultMessage:
-                    "3. Enter your <strong>unique one-time six-digit code</strong> from your <strong>authenticator app</strong> into the verification bar.",
-                  id: "oacrTu",
-                  description: "Text for third sign in step.",
-                })}
-              </Instructions.Step>
-              <Instructions.Step
-                includeArrow={false}
-                img={{
-                  src: step4Image,
-                  darkSrc: step4ImageDark,
-                }}
-              >
-                {intl.formatMessage({
-                  defaultMessage:
-                    "4. Hooray! <strong>You've signed in with GCKey</strong> and will be returned to the <strong>GC Digital Talent platform</strong>.",
-                  id: "eO9buR",
-                  description: "Text for final sign in step.",
-                })}
-              </Instructions.Step>
-            </Instructions.List>
             <Heading
               icon={InformationCircleIcon}
-              color="error"
-              level="h2"
-              size="h3"
-              className="mt-18 mb-6 font-normal"
+              color="primary"
+              level="h3"
+              size="h4"
+              className="mt-20 mb-5 justify-center font-normal xs:justify-start"
             >
               {intl.formatMessage({
                 defaultMessage: "Frequently Asked Questions (FAQs)",
@@ -1277,28 +876,34 @@ export const Component = () => {
               size="sm"
               mode="card"
               collapsible
-              className="my-6"
+              className="my-5 mt-4"
             >
               <Accordion.Item value="one">
-                <Accordion.Trigger as="h3">
-                  {intl.formatMessage(gckeyMessages.questionExistingAccount)}
+                <Accordion.Trigger as="h4">
+                  {intl.formatMessage(
+                    canadaLoginMessages.signInWithCanadaLogin,
+                  )}
                 </Accordion.Trigger>
                 <Accordion.Content>
                   <p className="mb-3">
-                    {intl.formatMessage(gckeyMessages.answerExistingAccount)}
+                    {intl.formatMessage(
+                      canadaLoginMessages.answerSignInWithCanadaLogin1,
+                    )}
+                  </p>
+                  <p className="mb-3">
+                    {intl.formatMessage(
+                      canadaLoginMessages.answerSignInWithCanadaLogin2,
+                    )}
+                  </p>
+                  <p className="mb-3">
+                    {intl.formatMessage(
+                      canadaLoginMessages.answerSignInWithCanadaLogin3,
+                    )}
                   </p>
                 </Accordion.Content>
               </Accordion.Item>
               <Accordion.Item value="two">
-                <Accordion.Trigger as="h3">
-                  {intl.formatMessage(gckeyMessages.questionWhatGCKey)}
-                </Accordion.Trigger>
-                <Accordion.Content>
-                  <p>{intl.formatMessage(gckeyMessages.answerWhatGCKey)}</p>
-                </Accordion.Content>
-              </Accordion.Item>
-              <Accordion.Item value="three">
-                <Accordion.Trigger as="h3">
+                <Accordion.Trigger as="h4">
                   {intl.formatMessage(gckeyMessages.questionContactGCkey)}
                 </Accordion.Trigger>
                 <Accordion.Content>
@@ -1353,21 +958,58 @@ export const Component = () => {
                   <p>{intl.formatMessage(gckeyMessages.answerContactGCkey5)}</p>
                 </Accordion.Content>
               </Accordion.Item>
-              <Accordion.Item value="four">
-                <Accordion.Trigger as="h3">
-                  {intl.formatMessage(gckeyMessages.questionAuthApp)}
-                </Accordion.Trigger>
-                <Accordion.Content>
-                  <p>{intl.formatMessage(gckeyMessages.answerAuthApp)}</p>
-                </Accordion.Content>
-              </Accordion.Item>
-              <Accordion.Item value="five">
-                <Accordion.Trigger as="h3">
-                  {intl.formatMessage(gckeyMessages.questionAuthAlternative)}
+
+              <Accordion.Item value="three">
+                <Accordion.Trigger as="h4">
+                  {intl.formatMessage(canadaLoginMessages.haveCanadaLogin)}
                 </Accordion.Trigger>
                 <Accordion.Content>
                   <p>
-                    {intl.formatMessage(gckeyMessages.answerAuthAlternative)}
+                    {intl.formatMessage(
+                      canadaLoginMessages.haveCanadaLoginAnswer,
+                    )}
+                  </p>
+                </Accordion.Content>
+              </Accordion.Item>
+              <Accordion.Item value="four">
+                <Accordion.Trigger as="h4">
+                  {intl.formatMessage(canadaLoginMessages.whatIsCanadaLogin)}
+                </Accordion.Trigger>
+                <Accordion.Content>
+                  <p>
+                    {intl.formatMessage(
+                      canadaLoginMessages.whatIsCanadaLoginAnswer,
+                    )}
+                  </p>
+                </Accordion.Content>
+              </Accordion.Item>
+              <Accordion.Item value="five">
+                <Accordion.Trigger as="h4">
+                  {intl.formatMessage(canadaLoginMessages.contactCanadaLogin)}
+                </Accordion.Trigger>
+                <Accordion.Content>
+                  <p>
+                    {intl.formatMessage(
+                      canadaLoginMessages.answerContactCanadaLogin1,
+                    )}
+                  </p>
+                  <p className="mt-4 mb-3">
+                    <Link
+                      color="black"
+                      external
+                      aria-label={intl.formatMessage(
+                        canadaLoginMessages.answerContactCanadaLogin2,
+                      )}
+                      href={
+                        intl.locale === "fr"
+                          ? "https://connexion.canada.ca/fr/utilisateurs/nous-contacter/"
+                          : "https://login.canada.ca/en/users/contact-us/"
+                      }
+                    >
+                      {intl.formatMessage(
+                        canadaLoginMessages.answerContactCanadaLogin2,
+                      )}
+                    </Link>
                   </p>
                 </Accordion.Content>
               </Accordion.Item>
@@ -1378,72 +1020,263 @@ export const Component = () => {
                   helpLink(chunks, paths.support()),
               })}
             </p>
-          </>
-        ) : (
-          <>
-            {/* IAP copy */}
-            <p className="mb-3">
-              {intl.formatMessage({
-                defaultMessage:
-                  "You can sign in to your IT Apprenticeship Program for Indigenous Peoples profile using your existing GCKey, even if you've never used this platform before.",
-                id: "6SfJEp",
-                description:
-                  "Instructions on how to sign in with GCKey - IAP variant",
-              })}
-            </p>
-            <p className="mb-3">
-              {intl.formatMessage({
-                defaultMessage:
-                  "If you're unsure of whether you have an existing GCKey account, continue to the website and try signing in. If you can't remember your password, you can also reset it there.",
-                id: "Z+gi2d",
-                description:
-                  "Instructions on what to do if user doesn't know if they have a GCKey - IAP variant",
-              })}
-            </p>
-            <p className="mb-3">
-              {intl.formatMessage(
+          </div>
+        </Container>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <SEO title={pageTitle} />
+      <Hero title={pageTitle} crumbs={crumbs} />
+      <Container className="my-18">
+        <Heading
+          icon={SparklesIcon}
+          color="warning"
+          level="h2"
+          size="h3"
+          className="mt-0 mb-6 font-normal"
+        >
+          {intl.formatMessage({
+            defaultMessage: "Welcome back",
+            id: "db3ZDX",
+            description:
+              "Heading at the top of the sign in page for applicant profiles",
+          })}
+        </Heading>
+        <p className="my-6">
+          {intl.formatMessage({
+            defaultMessage:
+              "Just a reminder you'll be leaving our site to sign in with GCKey. If anything goes wrong, we have prepared additional guidance for you.",
+            id: "ci1JMn",
+            description:
+              "Instructions on what to do if user doesn't know if they have a GCKey",
+          })}
+        </p>
+        <Link
+          href={loginPath}
+          mode="solid"
+          color="primary"
+          external
+          onClick={() => {
+            if (appInsights) {
+              const userId = appInsights.context?.user?.id;
+              appInsights.trackEvent(
+                { name: "GCKey Login Initiated" },
                 {
-                  defaultMessage:
-                    "<strong>Don't have a GCKey account?</strong> <a>Sign up for one</a>.",
-                  id: "QsWizb",
-                  description:
-                    "Instruction on what to do if user does not have a GCKey",
+                  aiUserId: userId,
+                  pageUrl: window.location.href,
+                  path: window.location.pathname,
+                  timestamp: new Date().toISOString(),
+                  userAgent: navigator.userAgent,
+                  referrer: document.referrer || "none",
+                  gcKeyStatus: "initiated",
                 },
-                {
-                  a: (chunks: ReactNode) =>
-                    buildExternalLink(loginPath, chunks),
-                },
-              )}
-            </p>
-            <p className="mb-12">
-              {intl.formatMessage({
-                defaultMessage:
-                  "<strong>Heads up!</strong> Before we send you off to set up your GCKey credentials, we ask that you take another look at the program's eligibility criteria to ensure that you meet the requirements.",
-                id: "ow71P8",
-                description:
-                  "A request for the user to review the IAP eligibility criteria",
-              })}
-            </p>
-            <p>
-              {intl.formatMessage(
-                {
-                  defaultMessage:
-                    "If you have questions concerning this step, or if you are unsure about how to proceed, please feel free to reach out to our support team at <a>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</a>.",
-                  id: "ltzA7w",
-                  description:
-                    "How to get help from the support team - IAP variant",
-                },
-                {
-                  a: (chunks: ReactNode) =>
-                    buildExternalLink(
-                      "mailto:edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca",
-                      chunks,
-                    ),
-                },
-              )}
-            </p>
-          </>
-        )}
+              );
+            }
+          }}
+        >
+          {intl.formatMessage({
+            defaultMessage: "Sign in with GCKey",
+            id: "oQNunm",
+            description: "GCKey sign in link text on the sign in page",
+          })}
+        </Link>
+        <Heading
+          icon={ArrowLeftEndOnRectangleIcon}
+          color="secondary"
+          level="h2"
+          size="h3"
+          className="mt-18 mb-6 font-normal"
+        >
+          {intl.formatMessage({
+            defaultMessage: "Signing in to your account",
+            id: "Wnid+N",
+            description:
+              "Heading for section of the sign in page showing the sign in steps",
+          })}
+        </Heading>
+        <Heading level="h3" size="h6" className="mt-12 mb-6 font-bold">
+          {intl.formatMessage({
+            defaultMessage:
+              "Steps to signing in with GCKey and completing two-factor authentication",
+            id: "QNMqSh",
+            description: "Subtitle for a section explaining sign in steps",
+          })}
+        </Heading>
+        <Instructions.List>
+          <Instructions.Step
+            img={{
+              src: step1Image,
+              darkSrc: step1ImageDark,
+            }}
+          >
+            {intl.formatMessage({
+              defaultMessage:
+                "1. Sign in with your username and password. Remember, <strong>your username is separate from your email address</strong>.",
+              id: "oR+6vE",
+              description: "Text for first sign in step.",
+            })}
+          </Instructions.Step>
+          <Instructions.Step
+            img={{
+              src: step2Image,
+              darkSrc: step2ImageDark,
+            }}
+          >
+            {intl.formatMessage({
+              defaultMessage:
+                "2. <strong>Open the authenticator app</strong> on your device.",
+              id: "QuHfUJ",
+              description: "Text for second sign in step.",
+            })}
+          </Instructions.Step>
+          <Instructions.Step
+            img={{
+              src: step3Image,
+              darkSrc: step3ImageDark,
+            }}
+          >
+            {intl.formatMessage({
+              defaultMessage:
+                "3. Enter your <strong>unique one-time six-digit code</strong> from your <strong>authenticator app</strong> into the verification bar.",
+              id: "oacrTu",
+              description: "Text for third sign in step.",
+            })}
+          </Instructions.Step>
+          <Instructions.Step
+            includeArrow={false}
+            img={{
+              src: step4Image,
+              darkSrc: step4ImageDark,
+            }}
+          >
+            {intl.formatMessage({
+              defaultMessage:
+                "4. Hooray! <strong>You've signed in with GCKey</strong> and will be returned to the <strong>GC Digital Talent platform</strong>.",
+              id: "eO9buR",
+              description: "Text for final sign in step.",
+            })}
+          </Instructions.Step>
+        </Instructions.List>
+        <Heading
+          icon={InformationCircleIcon}
+          color="error"
+          level="h2"
+          size="h3"
+          className="mt-18 mb-6 font-normal"
+        >
+          {intl.formatMessage({
+            defaultMessage: "Frequently Asked Questions (FAQs)",
+            id: "AUtIo9",
+            description:
+              "Heading for Frequently Asked Questions section on sign in page",
+          })}
+        </Heading>
+        <Accordion.Root
+          type="single"
+          size="sm"
+          mode="card"
+          collapsible
+          className="my-6"
+        >
+          <Accordion.Item value="one">
+            <Accordion.Trigger as="h3">
+              {intl.formatMessage(gckeyMessages.questionExistingAccount)}
+            </Accordion.Trigger>
+            <Accordion.Content>
+              <p className="mb-3">
+                {intl.formatMessage(gckeyMessages.answerExistingAccount)}
+              </p>
+            </Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="two">
+            <Accordion.Trigger as="h3">
+              {intl.formatMessage(gckeyMessages.questionWhatGCKey)}
+            </Accordion.Trigger>
+            <Accordion.Content>
+              <p>{intl.formatMessage(gckeyMessages.answerWhatGCKey)}</p>
+            </Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="three">
+            <Accordion.Trigger as="h3">
+              {intl.formatMessage(gckeyMessages.questionContactGCkey)}
+            </Accordion.Trigger>
+            <Accordion.Content>
+              <p className="mb-3">
+                {intl.formatMessage(gckeyMessages.answerContactGCkey1)}
+              </p>
+              <p className="mb-3">
+                {intl.formatMessage(gckeyMessages.answerContactGCkey2)}
+              </p>
+              <p className="mb-3">
+                <Link
+                  color="black"
+                  external
+                  href="tel:1-855-438-1102"
+                  // eslint-disable-next-line formatjs/no-literal-string-in-jsx
+                  aria-label="1 8 5 5 4 3 8 1 1 0 2"
+                  // eslint-disable-next-line formatjs/no-literal-string-in-jsx
+                >
+                  1-855-438-1102
+                </Link>
+              </p>
+              <p className="mb-3">
+                {intl.formatMessage(gckeyMessages.answerContactGCkey3)}
+              </p>
+              <p className="mb-3">
+                <Link
+                  color="black"
+                  external
+                  href="tel:1-855-438-1103"
+                  // eslint-disable-next-line formatjs/no-literal-string-in-jsx
+                  aria-label="1 8 5 5 4 3 8 1 1 0 3"
+                  // eslint-disable-next-line formatjs/no-literal-string-in-jsx
+                >
+                  1-855-438-1103
+                </Link>
+              </p>
+              <p className="mb-3">
+                {intl.formatMessage(gckeyMessages.answerContactGCkey4)}
+              </p>
+              <p className="mb-3">
+                <Link
+                  color="black"
+                  external
+                  href="tel:1-800-2318-6290"
+                  // eslint-disable-next-line formatjs/no-literal-string-in-jsx
+                  aria-label="1 8 0 0 2 3 1 8 6 2 9 0"
+                  // eslint-disable-next-line formatjs/no-literal-string-in-jsx
+                >
+                  1-800-2318-6290
+                </Link>
+              </p>
+              <p>{intl.formatMessage(gckeyMessages.answerContactGCkey5)}</p>
+            </Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="four">
+            <Accordion.Trigger as="h3">
+              {intl.formatMessage(gckeyMessages.questionAuthApp)}
+            </Accordion.Trigger>
+            <Accordion.Content>
+              <p>{intl.formatMessage(gckeyMessages.answerAuthApp)}</p>
+            </Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="five">
+            <Accordion.Trigger as="h3">
+              {intl.formatMessage(gckeyMessages.questionAuthAlternative)}
+            </Accordion.Trigger>
+            <Accordion.Content>
+              <p>{intl.formatMessage(gckeyMessages.answerAuthAlternative)}</p>
+            </Accordion.Content>
+          </Accordion.Item>
+        </Accordion.Root>
+        <p className="mt-6">
+          {intl.formatMessage(gckeyMessages.moreQuestions, {
+            helpLink: (chunks: ReactNode) => helpLink(chunks, paths.support()),
+          })}
+        </p>
         <Separator />
         <div className="flex items-center gap-6">
           <Link

--- a/apps/web/src/pages/Auth/SignUpPage/SignUpPage.tsx
+++ b/apps/web/src/pages/Auth/SignUpPage/SignUpPage.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from "react";
-import { useEffect } from "react";
 import { useIntl } from "react-intl";
 import { useSearchParams } from "react-router";
 import InformationCircleIcon from "@heroicons/react/24/outline/InformationCircleIcon";
@@ -17,7 +16,6 @@ import {
 } from "@gc-digital-talent/ui";
 import { useApiRoutes } from "@gc-digital-talent/auth";
 import { getLocale } from "@gc-digital-talent/i18n";
-import { useTheme } from "@gc-digital-talent/theme";
 import { useFeatureFlags } from "@gc-digital-talent/env";
 
 import Hero from "~/components/Hero";
@@ -72,21 +70,12 @@ const helpLink = (chunks: ReactNode, path: string) => (
   </Link>
 );
 
-const buildExternalLink = (path: string, chunks: ReactNode) => (
-  <Link external href={path}>
-    {chunks}
-  </Link>
-);
-
 export const Component = () => {
   const intl = useIntl();
   const paths = useRoutes();
   const apiPaths = useApiRoutes();
   const [searchParams] = useSearchParams();
-  const { key: themeKey, setKey: setThemeKey } = useTheme();
   const fromPath = searchParams.get("from");
-  const iapMode =
-    fromPath === paths.iap() || searchParams.get("personality") === "iap";
   const fallbackPath = paths.applicantDashboard();
   const loginPath = apiPaths.login(fromPath ?? fallbackPath, getLocale(intl));
 
@@ -123,12 +112,6 @@ export const Component = () => {
     ],
   });
 
-  useEffect(() => {
-    if (iapMode && themeKey !== "iap") {
-      setThemeKey("iap");
-    }
-  }, [iapMode, themeKey, setThemeKey]);
-
   // Feature Flag: Canada Login
   if (featureFlags?.canadaLogin) {
     return (
@@ -136,541 +119,452 @@ export const Component = () => {
         <SEO title={pageTitle} />
         <Hero title={pageTitle} crumbs={crumbs} overlap={true} centered={true}>
           <div className="mt-0 rounded-md bg-white px-6 py-12 shadow-sm sm:mt-10 dark:bg-gray-600">
-            {!iapMode && (
-              <div className="px-2">
-                <Heading
-                  level="h2"
+            <div className="px-2">
+              <Heading
+                level="h2"
+                color="primary"
+                icon={SparklesIcon}
+                className="mt-0 font-normal"
+              >
+                {intl.formatMessage({
+                  defaultMessage: "Welcome",
+                  id: "qrd+vb",
+                  description:
+                    "Welcome heading at the top of the registration page",
+                })}
+              </Heading>
+              <p className="pt-4 pl-2">
+                {intl.formatMessage({
+                  defaultMessage:
+                    "You'll be leaving our site to register with CanadaLogin. We have prepared additional guidance in the next section to help.",
+                  id: "xgrysZ",
+                  description:
+                    "Copy under welcome heading at the top of the registration page",
+                })}
+              </p>
+              <div className="flex flex-col items-start gap-4 pt-6 pl-2 xs:flex-row xs:items-center">
+                <Link
+                  href={`${loginPath}&skipmigration=true`}
+                  mode="solid"
                   color="primary"
-                  icon={SparklesIcon}
-                  className="mt-0 font-normal"
+                  utilityIcon={ChevronDoubleRightIcon}
+                  external
+                  className="xxs:px-3"
                 >
                   {intl.formatMessage({
-                    defaultMessage: "Welcome",
-                    id: "qrd+vb",
+                    defaultMessage: "Proceed to CanadaLogin",
+                    id: "KorMJQ",
                     description:
-                      "Welcome heading at the top of the registration page",
+                      "CanadaLogin sign up link text on the registration page",
                   })}
-                </Heading>
-                <p className="pt-4 pl-2">
-                  {intl.formatMessage({
-                    defaultMessage:
-                      "You'll be leaving our site to register with CanadaLogin. We have prepared additional guidance in the next section to help.",
-                    id: "xgrysZ",
-                    description:
-                      "Copy under welcome heading at the top of the registration page",
-                  })}
-                </p>
-                <div className="flex flex-col items-start gap-4 pt-6 pl-2 xs:flex-row xs:items-center">
+                </Link>
+
+                <p className="m-0 flex items-center pl-2">
                   <Link
-                    href={`${loginPath}&skipmigration=true`}
-                    mode="solid"
-                    color="primary"
-                    utilityIcon={ChevronDoubleRightIcon}
+                    href="#registrationInstructions"
+                    mode="inline"
                     external
-                    className="xxs:px-3"
+                    className="sm:ml-4"
                   >
                     {intl.formatMessage({
-                      defaultMessage: "Proceed to CanadaLogin",
-                      id: "KorMJQ",
+                      defaultMessage: "Instructions on how to register",
+                      id: "FnXbHv",
                       description:
-                        "CanadaLogin sign up link text on the registration page",
+                        "Heading for the instructions resource block on the registration page",
                     })}
                   </Link>
-
-                  <p className="m-0 flex items-center pl-2">
-                    <Link
-                      href="#registrationInstructions"
-                      mode="inline"
-                      external
-                      className="sm:ml-4"
-                    >
-                      {intl.formatMessage({
-                        defaultMessage: "Instructions on how to register",
-                        id: "FnXbHv",
-                        description:
-                          "Heading for the instructions resource block on the registration page",
-                      })}
-                    </Link>
-                  </p>
-                </div>
+                </p>
               </div>
-            )}
+            </div>
           </div>
         </Hero>
 
         <Container className="my-12">
-          {!iapMode ? (
-            <>
-              <div id="registrationInstructions" className="scroll-mt-20">
-                <Heading
-                  level="h3"
-                  size="h4"
-                  className="mt-6 mb-4 text-center font-normal xs:text-left"
-                >
+          <div id="registrationInstructions" className="scroll-mt-20">
+            <Heading
+              level="h3"
+              size="h4"
+              className="mt-6 mb-4 text-center font-normal xs:text-left"
+            >
+              {intl.formatMessage({
+                defaultMessage: "Part 1: Create a CanadaLogin account",
+                id: "Su2+bZ",
+                description:
+                  "Heading for section of the registration page showing the create steps",
+              })}
+            </Heading>
+
+            <InstructionsCardGrid columns={3}>
+              <InstructionsStepCard
+                className="rounded-t-md rounded-b-none pt-12 pb-7.5 xs:rounded-l-md xs:rounded-r-none"
+                img={{
+                  src: canadaLoginStep1,
+                  darkSrc: canadaLoginStep1Dark,
+                }}
+              >
+                <p>
                   {intl.formatMessage({
-                    defaultMessage: "Part 1: Create a CanadaLogin account",
-                    id: "Su2+bZ",
-                    description:
-                      "Heading for section of the registration page showing the create steps",
+                    defaultMessage: "Head to CanadaLogin.",
+                    id: "sRUaI5",
+                    description: "Text for first registration -> create step.",
                   })}
-                </Heading>
+                </p>
+                <p className="mt-4">
+                  {intl.formatMessage({
+                    defaultMessage: "Agree to the summary of terms.",
+                    id: "qSNLSc",
+                    description: "Text for first registration -> create step.",
+                  })}
+                </p>
+                <div className="mt-2 mb-6.75">
+                  <span className="text-sm font-normal text-gray-500 dark:text-gray-100">
+                    {intl.formatMessage({
+                      defaultMessage:
+                        "If you've already used CanadaLogin on another service, you can enter your email and password and skip to step two.",
+                      id: "h4BQ8C",
+                      description:
+                        "Text for first registration -> create step.",
+                    })}
+                  </span>
+                </div>
+              </InstructionsStepCard>
 
-                <InstructionsCardGrid columns={3}>
-                  <InstructionsStepCard
-                    className="rounded-t-md rounded-b-none pt-12 pb-7.5 xs:rounded-l-md xs:rounded-r-none"
-                    img={{
-                      src: canadaLoginStep1,
-                      darkSrc: canadaLoginStep1Dark,
-                    }}
-                  >
-                    <p>
-                      {intl.formatMessage({
-                        defaultMessage: "Head to CanadaLogin.",
-                        id: "sRUaI5",
-                        description:
-                          "Text for first registration -> create step.",
-                      })}
-                    </p>
-                    <p className="mt-4">
-                      {intl.formatMessage({
-                        defaultMessage: "Agree to the summary of terms.",
-                        id: "qSNLSc",
-                        description:
-                          "Text for first registration -> create step.",
-                      })}
-                    </p>
-                    <div className="mt-2 mb-6.75">
-                      <span className="text-sm font-normal text-gray-500 dark:text-gray-100">
-                        {intl.formatMessage({
-                          defaultMessage:
-                            "If you've already used CanadaLogin on another service, you can enter your email and password and skip to step two.",
-                          id: "h4BQ8C",
-                          description:
-                            "Text for first registration -> create step.",
-                        })}
-                      </span>
-                    </div>
-                  </InstructionsStepCard>
-
-                  <InstructionsStepCard
-                    className="rounded-none pt-12 pb-7.5"
-                    background="darker"
-                    img={{
-                      src: canadaLoginStep2,
-                      darkSrc: canadaLoginStep2Dark,
-                    }}
-                  >
-                    <p>
-                      {intl.formatMessage({
-                        defaultMessage: "Enter your first and last name.",
-                        id: "FD+jX4",
-                        description:
-                          "Text for first registration -> create step.",
-                      })}
-                    </p>
-                    <div className="mt-2 mb-6.75">
-                      <span className="text-sm font-normal text-gray-600 dark:text-gray-100">
-                        {intl.formatMessage({
-                          defaultMessage:
-                            "The name you use here will be on your GC Digital Talent profile.",
-                          id: "8dctGM",
-                          description:
-                            "Text for first registration -> create step.",
-                        })}
-                      </span>
-                    </div>
-                  </InstructionsStepCard>
-
-                  <InstructionsStepCard
-                    className="rounded-t-none rounded-b-md pt-12 pb-7.5 xs:rounded-l-none xs:rounded-r-md"
-                    includeArrow={false}
-                    img={{
-                      src: canadaLoginStep3,
-                      darkSrc: canadaLoginStep3Dark,
-                    }}
-                  >
-                    <p>
-                      {intl.formatMessage({
-                        defaultMessage: "Verify your personal email address.",
-                        id: "Ip9S/o",
-                        description:
-                          "Text for first registration -> create step.",
-                      })}
-                    </p>
-                    <p className="mt-4">
-                      {intl.formatMessage({
-                        defaultMessage:
-                          "Enter the code sent to your email into CanadaLogin.",
-                        id: "XLJuh+",
-                        description:
-                          "Text for first registration -> create step.",
-                      })}
-                    </p>
-                    <div className="mt-2 mb-6.75">
-                      <span className="text-sm font-normal text-gray-500 dark:text-gray-100">
-                        {intl.formatMessage({
-                          defaultMessage:
-                            "Using a personal email address will help ensure you don't lose access if you change jobs.",
-                          id: "OG/Fbe",
-                          description:
-                            "Text for first registration -> create step.",
-                        })}
-                      </span>
-                    </div>
-                  </InstructionsStepCard>
-                </InstructionsCardGrid>
-              </div>
-              <Heading
-                level="h3"
-                size="h4"
-                className="mt-20 mb-3.5 text-center font-normal xs:text-left"
+              <InstructionsStepCard
+                className="rounded-none pt-12 pb-7.5"
+                background="darker"
+                img={{
+                  src: canadaLoginStep2,
+                  darkSrc: canadaLoginStep2Dark,
+                }}
               >
-                {intl.formatMessage({
-                  defaultMessage: "Part 2: Set up two-step verification",
-                  id: "OxuU1/",
-                  description:
-                    "Heading for section of the registration page showing the create steps",
-                })}
-              </Heading>
-
-              <InstructionsCardGrid columns={3}>
-                <InstructionsStepCard
-                  className="rounded-t-md rounded-b-none pt-12 pb-7.5 xs:rounded-l-md xs:rounded-r-none"
-                  img={{ src: canadaLoginStep4, darkSrc: canadaLoginStep4Dark }}
-                >
-                  <p>
-                    {intl.formatMessage({
-                      defaultMessage: "Set up two-step verification.",
-                      id: "D/Tcaj",
-                      description:
-                        "Text for first registration -> create step.",
-                    })}
-                  </p>
-                  <p className="mt-4">
-                    {intl.formatMessage({
-                      defaultMessage: "Enter your personal phone number.",
-                      id: "XUt7q+",
-                      description:
-                        "Text for first registration -> create step.",
-                    })}
-                  </p>
-                  <div className="mt-2 mb-6.75">
-                    <span className="text-sm font-normal text-gray-500 dark:text-gray-100">
-                      {intl.formatMessage({
-                        defaultMessage:
-                          "Using a personal phone number will help ensure you don't lose access if you change jobs.",
-                        id: "QbJmAL",
-                        description:
-                          "Text for first registration -> create step.",
-                      })}
-                    </span>
-                  </div>
-                </InstructionsStepCard>
-
-                <InstructionsStepCard
-                  className="rounded-none pt-12 pb-7.5"
-                  background="darker"
-                  img={{ src: canadaLoginStep5, darkSrc: canadaLoginStep5Dark }}
-                >
-                  <p>
+                <p>
+                  {intl.formatMessage({
+                    defaultMessage: "Enter your first and last name.",
+                    id: "FD+jX4",
+                    description: "Text for first registration -> create step.",
+                  })}
+                </p>
+                <div className="mt-2 mb-6.75">
+                  <span className="text-sm font-normal text-gray-600 dark:text-gray-100">
                     {intl.formatMessage({
                       defaultMessage:
-                        "You will be sent a code to the number you provided.",
-                      id: "QU8yQJ",
+                        "The name you use here will be on your GC Digital Talent profile.",
+                      id: "8dctGM",
                       description:
                         "Text for first registration -> create step.",
                     })}
-                  </p>
-                  <p className="mt-4">
-                    {intl.formatMessage({
-                      defaultMessage: "Enter the code into CanadaLogin.",
-                      id: "pTOGhN",
-                      description:
-                        "Text for first registration -> create step.",
-                    })}
-                  </p>
-                  <div className="mt-2 mb-6.75">
-                    <span className="text-sm font-normal text-gray-600 dark:text-gray-100">
-                      {intl.formatMessage({
-                        defaultMessage:
-                          "This code will be sent by either text or phone call, and will expire after ten minutes.",
-                        id: "As56gg",
-                        description:
-                          "Text for first registration -> create step.",
-                      })}
-                    </span>
-                  </div>
-                </InstructionsStepCard>
+                  </span>
+                </div>
+              </InstructionsStepCard>
 
-                <InstructionsStepCard
-                  className="rounded-t-none rounded-b-md pt-12 pb-7.5 xs:rounded-l-none xs:rounded-r-md"
-                  includeArrow={false}
-                  img={{ src: canadaLoginStep6, darkSrc: canadaLoginStep6Dark }}
-                >
-                  <p>
-                    {intl.formatMessage({
-                      defaultMessage:
-                        "You've successfully created your CanadaLogin.",
-                      id: "To1Tf5",
-                      description:
-                        "Text for first registration -> create step.",
-                    })}
-                  </p>
-                  <p className="mt-4 mb-6.75">
-                    {intl.formatMessage({
-                      defaultMessage:
-                        "You will be returned to the GC Digital Talent platform.",
-                      id: "FJU6Pr",
-                      description:
-                        "Text for first registration -> create step.",
-                    })}
-                  </p>
-                </InstructionsStepCard>
-              </InstructionsCardGrid>
-
-              <Heading
-                level="h3"
-                size="h4"
-                className="mt-20 mb-3.5 text-center font-normal xs:text-left"
+              <InstructionsStepCard
+                className="rounded-t-none rounded-b-md pt-12 pb-7.5 xs:rounded-l-none xs:rounded-r-md"
+                includeArrow={false}
+                img={{
+                  src: canadaLoginStep3,
+                  darkSrc: canadaLoginStep3Dark,
+                }}
               >
-                {intl.formatMessage({
-                  defaultMessage: "Part 3: Access your account",
-                  id: "WsnfHy",
-                  description:
-                    "Heading for section of the registration page showing the create steps",
-                })}
-              </Heading>
-
-              <InstructionsCardGrid columns={3}>
-                <InstructionsStepCard
-                  className="rounded-t-md rounded-b-none pt-12 pb-7.5 xs:rounded-l-md xs:rounded-r-none"
-                  img={{ src: canadaLoginStep7, darkSrc: canadaLoginStep7Dark }}
-                >
-                  <p>
-                    {intl.formatMessage({
-                      defaultMessage:
-                        "View your details sent from CanadaLogin, linked to your GC Digital Talent profile.",
-                      id: "IHcJGO",
-                      description:
-                        "Text for first registration -> create step.",
-                    })}
-                  </p>
-                  <div className="mt-2 mb-6.75">
-                    <span className="text-sm font-normal text-gray-500 dark:text-gray-100">
-                      {intl.formatMessage({
-                        defaultMessage:
-                          "You can manage your CanadaLogin profile and security setting on the CanadaLogin website.",
-                        id: "dzXJ2h",
-                        description:
-                          "Text for first registration -> create step.",
-                      })}
-                    </span>
-                  </div>
-                </InstructionsStepCard>
-
-                <InstructionsStepCard
-                  className="rounded-none pt-12 pb-7.5"
-                  background="darker"
-                  img={{ src: canadaLoginStep8, darkSrc: canadaLoginStep8Dark }}
-                >
-                  <p>
-                    {intl.formatMessage({
-                      defaultMessage:
-                        "Verify your Government of Canada work email to unlock employee tools.",
-                      id: "jrDcs6",
-                      description:
-                        "Text for first registration -> create step.",
-                    })}
-                  </p>
-                  <div className="mt-2 mb-6.75">
-                    <span className="text-sm font-normal text-gray-600 dark:text-gray-100">
-                      {intl.formatMessage({
-                        defaultMessage:
-                          "This feature is only available to current Government of Canada employees.",
-                        id: "Bo2POt",
-                        description:
-                          "Text for first registration -> create step.",
-                      })}
-                    </span>
-                  </div>
-                </InstructionsStepCard>
-
-                <InstructionsStepCard
-                  className="rounded-t-none rounded-b-md pt-12 pb-7.5 xs:rounded-l-none xs:rounded-r-md"
-                  includeArrow={false}
-                  img={{ src: canadaLoginStep9, darkSrc: canadaLoginStep9Dark }}
-                >
-                  <p>
-                    {intl.formatMessage({
-                      defaultMessage:
-                        "Add your current work experience to your GC Digital Talent profile.",
-                      id: "eg07u9",
-                      description:
-                        "Text for first registration -> create step.",
-                    })}
-                  </p>
-                  <div className="mt-2 mb-6.75">
-                    <span className="text-sm font-normal text-gray-500 dark:text-gray-100">
-                      {intl.formatMessage({
-                        defaultMessage:
-                          "If you are a government employee this is the final step in-order to unlock your employee tools.",
-                        id: "2bKnmd",
-                        description:
-                          "Text for first registration -> create step.",
-                      })}
-                    </span>
-                  </div>
-                </InstructionsStepCard>
-              </InstructionsCardGrid>
-
-              <Heading
-                icon={InformationCircleIcon}
-                color="primary"
-                level="h3"
-                size="h4"
-                className="mt-12 mb-5 justify-center font-normal xs:justify-start"
-              >
-                {intl.formatMessage({
-                  defaultMessage: "Frequently Asked Questions (FAQs)",
-                  id: "AUtIo9",
-                  description:
-                    "Heading for Frequently Asked Questions section on sign in page",
-                })}
-              </Heading>
-              <Accordion.Root
-                type="single"
-                size="sm"
-                mode="card"
-                collapsible
-                className="my-5 mt-4"
-              >
-                <Accordion.Item value="one">
-                  <Accordion.Trigger as="h3">
-                    {intl.formatMessage(canadaLoginMessages.haveCanadaLogin)}
-                  </Accordion.Trigger>
-                  <Accordion.Content>
-                    <p>
-                      {intl.formatMessage(
-                        canadaLoginMessages.haveCanadaLoginAnswer,
-                      )}
-                    </p>
-                  </Accordion.Content>
-                </Accordion.Item>
-                <Accordion.Item value="two">
-                  <Accordion.Trigger as="h3">
-                    {intl.formatMessage(canadaLoginMessages.whatIsCanadaLogin)}
-                  </Accordion.Trigger>
-                  <Accordion.Content>
-                    <p className="mb-3">
-                      {intl.formatMessage(
-                        canadaLoginMessages.whatIsCanadaLoginAnswer,
-                      )}
-                    </p>
-                  </Accordion.Content>
-                </Accordion.Item>
-                <Accordion.Item value="three">
-                  <Accordion.Trigger as="h3">
-                    {intl.formatMessage(canadaLoginMessages.contactCanadaLogin)}
-                  </Accordion.Trigger>
-                  <Accordion.Content>
-                    <p>
-                      {intl.formatMessage(
-                        canadaLoginMessages.answerContactCanadaLogin1,
-                      )}
-                    </p>
-                    <p className="mt-4 mb-3">
-                      <Link
-                        color="black"
-                        external
-                        aria-label={intl.formatMessage(
-                          canadaLoginMessages.answerContactCanadaLogin2,
-                        )}
-                        href={
-                          intl.locale === "fr"
-                            ? "https://connexion.canada.ca/fr/utilisateurs/nous-contacter/"
-                            : "https://login.canada.ca/en/users/contact-us/"
-                        }
-                      >
-                        {intl.formatMessage(
-                          canadaLoginMessages.answerContactCanadaLogin2,
-                        )}
-                      </Link>
-                    </p>
-                  </Accordion.Content>
-                </Accordion.Item>
-              </Accordion.Root>
-              <p className="mt-5">
-                {intl.formatMessage(gckeyMessages.moreQuestions, {
-                  helpLink: (chunks: ReactNode) =>
-                    helpLink(chunks, paths.support()),
-                })}
-              </p>
-            </>
-          ) : (
-            <>
-              {/* IAP copy */}
-              <p className="mb-3">
-                {intl.formatMessage({
-                  defaultMessage:
-                    "You can sign in to your IT Apprenticeship Program for Indigenous Peoples profile using your existing GCKey, even if you've never used this platform before.",
-                  id: "6SfJEp",
-                  description:
-                    "Instructions on how to sign in with GCKey - IAP variant",
-                })}
-              </p>
-              <p className="mb-3">
-                {intl.formatMessage({
-                  defaultMessage:
-                    "If you're unsure of whether you have an existing GCKey account, continue to the website and try signing in. If you can't remember your password, you can also reset it there.",
-                  id: "Z+gi2d",
-                  description:
-                    "Instructions on what to do if user doesn't know if they have a GCKey - IAP variant",
-                })}
-              </p>
-              <p className="mb-6">
-                {intl.formatMessage(
-                  {
+                <p>
+                  {intl.formatMessage({
+                    defaultMessage: "Verify your personal email address.",
+                    id: "Ip9S/o",
+                    description: "Text for first registration -> create step.",
+                  })}
+                </p>
+                <p className="mt-4">
+                  {intl.formatMessage({
                     defaultMessage:
-                      "<strong>Don't have a GCKey account?</strong> <a>Sign up for one</a>.",
-                    id: "QsWizb",
-                    description:
-                      "Instruction on what to do if user does not have a GCKey",
-                  },
-                  {
-                    a: (chunks: ReactNode) =>
-                      buildExternalLink(loginPath, chunks),
-                  },
-                )}
-              </p>
-              <p className="mb-12">
-                {intl.formatMessage({
-                  defaultMessage:
-                    "<strong>Heads up!</strong> Before we send you off to set up your GCKey credentials, we ask that you take another look at the program's eligibility criteria to ensure that you meet the requirements.",
-                  id: "ow71P8",
-                  description:
-                    "A request for the user to review the IAP eligibility criteria",
-                })}
-              </p>
+                      "Enter the code sent to your email into CanadaLogin.",
+                    id: "XLJuh+",
+                    description: "Text for first registration -> create step.",
+                  })}
+                </p>
+                <div className="mt-2 mb-6.75">
+                  <span className="text-sm font-normal text-gray-500 dark:text-gray-100">
+                    {intl.formatMessage({
+                      defaultMessage:
+                        "Using a personal email address will help ensure you don't lose access if you change jobs.",
+                      id: "OG/Fbe",
+                      description:
+                        "Text for first registration -> create step.",
+                    })}
+                  </span>
+                </div>
+              </InstructionsStepCard>
+            </InstructionsCardGrid>
+          </div>
+          <Heading
+            level="h3"
+            size="h4"
+            className="mt-20 mb-3.5 text-center font-normal xs:text-left"
+          >
+            {intl.formatMessage({
+              defaultMessage: "Part 2: Set up two-step verification",
+              id: "OxuU1/",
+              description:
+                "Heading for section of the registration page showing the create steps",
+            })}
+          </Heading>
+
+          <InstructionsCardGrid columns={3}>
+            <InstructionsStepCard
+              className="rounded-t-md rounded-b-none pt-12 pb-7.5 xs:rounded-l-md xs:rounded-r-none"
+              img={{ src: canadaLoginStep4, darkSrc: canadaLoginStep4Dark }}
+            >
               <p>
-                {intl.formatMessage(
-                  {
-                    defaultMessage:
-                      "If you have questions concerning this step, or if you are unsure about how to proceed, please feel free to reach out to our support team at <a>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</a>.",
-                    id: "ltzA7w",
-                    description:
-                      "How to get help from the support team - IAP variant",
-                  },
-                  {
-                    a: (chunks: ReactNode) =>
-                      buildExternalLink(
-                        "mailto:edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca",
-                        chunks,
-                      ),
-                  },
-                )}
+                {intl.formatMessage({
+                  defaultMessage: "Set up two-step verification.",
+                  id: "D/Tcaj",
+                  description: "Text for first registration -> create step.",
+                })}
               </p>
-            </>
-          )}
+              <p className="mt-4">
+                {intl.formatMessage({
+                  defaultMessage: "Enter your personal phone number.",
+                  id: "XUt7q+",
+                  description: "Text for first registration -> create step.",
+                })}
+              </p>
+              <div className="mt-2 mb-6.75">
+                <span className="text-sm font-normal text-gray-500 dark:text-gray-100">
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "Using a personal phone number will help ensure you don't lose access if you change jobs.",
+                    id: "QbJmAL",
+                    description: "Text for first registration -> create step.",
+                  })}
+                </span>
+              </div>
+            </InstructionsStepCard>
+
+            <InstructionsStepCard
+              className="rounded-none pt-12 pb-7.5"
+              background="darker"
+              img={{ src: canadaLoginStep5, darkSrc: canadaLoginStep5Dark }}
+            >
+              <p>
+                {intl.formatMessage({
+                  defaultMessage:
+                    "You will be sent a code to the number you provided.",
+                  id: "QU8yQJ",
+                  description: "Text for first registration -> create step.",
+                })}
+              </p>
+              <p className="mt-4">
+                {intl.formatMessage({
+                  defaultMessage: "Enter the code into CanadaLogin.",
+                  id: "pTOGhN",
+                  description: "Text for first registration -> create step.",
+                })}
+              </p>
+              <div className="mt-2 mb-6.75">
+                <span className="text-sm font-normal text-gray-600 dark:text-gray-100">
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "This code will be sent by either text or phone call, and will expire after ten minutes.",
+                    id: "As56gg",
+                    description: "Text for first registration -> create step.",
+                  })}
+                </span>
+              </div>
+            </InstructionsStepCard>
+
+            <InstructionsStepCard
+              className="rounded-t-none rounded-b-md pt-12 pb-7.5 xs:rounded-l-none xs:rounded-r-md"
+              includeArrow={false}
+              img={{ src: canadaLoginStep6, darkSrc: canadaLoginStep6Dark }}
+            >
+              <p>
+                {intl.formatMessage({
+                  defaultMessage:
+                    "You've successfully created your CanadaLogin.",
+                  id: "To1Tf5",
+                  description: "Text for first registration -> create step.",
+                })}
+              </p>
+              <p className="mt-4 mb-6.75">
+                {intl.formatMessage({
+                  defaultMessage:
+                    "You will be returned to the GC Digital Talent platform.",
+                  id: "FJU6Pr",
+                  description: "Text for first registration -> create step.",
+                })}
+              </p>
+            </InstructionsStepCard>
+          </InstructionsCardGrid>
+
+          <Heading
+            level="h3"
+            size="h4"
+            className="mt-20 mb-3.5 text-center font-normal xs:text-left"
+          >
+            {intl.formatMessage({
+              defaultMessage: "Part 3: Access your account",
+              id: "WsnfHy",
+              description:
+                "Heading for section of the registration page showing the create steps",
+            })}
+          </Heading>
+
+          <InstructionsCardGrid columns={3}>
+            <InstructionsStepCard
+              className="rounded-t-md rounded-b-none pt-12 pb-7.5 xs:rounded-l-md xs:rounded-r-none"
+              img={{ src: canadaLoginStep7, darkSrc: canadaLoginStep7Dark }}
+            >
+              <p>
+                {intl.formatMessage({
+                  defaultMessage:
+                    "View your details sent from CanadaLogin, linked to your GC Digital Talent profile.",
+                  id: "IHcJGO",
+                  description: "Text for first registration -> create step.",
+                })}
+              </p>
+              <div className="mt-2 mb-6.75">
+                <span className="text-sm font-normal text-gray-500 dark:text-gray-100">
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "You can manage your CanadaLogin profile and security setting on the CanadaLogin website.",
+                    id: "dzXJ2h",
+                    description: "Text for first registration -> create step.",
+                  })}
+                </span>
+              </div>
+            </InstructionsStepCard>
+
+            <InstructionsStepCard
+              className="rounded-none pt-12 pb-7.5"
+              background="darker"
+              img={{ src: canadaLoginStep8, darkSrc: canadaLoginStep8Dark }}
+            >
+              <p>
+                {intl.formatMessage({
+                  defaultMessage:
+                    "Verify your Government of Canada work email to unlock employee tools.",
+                  id: "jrDcs6",
+                  description: "Text for first registration -> create step.",
+                })}
+              </p>
+              <div className="mt-2 mb-6.75">
+                <span className="text-sm font-normal text-gray-600 dark:text-gray-100">
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "This feature is only available to current Government of Canada employees.",
+                    id: "Bo2POt",
+                    description: "Text for first registration -> create step.",
+                  })}
+                </span>
+              </div>
+            </InstructionsStepCard>
+
+            <InstructionsStepCard
+              className="rounded-t-none rounded-b-md pt-12 pb-7.5 xs:rounded-l-none xs:rounded-r-md"
+              includeArrow={false}
+              img={{ src: canadaLoginStep9, darkSrc: canadaLoginStep9Dark }}
+            >
+              <p>
+                {intl.formatMessage({
+                  defaultMessage:
+                    "Add your current work experience to your GC Digital Talent profile.",
+                  id: "eg07u9",
+                  description: "Text for first registration -> create step.",
+                })}
+              </p>
+              <div className="mt-2 mb-6.75">
+                <span className="text-sm font-normal text-gray-500 dark:text-gray-100">
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "If you are a government employee this is the final step in-order to unlock your employee tools.",
+                    id: "2bKnmd",
+                    description: "Text for first registration -> create step.",
+                  })}
+                </span>
+              </div>
+            </InstructionsStepCard>
+          </InstructionsCardGrid>
+
+          <Heading
+            icon={InformationCircleIcon}
+            color="primary"
+            level="h3"
+            size="h4"
+            className="mt-12 mb-5 justify-center font-normal xs:justify-start"
+          >
+            {intl.formatMessage({
+              defaultMessage: "Frequently Asked Questions (FAQs)",
+              id: "AUtIo9",
+              description:
+                "Heading for Frequently Asked Questions section on sign in page",
+            })}
+          </Heading>
+          <Accordion.Root
+            type="single"
+            size="sm"
+            mode="card"
+            collapsible
+            className="my-5 mt-4"
+          >
+            <Accordion.Item value="one">
+              <Accordion.Trigger as="h3">
+                {intl.formatMessage(canadaLoginMessages.haveCanadaLogin)}
+              </Accordion.Trigger>
+              <Accordion.Content>
+                <p>
+                  {intl.formatMessage(
+                    canadaLoginMessages.haveCanadaLoginAnswer,
+                  )}
+                </p>
+              </Accordion.Content>
+            </Accordion.Item>
+            <Accordion.Item value="two">
+              <Accordion.Trigger as="h3">
+                {intl.formatMessage(canadaLoginMessages.whatIsCanadaLogin)}
+              </Accordion.Trigger>
+              <Accordion.Content>
+                <p className="mb-3">
+                  {intl.formatMessage(
+                    canadaLoginMessages.whatIsCanadaLoginAnswer,
+                  )}
+                </p>
+              </Accordion.Content>
+            </Accordion.Item>
+            <Accordion.Item value="three">
+              <Accordion.Trigger as="h3">
+                {intl.formatMessage(canadaLoginMessages.contactCanadaLogin)}
+              </Accordion.Trigger>
+              <Accordion.Content>
+                <p>
+                  {intl.formatMessage(
+                    canadaLoginMessages.answerContactCanadaLogin1,
+                  )}
+                </p>
+                <p className="mt-4 mb-3">
+                  <Link
+                    color="black"
+                    external
+                    aria-label={intl.formatMessage(
+                      canadaLoginMessages.answerContactCanadaLogin2,
+                    )}
+                    href={
+                      intl.locale === "fr"
+                        ? "https://connexion.canada.ca/fr/utilisateurs/nous-contacter/"
+                        : "https://login.canada.ca/en/users/contact-us/"
+                    }
+                  >
+                    {intl.formatMessage(
+                      canadaLoginMessages.answerContactCanadaLogin2,
+                    )}
+                  </Link>
+                </p>
+              </Accordion.Content>
+            </Accordion.Item>
+          </Accordion.Root>
+          <p className="mt-5">
+            {intl.formatMessage(gckeyMessages.moreQuestions, {
+              helpLink: (chunks: ReactNode) =>
+                helpLink(chunks, paths.support()),
+            })}
+          </p>
         </Container>
       </>
     );
@@ -680,431 +574,356 @@ export const Component = () => {
       <SEO title={pageTitle} />
       <Hero title={pageTitle} crumbs={crumbs} />
       <Container className="my-18">
-        {!iapMode ? (
-          <>
-            {/* Standard copy */}
-            <Heading
-              icon={MapIcon}
-              color="secondary"
-              level="h2"
-              size="h3"
-              className="mt-0 mb-6 font-normal"
-            >
-              {intl.formatMessage({
-                defaultMessage: "What to expect when creating an account",
-                id: "mV1/kq",
-                description:
-                  "Heading at the top of the sign up page for applicant profiles",
-              })}
-            </Heading>
-            <Ul className="my-6" space="md" noIndent>
-              <li>
-                {intl.formatMessage({
-                  defaultMessage:
-                    "To sign up (or authenticate) with GC Digital Talent, we require that you use GCKey.",
-                  id: "Dqsq+M",
-                  description: "A _what to expect_ point on the sign up page",
-                })}
-              </li>
-              <li>
-                {intl.formatMessage({
-                  defaultMessage:
-                    "GCKey is a Government of Canada credential that allows you to securely conduct online business with various governmental programs and services.",
-                  id: "XkA6s1",
-                  description: "A _what to expect_ point on the sign up page",
-                })}
-              </li>
-              <li>
-                {intl.formatMessage({
-                  defaultMessage:
-                    "In addition to GCKey, you will need to set up a two-factor authenticator app for an added layer of security. (See setting up two-factor authentication for details)",
-                  id: "RalbOM",
-                  description: "A _what to expect_ point on the sign up page",
-                })}
-              </li>
-              <li>
-                {intl.formatMessage({
-                  defaultMessage:
-                    "Expect to spend approximately 20 minutes to set up GCKey and the authenticator app.",
-                  id: "BfrCXV",
-                  description: "A _what to expect_ point on the sign up page",
-                })}
-              </li>
-              <li>
-                {intl.formatMessage({
-                  defaultMessage:
-                    "We have prepared additional guidance In the next section to help.",
-                  id: "UpwY5+",
-                  description: "A _what to expect_ point on the sign up page",
-                })}
-              </li>
-            </Ul>
-            <Link href={loginPath} mode="solid" color="primary" external>
-              {intl.formatMessage({
-                defaultMessage: "Sign up with GCKey",
-                id: "4LMyAD",
-                description: "GCKey sign up link text on the sign up page",
-              })}
-            </Link>
-            <Heading level="h3" size="h4" className="mt-20 mb-3.5 font-bold">
-              {intl.formatMessage({
-                defaultMessage: "Part 1: Creating a GCKey account",
-                id: "u98IOx",
-                description:
-                  "Heading for section of the sign up page showing the create steps",
-              })}
-            </Heading>
-            <Heading level="h4" size="h6" className="mt-12 mb-3 font-bold">
-              {intl.formatMessage({
-                defaultMessage: "Steps to create your GCKey account",
-                id: "lZwkcR",
-                description:
-                  "Subtitle for a section explaining the create steps",
-              })}
-            </Heading>
-            <Instructions.List>
-              <Instructions.Step
-                img={{ src: createStep1Image, darkSrc: createStep1ImageDark }}
-              >
-                {intl.formatMessage({
-                  defaultMessage:
-                    "1. Select <strong>sign up</strong> on the welcome page. This is <strong>located after the sign in</strong> section.",
-                  id: "MUYJr1",
-                  description: "Text for first sign up -> create step.",
-                })}
-              </Instructions.Step>
-              <Instructions.Step
-                img={{ src: createStep2Image, darkSrc: createStep2ImageDark }}
-              >
-                {intl.formatMessage({
-                  defaultMessage:
-                    "2. Create a username and password. Don’t forget to <strong>save your username</strong> separately from your <strong>email address</strong>.",
-                  id: "Jp/oeD",
-                  description: "Text for second sign up -> create step.",
-                })}
-              </Instructions.Step>
-              <Instructions.Step
-                img={{ src: createStep3Image, darkSrc: createStep3ImageDark }}
-              >
-                {intl.formatMessage({
-                  defaultMessage:
-                    "3. Complete your <strong>recovery questions</strong>. You are required to use a memorable <strong>person</strong> and <strong>date</strong>.",
-                  id: "3GkMHE",
-                  description: "Text for third sign up -> create step.",
-                })}
-              </Instructions.Step>
-              <Instructions.Step
-                includeArrow={false}
-                img={{ src: createStep4Image, darkSrc: createStep4ImageDark }}
-              >
-                {intl.formatMessage({
-                  defaultMessage:
-                    "4. Complete the email verification process. <strong>A unique one time code</strong> will be emailed to you to enter into GCKey.",
-                  id: "LbtstO",
-                  description: "Text for fourth sign up -> create step.",
-                })}
-              </Instructions.Step>
-            </Instructions.List>
-            <Heading level="h3" size="h4" className="mt-18 mb-6 font-bold">
-              {intl.formatMessage({
-                defaultMessage: "Part 2: Setting up two-factor authentication",
-                id: "wf3e6C",
-                description:
-                  "Heading for section of the sign up page showing the mfa steps",
-              })}
-            </Heading>
-            <Heading level="h4" size="h6" className="mt-12 mb-3 font-bold">
-              {intl.formatMessage({
-                defaultMessage: "Why set up a two-factor authentication?",
-                id: "mjUxjN",
-                description:
-                  "Subtitle for a section explaining why to set up mfa",
-              })}
-            </Heading>
-            <p>
-              {intl.formatMessage({
-                defaultMessage:
-                  "Think of the sign in as a security door to your account that can only be opened with a key (your password) and a secret code (from your two-factor authentication app). Even if someone finds or copies your key, they still won’t be able to get in because they don’t have your secret code.",
-                id: "1/LVZf",
-                description: "Copy explaining why to set up mfa",
-              })}
-            </p>
-            <Heading level="h4" size="h6" className="mt-12 mb-3 font-bold">
-              {intl.formatMessage({
-                defaultMessage: "You will need an authenticator app.",
-                id: "/WLsRj",
-                description: "Subtitle for a section explaining mfa apps",
-              })}
-            </Heading>
-            <p>
-              {intl.formatMessage({
-                defaultMessage:
-                  "If you don’t already have an authenticator app you will need to download one. Digital vendors, like Google Authenticator and Microsoft Authenticator, provide authenticator apps. Whichever app you choose, ensure that it comes from a reputable vendor.",
-                id: "mF1IpF",
-                description: "Copy explaining mfa apps",
-              })}
-            </p>
-            <Heading level="h4" size="h6" className="mt-12 mb-3 font-bold">
-              {intl.formatMessage({
-                defaultMessage: "Setting up your two-factor authentication app",
-                id: "eamuiH",
-                description: "Subtitle for a section explaining setting up mfa",
-              })}
-            </Heading>
-            <Instructions.List>
-              <Instructions.Step
-                img={{
-                  src: mfaStep1Image,
-                  darkSrc: mfaStep1ImageDark,
-                  lazy: true,
-                  width: 700,
-                  height: 507,
-                }}
-              >
-                {intl.formatMessage({
-                  defaultMessage:
-                    "1. <strong>Prepare your device</strong> by downloading your preferred two-factor authentication app.",
-                  id: "D6f8hs",
-                  description: "Text for first sign up -> mfa step.",
-                })}
-              </Instructions.Step>
-              <Instructions.Step
-                img={{
-                  src: mfaStep2Image,
-                  darkSrc: mfaStep2ImageDark,
-                  lazy: true,
-                  width: 700,
-                  height: 507,
-                }}
-              >
-                {intl.formatMessage({
-                  defaultMessage:
-                    "2. <strong>Scan the QR code</strong> or <strong>enter your secret code</strong> using your two-factor authenticator app.",
-                  id: "mVqKm+",
-                  description: "Text for second sign up -> mfa step.",
-                })}
-              </Instructions.Step>
-              <Instructions.Step
-                img={{
-                  src: mfaStep3Image,
-                  darkSrc: mfaStep3ImageDark,
-                  lazy: true,
-                  width: 700,
-                  height: 507,
-                }}
-              >
-                {intl.formatMessage({
-                  defaultMessage:
-                    "3. <strong>Enter</strong> the code generated <strong>from your authenticator app</strong> into the verification bar.",
-                  id: "W5vrNy",
-                  description: "Text for third sign up -> mfa step.",
-                })}
-              </Instructions.Step>
-              <Instructions.Step
-                includeArrow={false}
-                img={{
-                  src: mfaStep4Image,
-                  darkSrc: mfaStep4ImageDark,
-                  lazy: true,
-                  width: 700,
-                  height: 507,
-                }}
-              >
-                {intl.formatMessage({
-                  defaultMessage:
-                    "4. Hooray! You’ve completed your GCKey account and will be <strong>returned to the GC Digital Talent platform</strong>.",
-                  id: "d0EUOF",
-                  description: "Text for fourth sign up -> mfa step.",
-                })}
-              </Instructions.Step>
-            </Instructions.List>
-            <Heading
-              icon={InformationCircleIcon}
-              color="error"
-              level="h2"
-              size="h3"
-              className="mt-18 mb-6 font-normal"
-            >
-              {intl.formatMessage({
-                defaultMessage: "Frequently Asked Questions (FAQs)",
-                id: "AUtIo9",
-                description:
-                  "Heading for Frequently Asked Questions section on sign in page",
-              })}
-            </Heading>
-            <Accordion.Root
-              type="single"
-              size="sm"
-              mode="card"
-              collapsible
-              className="my-6"
-            >
-              <Accordion.Item value="one">
-                <Accordion.Trigger as="h3">
-                  {intl.formatMessage(gckeyMessages.questionWhatGCKey)}
-                </Accordion.Trigger>
-                <Accordion.Content>
-                  <p>{intl.formatMessage(gckeyMessages.answerWhatGCKey)}</p>
-                </Accordion.Content>
-              </Accordion.Item>
-              <Accordion.Item value="two">
-                <Accordion.Trigger as="h3">
-                  {intl.formatMessage(gckeyMessages.questionContactGCkey)}
-                </Accordion.Trigger>
-                <Accordion.Content>
-                  <p className="mb-3">
-                    {intl.formatMessage(gckeyMessages.answerContactGCkey1)}
-                  </p>
-                  <p className="mb-3">
-                    {intl.formatMessage(gckeyMessages.answerContactGCkey2)}
-                  </p>
-                  <p className="mb-3">
-                    <Link
-                      color="black"
-                      external
-                      href="tel:1-855-438-1102"
-                      // eslint-disable-next-line formatjs/no-literal-string-in-jsx
-                      aria-label="1 8 5 5 4 3 8 1 1 0 2"
-                      // eslint-disable-next-line formatjs/no-literal-string-in-jsx
-                    >
-                      1-855-438-1102
-                    </Link>
-                  </p>
-                  <p className="mb-3">
-                    {intl.formatMessage(gckeyMessages.answerContactGCkey3)}
-                  </p>
-                  <p className="mb-3">
-                    <Link
-                      color="black"
-                      external
-                      href="tel:1-855-438-1103"
-                      // eslint-disable-next-line formatjs/no-literal-string-in-jsx
-                      aria-label="1 8 5 5 4 3 8 1 1 0 3"
-                      // eslint-disable-next-line formatjs/no-literal-string-in-jsx
-                    >
-                      1-855-438-1103
-                    </Link>
-                  </p>
-                  <p className="mb-3">
-                    {intl.formatMessage(gckeyMessages.answerContactGCkey4)}
-                  </p>
-                  <p className="mb-3">
-                    <Link
-                      color="black"
-                      external
-                      href="tel:1-800-2318-6290"
-                      // eslint-disable-next-line formatjs/no-literal-string-in-jsx
-                      aria-label="1 8 0 0 2 3 1 8 6 2 9 0"
-                      // eslint-disable-next-line formatjs/no-literal-string-in-jsx
-                    >
-                      1-800-2318-6290
-                    </Link>
-                  </p>
-                  <p>{intl.formatMessage(gckeyMessages.answerContactGCkey5)}</p>
-                </Accordion.Content>
-              </Accordion.Item>
-              <Accordion.Item value="three">
-                <Accordion.Trigger as="h3">
-                  {intl.formatMessage(gckeyMessages.questionAuthApp)}
-                </Accordion.Trigger>
-                <Accordion.Content>
-                  <p>{intl.formatMessage(gckeyMessages.answerAuthApp)}</p>
-                </Accordion.Content>
-              </Accordion.Item>
-              <Accordion.Item value="four">
-                <Accordion.Trigger as="h3">
-                  {intl.formatMessage(gckeyMessages.questionAuthAlternative)}
-                </Accordion.Trigger>
-                <Accordion.Content>
-                  <p>
-                    {intl.formatMessage(gckeyMessages.answerAuthAlternative)}
-                  </p>
-                </Accordion.Content>
-              </Accordion.Item>
+        {/* Standard copy */}
+        <Heading
+          icon={MapIcon}
+          color="secondary"
+          level="h2"
+          size="h3"
+          className="mt-0 mb-6 font-normal"
+        >
+          {intl.formatMessage({
+            defaultMessage: "What to expect when creating an account",
+            id: "mV1/kq",
+            description:
+              "Heading at the top of the sign up page for applicant profiles",
+          })}
+        </Heading>
+        <Ul className="my-6" space="md" noIndent>
+          <li>
+            {intl.formatMessage({
+              defaultMessage:
+                "To sign up (or authenticate) with GC Digital Talent, we require that you use GCKey.",
+              id: "Dqsq+M",
+              description: "A _what to expect_ point on the sign up page",
+            })}
+          </li>
+          <li>
+            {intl.formatMessage({
+              defaultMessage:
+                "GCKey is a Government of Canada credential that allows you to securely conduct online business with various governmental programs and services.",
+              id: "XkA6s1",
+              description: "A _what to expect_ point on the sign up page",
+            })}
+          </li>
+          <li>
+            {intl.formatMessage({
+              defaultMessage:
+                "In addition to GCKey, you will need to set up a two-factor authenticator app for an added layer of security. (See setting up two-factor authentication for details)",
+              id: "RalbOM",
+              description: "A _what to expect_ point on the sign up page",
+            })}
+          </li>
+          <li>
+            {intl.formatMessage({
+              defaultMessage:
+                "Expect to spend approximately 20 minutes to set up GCKey and the authenticator app.",
+              id: "BfrCXV",
+              description: "A _what to expect_ point on the sign up page",
+            })}
+          </li>
+          <li>
+            {intl.formatMessage({
+              defaultMessage:
+                "We have prepared additional guidance In the next section to help.",
+              id: "UpwY5+",
+              description: "A _what to expect_ point on the sign up page",
+            })}
+          </li>
+        </Ul>
+        <Link href={loginPath} mode="solid" color="primary" external>
+          {intl.formatMessage({
+            defaultMessage: "Sign up with GCKey",
+            id: "4LMyAD",
+            description: "GCKey sign up link text on the sign up page",
+          })}
+        </Link>
+        <Heading level="h3" size="h4" className="mt-20 mb-3.5 font-bold">
+          {intl.formatMessage({
+            defaultMessage: "Part 1: Creating a GCKey account",
+            id: "u98IOx",
+            description:
+              "Heading for section of the sign up page showing the create steps",
+          })}
+        </Heading>
+        <Heading level="h4" size="h6" className="mt-12 mb-3 font-bold">
+          {intl.formatMessage({
+            defaultMessage: "Steps to create your GCKey account",
+            id: "lZwkcR",
+            description: "Subtitle for a section explaining the create steps",
+          })}
+        </Heading>
+        <Instructions.List>
+          <Instructions.Step
+            img={{ src: createStep1Image, darkSrc: createStep1ImageDark }}
+          >
+            {intl.formatMessage({
+              defaultMessage:
+                "1. Select <strong>sign up</strong> on the welcome page. This is <strong>located after the sign in</strong> section.",
+              id: "MUYJr1",
+              description: "Text for first sign up -> create step.",
+            })}
+          </Instructions.Step>
+          <Instructions.Step
+            img={{ src: createStep2Image, darkSrc: createStep2ImageDark }}
+          >
+            {intl.formatMessage({
+              defaultMessage:
+                "2. Create a username and password. Don’t forget to <strong>save your username</strong> separately from your <strong>email address</strong>.",
+              id: "Jp/oeD",
+              description: "Text for second sign up -> create step.",
+            })}
+          </Instructions.Step>
+          <Instructions.Step
+            img={{ src: createStep3Image, darkSrc: createStep3ImageDark }}
+          >
+            {intl.formatMessage({
+              defaultMessage:
+                "3. Complete your <strong>recovery questions</strong>. You are required to use a memorable <strong>person</strong> and <strong>date</strong>.",
+              id: "3GkMHE",
+              description: "Text for third sign up -> create step.",
+            })}
+          </Instructions.Step>
+          <Instructions.Step
+            includeArrow={false}
+            img={{ src: createStep4Image, darkSrc: createStep4ImageDark }}
+          >
+            {intl.formatMessage({
+              defaultMessage:
+                "4. Complete the email verification process. <strong>A unique one time code</strong> will be emailed to you to enter into GCKey.",
+              id: "LbtstO",
+              description: "Text for fourth sign up -> create step.",
+            })}
+          </Instructions.Step>
+        </Instructions.List>
+        <Heading level="h3" size="h4" className="mt-18 mb-6 font-bold">
+          {intl.formatMessage({
+            defaultMessage: "Part 2: Setting up two-factor authentication",
+            id: "wf3e6C",
+            description:
+              "Heading for section of the sign up page showing the mfa steps",
+          })}
+        </Heading>
+        <Heading level="h4" size="h6" className="mt-12 mb-3 font-bold">
+          {intl.formatMessage({
+            defaultMessage: "Why set up a two-factor authentication?",
+            id: "mjUxjN",
+            description: "Subtitle for a section explaining why to set up mfa",
+          })}
+        </Heading>
+        <p>
+          {intl.formatMessage({
+            defaultMessage:
+              "Think of the sign in as a security door to your account that can only be opened with a key (your password) and a secret code (from your two-factor authentication app). Even if someone finds or copies your key, they still won’t be able to get in because they don’t have your secret code.",
+            id: "1/LVZf",
+            description: "Copy explaining why to set up mfa",
+          })}
+        </p>
+        <Heading level="h4" size="h6" className="mt-12 mb-3 font-bold">
+          {intl.formatMessage({
+            defaultMessage: "You will need an authenticator app.",
+            id: "/WLsRj",
+            description: "Subtitle for a section explaining mfa apps",
+          })}
+        </Heading>
+        <p>
+          {intl.formatMessage({
+            defaultMessage:
+              "If you don’t already have an authenticator app you will need to download one. Digital vendors, like Google Authenticator and Microsoft Authenticator, provide authenticator apps. Whichever app you choose, ensure that it comes from a reputable vendor.",
+            id: "mF1IpF",
+            description: "Copy explaining mfa apps",
+          })}
+        </p>
+        <Heading level="h4" size="h6" className="mt-12 mb-3 font-bold">
+          {intl.formatMessage({
+            defaultMessage: "Setting up your two-factor authentication app",
+            id: "eamuiH",
+            description: "Subtitle for a section explaining setting up mfa",
+          })}
+        </Heading>
+        <Instructions.List>
+          <Instructions.Step
+            img={{
+              src: mfaStep1Image,
+              darkSrc: mfaStep1ImageDark,
+              lazy: true,
+              width: 700,
+              height: 507,
+            }}
+          >
+            {intl.formatMessage({
+              defaultMessage:
+                "1. <strong>Prepare your device</strong> by downloading your preferred two-factor authentication app.",
+              id: "D6f8hs",
+              description: "Text for first sign up -> mfa step.",
+            })}
+          </Instructions.Step>
+          <Instructions.Step
+            img={{
+              src: mfaStep2Image,
+              darkSrc: mfaStep2ImageDark,
+              lazy: true,
+              width: 700,
+              height: 507,
+            }}
+          >
+            {intl.formatMessage({
+              defaultMessage:
+                "2. <strong>Scan the QR code</strong> or <strong>enter your secret code</strong> using your two-factor authenticator app.",
+              id: "mVqKm+",
+              description: "Text for second sign up -> mfa step.",
+            })}
+          </Instructions.Step>
+          <Instructions.Step
+            img={{
+              src: mfaStep3Image,
+              darkSrc: mfaStep3ImageDark,
+              lazy: true,
+              width: 700,
+              height: 507,
+            }}
+          >
+            {intl.formatMessage({
+              defaultMessage:
+                "3. <strong>Enter</strong> the code generated <strong>from your authenticator app</strong> into the verification bar.",
+              id: "W5vrNy",
+              description: "Text for third sign up -> mfa step.",
+            })}
+          </Instructions.Step>
+          <Instructions.Step
+            includeArrow={false}
+            img={{
+              src: mfaStep4Image,
+              darkSrc: mfaStep4ImageDark,
+              lazy: true,
+              width: 700,
+              height: 507,
+            }}
+          >
+            {intl.formatMessage({
+              defaultMessage:
+                "4. Hooray! You’ve completed your GCKey account and will be <strong>returned to the GC Digital Talent platform</strong>.",
+              id: "d0EUOF",
+              description: "Text for fourth sign up -> mfa step.",
+            })}
+          </Instructions.Step>
+        </Instructions.List>
+        <Heading
+          icon={InformationCircleIcon}
+          color="error"
+          level="h2"
+          size="h3"
+          className="mt-18 mb-6 font-normal"
+        >
+          {intl.formatMessage({
+            defaultMessage: "Frequently Asked Questions (FAQs)",
+            id: "AUtIo9",
+            description:
+              "Heading for Frequently Asked Questions section on sign in page",
+          })}
+        </Heading>
+        <Accordion.Root
+          type="single"
+          size="sm"
+          mode="card"
+          collapsible
+          className="my-6"
+        >
+          <Accordion.Item value="one">
+            <Accordion.Trigger as="h3">
+              {intl.formatMessage(gckeyMessages.questionWhatGCKey)}
+            </Accordion.Trigger>
+            <Accordion.Content>
+              <p>{intl.formatMessage(gckeyMessages.answerWhatGCKey)}</p>
+            </Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="two">
+            <Accordion.Trigger as="h3">
+              {intl.formatMessage(gckeyMessages.questionContactGCkey)}
+            </Accordion.Trigger>
+            <Accordion.Content>
+              <p className="mb-3">
+                {intl.formatMessage(gckeyMessages.answerContactGCkey1)}
+              </p>
+              <p className="mb-3">
+                {intl.formatMessage(gckeyMessages.answerContactGCkey2)}
+              </p>
+              <p className="mb-3">
+                <Link
+                  color="black"
+                  external
+                  href="tel:1-855-438-1102"
+                  // eslint-disable-next-line formatjs/no-literal-string-in-jsx
+                  aria-label="1 8 5 5 4 3 8 1 1 0 2"
+                  // eslint-disable-next-line formatjs/no-literal-string-in-jsx
+                >
+                  1-855-438-1102
+                </Link>
+              </p>
+              <p className="mb-3">
+                {intl.formatMessage(gckeyMessages.answerContactGCkey3)}
+              </p>
+              <p className="mb-3">
+                <Link
+                  color="black"
+                  external
+                  href="tel:1-855-438-1103"
+                  // eslint-disable-next-line formatjs/no-literal-string-in-jsx
+                  aria-label="1 8 5 5 4 3 8 1 1 0 3"
+                  // eslint-disable-next-line formatjs/no-literal-string-in-jsx
+                >
+                  1-855-438-1103
+                </Link>
+              </p>
+              <p className="mb-3">
+                {intl.formatMessage(gckeyMessages.answerContactGCkey4)}
+              </p>
+              <p className="mb-3">
+                <Link
+                  color="black"
+                  external
+                  href="tel:1-800-2318-6290"
+                  // eslint-disable-next-line formatjs/no-literal-string-in-jsx
+                  aria-label="1 8 0 0 2 3 1 8 6 2 9 0"
+                  // eslint-disable-next-line formatjs/no-literal-string-in-jsx
+                >
+                  1-800-2318-6290
+                </Link>
+              </p>
+              <p>{intl.formatMessage(gckeyMessages.answerContactGCkey5)}</p>
+            </Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="three">
+            <Accordion.Trigger as="h3">
+              {intl.formatMessage(gckeyMessages.questionAuthApp)}
+            </Accordion.Trigger>
+            <Accordion.Content>
+              <p>{intl.formatMessage(gckeyMessages.answerAuthApp)}</p>
+            </Accordion.Content>
+          </Accordion.Item>
+          <Accordion.Item value="four">
+            <Accordion.Trigger as="h3">
+              {intl.formatMessage(gckeyMessages.questionAuthAlternative)}
+            </Accordion.Trigger>
+            <Accordion.Content>
+              <p>{intl.formatMessage(gckeyMessages.answerAuthAlternative)}</p>
+            </Accordion.Content>
+          </Accordion.Item>
 
-              <Accordion.Item value="five">
-                <Accordion.Trigger as="h3">
-                  {intl.formatMessage(gckeyMessages.questionExistingAccount)}
-                </Accordion.Trigger>
-                <Accordion.Content>
-                  <p>
-                    {intl.formatMessage(gckeyMessages.answerExistingAccount)}
-                  </p>
-                </Accordion.Content>
-              </Accordion.Item>
-            </Accordion.Root>
-            <p className="mt-6">
-              {intl.formatMessage(gckeyMessages.moreQuestions, {
-                helpLink: (chunks: ReactNode) =>
-                  helpLink(chunks, paths.support()),
-              })}
-            </p>
-          </>
-        ) : (
-          <>
-            {/* IAP copy */}
-            <p className="mb-3">
-              {intl.formatMessage({
-                defaultMessage:
-                  "You can sign in to your IT Apprenticeship Program for Indigenous Peoples profile using your existing GCKey, even if you've never used this platform before.",
-                id: "6SfJEp",
-                description:
-                  "Instructions on how to sign in with GCKey - IAP variant",
-              })}
-            </p>
-            <p className="mb-3">
-              {intl.formatMessage({
-                defaultMessage:
-                  "If you're unsure of whether you have an existing GCKey account, continue to the website and try signing in. If you can't remember your password, you can also reset it there.",
-                id: "Z+gi2d",
-                description:
-                  "Instructions on what to do if user doesn't know if they have a GCKey - IAP variant",
-              })}
-            </p>
-            <p className="mb-6">
-              {intl.formatMessage(
-                {
-                  defaultMessage:
-                    "<strong>Don't have a GCKey account?</strong> <a>Sign up for one</a>.",
-                  id: "QsWizb",
-                  description:
-                    "Instruction on what to do if user does not have a GCKey",
-                },
-                {
-                  a: (chunks: ReactNode) =>
-                    buildExternalLink(loginPath, chunks),
-                },
-              )}
-            </p>
-            <p className="mb-12">
-              {intl.formatMessage({
-                defaultMessage:
-                  "<strong>Heads up!</strong> Before we send you off to set up your GCKey credentials, we ask that you take another look at the program's eligibility criteria to ensure that you meet the requirements.",
-                id: "ow71P8",
-                description:
-                  "A request for the user to review the IAP eligibility criteria",
-              })}
-            </p>
-            <p>
-              {intl.formatMessage(
-                {
-                  defaultMessage:
-                    "If you have questions concerning this step, or if you are unsure about how to proceed, please feel free to reach out to our support team at <a>edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca</a>.",
-                  id: "ltzA7w",
-                  description:
-                    "How to get help from the support team - IAP variant",
-                },
-                {
-                  a: (chunks: ReactNode) =>
-                    buildExternalLink(
-                      "mailto:edsc.pda-iap.esdc@hrsdc-rhdcc.gc.ca",
-                      chunks,
-                    ),
-                },
-              )}
-            </p>
-          </>
-        )}
+          <Accordion.Item value="five">
+            <Accordion.Trigger as="h3">
+              {intl.formatMessage(gckeyMessages.questionExistingAccount)}
+            </Accordion.Trigger>
+            <Accordion.Content>
+              <p>{intl.formatMessage(gckeyMessages.answerExistingAccount)}</p>
+            </Accordion.Content>
+          </Accordion.Item>
+        </Accordion.Root>
+        <p className="mt-6">
+          {intl.formatMessage(gckeyMessages.moreQuestions, {
+            helpLink: (chunks: ReactNode) => helpLink(chunks, paths.support()),
+          })}
+        </p>
         <Separator />
         <div className="flex flex-col items-center gap-6 sm:flex-row">
           <Link href={loginPath} mode="solid" color="primary" external>


### PR DESCRIPTION
🤖 Resolves #16416 

## 👋 Introduction

Removes the customized IAP signin and signup pages.

## 🧪 Testing

> [!TIP]
> I suggest viewing the diff with whitespace changes ignored if possible. 

1. Make sure you're not logged in.
2. Navigate to /en/indigenous-it-apprentice
- [ ] Sign in nav link leads to regular GCDT themed sign in page
- [ ] Sign up nav link leads to regular GCDT themed sign up page
