### PR TITLE
[Copy] Fixes French translations on DND page

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1612,7 +1612,7 @@
     "description": "Aria text for icon indicating a skill to assessment step connection."
   },
   "4MAklr": {
-    "defaultMessage": "intégration de systèmes",
+    "defaultMessage": "informatique en nuage",
     "description": "The cloud computing skill"
   },
   "4Ncmb0": {
@@ -2652,7 +2652,7 @@
     "description": "Title for what to expect section"
   },
   "8vwKjc": {
-    "defaultMessage": "informatique en nuage",
+    "defaultMessage": "développement de logiciels",
     "description": "The software development skill"
   },
   "8wU0cq": {
@@ -10375,7 +10375,7 @@
     "description": "The eligible retirement year described as known."
   },
   "f2Jqya": {
-    "defaultMessage": "développement de logiciels",
+    "defaultMessage": "sécurité des réseaux",
     "description": "The network security skill"
   },
   "f3KZGn": {
@@ -14935,7 +14935,7 @@
     "description": "Message displayed to user if assessment result fails to get created/updated."
   },
   "xdV1ZI": {
-    "defaultMessage": "sécurité des réseaux",
+    "defaultMessage": "intégration de systèmes",
     "description": "The systems integration skill"
   },
   "xdojyj": {


### PR DESCRIPTION
🤖 Resolves #16708.

## 👋 Introduction

This PR fixes the translations of four of the skills listed on the DND page that were mixed up.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/dnd
3. In another windows, navigate to http://localhost:8000/fr/dnd
4. Compare list of skills and ensure they are in the same order in English and French

## 📸 Screenshot

<img width="996" height="562" alt="Screenshot 2026-05-06 at 12 52 11" src="https://github.com/user-attachments/assets/9ec29ff6-1725-4bbe-b72d-c45f8efc7ffe" />