### PR TITLE
[Bug] Allow Community admin to view talent management

### DIFF
--- a/apps/web/src/constants/permissionConstants.ts
+++ b/apps/web/src/constants/permissionConstants.ts
@@ -43,6 +43,7 @@ const permissionConstants: Readonly<Record<string, RoleName[]>> = {
   viewCommunityTalentNominations: [
     ROLE_NAME.CommunityTalentCoordinator,
     ROLE_NAME.PlatformAdmin,
+    ROLE_NAME.CommunityAdmin,
   ],
 };
 

--- a/apps/web/src/pages/TalentEvents/IndexTalentEventPage.tsx
+++ b/apps/web/src/pages/TalentEvents/IndexTalentEventPage.tsx
@@ -87,7 +87,11 @@ export const IndexTalentEventPage = () => {
 
 export const Component = () => (
   <RequireAuth
-    roles={[ROLE_NAME.CommunityTalentCoordinator, ROLE_NAME.PlatformAdmin]}
+    roles={[
+      ROLE_NAME.CommunityTalentCoordinator,
+      ROLE_NAME.PlatformAdmin,
+      ROLE_NAME.CommunityAdmin,
+    ]}
   >
     <IndexTalentEventPage />
   </RequireAuth>


### PR DESCRIPTION
🤖 Resolves #16679

## 👋 Introduction

Allow community admin to reach talent events index thru the community dashboard 

## 🧪 Testing

1. Login as a community admin (not any other community role)
2. Can reach talent events via dashboard 


