### PR TITLE
[Feat] Restore soft deleted experience skills

### DIFF
--- a/api/app/GraphQL/Queries/TrashedExperienceSkill.php
+++ b/api/app/GraphQL/Queries/TrashedExperienceSkill.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\GraphQL\Queries;
 
 use App\Models\ExperienceSkill;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;

--- a/api/app/GraphQL/Queries/TrashedExperienceSkill.php
+++ b/api/app/GraphQL/Queries/TrashedExperienceSkill.php
@@ -25,9 +25,8 @@ final readonly class TrashedExperienceSkill
         $experienceSkill = ExperienceSkill::with('userSkill')
             ->withTrashed()
             ->where('experience_id', $args['experienceId'])
-            ->whereHas('userSkill', function (Builder $query) use ($args, $user) {
-                $query->where('skill_id', $args['skillId'])
-                    ->where('user_id', $user->id);
+            ->whereHas('userSkill', function (Builder $query) use ($args) {
+                $query->where('skill_id', $args['skillId']);
             })
             ->first();
 

--- a/api/app/GraphQL/Queries/TrashedExperienceSkill.php
+++ b/api/app/GraphQL/Queries/TrashedExperienceSkill.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Queries;
+
+use App\Models\ExperienceSkill;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
+
+final readonly class TrashedExperienceSkill
+{
+    public function __invoke(null $_, array $args)
+    {
+
+        /** @var User | null */
+        $user = Auth::user();
+
+        // Can only be called by authenticated users
+        if (! $user) {
+            return null;
+        }
+
+        $experienceSkill = ExperienceSkill::with('userSkill')
+            ->withTrashed()
+            ->where('experience_id', $args['experienceId'])
+            ->whereHas('userSkill', function (Builder $query) use ($args, $user) {
+                $query->where('skill_id', $args['skillId'])
+                    ->where('user_id', $user->id);
+            })
+            ->first();
+
+        if ($experienceSkill && (bool) ($args['restore'] ?? false)) {
+            $experienceSkill->restore();
+        }
+
+        return $experienceSkill;
+    }
+}

--- a/api/app/GraphQL/Queries/TrashedExperienceSkill.php
+++ b/api/app/GraphQL/Queries/TrashedExperienceSkill.php
@@ -7,6 +7,7 @@ namespace App\GraphQL\Queries;
 use App\Models\ExperienceSkill;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 
 final readonly class TrashedExperienceSkill
 {
@@ -30,7 +31,11 @@ final readonly class TrashedExperienceSkill
             })
             ->first();
 
+        Gate::authorize('viewTrashed', [ExperienceSkill::class, $experienceSkill]);
+
         if ($experienceSkill && (bool) ($args['restore'] ?? false)) {
+            Gate::authorize('restore', [ExperienceSkill::class, $experienceSkill]);
+
             $experienceSkill->restore();
         }
 

--- a/api/app/Policies/ExperienceSkillPolicy.php
+++ b/api/app/Policies/ExperienceSkillPolicy.php
@@ -10,9 +10,19 @@ class ExperienceSkillPolicy
 {
     use HandlesAuthorization;
 
-    public function viewTrashed(User $user, ExperienceSkill $experienceSkill)
+    public function viewTrashed(User $user, ?ExperienceSkill $experienceSkill)
     {
+        // If no model was resolved, there's nothing to authorize.
+        if ($experienceSkill === null) {
+            return true;
+        }
+
         // Only allow owners view trashed skills
+        return $user->id === $experienceSkill->userSkill->user_id;
+    }
+
+    public function restore(User $user, ExperienceSkill $experienceSkill)
+    {
         return $user->id === $experienceSkill->userSkill->user_id;
     }
 }

--- a/api/app/Policies/ExperienceSkillPolicy.php
+++ b/api/app/Policies/ExperienceSkillPolicy.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\ExperienceSkill;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ExperienceSkillPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewTrashed(User $user, ExperienceSkill $experienceSkill)
+    {
+        // Only allow owners view trashed skills
+        return $user->id === $experienceSkill->userSkill->user_id;
+    }
+}

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1608,9 +1608,7 @@ type Query {
     @canModel(ability: "viewBasicInfo", model: "User")
   trashedExperienceSkill(
     where: TrashedExperienceSkillInput! @spread
-  ): ExperienceSkillRecord
-    @guard
-    @canResolved(ability: "viewTrashed", model: "ExperienceSkill")
+  ): ExperienceSkillRecord @guard
   countApplicantsForSearch(where: ApplicantFilterInput): Int!
   pool(id: UUID! @eq): Pool
     @find

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1557,6 +1557,12 @@ input ProcessActivityFilterInput {
   events: [ActivityEvent!] @scope(name: "whereEventIn")
 }
 
+input TrashedExperienceSkillInput {
+  skillId: UUID!
+  experienceId: UUID!
+  restore: Boolean
+}
+
 type Query {
   myAuth: UserAuthInfo @auth
   me: User @auth
@@ -1600,6 +1606,11 @@ type Query {
     )
     @guard
     @canModel(ability: "viewBasicInfo", model: "User")
+  trashedExperienceSkill(
+    where: TrashedExperienceSkillInput! @spread
+  ): ExperienceSkillRecord
+    @guard
+    @canResolved(ability: "viewTrashed", model: "ExperienceSkill")
   countApplicantsForSearch(where: ApplicantFilterInput): Int!
   pool(id: UUID! @eq): Pool
     @find

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -419,6 +419,7 @@ type Query {
   ): User
   govEmployeeProfile(workEmail: String!): BasicGovEmployeeProfile
   workEmails(search: String): [UserWorkEmail!]!
+  trashedExperienceSkill(where: TrashedExperienceSkillInput!): ExperienceSkillRecord
   countApplicantsForSearch(where: ApplicantFilterInput): Int!
   pool(id: UUID!): Pool
   publishedPools(closingAfter: DateTime, publishingGroup: PublishingGroup): [Pool!]!
@@ -1891,6 +1892,12 @@ input ProcessActivityFilterInput {
   causers: [UUID!]
   candidates: [UUID!]
   events: [ActivityEvent!]
+}
+
+input TrashedExperienceSkillInput {
+  skillId: UUID!
+  experienceId: UUID!
+  restore: Boolean
 }
 
 input ClassificationBelongsTo {

--- a/api/tests/Feature/TrashedExperienceSkillTest.php
+++ b/api/tests/Feature/TrashedExperienceSkillTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ExperienceSkill;
+use App\Models\PersonalExperience;
+use App\Models\Skill;
+use App\Models\User;
+use App\Models\UserSkill;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+use Tests\UsesUnprotectedGraphqlEndpoint;
+
+class TrashedExperienceSkillTest extends TestCase
+{
+    use MakesGraphQLRequests;
+    use RefreshDatabase;
+    use RefreshesSchemaCache;
+    use UsesUnprotectedGraphqlEndpoint;
+
+    protected User $user;
+
+    protected Skill $skill;
+
+    protected PersonalExperience $experience;
+
+    protected UserSkill $userSkill;
+
+    protected string $query = <<<'GRAPHQL'
+        query TrashedExperienceSkill($where: TrashedExperienceSkillInput!) {
+            trashedExperienceSkill(where: $where) {
+                details
+            }
+        }
+    GRAPHQL;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolePermissionSeeder::class);
+
+        $this->user = User::factory()
+            ->asApplicant()
+            ->create();
+
+        $this->skill = Skill::factory()->create();
+
+        $this->experience = PersonalExperience::factory()->create([
+            'user_id' => $this->user->id,
+        ]);
+
+        $this->userSkill = UserSkill::factory()->create([
+            'user_id' => $this->user->id,
+            'skill_id' => $this->skill->id,
+        ]);
+    }
+
+    #[DataProvider('trashedExperienceSkillProvider')]
+    public function testTrashedExperienceSkill($expected, $pivotData, $restore, $isOwner): void
+    {
+        $skillId = $this->skill->id;
+        $activeUserSkill = $this->userSkill;
+
+        if (! $isOwner) {
+            $otherUser = User::factory()->asApplicant()->create();
+            $otherSkill = Skill::factory()->create();
+            $skillId = $otherSkill->id;
+            $activeUserSkill = UserSkill::factory()->create([
+                'user_id' => $otherUser->id,
+                'skill_id' => $otherSkill->id,
+            ]);
+        }
+
+        if ($pivotData !== null) {
+            // Use the relationship to attach the pivot data
+            $this->experience->userSkills()->attach($activeUserSkill->id, [
+                'details' => $pivotData['details'],
+            ]);
+
+            if ($pivotData['trashed']) {
+                // Fetch the pivot to soft delete it
+                ExperienceSkill::where([
+                    'experience_id' => $this->experience->id,
+                    'user_skill_id' => $activeUserSkill->id,
+                ])->delete();
+            }
+        }
+
+        $response = $this->actingAs($this->user, 'api')
+            ->graphQL($this->query, [
+                'where' => [
+                    'experienceId' => $this->experience->id,
+                    'skillId' => $skillId,
+                    'restore' => $restore,
+                ],
+            ]);
+
+        if (! $isOwner) {
+            $response->assertGraphQLErrorMessage('This action is unauthorized.');
+
+            return;
+        }
+
+        $response->assertJson([
+            'data' => [
+                'trashedExperienceSkill' => $expected === null ? null : ['details' => $expected],
+            ],
+        ]);
+
+        if ($restore && ($pivotData['trashed'] ?? false)) {
+            $this->assertDatabaseHas('experience_skill', [
+                'experience_id' => $this->experience->id,
+                'user_skill_id' => $activeUserSkill->id,
+                'deleted_at' => null,
+            ]);
+        }
+    }
+
+    public static function trashedExperienceSkillProvider(): array
+    {
+        return [
+            'successfully restore soft deleted record' => [
+                'expected' => 'Found you!',
+                'pivotData' => ['details' => 'Found you!', 'trashed' => true],
+                'restore' => true,
+                'isOwner' => true,
+            ],
+            'view soft deleted record without restoring' => [
+                'expected' => 'Stay trashed',
+                'pivotData' => ['details' => 'Stay trashed', 'trashed' => true],
+                'restore' => false,
+                'isOwner' => true,
+            ],
+            'return already active record' => [
+                'expected' => 'Active record',
+                'pivotData' => ['details' => 'Active record', 'trashed' => false],
+                'restore' => false,
+                'isOwner' => true,
+            ],
+            'return null if no pivot exists for this experience' => [
+                'expected' => null,
+                'pivotData' => null,
+                'restore' => false,
+                'isOwner' => true,
+            ],
+            'unauthorized if pivot belongs to another user' => [
+                'expected' => null,
+                'pivotData' => ['details' => 'Someone elses', 'trashed' => true],
+                'restore' => false,
+                'isOwner' => false,
+            ],
+        ];
+    }
+}

--- a/api/tests/Feature/TrashedExperienceSkillTest.php
+++ b/api/tests/Feature/TrashedExperienceSkillTest.php
@@ -60,32 +60,28 @@ class TrashedExperienceSkillTest extends TestCase
     }
 
     #[DataProvider('trashedExperienceSkillProvider')]
-    public function testTrashedExperienceSkill($expected, $pivotData, $restore, $isOwner): void
+    public function testTrashedExperienceSkill($expected, $pivotData, $restore, $isOwner, $shouldError = false): void
     {
         $skillId = $this->skill->id;
-        $activeUserSkill = $this->userSkill;
+        $targetUserSkill = $this->userSkill;
 
         if (! $isOwner) {
             $otherUser = User::factory()->asApplicant()->create();
-            $otherSkill = Skill::factory()->create();
-            $skillId = $otherSkill->id;
-            $activeUserSkill = UserSkill::factory()->create([
+            $targetUserSkill = UserSkill::factory()->create([
                 'user_id' => $otherUser->id,
-                'skill_id' => $otherSkill->id,
+                'skill_id' => $this->skill->id,
             ]);
         }
 
         if ($pivotData !== null) {
-            // Use the relationship to attach the pivot data
-            $this->experience->userSkills()->attach($activeUserSkill->id, [
+            $this->experience->userSkills()->attach($targetUserSkill->id, [
                 'details' => $pivotData['details'],
             ]);
 
             if ($pivotData['trashed']) {
-                // Fetch the pivot to soft delete it
                 ExperienceSkill::where([
                     'experience_id' => $this->experience->id,
-                    'user_skill_id' => $activeUserSkill->id,
+                    'user_skill_id' => $targetUserSkill->id,
                 ])->delete();
             }
         }
@@ -99,7 +95,7 @@ class TrashedExperienceSkillTest extends TestCase
                 ],
             ]);
 
-        if (! $isOwner) {
+        if ($shouldError) {
             $response->assertGraphQLErrorMessage('This action is unauthorized.');
 
             return;
@@ -111,10 +107,10 @@ class TrashedExperienceSkillTest extends TestCase
             ],
         ]);
 
-        if ($restore && ($pivotData['trashed'] ?? false)) {
+        if ($restore && ($pivotData['trashed'] ?? false) && $isOwner) {
             $this->assertDatabaseHas('experience_skill', [
                 'experience_id' => $this->experience->id,
-                'user_skill_id' => $activeUserSkill->id,
+                'user_skill_id' => $targetUserSkill->id,
                 'deleted_at' => null,
             ]);
         }
@@ -152,6 +148,14 @@ class TrashedExperienceSkillTest extends TestCase
                 'pivotData' => ['details' => 'Someone elses', 'trashed' => true],
                 'restore' => false,
                 'isOwner' => false,
+                'shouldError' => true,
+            ],
+            'unauthorized if attempting to restore someone elses record' => [
+                'expected' => null,
+                'pivotData' => ['details' => 'Forbidden Restore', 'trashed' => true],
+                'restore' => true,
+                'isOwner' => false,
+                'shouldError' => true,
             ],
         ];
     }

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -576,6 +576,7 @@ export const ExperienceForm = ({
                 <TableOfContents.Section id="skills">
                   <ExperienceSkills
                     experienceType={experienceType}
+                    experienceId={experienceId}
                     skills={[...skills]}
                   />
                 </TableOfContents.Section>

--- a/apps/web/src/pages/Profile/ExperienceFormPage/components/ExperienceSkills.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/components/ExperienceSkills.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useIntl } from "react-intl";
+import { useClient } from "urql";
 import { useFieldArray, useFormContext } from "react-hook-form";
 
 import { Accordion, Heading, Ul, Notice } from "@gc-digital-talent/ui";
@@ -10,7 +11,6 @@ import type { ExperienceType, FormSkill, FormSkills } from "~/types/experience";
 import SkillBrowserDialog from "~/components/SkillBrowser/SkillBrowserDialog";
 import type { FormValues as SkillBrowserDialogFormValues } from "~/components/SkillBrowser/types";
 import NullExperienceType from "~/components/ExperienceFormFields/NullExperienceType";
-import { useClient, useQuery } from "urql";
 
 const TrashedExperienceSkill_Query = graphql(/** GraphQL */ `
   query TrashedExperienceSkill($where: TrashedExperienceSkillInput!) {

--- a/apps/web/src/pages/Profile/ExperienceFormPage/components/ExperienceSkills.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/components/ExperienceSkills.tsx
@@ -3,13 +3,22 @@ import { useIntl } from "react-intl";
 import { useFieldArray, useFormContext } from "react-hook-form";
 
 import { Accordion, Heading, Ul, Notice } from "@gc-digital-talent/ui";
-import type { Skill } from "@gc-digital-talent/graphql";
+import { graphql, type Scalars, type Skill } from "@gc-digital-talent/graphql";
 
 import SkillsInDetail from "~/components/SkillsInDetail/SkillsInDetail";
 import type { ExperienceType, FormSkill, FormSkills } from "~/types/experience";
 import SkillBrowserDialog from "~/components/SkillBrowser/SkillBrowserDialog";
 import type { FormValues as SkillBrowserDialogFormValues } from "~/components/SkillBrowser/types";
 import NullExperienceType from "~/components/ExperienceFormFields/NullExperienceType";
+import { useClient, useQuery } from "urql";
+
+const TrashedExperienceSkill_Query = graphql(/** GraphQL */ `
+  query TrashedExperienceSkill($where: TrashedExperienceSkillInput!) {
+    trashedExperienceSkill(where: $where) {
+      details
+    }
+  }
+`);
 
 interface ExperienceSkillValues {
   experienceType?: ExperienceType;
@@ -17,19 +26,23 @@ interface ExperienceSkillValues {
 }
 
 type AccordionStates = "learn-more" | "";
+
 interface ExperienceSkillsProps {
   skills: Skill[];
   experienceType?: ExperienceType;
+  experienceId?: Scalars["UUID"]["output"];
 }
 
 const ExperienceSkills = ({
   skills,
   experienceType,
+  experienceId,
 }: ExperienceSkillsProps) => {
   const intl = useIntl();
   const { control, watch } = useFormContext<ExperienceSkillValues>();
   const type = watch("experienceType");
   const derivedType = type ?? experienceType;
+  const client = useClient();
   const watchedSkills: FormSkills = watch("skills");
   const { fields, remove, append } = useFieldArray({
     control,
@@ -39,9 +52,25 @@ const ExperienceSkills = ({
   const [accordionState, setAccordionState] = useState<AccordionStates>("");
 
   // Note: Needed for function colouring
-  // eslint-disable-next-line @typescript-eslint/require-await
   const handleAddSkill = async (values: SkillBrowserDialogFormValues) => {
     const skillId = values.skill;
+    let details = "";
+    if (experienceId && skillId) {
+      const { data, error } = await client
+        .query(TrashedExperienceSkill_Query, {
+          where: {
+            experienceId,
+            skillId,
+            restore: true,
+          },
+        })
+        .toPromise();
+
+      if (!error && data?.trashedExperienceSkill?.details) {
+        details = data.trashedExperienceSkill.details;
+      }
+    }
+
     const skill = skills.find(({ id }) => id === skillId);
 
     if (skill) {
@@ -49,7 +78,7 @@ const ExperienceSkills = ({
         {
           skillId: skill.id,
           name: skill.name,
-          details: "",
+          details,
         },
         { shouldFocus: false },
       );


### PR DESCRIPTION
🤖 Resolves #7833 

## 👋 Introduction

Updates the experience form to restore details from a soft-deleted experience skill record.

## 🕵️ Details

This works by querying for a trashed experience skill after selecting a skill from the dialog. If it finds one, it is restored and the details are populated in the form.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Create an experience, attaching a skill with some details
4. Delete the skill and save the experience
5. Go back and select the same skill
6. Confirm that the details from step 3 are populated