### PR TITLE
[Bug] Stop Azure logging noise

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -168,6 +168,6 @@ SERVER_TIMING_ENABLED=true
 # IDENTITY_ENDPOINT=
 
 # Azure data collection
-AZURE_LOG_INGESTION_ENDPOINT="http://host.docker.internal:8000/api/log"
-AZURE_DCR_IMMUTABLE_ID="dcr-000a00a000a00000a000000aa000a0aa"
-AZURE_STREAM_NAME="Custom-MyTable"
+# AZURE_LOG_INGESTION_ENDPOINT="http://host.docker.internal:8000/api/log"
+# AZURE_DCR_IMMUTABLE_ID="dcr-000a00a000a00000a000000aa000a0aa"
+# AZURE_STREAM_NAME="Custom-MyTable"

--- a/api/app/Logging/Azure/CreateAzureLogger.php
+++ b/api/app/Logging/Azure/CreateAzureLogger.php
@@ -4,7 +4,8 @@ namespace App\Logging\Azure;
 
 use App\Contracts\ManagedIdentityService;
 use App\Logging\TbsLoggingStandardProcessor;
-use Illuminate\Queue\Events\Looping;
+use Illuminate\Console\Events\CommandFinished;
+use Illuminate\Queue\Events\JobAttempted;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Event;
 use Monolog\Handler\BufferHandler;
@@ -35,8 +36,8 @@ class CreateAzureLogger
             flushOnOverflow: true
         );
 
-        // manually flush the buffer when the queue worker cycles
-        Event::listen(function (Looping $event) use ($wrappingHandler) {
+        // manually flush the buffer when an artisan command finishes or after a job was attempted (success or failure)
+        Event::listen([CommandFinished::class, JobAttempted::class], function () use ($wrappingHandler) {
             $wrappingHandler->flush();
         });
 

--- a/api/config/logging.php
+++ b/api/config/logging.php
@@ -145,11 +145,11 @@ return [
         'jobs' => [
             'driver' => 'stack',
             'level' => env('LOG_LEVEL', 'debug'),
-            'channels' => [
+            'channels' => array_filter([
                 'jobs_file',
                 // only try to include the azure logger in the stack if configured
-                (! empty(env('AZURE_LOG_INGESTION_ENDPOINT')) ? 'azure' : null),
-            ],
+                ! empty(env('AZURE_LOG_INGESTION_ENDPOINT')) ? 'azure' : null,
+            ]),
             'ignore_exceptions' => false,
         ],
     ],

--- a/api/config/logging.php
+++ b/api/config/logging.php
@@ -145,7 +145,11 @@ return [
         'jobs' => [
             'driver' => 'stack',
             'level' => env('LOG_LEVEL', 'debug'),
-            'channels' => ['jobs_file', 'azure'],
+            'channels' => [
+                'jobs_file',
+                // only try to include the azure logger in the stack if configured
+                (! empty(env('AZURE_LOG_INGESTION_ENDPOINT')) ? 'azure' : null),
+            ],
             'ignore_exceptions' => false,
         ],
     ],


### PR DESCRIPTION
🤖 Resolves #16595 

## 👋 Introduction

Stops Azure logging when it is not properly configured (like locally).

## 🕵️ Details

Three things done:
- Comments out the junk values in the .env.example file
- Conditionally removes Azure logging from the jobs channel stack when not configured
- Listens to better events for flushing ( I think some logs were getting dropped.)

## 🧪 Testing

### :computer: Locally

1. Ensure that the Azure variables in /api/.env are commented out like in the example file
2. Start Tinker
3. Test the logger

- [ ] Trying to run the Azure logging directly still makes noise `Log::channel('azure')->debug('test azure')`
- [ ] Trying to run the jobs logging is quiet `Log::channel('jobs')->debug('test jobs')`

### :cloud: Azure

1. Deploy to dev
2. Open the TalentAppInsights LAW and query AppLogsDev_CL
3. SSH into the server

- [ ] A manual logging like `./artisan tinker --execute=" Log::channel('azure')→info('hello from tinker execute')"
` still logs
    - I can't seem to make an interactive tinker session flush on close anymore.  :shrug:   If you really want to use that you'll need to do a manual flush with `Log::channel('azure')→getHandlers()[0]→flush()
`.
- [ ] A queued job like `send-notifications:test my@email.com` still logs

## 📸 Screenshot

<img width="910" height="915" alt="image" src="https://github.com/user-attachments/assets/c575cc3c-9aa6-4ab9-ac47-1eec561702a8" />
