### PR TITLE
[Refactor] Team-aware role checks for departments

### DIFF
--- a/apps/web/src/pages/Departments/AdvancedToolsDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/AdvancedToolsDepartmentPage.tsx
@@ -12,13 +12,14 @@ import { ROLE_NAME } from "@gc-digital-talent/auth";
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
 import useRequiredParams from "~/hooks/useRequiredParams";
-import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import Hero from "~/components/Hero";
 import adminMessages from "~/messages/adminMessages";
+import { requireUser } from "~/routing/auth";
 
 import { ArchiveDepartment } from "./components/ArchiveDepartment";
 import { RestoreDepartment } from "./components/RestoreDepartment";
 import type { ContextType } from "./ManageAccessPage/components/types";
+import type { Route } from "./+types/AdvancedToolsDepartmentPage";
 
 export const DepartmentAdvancedTools_Fragment = graphql(/* GraphQL */ `
   fragment DepartmentAdvancedTools on Department {
@@ -93,7 +94,14 @@ const AdvancedToolsDepartment_Query = graphql(/* GraphQL */ `
   }
 `);
 
-const AdvancedToolsDepartmentPage = () => {
+export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
+  async ({ context, request }, next) => {
+    requireUser(context, request, [{ name: ROLE_NAME.PlatformAdmin }]);
+    return await next();
+  },
+];
+
+const Component = () => {
   const intl = useIntl();
   const routes = useRoutes();
   const { departmentId } = useRequiredParams<RouteParams>("departmentId");
@@ -154,12 +162,6 @@ const AdvancedToolsDepartmentPage = () => {
     </>
   );
 };
-
-export const Component = () => (
-  <RequireAuth roles={[ROLE_NAME.PlatformAdmin]}>
-    <AdvancedToolsDepartmentPage />
-  </RequireAuth>
-);
 
 Component.displayName = "AdminAdvancedToolsDepartmentPage";
 

--- a/apps/web/src/pages/Departments/CreateDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/CreateDepartmentPage.tsx
@@ -26,13 +26,14 @@ import {
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
-import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import pageTitles from "~/messages/pageTitles";
 import Hero from "~/components/Hero";
+import { requireUser } from "~/routing/auth";
 
 import FormFields from "./FormFields";
 import type { DepartmentType } from "./utils";
 import { departmentTypeToInput } from "./utils";
+import type { Route } from "./+types/CreateDepartmentPage";
 
 interface FormValues {
   name?: LocalizedStringInput;
@@ -163,7 +164,14 @@ const CreateDepartment_Mutation = graphql(/* GraphQL */ `
   }
 `);
 
-const CreateDepartmentPage = () => {
+export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
+  async ({ context, request }, next) => {
+    requireUser(context, request, [{ name: ROLE_NAME.PlatformAdmin }]);
+    return await next();
+  },
+];
+
+const Component = () => {
   const intl = useIntl();
   const routes = useRoutes();
   const [, executeMutation] = useMutation(CreateDepartment_Mutation);
@@ -211,12 +219,6 @@ const CreateDepartmentPage = () => {
     </>
   );
 };
-
-export const Component = () => (
-  <RequireAuth roles={[ROLE_NAME.PlatformAdmin]}>
-    <CreateDepartmentPage />
-  </RequireAuth>
-);
 
 Component.displayName = "AdminCreateDepartmentPage";
 

--- a/apps/web/src/pages/Departments/IndexDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/IndexDepartmentPage.tsx
@@ -5,14 +5,26 @@ import { ROLE_NAME } from "@gc-digital-talent/auth";
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
-import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import pageTitles from "~/messages/pageTitles";
 import Hero from "~/components/Hero";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
+import { requireUser } from "~/routing/auth";
 
+import type { Route } from "./+types/IndexDepartmentPage";
 import DepartmentTableApi from "./components/DepartmentTable";
 
-export const DepartmentPage = () => {
+export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
+  async ({ context, request }, next) => {
+    requireUser(context, request, [
+      { name: ROLE_NAME.PlatformAdmin },
+      { name: ROLE_NAME.DepartmentAdmin },
+      { name: ROLE_NAME.DepartmentHRAdvisor },
+    ]);
+    return await next();
+  },
+];
+
+const Component = () => {
   const intl = useIntl();
   const routes = useRoutes();
   const formattedPageTitle = intl.formatMessage(pageTitles.departments);
@@ -36,18 +48,6 @@ export const DepartmentPage = () => {
     </>
   );
 };
-
-export const Component = () => (
-  <RequireAuth
-    roles={[
-      ROLE_NAME.PlatformAdmin,
-      ROLE_NAME.DepartmentAdmin,
-      ROLE_NAME.DepartmentHRAdvisor,
-    ]}
-  >
-    <DepartmentPage />
-  </RequireAuth>
-);
 
 Component.displayName = "AdminIndexDepartmentPage";
 

--- a/apps/web/src/pages/Departments/ManageAccessPage/ManageAccessPage.tsx
+++ b/apps/web/src/pages/Departments/ManageAccessPage/ManageAccessPage.tsx
@@ -6,7 +6,11 @@ import { useQuery } from "urql";
 import { useOutletContext } from "react-router";
 
 import { Container, Pending, ThrowNotFound } from "@gc-digital-talent/ui";
-import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
+import {
+  notEmpty,
+  unpackMaybes,
+  NotFoundError,
+} from "@gc-digital-talent/helpers";
 import { ROLE_NAME, useAuthorization } from "@gc-digital-talent/auth";
 import { commonMessages } from "@gc-digital-talent/i18n";
 import type {
@@ -29,6 +33,8 @@ import {
   checkRoleDepartments,
   groupRoleAssignmentsByUserDepartments,
 } from "~/utils/departmentUtils";
+import { requireUser } from "~/routing/auth";
+import { graphqlClientContext, intlContext } from "~/routing/context";
 
 import AddDepartmentMembershipDialog from "./components/AddDepartmentMembership";
 import { actionCell, emailLinkCell, roleAccessor, roleCell } from "./helpers";
@@ -37,6 +43,7 @@ import type {
   DepartmentManageAccessPageFragment,
 } from "./components/types";
 import { DepartmentManageAccessPage_DepartmentFragment } from "./components/operations";
+import type { Route } from "./+types/ManageAccessPage";
 
 const pageTitle = defineMessage({
   defaultMessage: "Department members",
@@ -218,6 +225,50 @@ const DepartmentManageAccessPage = ({
     </>
   );
 };
+
+const DepartmentTeams_Query = graphql(/** GraphQL */ `
+  query DepartmentTeams($id: UUID!) {
+    department(id: $id) {
+      teamIdForRoleAssignment
+    }
+  }
+`);
+
+export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
+  async ({ context, request, params }, next) => {
+    const intl = context.get(intlContext);
+    const client = context.get(graphqlClientContext);
+    const res = await client
+      .query(DepartmentTeams_Query, { id: params.departmentId })
+      .toPromise();
+
+    if (!res.data?.department) {
+      throw new NotFoundError(
+        intl.formatMessage(
+          {
+            defaultMessage: "Department {departmentId} not found.",
+            id: "8Otaw9",
+            description: "Message displayed for department not found.",
+          },
+          { departmentId: params.departmentId },
+        ),
+      );
+    }
+
+    requireUser(context, request, [
+      { name: ROLE_NAME.PlatformAdmin },
+      {
+        name: ROLE_NAME.DepartmentAdmin,
+        teamId: res.data.department.teamIdForRoleAssignment,
+      },
+      {
+        name: ROLE_NAME.DepartmentHRAdvisor,
+        teamId: res.data.department.teamIdForRoleAssignment,
+      },
+    ]);
+    return await next();
+  },
+];
 
 // Since the SEO and Hero need API-loaded data, we wrap the entire page in a Pending
 const DepartmentManageAccessPageApiWrapper = () => {

--- a/apps/web/src/pages/Departments/ManageAccessPage/ManageAccessPage.tsx
+++ b/apps/web/src/pages/Departments/ManageAccessPage/ManageAccessPage.tsx
@@ -44,6 +44,8 @@ import type {
 } from "./components/types";
 import { DepartmentManageAccessPage_DepartmentFragment } from "./components/operations";
 import type { Route } from "./+types/ManageAccessPage";
+import { DepartmentTeams_Query } from "../utils";
+import messages from "../messages";
 
 const pageTitle = defineMessage({
   defaultMessage: "Department members",
@@ -226,14 +228,6 @@ const DepartmentManageAccessPage = ({
   );
 };
 
-const DepartmentTeams_Query = graphql(/** GraphQL */ `
-  query DepartmentTeams($id: UUID!) {
-    department(id: $id) {
-      teamIdForRoleAssignment
-    }
-  }
-`);
-
 export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
   async ({ context, request, params }, next) => {
     const intl = context.get(intlContext);
@@ -244,14 +238,9 @@ export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
 
     if (!res.data?.department) {
       throw new NotFoundError(
-        intl.formatMessage(
-          {
-            defaultMessage: "Department {departmentId} not found.",
-            id: "8Otaw9",
-            description: "Message displayed for department not found.",
-          },
-          { departmentId: params.departmentId },
-        ),
+        intl.formatMessage(messages.departmentNotFound, {
+          departmentId: params.departmentId,
+        }),
       );
     }
 

--- a/apps/web/src/pages/Departments/ManageAccessPage/ManageAccessPage.tsx
+++ b/apps/web/src/pages/Departments/ManageAccessPage/ManageAccessPage.tsx
@@ -23,7 +23,6 @@ import SEO from "~/components/SEO/SEO";
 import { getFullNameLabel } from "~/utils/nameUtils";
 import useRequiredParams from "~/hooks/useRequiredParams";
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
-import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import tableMessages from "~/components/Table/tableMessages";
 import Hero from "~/components/Hero";
 import useRoutes from "~/hooks/useRoutes";
@@ -260,7 +259,7 @@ export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
 ];
 
 // Since the SEO and Hero need API-loaded data, we wrap the entire page in a Pending
-const DepartmentManageAccessPageApiWrapper = () => {
+const Component = () => {
   const { departmentId } = useRequiredParams<RouteParams>("departmentId");
   const [{ data, fetching, error }] = useQuery({
     query: DepartmentMembersTeam_Query,
@@ -276,18 +275,6 @@ const DepartmentManageAccessPageApiWrapper = () => {
     </Pending>
   );
 };
-
-export const Component = () => (
-  <RequireAuth
-    roles={[
-      ROLE_NAME.PlatformAdmin,
-      ROLE_NAME.DepartmentAdmin,
-      ROLE_NAME.DepartmentHRAdvisor,
-    ]}
-  >
-    <DepartmentManageAccessPageApiWrapper />
-  </RequireAuth>
-);
 
 Component.displayName = "ManageAccessDepartmentPage";
 

--- a/apps/web/src/pages/Departments/ManageAccessPage/ManageAccessPage.tsx
+++ b/apps/web/src/pages/Departments/ManageAccessPage/ManageAccessPage.tsx
@@ -6,12 +6,8 @@ import { useQuery } from "urql";
 import { useOutletContext } from "react-router";
 
 import { Container, Pending, ThrowNotFound } from "@gc-digital-talent/ui";
-import {
-  notEmpty,
-  unpackMaybes,
-  NotFoundError,
-} from "@gc-digital-talent/helpers";
-import { ROLE_NAME, useAuthorization } from "@gc-digital-talent/auth";
+import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
+import { ROLE_NAME as ROLE, useAuthorization } from "@gc-digital-talent/auth";
 import { commonMessages } from "@gc-digital-talent/i18n";
 import type {
   Scalars,
@@ -33,7 +29,6 @@ import {
   groupRoleAssignmentsByUserDepartments,
 } from "~/utils/departmentUtils";
 import { requireUser } from "~/routing/auth";
-import { graphqlClientContext, intlContext } from "~/routing/context";
 
 import AddDepartmentMembershipDialog from "./components/AddDepartmentMembership";
 import { actionCell, emailLinkCell, roleAccessor, roleCell } from "./helpers";
@@ -43,8 +38,7 @@ import type {
 } from "./components/types";
 import { DepartmentManageAccessPage_DepartmentFragment } from "./components/operations";
 import type { Route } from "./+types/ManageAccessPage";
-import { DepartmentTeams_Query } from "../utils";
-import messages from "../messages";
+import { getTeamIdInMiddleware } from "../utils";
 
 const pageTitle = defineMessage({
   defaultMessage: "Department members",
@@ -71,7 +65,7 @@ const DepartmentMembersTable = ({
   const { userAuthInfo } = useAuthorization();
   const roleAssignments = unpackMaybes(userAuthInfo?.roleAssignments);
   const hasPlatformAdmin = checkRoleDepartments(
-    [ROLE_NAME.PlatformAdmin],
+    [ROLE.PlatformAdmin],
     roleAssignments,
   );
 
@@ -229,31 +223,17 @@ const DepartmentManageAccessPage = ({
 
 export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
   async ({ context, request, params }, next) => {
-    const intl = context.get(intlContext);
-    const client = context.get(graphqlClientContext);
-    const res = await client
-      .query(DepartmentTeams_Query, { id: params.departmentId })
-      .toPromise();
-
-    if (!res.data?.department) {
-      throw new NotFoundError(
-        intl.formatMessage(messages.departmentNotFound, {
-          departmentId: params.departmentId,
-        }),
-      );
-    }
-
-    requireUser(context, request, [
-      { name: ROLE_NAME.PlatformAdmin },
-      {
-        name: ROLE_NAME.DepartmentAdmin,
-        teamId: res.data.department.teamIdForRoleAssignment,
-      },
-      {
-        name: ROLE_NAME.DepartmentHRAdvisor,
-        teamId: res.data.department.teamIdForRoleAssignment,
-      },
-    ]);
+    const teamId = await getTeamIdInMiddleware(context, params.departmentId);
+    requireUser(
+      context,
+      request,
+      [
+        { name: ROLE.PlatformAdmin },
+        { name: ROLE.DepartmentAdmin, teamId: teamId },
+        { name: ROLE.DepartmentHRAdvisor, teamId: teamId },
+      ],
+      true,
+    );
     return await next();
   },
 ];

--- a/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/UpdateDepartmentPage.tsx
@@ -35,14 +35,15 @@ import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
 import useRequiredParams from "~/hooks/useRequiredParams";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
-import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import pageTitles from "~/messages/pageTitles";
 import Hero from "~/components/Hero";
+import { requireUser } from "~/routing/auth";
 
 import type { DepartmentFormOptions_Fragment } from "./FormFields";
 import FormFields from "./FormFields";
 import type { DepartmentType } from "./utils";
 import { departmentTypeToInput } from "./utils";
+import type { Route } from "./+types/UpdateDepartmentPage";
 
 interface FormValues {
   name?: LocalizedStringInput;
@@ -220,7 +221,14 @@ const UpdateDepartment_Mutation = graphql(/* GraphQL */ `
   }
 `);
 
-const UpdateDepartmentPage = () => {
+export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
+  async ({ context, request }, next) => {
+    requireUser(context, request, [{ name: ROLE_NAME.PlatformAdmin }]);
+    return await next();
+  },
+];
+
+const Component = () => {
   const intl = useIntl();
   const routes = useRoutes();
   const { departmentId } = useRequiredParams<RouteParams>("departmentId");
@@ -312,12 +320,6 @@ const UpdateDepartmentPage = () => {
     </>
   );
 };
-
-export const Component = () => (
-  <RequireAuth roles={[ROLE_NAME.PlatformAdmin]}>
-    <UpdateDepartmentPage />
-  </RequireAuth>
-);
 
 Component.displayName = "AdminUpdateDepartmentPage";
 

--- a/apps/web/src/pages/Departments/ViewDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/ViewDepartmentPage.tsx
@@ -17,17 +17,22 @@ import {
 import type { FragmentType, Scalars } from "@gc-digital-talent/graphql";
 import { getFragment, graphql } from "@gc-digital-talent/graphql";
 import { ROLE_NAME } from "@gc-digital-talent/auth";
+import { NotFoundError } from "@gc-digital-talent/helpers";
 
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
 import useRequiredParams from "~/hooks/useRequiredParams";
-import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import Hero from "~/components/Hero";
 import FieldDisplay from "~/components/FieldDisplay/FieldDisplay";
 import BoolCheckIcon from "~/components/BoolCheckIcon/BoolCheckIcon";
+import { graphqlClientContext, intlContext } from "~/routing/context";
+import { requireUser } from "~/routing/auth";
 
 import labels from "./labels";
 import type { ContextType } from "./ManageAccessPage/components/types";
+import type { Route } from "./+types/ViewDepartmentPage";
+import { DepartmentTeams_Query } from "./utils";
+import messages from "./messages";
 
 export const DepartmentView_Fragment = graphql(/* GraphQL */ `
   fragment DepartmentView on Department {
@@ -157,7 +162,43 @@ const Department_Query = graphql(/* GraphQL */ `
   }
 `);
 
-const ViewDepartmentPage = () => {
+export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
+  async ({ context, request, params }, next) => {
+    const intl = context.get(intlContext);
+    const client = context.get(graphqlClientContext);
+    const res = await client
+      .query(DepartmentTeams_Query, { id: params.departmentId })
+      .toPromise();
+
+    if (!res.data?.department) {
+      throw new NotFoundError(
+        intl.formatMessage(messages.departmentNotFound, {
+          departmentId: params.departmentId,
+        }),
+      );
+    }
+
+    requireUser(
+      context,
+      request,
+      [
+        { name: ROLE_NAME.PlatformAdmin },
+        {
+          name: ROLE_NAME.DepartmentAdmin,
+          teamId: res.data.department.teamIdForRoleAssignment,
+        },
+        {
+          name: ROLE_NAME.DepartmentHRAdvisor,
+          teamId: res.data.department.teamIdForRoleAssignment,
+        },
+      ],
+      true,
+    );
+    return await next();
+  },
+];
+
+const Component = () => {
   const intl = useIntl();
   const { departmentId } = useRequiredParams<RouteParams>("departmentId");
   const [{ data: departmentData, fetching, error }] = useQuery({
@@ -192,14 +233,9 @@ const ViewDepartmentPage = () => {
               headingMessage={intl.formatMessage(commonMessages.notFound)}
             >
               <p>
-                {intl.formatMessage(
-                  {
-                    defaultMessage: "Department {departmentId} not found.",
-                    id: "8Otaw9",
-                    description: "Message displayed for department not found.",
-                  },
-                  { departmentId },
-                )}
+                {intl.formatMessage(messages.departmentNotFound, {
+                  departmentId,
+                })}
               </p>
             </NotFound>
           )}
@@ -208,18 +244,6 @@ const ViewDepartmentPage = () => {
     </>
   );
 };
-
-export const Component = () => (
-  <RequireAuth
-    roles={[
-      ROLE_NAME.PlatformAdmin,
-      ROLE_NAME.DepartmentAdmin,
-      ROLE_NAME.DepartmentHRAdvisor,
-    ]}
-  >
-    <ViewDepartmentPage />
-  </RequireAuth>
-);
 
 Component.displayName = "AdminUpdateDepartmentPage";
 

--- a/apps/web/src/pages/Departments/ViewDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/ViewDepartmentPage.tsx
@@ -16,8 +16,7 @@ import {
 } from "@gc-digital-talent/ui";
 import type { FragmentType, Scalars } from "@gc-digital-talent/graphql";
 import { getFragment, graphql } from "@gc-digital-talent/graphql";
-import { ROLE_NAME } from "@gc-digital-talent/auth";
-import { NotFoundError } from "@gc-digital-talent/helpers";
+import { ROLE_NAME as ROLE } from "@gc-digital-talent/auth";
 
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
@@ -25,13 +24,12 @@ import useRequiredParams from "~/hooks/useRequiredParams";
 import Hero from "~/components/Hero";
 import FieldDisplay from "~/components/FieldDisplay/FieldDisplay";
 import BoolCheckIcon from "~/components/BoolCheckIcon/BoolCheckIcon";
-import { graphqlClientContext, intlContext } from "~/routing/context";
 import { requireUser } from "~/routing/auth";
 
 import labels from "./labels";
 import type { ContextType } from "./ManageAccessPage/components/types";
 import type { Route } from "./+types/ViewDepartmentPage";
-import { DepartmentTeams_Query } from "./utils";
+import { getTeamIdInMiddleware } from "./utils";
 import messages from "./messages";
 
 export const DepartmentView_Fragment = graphql(/* GraphQL */ `
@@ -164,33 +162,14 @@ const Department_Query = graphql(/* GraphQL */ `
 
 export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
   async ({ context, request, params }, next) => {
-    const intl = context.get(intlContext);
-    const client = context.get(graphqlClientContext);
-    const res = await client
-      .query(DepartmentTeams_Query, { id: params.departmentId })
-      .toPromise();
-
-    if (!res.data?.department) {
-      throw new NotFoundError(
-        intl.formatMessage(messages.departmentNotFound, {
-          departmentId: params.departmentId,
-        }),
-      );
-    }
-
+    const teamId = await getTeamIdInMiddleware(context, params.departmentId);
     requireUser(
       context,
       request,
       [
-        { name: ROLE_NAME.PlatformAdmin },
-        {
-          name: ROLE_NAME.DepartmentAdmin,
-          teamId: res.data.department.teamIdForRoleAssignment,
-        },
-        {
-          name: ROLE_NAME.DepartmentHRAdvisor,
-          teamId: res.data.department.teamIdForRoleAssignment,
-        },
+        { name: ROLE.PlatformAdmin },
+        { name: ROLE.DepartmentAdmin, teamId: teamId },
+        { name: ROLE.DepartmentHRAdvisor, teamId: teamId },
       ],
       true,
     );

--- a/apps/web/src/pages/Departments/messages.ts
+++ b/apps/web/src/pages/Departments/messages.ts
@@ -1,0 +1,9 @@
+import { defineMessages } from "react-intl";
+
+export default defineMessages({
+  departmentNotFound: {
+    defaultMessage: "Department {departmentId} not found.",
+    id: "8Otaw9",
+    description: "Message displayed for department not found.",
+  },
+});

--- a/apps/web/src/pages/Departments/utils.tsx
+++ b/apps/web/src/pages/Departments/utils.tsx
@@ -149,3 +149,11 @@ export function roleAssignmentsToRoleDepartmentArray(
 
   return collection;
 }
+
+export const DepartmentTeams_Query = graphql(/** GraphQL */ `
+  query DepartmentTeams($id: UUID!) {
+    department(id: $id) {
+      teamIdForRoleAssignment
+    }
+  }
+`);

--- a/apps/web/src/pages/Departments/utils.tsx
+++ b/apps/web/src/pages/Departments/utils.tsx
@@ -1,4 +1,5 @@
 import type { IntlShape } from "react-intl";
+import type { RouterContextProvider } from "react-router";
 
 import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 import type { FragmentType, LocalizedString } from "@gc-digital-talent/graphql";
@@ -8,6 +9,11 @@ import {
   graphql,
 } from "@gc-digital-talent/graphql";
 import { Chip } from "@gc-digital-talent/ui";
+import { NotFoundError } from "@gc-digital-talent/helpers";
+
+import { graphqlClientContext, intlContext } from "~/routing/context";
+
+import messages from "./messages";
 
 export type DepartmentType =
   | "isCorePublicAdministration"
@@ -150,10 +156,32 @@ export function roleAssignmentsToRoleDepartmentArray(
   return collection;
 }
 
-export const DepartmentTeams_Query = graphql(/** GraphQL */ `
+const DepartmentTeams_Query = graphql(/** GraphQL */ `
   query DepartmentTeams($id: UUID!) {
     department(id: $id) {
       teamIdForRoleAssignment
     }
   }
 `);
+
+export async function getTeamIdInMiddleware(
+  context: Readonly<RouterContextProvider>,
+  departmentId: string,
+) {
+  const intl = context.get(intlContext);
+  const client = context.get(graphqlClientContext);
+
+  const res = await client
+    .query(DepartmentTeams_Query, { id: departmentId })
+    .toPromise();
+
+  if (!res.data?.department) {
+    throw new NotFoundError(
+      intl.formatMessage(messages.departmentNotFound, {
+        departmentId: departmentId,
+      }),
+    );
+  }
+
+  return res.data.department.teamIdForRoleAssignment;
+}


### PR DESCRIPTION
🤖 Resolves #15942 

## 👋 Introduction

Switches the RequireAuth checks to client middleware with team-aware checks.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

Set up four users:
1. admin (admin@test.com)
2. TBS dept admin (department-admin@test.com)
3. CRA dept admin (grant the department_adminrole to another user, like applicant-employee@test.com)
4. applicant (applicant@test.com)

> [!TIP]
> The Firefox containers extension is a convenient way to have multiple tabs logged in as different users. 

Test the pages:
1. Department index page (/admin/settings/departments)
    - [ ] platform admin and both departments admins can access
    - [ ] applicant cannot access
5. Create department page (/admin/settings/departments/create)
    - [ ] platform admin can access
    - [ ] department admins and applicant cannot access
6. View department page for TBS (/admin/settings/departments/:dept_id_for_tbs)
    - [ ] platform admin and TBS admin can access
    - [ ] CRA admin and applicant cannot access
7. Edit department page for TBS (/admin/settings/departments/:dept_id_for_tbs/edit)
    - [ ] platform admin can access
    - [ ] department admins and applicant cannot access
8. Manage access page for TBS (/admin/settings/departments/:dept_id_for_tbs/manage-access)
    - [ ] platform admin and TBS admin can access
    - [ ] CRA admin and applicant cannot access
9. Advanced tools page for TBS (/admin/settings/departments/:dept_id_for_tbs/advanced-tools)
    - [ ] platform admin can access
    - [ ] department admins and applicant cannot access


## 📸 Screenshot

<img width="778" height="629" alt="image" src="https://github.com/user-attachments/assets/0d555d58-bba3-47da-94d4-055bd811d7c5" />

## 🚚 Deployment

<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the PR if deployment steps are needed

 -->
