### PR TITLE
[Fix] Make post deployment idempotent

### DIFF
--- a/infrastructure/bin/post_deployment.sh
+++ b/infrastructure/bin/post_deployment.sh
@@ -98,6 +98,7 @@ add_section_block "$TRIPLE_BACK_TICK $CLEANED_STDOUT $TRIPLE_BACK_TICK"
 if cat > /etc/cron.d/gc-digital-talent << 'EOF'
   *  *  *  *  * www-data . /etc/profile ; php /home/site/wwwroot/api/artisan schedule:run
 EOF
+then
     add_section_block ":white_check_mark: Laravel Scheduler cron setup *successful*."
 else
     add_section_block ":X: Laravel Scheduler cron setup *failed*. $MENTION"

--- a/infrastructure/bin/post_deployment.sh
+++ b/infrastructure/bin/post_deployment.sh
@@ -94,7 +94,10 @@ add_section_block "$TRIPLE_BACK_TICK $CLEANED_STDOUT $TRIPLE_BACK_TICK"
 
 # Load Laravel Scheduler cron
 # For extra debugging you can add `>> /tmp/run_laravel_scheduler.log 2>&1` to the end of the cron'd command
-if echo "  *  *  *  *  * www-data . /etc/profile ; php /home/site/wwwroot/api/artisan schedule:run" >> /etc/crontab ; then
+# Write to a drop-in file in /etc/cron.d/ (overwrite) so re-runs are idempotent and changes are always applied
+if cat > /etc/cron.d/gc-digital-talent << 'EOF'
+  *  *  *  *  * www-data . /etc/profile ; php /home/site/wwwroot/api/artisan schedule:run
+EOF
     add_section_block ":white_check_mark: Laravel Scheduler cron setup *successful*."
 else
     add_section_block ":X: Laravel Scheduler cron setup *failed*. $MENTION"

--- a/infrastructure/bin/post_deployment.sh
+++ b/infrastructure/bin/post_deployment.sh
@@ -35,8 +35,8 @@ else
     add_section_block ":X: Remove bad source *failed*.. $MENTION"
 fi
 
-# Configure PHP CLI
-if echo 'memory_limit=256M' >> /usr/local/etc/php/conf.d/php.ini ; then
+# Configure PHP CLI — write to a drop-in file (not append) so re-runs are idempotent
+if echo 'memory_limit=256M' > /usr/local/etc/php/conf.d/memory-limit.ini ; then
     add_section_block ":white_check_mark: Configure PHP CLI *successful*."
 else
     add_section_block ":X: Configure PHP CLI *failed*. $MENTION"

--- a/infrastructure/bin/setup_supervisor.sh
+++ b/infrastructure/bin/setup_supervisor.sh
@@ -5,4 +5,13 @@ cp /home/site/wwwroot/infrastructure/conf/supervisord.conf /etc/supervisor/
 cp /home/site/wwwroot/infrastructure/conf/laravel-worker.conf /etc/supervisor/conf.d/
 cp /home/site/wwwroot/infrastructure/conf/cron.conf /etc/supervisor/conf.d/
 cp /home/site/wwwroot/infrastructure/conf/reverb.conf /etc/supervisor/conf.d/
-supervisord -c /etc/supervisor/supervisord.conf
+
+if supervisorctl status > /dev/null 2>&1 ; then
+    # Already running — reload config so new conf.d files are picked up
+    supervisorctl reread && supervisorctl update
+else
+    supervisord -c /etc/supervisor/supervisord.conf
+fi
+
+# Verify supervisord is actually running regardless of which path was taken
+supervisorctl status > /dev/null 2>&1


### PR DESCRIPTION
🤖 Resolves #16646 

## 👋 Introduction

Updates the `post_deployment.sh` script idempotent in case we ever need to re-run it on demand.

## 🕵️ Details

Previously, we were appending onto the end of both the `crontab` and `php.ini`. This was fine for a single run, but when we do this a second time, it was duplicating things since it just kept appending items on the end.

This updates both those lines to use the drop-in directories with custom files that are loaded. We then overwrite the files entirely on runs since it should be safe to do so (only our contents go in them).

### Question/Future

I wonder if instead of writing these files, we just keep them in the `./infrastructure` folder and copy them into the correct location instead? :thinking: Anyway, this should work for now and be a lighter touch.

## 🧪 Testing

```sh
php -i | grep memory_limit
crontab -l -u www-data
```

1. Deploy to dev
2. SSH into dev machine
3. Confirm the settings exist
4. Re-run `./post_deployment.sh`
5. Confirm no duplicates and settings are the exact same as step 3