### PR TITLE
[Bug] Set CSP on index.html only

### DIFF
--- a/infrastructure/conf/nginx-conf-deploy/default
+++ b/infrastructure/conf/nginx-conf-deploy/default
@@ -1,9 +1,3 @@
-
-map $request_uri $csp_header {
-    default "default-src 'self'; font-src fonts.gstatic.com 'self'; style-src-elem fonts.googleapis.com 'self' 'nonce-$cspNonce' 'unsafe-inline'; connect-src 'self' https://canadacentral-1.in.applicationinsights.azure.com https://js.monitor.azure.com ws://$host wss://$host; script-src-elem 'self' 'nonce-$cspNonce'; img-src 'self' 'nonce-$cspNonce' data:; frame-ancestors 'none'; report-uri /api/csp-report/; report-to csp;";
-    ~^/robots.txt "default-src 'self'; style-src-attr 'unsafe-inline';";
-}
-
 server {
     #proxy_cache cache;
     #proxy_cache_valid 200 1s;
@@ -15,21 +9,12 @@ server {
     root /home/site/wwwroot;
     index  index.php index.html index.htm;
     server_name $HTTP_DISGUISED_HOST;
-    absolute_redirect off;
     gzip_static on;
+    absolute_redirect off;
 
     # redirect server error pages
     error_page   404  /404;
 
-    # CSP Headers
-    set $cspNonce $request_id;
-    sub_filter_types *;
-    sub_filter '**CSP_NONCE**' $cspNonce;
-    sub_filter_once off;
-
-    add_header X-Frame-Options DENY;
-    add_header Reporting-Endpoints csp="/api/csp-report";
-    add_header Content-Security-Policy $csp_header always;
 
     # Permanent redirects to avoid dead links
     location = /en/communities/digital-talent {
@@ -60,7 +45,7 @@ server {
     }
     location = /en/browse/pools { return 301 /en/jobs$is_args$args; }
     location = /fr/browse/pools { return 301 /fr/jobs$is_args$args; }
-# permanent redirect for documents moved to static hosting
+    # permanent redirect for documents moved to static hosting
     location = "/documents/Arbre_decisionnel_PDF_FR.pdf" { return 301 "/static/documents/Arbre_decisionnel_PDF_FR.pdf$is_args$args"; }
     location = "/documents/Arbre_decisionnel_texte_FR.docx" { return 301 "/static/documents/Arbre_decisionnel_texte_FR.docx$is_args$args"; }
     location = "/documents/Decision_Tree_PDF_EN.pdf" { return 301 "/static/documents/Decision_Tree_PDF_EN.pdf$is_args$args"; }
@@ -224,6 +209,16 @@ server {
 
     # for all other uris, serve SPA index with no caching
     location / {
+        # CSP Headers
+        set $cspNonce $request_id;
+        sub_filter_types *;
+        sub_filter '**CSP_NONCE**' $cspNonce;
+        sub_filter_once off;
+
+        add_header X-Frame-Options DENY;
+        add_header Reporting-Endpoints csp="/api/csp-report";
+        add_header Content-Security-Policy "default-src 'self'; font-src fonts.gstatic.com 'self'; style-src-elem fonts.googleapis.com 'self' 'nonce-$cspNonce' 'unsafe-inline'; connect-src 'self' https://canadacentral-1.in.applicationinsights.azure.com https://js.monitor.azure.com ws://$host wss://$host; script-src-elem 'self' 'nonce-$cspNonce'; img-src 'self' 'nonce-$cspNonce' data:; frame-ancestors 'none'; report-uri /api/csp-report/; report-to csp;" always;
+
         root /home/site;
         add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild
         try_files /index.html =404;

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -235,14 +235,12 @@ server {
     # NOTE: this is set up like this to mirror prod version, where different location blocks allow unique cache-control headers
     # NOTE2: this excludes assets starting with /static/ since there's a redirect to static hosting for that case below
     location ~ "^(?!/static/).*\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest|webp|pptx)$" {
-        # contenthashed asset files get cached for a year
         location ~ "-[A-z0-9-]{8}\.(png|ico|gif|jpg|jpeg|svg|css|js|pdf|map|doc|docx|webmanifest|webp|pptx)$" {
-            # add_header Cache-Control "public, max-age=31536000"; # 1 year
+            add_header Cache-Control "no-store";
             try_files /apps/web/dist/client/$uri =404;
         }
 
-        # unhashed assets get cached for an hour
-        # add_header Cache-Control "public, max-age=3600"; # 1 hour
+        add_header Cache-Control "no-store";
         try_files /apps/web/dist/client/$uri =404;
     }
 

--- a/infrastructure/conf/nginx-conf-local/default
+++ b/infrastructure/conf/nginx-conf-local/default
@@ -3,18 +3,6 @@
 error_log /var/log/nginx/error.log notice;
 # rewrite_log on;
 
-# never cache locally
-# Set default $hdr_cache_control if Cache-Control does not exist
-# https://www.axllent.org/docs/add-nginx-headers-if-not-set/
-map $upstream_http_cache_control $hdr_cache_control {
-    '' "no-store";
-}
-
-map $request_uri $csp_header {
-    default "default-src 'self'; font-src fonts.gstatic.com 'self'; style-src-elem fonts.googleapis.com 'self' 'nonce-$cspNonce' 'unsafe-inline'; connect-src 'self' https://canadacentral-1.in.applicationinsights.azure.com https://js.monitor.azure.com ws://$host wss://$host; script-src-elem 'self' 'nonce-$cspNonce'; img-src 'self' 'nonce-$cspNonce' data:; frame-ancestors 'none'; report-uri /api/csp-report/; report-to csp;";
-    ~^/robots.txt "default-src 'self'; style-src-attr 'unsafe-inline';";
-}
-
 server {
     #proxy_cache cache;
     #proxy_cache_valid 200 1s;
@@ -31,18 +19,6 @@ server {
     # redirect server error pages
     error_page   404  /404;
 
-    # The following are only added if they do not already exist.  Avoid overwriting headers from PHP.
-    add_header Cache-Control $hdr_cache_control;
-
-    # CSP Headers
-    set $cspNonce $request_id;
-    sub_filter_types *;
-    sub_filter '**CSP_NONCE**' $cspNonce;
-    sub_filter_once off;
-
-    add_header X-Frame-Options DENY;
-    add_header Reporting-Endpoints csp="/api/csp-report";
-    add_header Content-Security-Policy $csp_header always;
 
     # Permanent redirects to avoid dead links
     location = /en/communities/digital-talent {
@@ -277,7 +253,17 @@ server {
 
     # for all other uris, serve SPA index with no caching
     location / {
-        # add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild
+        # CSP Headers
+        set $cspNonce $request_id;
+        sub_filter_types *;
+        sub_filter '**CSP_NONCE**' $cspNonce;
+        sub_filter_once off;
+
+        add_header X-Frame-Options DENY;
+        add_header Reporting-Endpoints csp="/api/csp-report";
+        add_header Content-Security-Policy "default-src 'self'; font-src fonts.gstatic.com 'self'; style-src-elem fonts.googleapis.com 'self' 'nonce-$cspNonce' 'unsafe-inline'; connect-src 'self' https://canadacentral-1.in.applicationinsights.azure.com https://js.monitor.azure.com ws://$host wss://$host; script-src-elem 'self' 'nonce-$cspNonce'; img-src 'self' 'nonce-$cspNonce' data:; frame-ancestors 'none'; report-uri /api/csp-report/; report-to csp;" always;
+
+        add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild
         try_files /apps/web/dist/client/index.html =404;
     }
 }


### PR DESCRIPTION
🤖 Resolves #16690 

## 👋 Introduction

Adjusts the Ngnix conf to send CSP headers in production.

## 🕵️ Details

Nginx conf is a little funny.  If you set headers at the server level (like the CSP headers) and also set headers at the location level (like the cache headers) then the server-level headers are wiped and totally replaced with the location-level headers.  

I've solved this by pulling the CSP and cache headers out of the server level and moving them to the location blocks.  The CSP header is just the single location for index.html. As a side effect, the CSP headers are no longer sent for assets, API requests, and robots.txt.  I think that's fine.

We had some fancy logic to try and preserve upstream cache headers from PHP.  I removed that as unnecessary now that there are no server-level cache headers to overwrite them.

I made a few cosmetic changes to try and reduce the diff between the conf files a bit more, too.

## 🧪 Testing

> [!TIP]
> As of 2026-05-05, this PR is deployed on the dev vertical. 

1. Test locally and in Azure.
2. CSP headers are sent only on index.html responses.
3. Different cache headers are sent on index.html, *.js, *.webp, and graphql respnses.

