### PR TITLE
[Feature] Back up emails instead of mangling

### DIFF
--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -180,13 +180,16 @@ class AuthController extends Controller
                     $existingUser = User::where('id', '!=', $userMatch->id)
                         ->where(fn ($subquery) => $subquery
                             ->where('email', 'ilike', $incomingEmailAddress)
-                            ->orWhere('work_email', 'ilike', $incomingEmailAddress)
-                        )->first();
+                            ->orWhere('work_email', 'ilike', $incomingEmailAddress))
+                        ->withTrashed()
+                        ->first();
                     if (strcasecmp($existingUser->email, $incomingEmailAddress) == 0) {
-                        $existingUser->email = $existingUser->email.'-taken-at-'.Carbon::now()->timestamp;
+                        $existingUser->email_backup = $existingUser->email;
+                        $existingUser->email = null;
                     }
                     if (strcasecmp($existingUser->work_email, $incomingEmailAddress) == 0) {
-                        $existingUser->work_email = $existingUser->work_email.'-taken-at-'.Carbon::now()->timestamp;
+                        $existingUser->work_email_backup = $existingUser->work_email;
+                        $existingUser->work_email = null;
                     }
                     $existingUser->save();
                 } catch (\Throwable $e) {

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -109,6 +109,8 @@ use Staudenmeir\EloquentHasManyDeep\HasRelationships;
  * @property OffPlatformRecruitmentProcess $offPlatformRecruitmentProcesses
  * @property ?EmployeeProfile $employeeProfile
  * @property ?string $last_sign_in_iss
+ * @property ?string $email_backup
+ * @property ?string $work_email_backup
  */
 class User extends Model implements Authenticatable, HasLocalePreference, LaratrustUser
 {
@@ -707,10 +709,14 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
                 // Cascade delete to child models
                 $user->poolCandidates()->delete();
 
-                // Modify the email(s) to allow use by another user
-                $user->email = $user->email.'-deleted-at-'.Carbon::now()->format('Y-m-d');
+                // Backup the email(s) to allow use by another user
+                if (! is_null($user->email)) {
+                    $user->email_backup = $user->email;
+                    $user->email = null;
+                }
                 if (! is_null($user->work_email)) {
-                    $user->work_email = $user->work_email.'-deleted-at-'.Carbon::now()->format('Y-m-d');
+                    $user->work_email_backup = $user->work_email;
+                    $user->work_email = null;
                 }
                 $user->save();
             }
@@ -723,12 +729,37 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
                 $candidate->restore();
             }
 
-            $newContactEmail = $user->email.'-restored-at-'.Carbon::now()->format('Y-m-d');
-            $user->update(['email' => $newContactEmail]);
-            if (! is_null($user->work_email)) {
-                $newWorkEmail = $user->work_email.'-restored-at-'.Carbon::now()->format('Y-m-d');
-                $user->update(['email' => $newWorkEmail]);
+            // see if we can restore email
+            if (is_null($user->email) && ! is_null($user->email_backup)) {
+                $existingUserCount = User::where('id', '!=', $user->id)
+                    ->where(fn ($subquery) => $subquery
+                        ->where('email', 'ilike', $user->email_backup)
+                        ->orWhere('work_email', 'ilike', $user->email_backup))
+                    ->withTrashed()
+                    ->count();
+
+                if ($existingUserCount == 0) {
+                    $user->email = $user->email_backup;
+                    $user->email_backup = null;
+                }
             }
+
+            // see if we can restore work email
+            if (is_null($user->work_email) && ! is_null($user->work_email_backup)) {
+                $existingUserCount = User::where('id', '!=', $user->id)
+                    ->where(fn ($subquery) => $subquery
+                        ->where('email', 'ilike', $user->work_email_backup)
+                        ->orWhere('work_email', 'ilike', $user->work_email_backup))
+                    ->withTrashed()
+                    ->count();
+
+                if ($existingUserCount == 0) {
+                    $user->work_email = $user->work_email_backup;
+                    $user->work_email_backup = null;
+                }
+            }
+
+            $user->save();
         });
 
         static::roleAdded(function (User $user, string $role, $team) {

--- a/api/database/migrations/2026_04_30_152311_add_email_backup_columns.php
+++ b/api/database/migrations/2026_04_30_152311_add_email_backup_columns.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('email_backup')->nullable();
+            $table->string('work_email_backup')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('email_backup');
+            $table->dropColumn('work_email_backup');
+        });
+    }
+};

--- a/api/tests/Feature/Snapshots/SnapshotShapeTest.php
+++ b/api/tests/Feature/Snapshots/SnapshotShapeTest.php
@@ -124,6 +124,8 @@ class SnapshotShapeTest extends TestCase
             'careerObjectiveCSuiteRoleTitle',
             'careerPlanningLearningOpportunitiesInterest',
             'lastSignInIss',
+            'emailBackup',
+            'workEmailBackup',
         ],
         UserSkill::class => [
             'userId',

--- a/api/tests/Feature/UserTest.php
+++ b/api/tests/Feature/UserTest.php
@@ -2312,4 +2312,71 @@ class UserTest extends TestCase
                 ],
             ]);
     }
+
+    // When a user is deleted, their email and work email is backed up and cleared
+    public function testUserDeleteBacksUpTheEmailAndWorkEmail()
+    {
+        $user = User::factory()->create([
+            'email' => 'testuser@example.com',
+            'work_email' => 'workuser@gc.ca',
+        ]);
+
+        $user->delete();
+        $user->refresh();
+
+        $this->assertNull($user->email);
+        $this->assertNull($user->work_email);
+        $this->assertEquals('testuser@example.com', $user->email_backup);
+        $this->assertEquals('workuser@gc.ca', $user->work_email_backup);
+    }
+
+    // When a user is restored, if their backed up email and work email are unused then they are restored
+    public function testUserRestoreUnusedEmailAndWorkEmail()
+    {
+        $user = User::factory()->create([
+            'email' => 'restoreuser@example.com',
+            'email_verified_at' => '2000-01-01',
+            'work_email' => 'restorework@gc.ca',
+            'work_email_verified_at' => '2000-01-01',
+        ]);
+        $user->delete();
+        $user->refresh();
+
+        // Simulate restore when no other user uses these emails
+        $user->restore();
+        $user->refresh();
+
+        $this->assertEquals('restoreuser@example.com', $user->email);
+        $this->assertNull($user->email_verified_at);
+        $this->assertEquals('restorework@gc.ca', $user->work_email);
+        $this->assertNull($user->work_email_verified_at);
+        $this->assertNull($user->email_backup);
+        $this->assertNull($user->work_email_backup);
+    }
+
+    // When a user is restored, if their backed up email and work email are already used then they remain null
+    public function testUserDoesntRestoreUsedEmailAndWorkEmail()
+    {
+        $user = User::factory()->create([
+            'email' => 'used@example.com',
+            'work_email' => 'usedwork@gc.ca',
+        ]);
+        $user->delete();
+        $user->refresh();
+
+        // Create a user with the email that will block restoration
+        $blocker = User::factory()->create([
+            'email' => 'used@example.com',
+            'work_email' => 'usedwork@gc.ca',
+        ]);
+
+        // Now, try to restore the user, but the emails are already in use
+        $user->restore();
+        $user->refresh();
+
+        $this->assertNull($user->email);
+        $this->assertNull($user->work_email);
+        $this->assertEquals('used@example.com', $user->email_backup);
+        $this->assertEquals('usedwork@gc.ca', $user->work_email_backup);
+    }
 }

--- a/api/tests/Unit/AuthControllerTest.php
+++ b/api/tests/Unit/AuthControllerTest.php
@@ -155,10 +155,12 @@ class AuthControllerTest extends TestCase
             'code' => 'code',
         ]);
 
-        // The existing user's email should be updated
+        // The existing user's email should be backed up
         $existingUser->refresh();
-        $this->assertStringContainsString('-taken-at-', $existingUser->email);
-        $this->assertStringContainsString('-taken-at-', $existingUser->work_email);
+        $this->assertNull($existingUser->email);
+        $this->assertNull($existingUser->work_email);
+        $this->assertSame('duplicate@gc.ca', $existingUser->email_backup);
+        $this->assertSame('duplicate@gc.ca', $existingUser->work_email_backup);
 
         // The new user should have the duplicate email
         $newUser = User::where('sub', 'newsub')->sole();


### PR DESCRIPTION
🤖 Resolves #16643 

## 👋 Introduction

Backs up email addresses instead of mangling when deleting or when a collision occurs on log in.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

### Delete / Restore

> [!NOTE]
> You can use mock auth for this part


 Handy SQL query :point_down: 
```sql
select email, email_verified_at , email_backup, work_email, work_email_verified_at, work_email_backup  from users where sub = 'applicant-employee@test.com'
```



1. Log in as admin@test.com
2. Pick a user with email address and work email address et
3. Navigate to the admin advanced tools tab for that user

- [ ] Can archive user
- [ ] User's email addresses were backed up
- [ ] Can restore user
- [ ] User's email addresses were restored
- [ ] User's email addresses are unverified

### Login collisions

> [!IMPORTANT]
> You must use CanadaLogin for this part

1. Pick a secondary user and manually set the email address to match your primary CanadaLogin user
2. Log in as that CanadaLogin user

- [ ] Primary user has the verified email address
- [ ] Secondary user's email was backed up

