### PR TITLE
[Feat] Manage CL link opens in new tab

### DIFF
--- a/apps/web/src/components/NavMenu/MenuItem.tsx
+++ b/apps/web/src/components/NavMenu/MenuItem.tsx
@@ -6,6 +6,7 @@ interface MenuItemProps {
   title: string;
   subMenu?: boolean;
   state?: LinkProps["state"];
+  newTab?: LinkProps["newTab"];
   end?: boolean;
   className?: string;
 }
@@ -17,6 +18,7 @@ const MenuItem = ({
   state,
   end,
   className,
+  newTab = false,
   ...rest
 }: MenuItemProps) => {
   return (
@@ -24,7 +26,7 @@ const MenuItem = ({
       <NavMenu.Link
         type={subMenu ? "subMenuLink" : "link"}
         // NOTE: Comes from react-router
-        {...{ state, href, end }}
+        {...{ state, href, end, newTab }}
       >
         {title}
       </NavMenu.Link>

--- a/apps/web/src/components/NavMenu/useMainNavLinks.tsx
+++ b/apps/web/src/components/NavMenu/useMainNavLinks.tsx
@@ -282,6 +282,7 @@ const useMainNavLinks = () => {
         href={manageAuthAccountLink}
         title={intl.formatMessage(authMessages.manageAuthAccount)}
         subMenu
+        newTab
       />
     ) : null;
 

--- a/packages/ui/src/components/NavMenu/NavMenu.tsx
+++ b/packages/ui/src/components/NavMenu/NavMenu.tsx
@@ -108,14 +108,18 @@ const List = forwardRef<
   </NavigationMenuPrimitive.List>
 ));
 
+const item = tv({
+  base: "w-full sm:relative sm:w-auto data-[state=active]:[&_span]:font-bold! data-[state=active]:[&_span]:no-underline!",
+});
+
 const Item = forwardRef<
   ComponentRef<typeof NavigationMenuPrimitive.Item>,
   ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Item>
->((props, forwardedRef) => (
+>(({ className, ...rest }, forwardedRef) => (
   <NavigationMenuPrimitive.Item
     ref={forwardedRef}
-    {...props}
-    className={`w-full sm:relative sm:w-auto data-[state=active]:[&_span]:font-bold! data-[state=active]:[&_span]:no-underline! ${props.className}`}
+    className={item({ class: className })}
+    {...rest}
   />
 ));
 


### PR DESCRIPTION
🤖 Resolves #16602 

## 👋 Introduction

Updates our nav menu links to accept a `newTab` prop and applies that to the manage auth link.

**Bonus**: Fixed an issue where class has `undefined` at the end.

## 🧪 Testing

1. Set `FEATURE_CANADALOGIN=true`
2. Build `pnpm dev:fresh`
3. Login as any user
4. Open the "Your account" menu
5. Confirm that the "Manage CanadaLogin" link opens in a new tab

## 📸 Screenshot

<img width="439" height="308" alt="swappy-20260424_131452" src="https://github.com/user-attachments/assets/d7895539-3bb7-45c3-bdf5-79a0eb623213" />
