### PR TITLE
[Fix] OCIO/BDPI links homepage

### DIFF
--- a/apps/web/src/pages/Home/HomePage/components/About.tsx
+++ b/apps/web/src/pages/Home/HomePage/components/About.tsx
@@ -43,8 +43,8 @@ const About = () => {
                 mode: "solid",
                 href:
                   locale === "en"
-                    ? "https://www.canada.ca/en/treasury-board-secretariat/corporate/mandate/chief-information-officer.html"
-                    : "https://www.canada.ca/fr/secretariat-conseil-tresor/organisation/mandat/dirigeant-principal-information.html",
+                    ? "https://www.canada.ca/en/treasury-board-secretariat/corporate/organization.html#ocio"
+                    : "https://www.canada.ca/fr/secretariat-conseil-tresor/organisation/organisation.html#org5",
                 label: intl.formatMessage({
                   defaultMessage:
                     "Learn more<hidden> about the Office of the Chief Information Officer</hidden>",


### PR DESCRIPTION
🤖 Resolves #16530.

## 👋 Introduction

This PR updates the OCIO/BDPI links on the homepage.

## 🧪 Testing

1. `pnpm dev`
2. Navigate to http://localhost:8000/en/
3. Verify OCIO/BDPI action links have been updated with URLs from linked issue

## 📸 Screenshots

<img width="517" height="784" alt="Screenshot 2026-04-29 at 10 25 05" src="https://github.com/user-attachments/assets/dc49529e-745a-43e3-b8a9-c927eafa892e" />
<img width="509" height="778" alt="Screenshot 2026-04-29 at 10 25 20" src="https://github.com/user-attachments/assets/f74447ff-0c5c-4362-9898-ab6a20b702f6" />