### PR TITLE
[Feat] Add runtime var support to storybook

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -6,6 +6,7 @@ import {
   MockGraphqlDecorator,
   ReducedMotionDecorator,
   RouterDecorator,
+  RuntimeVariableDecorator,
   ThemeDecorator,
   VIEWPORTS,
 } from "@gc-digital-talent/storybook-helpers";
@@ -77,6 +78,7 @@ export const parameters = {
 };
 
 export const decorators = [
+  RuntimeVariableDecorator,
   FeatureFlagDecorator,
   HelmetDecorator,
   ToastDecorator,

--- a/packages/storybook-helpers/decorators/RuntimeVariableDecorator.tsx
+++ b/packages/storybook-helpers/decorators/RuntimeVariableDecorator.tsx
@@ -74,9 +74,13 @@ const RuntimeVariableDecorator: Decorator = (Story) => {
       serverConfig.set(key, value);
     });
 
-    // Cleanup: Restore original values on unmount or when variables change
+    // Cleanup: only restore values that this decorator instance still owns.
+    // If another mounted story has since changed the same key, leave it alone.
     return () => {
-      Object.keys(runtimeVariables).forEach((key) => {
+      Object.entries(runtimeVariables).forEach(([key, value]) => {
+        if (serverConfig.get(key) !== value) {
+          return;
+        }
         const originalValue = originalValues.get(key);
         if (originalValue !== undefined) {
           serverConfig.set(key, originalValue);

--- a/packages/storybook-helpers/decorators/RuntimeVariableDecorator.tsx
+++ b/packages/storybook-helpers/decorators/RuntimeVariableDecorator.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useState } from "react";
+import { useLayoutEffect } from "react";
 import type { Decorator } from "@storybook/react-vite";
 import { useParameter } from "storybook/preview-api";
 

--- a/packages/storybook-helpers/decorators/RuntimeVariableDecorator.tsx
+++ b/packages/storybook-helpers/decorators/RuntimeVariableDecorator.tsx
@@ -1,0 +1,93 @@
+import { useEffect } from "react";
+import type { Decorator } from "@storybook/react-vite";
+import { useParameter } from "storybook/preview-api";
+
+export type RuntimeVariables = Record<string, string>;
+
+interface HasServerConfig {
+  __SERVER_CONFIG__?: Map<string, string>;
+}
+
+/**
+ * Access the window object with the server config type
+ */
+const getWindowWithConfig = (): HasServerConfig | undefined => {
+  if (typeof window === "undefined") return undefined;
+  return window as unknown as HasServerConfig;
+};
+
+/**
+ * Get the server config from window, initializing if needed
+ */
+const getServerConfig = (): Map<string, string> => {
+  const windowWithConfig = getWindowWithConfig();
+  if (!windowWithConfig) {
+    return new Map<string, string>();
+  }
+
+  // eslint-disable-next-line no-underscore-dangle
+  windowWithConfig.__SERVER_CONFIG__ ??= new Map<string, string>();
+
+  // eslint-disable-next-line no-underscore-dangle
+  return windowWithConfig.__SERVER_CONFIG__;
+};
+
+/**
+ * A Storybook decorator that provides runtime variables for stories.
+ *
+ * This allows stories to use `getRuntimeVariable` from `@gc-digital-talent/env`
+ * by configuring the `runtimeVariables` parameter.
+ *
+ * @example
+ * ```tsx
+ * const meta = {
+ *   title: 'Components/MyComponent',
+ *   component: MyComponent,
+ *   parameters: {
+ *     runtimeVariables: {
+ *       LOG_CONSOLE_LEVEL: "Debug",
+ *       OAUTH_LOGOUT_URI: "https://example.com/logout",
+ *     },
+ *   },
+ * };
+ * ```
+ */
+const RuntimeVariableDecorator: Decorator = (Story) => {
+  const runtimeVariables = useParameter<RuntimeVariables | undefined>(
+    "runtimeVariables",
+    undefined,
+  );
+
+  useEffect(() => {
+    if (!runtimeVariables) return undefined;
+
+    const serverConfig = getServerConfig();
+
+    // Save the original values before overwriting
+    const originalValues = new Map<string, string | undefined>();
+    Object.keys(runtimeVariables).forEach((key) => {
+      originalValues.set(key, serverConfig.get(key));
+    });
+
+    // Set the runtime variables
+    Object.entries(runtimeVariables).forEach(([key, value]) => {
+      serverConfig.set(key, value);
+    });
+
+    // Cleanup: Restore original values on unmount or when variables change
+    return () => {
+      Object.keys(runtimeVariables).forEach((key) => {
+        const originalValue = originalValues.get(key);
+        if (originalValue !== undefined) {
+          serverConfig.set(key, originalValue);
+        } else {
+          serverConfig.delete(key);
+        }
+      });
+    };
+  }, [runtimeVariables]);
+
+  return Story();
+};
+
+export default RuntimeVariableDecorator;

--- a/packages/storybook-helpers/decorators/RuntimeVariableDecorator.tsx
+++ b/packages/storybook-helpers/decorators/RuntimeVariableDecorator.tsx
@@ -58,13 +58,8 @@ const RuntimeVariableDecorator: Decorator = (Story) => {
     undefined,
   );
 
-  // Gate rendering until variables are applied so the story's initial render
-  // always sees the correct values (useEffect fires after paint and is too late).
-  const [ready, setReady] = useState(false);
-
   useLayoutEffect(() => {
     if (!runtimeVariables) {
-      setReady(true);
       return undefined;
     }
 
@@ -80,8 +75,6 @@ const RuntimeVariableDecorator: Decorator = (Story) => {
     Object.entries(runtimeVariables).forEach(([key, value]) => {
       serverConfig.set(key, value);
     });
-
-    setReady(true);
 
     // Cleanup: only restore values that this decorator instance still owns.
     // If another mounted story has since changed the same key, leave it alone.
@@ -100,8 +93,7 @@ const RuntimeVariableDecorator: Decorator = (Story) => {
     };
   }, [runtimeVariables]);
 
-  if (!ready) return null;
-  return Story();
+  return <Story />;
 };
 
 export default RuntimeVariableDecorator;

--- a/packages/storybook-helpers/decorators/RuntimeVariableDecorator.tsx
+++ b/packages/storybook-helpers/decorators/RuntimeVariableDecorator.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useLayoutEffect, useState } from "react";
 import type { Decorator } from "@storybook/react-vite";
 import { useParameter } from "storybook/preview-api";
 
@@ -58,8 +58,15 @@ const RuntimeVariableDecorator: Decorator = (Story) => {
     undefined,
   );
 
-  useEffect(() => {
-    if (!runtimeVariables) return undefined;
+  // Gate rendering until variables are applied so the story's initial render
+  // always sees the correct values (useEffect fires after paint and is too late).
+  const [ready, setReady] = useState(false);
+
+  useLayoutEffect(() => {
+    if (!runtimeVariables) {
+      setReady(true);
+      return undefined;
+    }
 
     const serverConfig = getServerConfig();
 
@@ -69,14 +76,17 @@ const RuntimeVariableDecorator: Decorator = (Story) => {
       originalValues.set(key, serverConfig.get(key));
     });
 
-    // Set the runtime variables
+    // Set the runtime variables before the story renders
     Object.entries(runtimeVariables).forEach(([key, value]) => {
       serverConfig.set(key, value);
     });
 
+    setReady(true);
+
     // Cleanup: only restore values that this decorator instance still owns.
     // If another mounted story has since changed the same key, leave it alone.
     return () => {
+      setReady(false);
       Object.entries(runtimeVariables).forEach(([key, value]) => {
         if (serverConfig.get(key) !== value) {
           return;
@@ -91,6 +101,7 @@ const RuntimeVariableDecorator: Decorator = (Story) => {
     };
   }, [runtimeVariables]);
 
+  if (!ready) return null;
   return Story();
 };
 

--- a/packages/storybook-helpers/decorators/RuntimeVariableDecorator.tsx
+++ b/packages/storybook-helpers/decorators/RuntimeVariableDecorator.tsx
@@ -86,7 +86,6 @@ const RuntimeVariableDecorator: Decorator = (Story) => {
     // Cleanup: only restore values that this decorator instance still owns.
     // If another mounted story has since changed the same key, leave it alone.
     return () => {
-      setReady(false);
       Object.entries(runtimeVariables).forEach(([key, value]) => {
         if (serverConfig.get(key) !== value) {
           return;

--- a/packages/storybook-helpers/index.ts
+++ b/packages/storybook-helpers/index.ts
@@ -5,10 +5,14 @@ import MockGraphqlDecorator from "./decorators/MockGraphqlDecorator";
 import OverlayOrDialogDecorator from "./decorators/OverlayOrDialogDecorator";
 import ReducedMotionDecorator from "./decorators/ReducedMotionDecorator";
 import RouterDecorator from "./decorators/RouterDecorator";
+import RuntimeVariableDecorator from "./decorators/RuntimeVariableDecorator";
+import type { RuntimeVariables } from "./decorators/RuntimeVariableDecorator";
 import ThemeDecorator, { THEMES } from "./decorators/ThemeDecorator";
 import allModes from "./modes";
 import { CHROMATIC_VIEWPORTS, VIEWPORTS, VIEWPORT } from "./viewports";
 import { GLOBAL_A11Y_EXCLUDES } from "./a11y";
+
+export type { RuntimeVariables };
 
 export {
   ContainerDecorator,
@@ -18,6 +22,7 @@ export {
   OverlayOrDialogDecorator,
   ReducedMotionDecorator,
   RouterDecorator,
+  RuntimeVariableDecorator,
   ThemeDecorator,
   THEMES,
   VIEWPORT,


### PR DESCRIPTION
🤖 Resolves #16531 

## 👋 Introduction

Adds support for runtime vars in storybook similar to the feature flag support.

## 🕵️ Details

Agent-Logs-Url: https://github.com/GCTC-NTGC/gc-digital-talent/sessions/8522803c-ffa8-4d14-9423-57f08dd93311

### Usage

```tsx
const meta = {
  title: 'Components/MyComponent',
  component: MyComponent,
  parameters: {
    runtimeVariables: {
      LOG_CONSOLE_LEVEL: "Debug",
      OAUTH_LOGOUT_URI: "https://example.com/logout",
      // Any runtime variable key can be set here
    },
  },
};
```
## :question: Question

Do we want to populate some defaults in `.storybook/preview.ts`? Right now it is only "as needed" so you need to manually add them.

## 🧪 Testing

1. Open any story file
2. Add the `runtimeVariables` parameter
3. Add a `getRuntimeVariable` call for that added variable
4. Run storybook `pnpm storybook`
5. Open the javascript console and run `window.__SERVER_CONFIG__`
6. Confirm your variable is there and accurate
7. Confirm the `getRuntimeVariable` gets the proper value you set

## 📸 Screenshot

<img width="805" height="660" alt="swappy-20260428_125715" src="https://github.com/user-attachments/assets/1a112eab-5ed2-41ca-bd25-4aaae70d5dd2" />
