### PR TITLE
[Fix] Theme provider type

### DIFF
--- a/apps/web/src/components/ActivityContext/InactivityDialog.tsx
+++ b/apps/web/src/components/ActivityContext/InactivityDialog.tsx
@@ -54,7 +54,7 @@ const InactivityDialog = ({
 }: InactivityDialogProps) => {
   const intl = useIntl();
   const theme = useTheme();
-  const themeMode = theme.mode as "dark" | "light"; // can remove type override when #16536 is fixed
+  const themeMode = theme.mode;
 
   const imgSrcs = {
     light: pugLightLg,

--- a/packages/theme/src/components/ThemeProvider.tsx
+++ b/packages/theme/src/components/ThemeProvider.tsx
@@ -11,6 +11,7 @@ import type {
   SetThemeModeFunc,
   Theme,
   ThemeOverride,
+  SimpleThemeMode,
 } from "../types";
 
 export interface ThemeState {
@@ -20,7 +21,7 @@ export interface ThemeState {
    * Mode omits "pref" and is used by tailwind that only supports light/dark
    * where pref will fallback to one based on users `prefers-color-scheme`
    * */
-  mode: Omit<ThemeMode, "pref">;
+  mode: SimpleThemeMode;
   key: ThemeKey;
   isPref: boolean;
   setMode: SetThemeModeFunc;
@@ -29,9 +30,9 @@ export interface ThemeState {
 }
 
 const defaultThemeState = {
-  fullMode: "pref" as ThemeMode,
-  mode: "light" as ThemeMode,
-  key: "default" as ThemeKey,
+  fullMode: "pref",
+  mode: "light",
+  key: "default",
   isPref: true,
   setMode: () => {
     // PASS
@@ -42,7 +43,7 @@ const defaultThemeState = {
   setTheme: () => {
     // PASS
   },
-};
+} satisfies ThemeState;
 
 export const ThemeContext = createContext<ThemeState>(defaultThemeState);
 
@@ -55,6 +56,18 @@ const getDefaultTheme = (override?: ThemeOverride): Theme => ({
   mode: override?.mode ?? defaultTheme.mode,
   key: override?.key ?? defaultTheme.key,
 });
+
+const narrowMode = (
+  mode?: ThemeMode,
+  prefersDark?: boolean,
+  isLight?: boolean,
+): SimpleThemeMode | undefined => {
+  if (mode !== "pref") {
+    return mode;
+  }
+
+  return prefersDark && !isLight ? "dark" : "light";
+};
 
 interface ThemeProviderProps {
   children: ReactNode;
@@ -75,12 +88,10 @@ const ThemeProvider = ({
     getDefaultTheme(override),
   );
   const { key, mode } = theme;
-  let computedMode: ThemeMode = mode;
   const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-  const isSetLight = localStorage.theme === "light";
-  if (mode === "pref") {
-    computedMode = prefersDark && !isSetLight ? "dark" : "light";
-  }
+  const computedMode =
+    narrowMode(mode, prefersDark, localStorage.theme === "light") ?? "light";
+  const overrideMode = narrowMode(override?.mode);
 
   const setKey = useCallback(
     (newKey: ThemeKey) => {
@@ -161,7 +172,7 @@ const ThemeProvider = ({
   const state = useMemo(
     () => ({
       fullMode: override?.mode ?? mode,
-      mode: override?.mode ?? computedMode,
+      mode: overrideMode ?? computedMode,
       key: override?.key ?? key,
       setTheme,
       setMode,
@@ -172,6 +183,7 @@ const ThemeProvider = ({
       override?.mode,
       override?.key,
       computedMode,
+      overrideMode,
       key,
       setTheme,
       setMode,

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -1,6 +1,8 @@
 export type ThemeKey = "default" | "iap";
 export type SetThemeKeyFunc = (newThemeKey: ThemeKey) => void;
 export type ThemeMode = "dark" | "light" | "pref";
+export type SimpleThemeMode = Exclude<ThemeMode, "pref">;
+
 export type SetThemeModeFunc = (newThemeMode: ThemeMode) => void;
 export type SetThemeFunc = (value: Theme | ((val: Theme) => Theme)) => void;
 


### PR DESCRIPTION
🤖 Resolves #16536 

## 👋 Introduction

Updates the theme provider type to use `Exclude` over `Omit` for more accurate, stronger type.

## 🧪 Testing

1. Confirm no tsc or lint errors `CI=true pnpm lint --force; pnpm tsc --force;`
2. Confirm theme provider still funcitons in app and storybook