### PR TITLE
[Fix] Adjust nominations page styles

### DIFF
--- a/apps/web/src/pages/TalentNominations/NominationGroup/CareerExperience.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/CareerExperience.tsx
@@ -54,13 +54,13 @@ const TalentNominationGroupCareerExperience = ({
 
   return (
     <Pending fetching={fetching} error={error}>
-      <Card className="mb-6 flex flex-col gap-y-3">
+      <Card space="lg" className="mb-6">
         <CurrentPositionExperiences
           query={nomineeData?.user}
           shareProfile={shareProfile}
         />
       </Card>
-      <Card className="mb-6 flex flex-col gap-y-3">
+      <Card space="lg">
         <FullCareerExperiences
           userQuery={nomineeData?.user}
           talentNominationGroupQuery={talentNominationGroup}

--- a/apps/web/src/pages/TalentNominations/NominationGroup/Details.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/Details.tsx
@@ -99,14 +99,14 @@ const TalentNominationGroupDetails = ({
   };
 
   return (
-    <Card space="lg" className="flex flex-col gap-6 sm:gap-9">
+    <Card space="lg">
       {/* heading section */}
       <div className="flex items-center justify-between">
         <Heading
           level="h2"
           icon={ClipboardDocumentListIcon}
           color="secondary"
-          className="mt-0 font-normal"
+          className="my-0 font-normal"
         >
           {intl.formatMessage(detailTabMessages.nominationDetailsPageTitle)}
         </Heading>
@@ -123,7 +123,7 @@ const TalentNominationGroupDetails = ({
           )}
         </Button>
       </div>
-      <Card.Separator />
+      <Card.Separator className="my-9" />
       <Accordion.Root
         mode="simple"
         type="multiple"

--- a/apps/web/src/pages/TalentNominations/NominationGroup/Details.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/Details.tsx
@@ -104,7 +104,7 @@ const TalentNominationGroupDetails = ({
       <div className="flex items-center justify-between">
         <Heading
           level="h2"
-          size="h3"
+          size="h4"
           icon={ClipboardDocumentListIcon}
           color="secondary"
           className="my-0 font-normal"

--- a/apps/web/src/pages/TalentNominations/NominationGroup/Details.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/Details.tsx
@@ -104,6 +104,7 @@ const TalentNominationGroupDetails = ({
       <div className="flex items-center justify-between">
         <Heading
           level="h2"
+          size="h3"
           icon={ClipboardDocumentListIcon}
           color="secondary"
           className="my-0 font-normal"

--- a/apps/web/src/pages/TalentNominations/NominationGroup/Profile.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/Profile.tsx
@@ -83,7 +83,7 @@ const TalentNominationGroupProfile = ({
           <Heading
             icon={UserCircleIcon}
             level="h2"
-            size="h3"
+            size="h4"
             color="secondary"
             className="mt-0 font-normal"
           >

--- a/apps/web/src/pages/TalentNominations/NominationGroup/Profile.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/Profile.tsx
@@ -83,6 +83,7 @@ const TalentNominationGroupProfile = ({
           <Heading
             icon={UserCircleIcon}
             level="h2"
+            size="h3"
             color="secondary"
             className="mt-0 font-normal"
           >

--- a/apps/web/src/pages/TalentNominations/NominationGroup/Profile.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/Profile.tsx
@@ -78,7 +78,7 @@ const TalentNominationGroupProfile = ({
 
   return (
     <Pending fetching={fetching} error={error}>
-      <Card className="rounded-b-none bg-transparent">
+      <Card className="rounded-b-none" space="lg">
         <div className="flex flex-col items-center justify-between gap-y-6 sm:flex-row sm:gap-x-3 sm:gap-y-0">
           <Heading
             icon={UserCircleIcon}
@@ -113,7 +113,7 @@ const TalentNominationGroupProfile = ({
             </Button>
           )}
         </div>
-        <p className="my-6">
+        <p>
           {intl.formatMessage({
             defaultMessage:
               "The following sections can be expanded to show information about the nominee’s profile, their interest in this community, and their career goals.",
@@ -123,7 +123,7 @@ const TalentNominationGroupProfile = ({
           })}
         </p>
         {!shareProfile && (
-          <Notice.Root color="error">
+          <Notice.Root color="error" className="mt-6">
             <Notice.Title>
               {intl.formatMessage({
                 defaultMessage:

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/CurrentPositionExperiences.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/CurrentPositionExperiences.tsx
@@ -16,7 +16,7 @@ import {
   parseDateTimeUtc,
 } from "@gc-digital-talent/date-helpers";
 import { MAX_DATE } from "@gc-digital-talent/date-helpers/const";
-import { CardSeparator, Heading, Ul, Notice } from "@gc-digital-talent/ui";
+import { Heading, Ul, Notice, Card } from "@gc-digital-talent/ui";
 import { commonMessages } from "@gc-digital-talent/i18n";
 
 import ExperienceCard from "~/components/ExperienceCard/ExperienceCard";
@@ -104,7 +104,7 @@ const CurrentPositionExperiences = ({
         icon={FlagIcon}
         level="h2"
         color="secondary"
-        className="mt-0 mb-3 font-normal"
+        className="mt-0 font-normal"
       >
         {intl.formatMessage({
           defaultMessage: "Current position",
@@ -120,7 +120,7 @@ const CurrentPositionExperiences = ({
           description: "Description for the career page current role section",
         })}
       </p>
-      {shareProfile && <CardSeparator className="mb-6" space="none" />}
+      {shareProfile && <Card.Separator className="my-9" />}
 
       {shareProfile && !empty(data) && (
         <div>
@@ -178,11 +178,15 @@ const CurrentPositionExperiences = ({
                 </Notice.Content>
               </Notice.Root>
             )}
-            <div className="-mt-9">
+            <div>
               {Object.keys(currentWorkExperiencesByGovPositionType).map(
                 (key, i) => (
                   <Fragment key={key}>
-                    <Heading level="h3" className="mb-3 font-normal">
+                    <Heading
+                      level="h3"
+                      size="h4"
+                      className="mt-0 mb-3 font-normal"
+                    >
                       {getGovernmentPositionTypeLabel(
                         key as GovPositionType,
                         intl,
@@ -199,7 +203,7 @@ const CurrentPositionExperiences = ({
                     {i !==
                       Object.keys(currentWorkExperiencesByGovPositionType)
                         .length -
-                        1 && <CardSeparator />}
+                        1 && <Card.Separator className="my-6" />}
                   </Fragment>
                 ),
               )}
@@ -208,7 +212,7 @@ const CurrentPositionExperiences = ({
         </div>
       )}
       {!shareProfile && (
-        <Notice.Root className="mb-9" color="error">
+        <Notice.Root color="error">
           <Notice.Title>
             {intl.formatMessage({
               defaultMessage:
@@ -229,7 +233,7 @@ const CurrentPositionExperiences = ({
           </Notice.Content>
         </Notice.Root>
       )}
-      {shareProfile && <CardSeparator space="sm" />}
+      {shareProfile && <Card.Separator className="my-9" />}
       {shareProfile && (
         <p className="text-gray-600 dark:text-gray-200">
           {intl.formatMessage(

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/CurrentPositionExperiences.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/CurrentPositionExperiences.tsx
@@ -103,6 +103,7 @@ const CurrentPositionExperiences = ({
       <Heading
         icon={FlagIcon}
         level="h2"
+        size="h3"
         color="secondary"
         className="mt-0 font-normal"
       >

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/CurrentPositionExperiences.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/CurrentPositionExperiences.tsx
@@ -103,7 +103,7 @@ const CurrentPositionExperiences = ({
       <Heading
         icon={FlagIcon}
         level="h2"
-        size="h3"
+        size="h4"
         color="secondary"
         className="mt-0 font-normal"
       >
@@ -185,7 +185,7 @@ const CurrentPositionExperiences = ({
                   <Fragment key={key}>
                     <Heading
                       level="h3"
-                      size="h4"
+                      size="h5"
                       className="mt-0 mb-3 font-normal"
                     >
                       {getGovernmentPositionTypeLabel(

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/FullCareerExperiences.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/FullCareerExperiences.tsx
@@ -175,6 +175,7 @@ const FullCareerExperiences = ({
         <div>
           <Heading
             level="h2"
+            size="h3"
             icon={NewspaperIcon}
             color="warning"
             className="mt-0 font-normal"

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/FullCareerExperiences.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/FullCareerExperiences.tsx
@@ -175,7 +175,7 @@ const FullCareerExperiences = ({
         <div>
           <Heading
             level="h2"
-            size="h3"
+            size="h4"
             icon={NewspaperIcon}
             color="warning"
             className="mt-0 font-normal"

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/FullCareerExperiences.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/FullCareerExperiences.tsx
@@ -6,11 +6,11 @@ import NewspaperIcon from "@heroicons/react/24/outline/NewspaperIcon";
 import {
   Accordion,
   Button,
-  CardSeparator,
   Heading,
   Ul,
   Notice,
   wrapParens,
+  Card,
 } from "@gc-digital-talent/ui";
 import type { FragmentType } from "@gc-digital-talent/graphql";
 import { getFragment, graphql } from "@gc-digital-talent/graphql";
@@ -177,7 +177,7 @@ const FullCareerExperiences = ({
             level="h2"
             icon={NewspaperIcon}
             color="warning"
-            className="m-0 font-normal"
+            className="mt-0 font-normal"
           >
             {intl.formatMessage({
               defaultMessage: "Full career",
@@ -204,7 +204,7 @@ const FullCareerExperiences = ({
         )}
       </div>
 
-      <p className="mt-3 mb-6">
+      <p className="mb-6">
         {intl.formatMessage({
           defaultMessage:
             "This section allows you to browse the nominee’s full career experience. By default, experience is organized by type, however you can choose to see how much experience the nominee has in a particular work stream or type of department using the options provided.",
@@ -212,119 +212,114 @@ const FullCareerExperiences = ({
           description: "Description for the career page full career section",
         })}
       </p>
-      <div>
-        {/* If can share profile, show controls. Otherwise, show error well */}
-        {shareProfile ? (
-          <div className="flex items-center gap-6">
-            <p id={showExperienceByLabelId}>
-              {intl.formatMessage({
-                defaultMessage: "Show experience by:",
-                id: "KR4kRt",
-                description: "Label for experience sorting options",
-              })}
-            </p>
-            <Button
-              type="button"
-              mode="inline"
-              color="primary"
-              onClick={() => setSelectedView("type")}
-              // Bold when selected
-              className={selectedView === "type" ? "font-bold" : "font-normal"}
-              aria-pressed={selectedView === "type"}
-              aria-describedby={showExperienceByLabelId}
-            >
-              {intl.formatMessage({
-                defaultMessage: "Type",
-                id: "trerKD",
-                description: "Button to filter experiences by type",
-              })}
-            </Button>
-            <Button
-              type="button"
-              mode="inline"
-              color="primary"
-              onClick={() => setSelectedView("workStream")} // Set view to "workStream"
-              // Bold when selected
-              className={selectedView === "type" ? "font-bold" : "font-normal"}
-              aria-pressed={selectedView === "workStream"}
-              aria-describedby={showExperienceByLabelId}
-            >
-              {intl.formatMessage(processMessages.stream)}
-            </Button>
-          </div>
-        ) : (
-          <Notice.Root className="mb-9" color="error">
-            <Notice.Title>
+      {/* If can share profile, show controls. Otherwise, show error well */}
+      {shareProfile ? (
+        <div className="mb-3 flex items-center gap-6">
+          <p id={showExperienceByLabelId}>
+            {intl.formatMessage({
+              defaultMessage: "Show experience by:",
+              id: "KR4kRt",
+              description: "Label for experience sorting options",
+            })}
+          </p>
+          <Button
+            type="button"
+            mode="inline"
+            color="primary"
+            onClick={() => setSelectedView("type")}
+            // Bold when selected
+            className={selectedView === "type" ? "font-bold" : "font-normal"}
+            aria-pressed={selectedView === "type"}
+            aria-describedby={showExperienceByLabelId}
+          >
+            {intl.formatMessage({
+              defaultMessage: "Type",
+              id: "trerKD",
+              description: "Button to filter experiences by type",
+            })}
+          </Button>
+          <Button
+            type="button"
+            mode="inline"
+            color="primary"
+            onClick={() => setSelectedView("workStream")} // Set view to "workStream"
+            // Bold when selected
+            className={selectedView === "type" ? "font-bold" : "font-normal"}
+            aria-pressed={selectedView === "workStream"}
+            aria-describedby={showExperienceByLabelId}
+          >
+            {intl.formatMessage(processMessages.stream)}
+          </Button>
+        </div>
+      ) : (
+        <Notice.Root color="error">
+          <Notice.Title>
+            {intl.formatMessage({
+              defaultMessage:
+                "This nominee has not agreed to share their information with your community",
+              id: "4ujr5X",
+              description: "Null message for nominee profile",
+            })}
+          </Notice.Title>
+          <Notice.Content>
+            <p>
               {intl.formatMessage({
                 defaultMessage:
-                  "This nominee has not agreed to share their information with your community",
-                id: "4ujr5X",
-                description: "Null message for nominee profile",
+                  "Nominees can agree to provide access to their profile using the “Functional communities” tool on their dashboard.",
+                id: "8plD42",
+                description: "Null secondary message for nominee profile",
               })}
-            </Notice.Title>
-            <Notice.Content>
-              <p>
-                {intl.formatMessage({
-                  defaultMessage:
-                    "Nominees can agree to provide access to their profile using the “Functional communities” tool on their dashboard.",
-                  id: "8plD42",
-                  description: "Null secondary message for nominee profile",
-                })}
-              </p>
-            </Notice.Content>
-          </Notice.Root>
-        )}
-      </div>
-      <div>
-        {/* If can share profile, show accordion. Otherwise, show nothing */}
-        {shareProfile ? (
-          <>
-            <Accordion.Root
-              type="multiple"
-              mode="card"
-              value={openSections}
-              onValueChange={setOpenSections} // Sync state with Accordion
-              className="m-0"
-            >
-              {accordionSections.map(
-                ({ id, title, subtitle, experiences: sectionExperiences }) => (
-                  <Accordion.Item key={id} value={id}>
-                    <Accordion.Trigger subtitle={subtitle ?? undefined}>
-                      {title}
-                      <span className="ml-1">
-                        {wrapParens(sectionExperiences.length)}
-                      </span>
-                    </Accordion.Trigger>
-                    <Accordion.Content>
-                      <div>
-                        <div className="flex flex-col gap-y-3">
-                          {unpackMaybes(
-                            sectionExperiences.map((experience) => {
-                              return (
-                                <ExperienceCard
-                                  key={experience?.id}
-                                  experienceQuery={experience}
-                                  showEdit={false}
-                                />
-                              );
-                            }),
-                          )}
-                        </div>
+            </p>
+          </Notice.Content>
+        </Notice.Root>
+      )}
+      {/* If can share profile, show accordion. Otherwise, show nothing */}
+      {shareProfile ? (
+        <>
+          <Accordion.Root
+            type="multiple"
+            mode="card"
+            value={openSections}
+            onValueChange={setOpenSections} // Sync state with Accordion
+          >
+            {accordionSections.map(
+              ({ id, title, subtitle, experiences: sectionExperiences }) => (
+                <Accordion.Item key={id} value={id}>
+                  <Accordion.Trigger subtitle={subtitle ?? undefined}>
+                    {title}
+                    <span className="ml-1">
+                      {wrapParens(sectionExperiences.length)}
+                    </span>
+                  </Accordion.Trigger>
+                  <Accordion.Content>
+                    <div>
+                      <div className="flex flex-col gap-y-3">
+                        {unpackMaybes(
+                          sectionExperiences.map((experience) => {
+                            return (
+                              <ExperienceCard
+                                key={experience?.id}
+                                experienceQuery={experience}
+                                showEdit={false}
+                              />
+                            );
+                          }),
+                        )}
                       </div>
-                    </Accordion.Content>
-                  </Accordion.Item>
-                ),
-              )}
-            </Accordion.Root>
-            {footer ? (
-              <>
-                <CardSeparator space="sm" />
-                {footer}
-              </>
-            ) : null}
-          </>
-        ) : null}
-      </div>
+                    </div>
+                  </Accordion.Content>
+                </Accordion.Item>
+              ),
+            )}
+          </Accordion.Root>
+          {footer ? (
+            <>
+              <Card.Separator className="my-9" />
+              {footer}
+            </>
+          ) : null}
+        </>
+      ) : null}
     </>
   );
 };


### PR DESCRIPTION
🤖 Resolves #16460 

## 👋 Introduction

Makes some small adjustments to the nomination pages to keep them consistent across the tabs.

## 🕵️ Details

I did some extra things I notice where the spacing was inconsistent leading to some odd looking things:

1. Replaced the generic `CardSeparator` with `Card.Separator` that properly ajusts to match the parent card spacing
2. Adjusted some other heading sizes so subheadings were not the same size as the main card headings

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to a nomination
4. Confirm the styles match the desisng and each tab is consistent in font size and spacing

## 📸 Screenshot

<img width="3413" height="1978" alt="localhost_8000_en_admin_talent-events_2ec024ea-22f4-446a-894b-2f79fa0f64f2_nominations_e499f69b-9346-47c6-a3a5-413296dc5674_career-experience (4)" src="https://github.com/user-attachments/assets/5e5a64d4-876a-415c-bf96-efcaeba7373e" />
<img width="3413" height="1836" alt="localhost_8000_en_admin_talent-events_2ec024ea-22f4-446a-894b-2f79fa0f64f2_nominations_e499f69b-9346-47c6-a3a5-413296dc5674_career-experience (3)" src="https://github.com/user-attachments/assets/685429c6-c33a-4da1-9f40-4173cdbd8287" />
<img width="3413" height="1757" alt="localhost_8000_en_admin_talent-events_2ec024ea-22f4-446a-894b-2f79fa0f64f2_nominations_e499f69b-9346-47c6-a3a5-413296dc5674_career-experience (2)" src="https://github.com/user-attachments/assets/64b64f6a-373e-4071-8299-8e45c77973b9" />
