### PR TITLE
[Bug] Fix id ambiguous error

### DIFF
--- a/api/app/Models/DevelopmentProgramUser.php
+++ b/api/app/Models/DevelopmentProgramUser.php
@@ -37,7 +37,9 @@ class DevelopmentProgramUser extends Model
         'completion_date',
     ];
 
-    protected $casts = [];
+    protected $casts = [
+        'completion_date' => 'datetime',
+    ];
 
     //
     // Relations

--- a/api/app/Traits/Generator/Filterable.php
+++ b/api/app/Traits/Generator/Filterable.php
@@ -97,7 +97,7 @@ trait Filterable
         }
 
         if (! is_null($this->ids)) {
-            $query->whereIn('id', $this->ids);
+            $query->whereIn($query->qualifyColumn('id'), $this->ids);
         }
 
         return $query;


### PR DESCRIPTION
🤖 Resolves #16475

## 👋 Introduction

Fixes crashing when downloading Excel files for the community interest table using text search.

## 🕵️ Details

Two different fixes:
- Adds qualification to the ID column to fix ambiguity
- Adds the missing date cast so that the column can be formatted (unrelated to issue AC but was also causing crashes :laughing: )

## 🧪 Testing

1. Rebuild the app
2. Start a queue worker

- [ ] community interest table
    - [ ] can use text search
    - [ ] can download excel with text search
    - [ ] can download word with text search
- [ ] user table
    - [ ] can use text search
    - [ ] can download excel with text search
    - [ ] can download word with text search
- [ ] pool candidates table
    - [ ] can use text search
    - [ ] can download excel with text search
    - [ ] can download word with text search
