### PR TITLE
[Bug] Fix playwright crashing

### DIFF
--- a/apps/playwright/.env.example
+++ b/apps/playwright/.env.example
@@ -1,4 +1,4 @@
-# Timeouts in ms
+# Timeouts in  ms
 # See: https://playwright.dev/docs/test-timeouts
 #TEST_TIMEOUT=30000
 #EXPECT_TIMEOUT=5000

--- a/infrastructure/maintenance-container/Dockerfile
+++ b/infrastructure/maintenance-container/Dockerfile
@@ -10,8 +10,8 @@ FROM ubuntu:24.04
 # then update again and install everything else
 # installing tzdata has an interactive prompt by default
 RUN apt-get update \
-  && apt-get install -y software-properties-common \
-  && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common \
+  && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php -y \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata \
   && apt-get install -y perl unzip wget curl \

--- a/infrastructure/webserver.Dockerfile
+++ b/infrastructure/webserver.Dockerfile
@@ -1,7 +1,7 @@
 # This setup should only install things that are set up in infrastructure/bin/post_deployment.sh as well
 
 # All images: https://mcr.microsoft.com/v2/appsvc/php/tags/list
-FROM mcr.microsoft.com/appsvc/php:8.4-fpm-xdebug_20250728.2.tuxprod
+FROM mcr.microsoft.com/appsvc/php:8.4-fpm-xdebug_20260428.5.tuxprod
 
 RUN echo 'memory_limit=256M' >> /usr/local/etc/php/conf.d/php.ini
 


### PR DESCRIPTION
🤖 Resolves #16629 

## 👋 Introduction

Bumps the base image for our webserver container to fix a bug with the sources. It took me way too long to notice that the errors were emitting from the webserver build, not the maintenance build. :laughing: 

## 🕵️ Details


## 🧪 Testing

Playwright CI builds and runs.

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

## 🚚 Deployment

<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the PR if deployment steps are needed

 -->
