### PR TITLE
[Fix]  Dialog title close overlap

### DIFF
--- a/packages/ui/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.stories.tsx
@@ -1,3 +1,4 @@
+import type { ComponentPropsWithoutRef } from "react";
 import type { StoryObj, Meta } from "@storybook/react-vite";
 import { faker } from "@faker-js/faker/locale/en";
 
@@ -8,7 +9,6 @@ import {
 
 import Button from "../Button";
 import Dialog from "./Dialog";
-import type { ComponentPropsWithoutRef } from "react";
 
 faker.seed(0);
 

--- a/packages/ui/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryFn, Meta } from "@storybook/react-vite";
+import type { StoryObj, Meta } from "@storybook/react-vite";
 import { faker } from "@faker-js/faker/locale/en";
 
 import {
@@ -8,10 +8,15 @@ import {
 
 import Button from "../Button";
 import Dialog from "./Dialog";
+import type { ComponentPropsWithoutRef } from "react";
 
 faker.seed(0);
 
-export default {
+interface DialogArgs extends ComponentPropsWithoutRef<typeof Dialog.Root> {
+  title: string;
+}
+
+const meta = {
   component: Dialog.Root,
   decorators: [OverlayOrDialogDecorator],
   parameters: {
@@ -22,27 +27,42 @@ export default {
       },
     },
   },
-} as Meta<typeof Dialog.Root>;
+  args: {
+    title: "Basic dialog",
+  },
+  argTypes: {
+    title: { control: "text" },
+  },
+  render: (args) => (
+    <Dialog.Root defaultOpen>
+      <Dialog.Trigger>
+        <Button>Open Dialog</Button>
+      </Dialog.Trigger>
+      <Dialog.Content hasSubtitle>
+        <Dialog.Header subtitle="A dialog is a window overlaid on either the primary window or another dialog window.">
+          {args.title}
+        </Dialog.Header>
+        <Dialog.Body>
+          <p>{faker.lorem.sentences(3)}</p>
+          <Dialog.Footer>
+            <Dialog.Close>
+              <Button color="primary">Close</Button>
+            </Dialog.Close>
+          </Dialog.Footer>
+        </Dialog.Body>
+      </Dialog.Content>
+    </Dialog.Root>
+  ),
+} satisfies Meta<DialogArgs>;
 
-const Template: StoryFn<typeof Dialog.Root> = () => (
-  <Dialog.Root defaultOpen>
-    <Dialog.Trigger>
-      <Button>Open Dialog</Button>
-    </Dialog.Trigger>
-    <Dialog.Content hasSubtitle>
-      <Dialog.Header subtitle="A dialog is a window overlaid on either the primary window or another dialog window.">
-        Basic Dialog
-      </Dialog.Header>
-      <Dialog.Body>
-        <p>{faker.lorem.sentences(3)}</p>
-        <Dialog.Footer>
-          <Dialog.Close>
-            <Button color="primary">Close</Button>
-          </Dialog.Close>
-        </Dialog.Footer>
-      </Dialog.Body>
-    </Dialog.Content>
-  </Dialog.Root>
-);
+export default meta;
 
-export const Default = Template.bind({});
+type Story = StoryObj<DialogArgs>;
+
+export const Default: Story = {};
+
+export const WithLongTitle: Story = {
+  args: {
+    title: "Basic dialog that is actually a very long and descriptive sentence",
+  },
+};

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -184,7 +184,7 @@ interface DialogHeaderProps {
 
 const Header = ({ subtitle, children }: DialogHeaderProps) => (
   <>
-    <div className="relative overflow-hidden rounded-t-md bg-black p-6 text-white">
+    <div className="relative overflow-hidden rounded-t-md bg-black p-6 pr-18 text-white">
       <div className="relative">
         <StyledTitle>{children}</StyledTitle>
         {subtitle ? <StyledDescription>{subtitle}</StyledDescription> : ""}


### PR DESCRIPTION
🤖 Resolves #16544 

## 👋 Introduction

Updates the dialog header to avoid titles overlapping the close button.

## 🕵️ Details

Adds up all the spacing values (position, padding, size) to pad the heading on the right to create the same space between the text and close button as the close button and the edge of the dialog contents.

## 🧪 Testing

1. Start storybook `pnpm storybook` (or review chromatic)
2. Navigate to the Dialog > With long title story
3. Confirm the text never overlaps the close button on any screen width and any length of string

## 📸 Screenshot

<img width="828" height="473" alt="swappy-20260428_080228" src="https://github.com/user-attachments/assets/46cf55f3-9a2f-479c-a5c9-06927368af93" />
