### PR TITLE
[Copy] Removes duplicate key, updates key to disambiguate

### DIFF
--- a/api/app/Traits/Generator/GeneratesUserDoc.php
+++ b/api/app/Traits/Generator/GeneratesUserDoc.php
@@ -128,7 +128,7 @@ trait GeneratesUserDoc
             }
 
             if ($user->looking_for_bilingual) {
-                $section->addListItem($this->localize('common.bilingual'));
+                $section->addListItem($this->localize('common.bilingual_positions'));
             }
         }
 

--- a/api/lang/en/common.php
+++ b/api/lang/en/common.php
@@ -35,7 +35,7 @@ return [
     'featured_skills' => 'Featured skills:',
     'en_only' => 'English-only positions',
     'fr_only' => 'French-only positions',
-    'bilingual' => 'Bilingual positions',
+    'bilingual_positions' => 'Bilingual positions',
     'skill_showcase_text' => 'The skill showcase allows a candidate to provide a curated series of lists that highlight their specific strengths, weaknesses, and skill growth opportunities. These lists can provide you with insight into a candidate\'s broader skillset and where they might be interested in learning new skills.',
     'not_available' => 'Not available',
     'advancement' => 'Advancement',

--- a/api/lang/en/common.php
+++ b/api/lang/en/common.php
@@ -47,7 +47,6 @@ return [
     'off_platform_processes_text' => 'Recruitment processes that the nominee has qualified in on other Government of Canada platforms. Note that this information is provided by the nominee without verification. Please ensure you verify the validity of process information before using it for hiring or placement purposes.',
     'nominations' => 'Nominations',
     'skill_requirements' => 'Skill requirements',
-    'expired' => 'Expired',
     'interested_in_program' => 'Interested in this program',
     'currently_enrolled' => 'Currently enrolled',
     'completed_in' => 'Completed in ',

--- a/api/lang/fr/common.php
+++ b/api/lang/fr/common.php
@@ -48,7 +48,6 @@ return [
     'off_platform_processes_text' => 'Les processus de recrutement pour lesquels la personne candidate a été qualifiée sur d\'autres plateformes du gouvernement du Canada. Il est à noter que ces renseignements sont fournis par la personne candidate sans vérification. Veillez à vérifier la validité des renseignements relatifs au processus avant de les utiliser à des fins d\'embauche ou de placement.',
     'nominations' => 'Nominations',
     'skill_requirements' => 'Exigences en matière de compétences',
-    'expired' => 'Expiré',
     'interested_in_program' => 'Ce programme m\'intéresse',
     'currently_enrolled' => 'Programme en cours',
     'completed_in' => 'Achevé en ',

--- a/api/lang/fr/common.php
+++ b/api/lang/fr/common.php
@@ -36,7 +36,7 @@ return [
     // position types
     'en_only' => 'Postes en anglais uniquement',
     'fr_only' => 'Postes en français uniquement',
-    'bilingual' => 'Postes bilingues',
+    'bilingual_positions' => 'Postes bilingues',
     'skill_showcase_text' => 'La vitrine de compétences permet aux utilisateurs de présenter des listes qui mettent en valeur leurs points forts, leurs points faibles ainsi que leurs occasions de développement. Ces listes offrent un aperçu global de leurs compétences et indiquent les domaines dans lesquels ils souhaitent progresser ou acquérir de nouvelles compétences.',
     'not_available' => 'Non disponible',
     'advancement' => 'Avancement',


### PR DESCRIPTION
🤖 Resolves #16705.

## 👋 Introduction

This PR removes a duplicate key and value for `expired`. It also updates the `bilingual` key to be `bilingual_positions` in order to disambiguate it from another key named `bilingual` that has a different value.

## 🕵️ Details

The PR where the second `bilingual` key and value were added, #13883, only had one file and instance where its sibling keys (`common.en_only`, `common.fr_only`) were added, so there was only one reference to change from `bilingual` to  `bilingual_positions`.

## 🧪 Testing

1. Verify no duplicate keys remain in either api/lang/en/common.php or api/lang/fr/common.php
2. Search codebase for instances of `common.bilingual`
3. Verify none should be changed to `common.bilingual_positions`