### PR TITLE
[Feat] Add `SummaryList` component

### DIFF
--- a/packages/ui/src/components/Box/Box.tsx
+++ b/packages/ui/src/components/Box/Box.tsx
@@ -1,0 +1,23 @@
+import type { ElementType, ComponentPropsWithRef, ReactNode } from "react";
+
+export type BoxProps<T extends ElementType> = {
+  as?: T;
+  children?: ReactNode;
+} & Omit<ComponentPropsWithRef<T>, "as" | "children">;
+
+function Box<T extends ElementType = "div">({
+  as,
+  children,
+  ref,
+  ...props
+}: BoxProps<T>) {
+  const Component = as ?? "div";
+
+  return (
+    <Component {...props} ref={ref}>
+      {children}
+    </Component>
+  );
+}
+
+export default Box;

--- a/packages/ui/src/components/Box/Box.tsx
+++ b/packages/ui/src/components/Box/Box.tsx
@@ -1,6 +1,6 @@
 import type { ElementType, ComponentPropsWithRef, ReactNode } from "react";
 
-export type BoxProps<T extends ElementType> = {
+type BoxProps<T extends ElementType> = {
   as?: T;
   children?: ReactNode;
 } & Omit<ComponentPropsWithRef<T>, "as" | "children">;

--- a/packages/ui/src/components/SummaryList/SummaryAction.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryAction.tsx
@@ -13,16 +13,15 @@ import {
 import type { SummaryColor } from "./SummaryContext";
 
 const action = tv({
-  base: "summary-action flex shrink-0 self-stretch",
+  base: "summary-action -mt-px flex shrink-0 items-start self-stretch",
   variants: {
     justify: {
       start: "order-2",
       end: "order-4",
     },
     align: {
-      start: "-mt-px items-start",
-      middle: "items-center",
-      end: "items-end",
+      start: "",
+      middle: "sm:items-center",
     },
     expand: {
       true: "expanded *:after:absolute *:after:inset-0 *:after:content-['']",

--- a/packages/ui/src/components/SummaryList/SummaryAction.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryAction.tsx
@@ -85,9 +85,9 @@ type ActionMenuTriggerProps = Omit<Menu.Trigger.Props, "render"> &
   IconButtonProps;
 
 /**
- * Trigger button for the action dropdown menu. Renders an `IconButton` wired
- * as a Base UI `Menu.Trigger`. Accepts a `ref` for manual focus restoration
- * when a dialog opened from a menu item needs to return focus after close.
+ * Trigger button for `SummaryItem.Menu`. Renders an `IconButton` wired as a
+ * Base UI `Menu.Trigger`. Accepts a `ref` for manual focus restoration when a
+ * dialog opened from a menu item needs to return focus after close.
  */
 const ActionMenuTrigger = ({
   icon,
@@ -116,17 +116,17 @@ const ActionMenuTrigger = ({
 };
 
 /**
- * Dropdown menu namespace for summary item actions.
+ * Dropdown menu for summary item actions.
  *
- * Usage: `<SummaryList.Item.ActionMenu.Root>` → `<…Trigger>` → `<…Popup>` → `<…Item>`.
+ * `SummaryItem.Menu` is itself the root — no `.Root` needed.
+ * Usage: `<SummaryItem.Menu>` → `<SummaryItem.Menu.Trigger>` → `<SummaryItem.Menu.Popup>` → `<SummaryItem.Menu.Item>`.
  *
  * When a menu item opens a dialog, store a `ref` on `Trigger` and pass it to
  * `Dialog.Content`'s `onCloseAutoFocus` — the menu item unmounts on close so
  * Radix cannot restore focus automatically. See the `WithDialogs` story for the
  * full pattern.
  */
-const ActionMenu = {
-  Root: DropdownMenu.Root,
+const ActionMenu = Object.assign(DropdownMenu.Root, {
   Trigger: ActionMenuTrigger,
   Popup: DropdownMenu.Popup,
   Item: DropdownMenu.Item,
@@ -136,7 +136,7 @@ const ActionMenu = {
   Group: DropdownMenu.Group,
   GroupLabel: DropdownMenu.GroupLabel,
   Separator: DropdownMenu.Separator,
-};
+});
 
 export default {
   Root: Action,

--- a/packages/ui/src/components/SummaryList/SummaryAction.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryAction.tsx
@@ -39,6 +39,15 @@ interface ActionProps extends ComponentPropsWithRef<"div">, ActionVariants {
   color?: SummaryColor;
 }
 
+/**
+ * Slot for interactive controls (buttons, links, menus) attached to a summary item.
+ *
+ * - `justify="start"` places the action before the content; `"end"` places it after (default).
+ * - `align="middle"` centers the action vertically on wider viewports (default).
+ * - `expand` stretches an `::after` pseudo-element across the entire item, making the
+ *   action's first child a full-card click target (combine with `SummaryList.Item.Title`
+ *   for link-style hover treatment).
+ */
 const Action = ({
   className,
   color: colorProp,
@@ -60,11 +69,13 @@ const Action = ({
   );
 };
 
+/** Icon button pre-wired to the item's color. Accepts all `IconButton` props. */
 const ActionButton = ({ color: colorProp, ...rest }: IconButtonProps) => {
   const { color } = useSummaryAction();
   return <IconButton color={colorProp ?? color} {...rest} />;
 };
 
+/** Icon link pre-wired to the item's color. Accepts all `IconLink` props. */
 const ActionLink = ({ color: colorProp, ...rest }: IconLinkProps) => {
   const { color } = useSummaryAction();
   return <IconLink color={colorProp ?? color} {...rest} />;
@@ -73,6 +84,11 @@ const ActionLink = ({ color: colorProp, ...rest }: IconLinkProps) => {
 type ActionMenuTriggerProps = Omit<Menu.Trigger.Props, "render"> &
   IconButtonProps;
 
+/**
+ * Trigger button for the action dropdown menu. Renders an `IconButton` wired
+ * as a Base UI `Menu.Trigger`. Accepts a `ref` for manual focus restoration
+ * when a dialog opened from a menu item needs to return focus after close.
+ */
 const ActionMenuTrigger = ({
   icon,
   label,
@@ -99,6 +115,16 @@ const ActionMenuTrigger = ({
   );
 };
 
+/**
+ * Dropdown menu namespace for summary item actions.
+ *
+ * Usage: `<SummaryList.Item.ActionMenu.Root>` → `<…Trigger>` → `<…Popup>` → `<…Item>`.
+ *
+ * When a menu item opens a dialog, store a `ref` on `Trigger` and pass it to
+ * `Dialog.Content`'s `onCloseAutoFocus` — the menu item unmounts on close so
+ * Radix cannot restore focus automatically. See the `WithDialogs` story for the
+ * full pattern.
+ */
 const ActionMenu = {
   Root: DropdownMenu.Root,
   Trigger: ActionMenuTrigger,

--- a/packages/ui/src/components/SummaryList/SummaryAction.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryAction.tsx
@@ -7,10 +7,10 @@ import DropdownMenu from "../DropdownMenu/DropdownMenu";
 import IconLink, { type IconLinkProps } from "../Link/IconLink";
 import {
   useSummaryItem,
-  SummaryActionContext,
   useSummaryAction,
+  SummaryActionContext,
+  type SummaryColor,
 } from "./SummaryContext";
-import type { SummaryColor } from "./SummaryContext";
 
 const action = tv({
   base: "summary-action -mt-px flex shrink-0 items-start self-stretch",
@@ -95,7 +95,6 @@ const ActionMenuTrigger = ({
   color: colorProp,
   size,
   disabled,
-  children,
   ...triggerProps
 }: ActionMenuTriggerProps) => {
   const { color } = useSummaryAction();

--- a/packages/ui/src/components/SummaryList/SummaryAction.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryAction.tsx
@@ -95,6 +95,7 @@ const ActionMenuTrigger = ({
   color: colorProp,
   size,
   disabled,
+  children: _children,
   ...triggerProps
 }: ActionMenuTriggerProps) => {
   const { color } = useSummaryAction();

--- a/packages/ui/src/components/SummaryList/SummaryAction.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryAction.tsx
@@ -1,0 +1,121 @@
+import { type ComponentPropsWithRef } from "react";
+import { tv, type VariantProps } from "tailwind-variants";
+import { Menu } from "@base-ui/react/menu";
+
+import IconButton, { type IconButtonProps } from "../Button/IconButton";
+import DropdownMenu from "../DropdownMenu/DropdownMenu";
+import IconLink, { type IconLinkProps } from "../Link/IconLink";
+import {
+  useSummaryItem,
+  SummaryActionContext,
+  useSummaryAction,
+} from "./SummaryContext";
+import type { SummaryColor } from "./SummaryContext";
+
+const action = tv({
+  base: "summary-action flex shrink-0 self-stretch",
+  variants: {
+    justify: {
+      start: "order-2",
+      end: "order-4",
+    },
+    align: {
+      start: "-mt-px items-start",
+      middle: "items-center",
+      end: "items-end",
+    },
+    expand: {
+      true: "expanded *:after:absolute *:after:inset-0 *:after:content-['']",
+    },
+  },
+  defaultVariants: {
+    justify: "end",
+    align: "middle",
+  },
+});
+
+type ActionVariants = VariantProps<typeof action>;
+
+interface ActionProps extends ComponentPropsWithRef<"div">, ActionVariants {
+  color?: SummaryColor;
+}
+
+const Action = ({
+  className,
+  color: colorProp,
+  justify,
+  align,
+  expand,
+  ...rest
+}: ActionProps) => {
+  const { color: itemColor } = useSummaryItem();
+  const color = colorProp ?? itemColor;
+
+  return (
+    <SummaryActionContext.Provider value={{ color }}>
+      <div
+        className={action({ align, expand, justify, class: className })}
+        {...rest}
+      />
+    </SummaryActionContext.Provider>
+  );
+};
+
+const ActionButton = ({ color: colorProp, ...rest }: IconButtonProps) => {
+  const { color } = useSummaryAction();
+  return <IconButton color={colorProp ?? color} {...rest} />;
+};
+
+const ActionLink = ({ color: colorProp, ...rest }: IconLinkProps) => {
+  const { color } = useSummaryAction();
+  return <IconLink color={colorProp ?? color} {...rest} />;
+};
+
+type ActionMenuTriggerProps = Omit<Menu.Trigger.Props, "render"> &
+  IconButtonProps;
+
+const ActionMenuTrigger = ({
+  icon,
+  label,
+  color: colorProp,
+  size,
+  disabled,
+  children,
+  ...triggerProps
+}: ActionMenuTriggerProps) => {
+  const { color } = useSummaryAction();
+  return (
+    <Menu.Trigger
+      render={
+        <IconButton
+          icon={icon}
+          label={label}
+          color={colorProp ?? color}
+          size={size}
+          disabled={disabled}
+        />
+      }
+      {...triggerProps}
+    />
+  );
+};
+
+const ActionMenu = {
+  Root: DropdownMenu.Root,
+  Trigger: ActionMenuTrigger,
+  Popup: DropdownMenu.Popup,
+  Item: DropdownMenu.Item,
+  CheckboxItem: DropdownMenu.CheckboxItem,
+  RadioGroup: DropdownMenu.RadioGroup,
+  RadioItem: DropdownMenu.RadioItem,
+  Group: DropdownMenu.Group,
+  GroupLabel: DropdownMenu.GroupLabel,
+  Separator: DropdownMenu.Separator,
+};
+
+export default {
+  Root: Action,
+  Button: ActionButton,
+  Link: ActionLink,
+  Menu: ActionMenu,
+};

--- a/packages/ui/src/components/SummaryList/SummaryContext.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryContext.tsx
@@ -1,0 +1,39 @@
+import { createContext, useContext } from "react";
+
+import type { Color } from "../../types";
+
+export type SummaryColor = Exclude<Color, "black" | "white">;
+
+interface SummaryListContextValue {
+  color?: SummaryColor;
+  striped?: boolean;
+  timeline?: boolean;
+  inList?: boolean;
+}
+
+export const SummaryListContext = createContext<SummaryListContextValue>({
+  inList: false,
+  striped: false,
+  color: "primary",
+  timeline: false,
+});
+
+export const useSummaryList = () => useContext(SummaryListContext);
+
+interface SummaryItemContextValue {
+  color?: SummaryColor;
+}
+
+export const SummaryItemContext = createContext<SummaryItemContextValue>({});
+
+export const useSummaryItem = () => useContext(SummaryItemContext);
+
+interface SummaryActionContextValue {
+  color?: SummaryColor;
+}
+
+export const SummaryActionContext = createContext<SummaryActionContextValue>(
+  {},
+);
+
+export const useSummaryAction = () => useContext(SummaryActionContext);

--- a/packages/ui/src/components/SummaryList/SummaryContext.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryContext.tsx
@@ -2,12 +2,18 @@ import { createContext, useContext } from "react";
 
 import type { Color } from "../../types";
 
+/** All theme colors except black and white. */
 export type SummaryColor = Exclude<Color, "black" | "white">;
 
+/** Shared values propagated from `SummaryList.Root` to every descendant item. */
 export interface SummaryListContextValue {
+  /** Accent color applied to timeline markers, action buttons, and title hover states. */
   color?: SummaryColor;
+  /** Alternates item background for improved scannability. */
   striped?: boolean;
+  /** Visual separator between items. `"line"` draws a border; `"timeline"` renders a connected dot-and-line track. */
   divider?: "line" | "timeline";
+  /** `true` when rendered inside a `SummaryList.Root` `<ul>`; controls whether items render as `<li>` or `<div>`. */
   inList?: boolean;
 }
 
@@ -17,6 +23,7 @@ export const SummaryListContext = createContext<SummaryListContextValue>({
   color: "primary",
 });
 
+/** Returns the nearest `SummaryList.Root` context values. */
 export const useSummaryList = () => useContext(SummaryListContext);
 
 interface SummaryItemContextValue {
@@ -25,6 +32,7 @@ interface SummaryItemContextValue {
 
 export const SummaryItemContext = createContext<SummaryItemContextValue>({});
 
+/** Returns the resolved color for the current item (item prop overrides list default). */
 export const useSummaryItem = () => useContext(SummaryItemContext);
 
 interface SummaryActionContextValue {
@@ -35,4 +43,5 @@ export const SummaryActionContext = createContext<SummaryActionContextValue>(
   {},
 );
 
+/** Returns the resolved color for the current action slot (inherits from item context). */
 export const useSummaryAction = () => useContext(SummaryActionContext);

--- a/packages/ui/src/components/SummaryList/SummaryContext.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryContext.tsx
@@ -4,10 +4,10 @@ import type { Color } from "../../types";
 
 export type SummaryColor = Exclude<Color, "black" | "white">;
 
-interface SummaryListContextValue {
+export interface SummaryListContextValue {
   color?: SummaryColor;
   striped?: boolean;
-  timeline?: boolean;
+  divider?: "line" | "timeline";
   inList?: boolean;
 }
 
@@ -15,7 +15,6 @@ export const SummaryListContext = createContext<SummaryListContextValue>({
   inList: false,
   striped: false,
   color: "primary",
-  timeline: false,
 });
 
 export const useSummaryList = () => useContext(SummaryListContext);

--- a/packages/ui/src/components/SummaryList/SummaryItem.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryItem.tsx
@@ -71,11 +71,11 @@ function SummaryItem({
   );
 }
 
+type ContentProps = ComponentPropsWithRef<"div">;
+
 const content = tv({
   base: "order-3 grow",
 });
-
-type ContentProps = ComponentPropsWithRef<"div">;
 
 /** Primary content area of a summary item. Grows to fill available horizontal space. */
 const Content = ({ className, ...rest }: ContentProps) => {
@@ -119,6 +119,9 @@ const Title = ({ className, ...rest }: Omit<HeadingProps, "size">) => {
   return <Heading className={title({ color, class: className })} {...rest} />;
 };
 
+interface MetaProps
+  extends ComponentPropsWithRef<"div">, VariantProps<typeof meta> {}
+
 const meta = tv({
   base: "mt-3 flex flex-col gap-3 justify-self-start sm:flex-row",
   variants: {
@@ -127,9 +130,6 @@ const meta = tv({
     },
   },
 });
-
-interface MetaProps
-  extends ComponentPropsWithRef<"div">, VariantProps<typeof meta> {}
 
 /**
  * Secondary metadata row rendered below the item body.

--- a/packages/ui/src/components/SummaryList/SummaryItem.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryItem.tsx
@@ -14,31 +14,23 @@ import type { SummaryColor } from "./SummaryContext";
 import TimelineMarker from "./TimelineMarker";
 
 const item = tv({
-  base: "group/item relative flex gap-x-3 px-9 py-7.5",
+  base: "group/item relative z-1 flex gap-x-3 px-9 py-7.5",
   variants: {
     striped: {
       true: "odd:bg-gray-100/20 dark:odd:bg-gray-700/40",
     },
-    inList: {
-      true: "not-first:border-t not-first:border-t-gray-200 dark:not-first:border-t-gray-700",
-    },
-    timeline: {
-      true: "",
+    divider: {
+      line: "not-last:border-b not-last:border-b-gray-200 dark:not-last:border-b-gray-700",
+      timeline: "",
     },
   },
-  compoundVariants: [
-    { timeline: true, inList: true, class: "not-first:border-t-0" },
-  ],
   defaultVariants: {
     striped: false,
   },
 });
 
-// striped / inList / timeline are injected from context; not exposed as props
-type ItemVariants = Omit<
-  VariantProps<typeof item>,
-  "striped" | "inList" | "timeline"
->;
+// striped / divider are injected from context; not exposed as props
+type ItemVariants = Omit<VariantProps<typeof item>, "striped" | "divider">;
 
 interface SummaryItemProps
   extends
@@ -56,20 +48,15 @@ function SummaryItem({
   children,
   ...rest
 }: SummaryItemProps) {
-  const {
-    inList,
-    striped,
-    color: listColor = "primary",
-    timeline = false,
-  } = useSummaryList();
+  const { inList, striped, color: listColor = "primary", divider } = useSummaryList();
   const color = colorProp ?? listColor;
-  const cls = item({ striped, inList, timeline, class: className });
+  const cls = item({ striped, divider, class: className });
 
   return (
     <SummaryItemContext.Provider value={{ color }}>
       {inList ? (
         <Box<"li"> as="li" className={cls} {...rest}>
-          {timeline && <TimelineMarker />}
+          {divider === "timeline" && <TimelineMarker />}
           {children}
         </Box>
       ) : (

--- a/packages/ui/src/components/SummaryList/SummaryItem.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryItem.tsx
@@ -33,11 +33,7 @@ const item = tv({
 type ItemVariants = Omit<VariantProps<typeof item>, "striped" | "divider">;
 
 interface SummaryItemProps
-  extends
-    Omit<
-      ComponentPropsWithRef<"li"> & ComponentPropsWithRef<"div">,
-      "as" | "color"
-    >,
+  extends Omit<ComponentPropsWithRef<"li">, "color">,
     ItemVariants {
   color?: SummaryColor;
 }

--- a/packages/ui/src/components/SummaryList/SummaryItem.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryItem.tsx
@@ -1,4 +1,4 @@
-import type { ComponentPropsWithRef } from "react";
+import type { ComponentPropsWithRef, HTMLAttributes } from "react";
 import { tv, type VariantProps } from "tailwind-variants";
 
 import Action from "./SummaryAction";
@@ -32,9 +32,7 @@ const item = tv({
 // striped / divider are injected from context; not exposed as props
 type ItemVariants = Omit<VariantProps<typeof item>, "striped" | "divider">;
 
-interface SummaryItemProps
-  extends Omit<ComponentPropsWithRef<"li">, "color">,
-    ItemVariants {
+interface SummaryItemProps extends HTMLAttributes<HTMLElement>, ItemVariants {
   color?: SummaryColor;
 }
 
@@ -50,7 +48,12 @@ function SummaryItem({
   children,
   ...rest
 }: SummaryItemProps) {
-  const { inList, striped, color: listColor = "primary", divider } = useSummaryList();
+  const {
+    inList,
+    striped,
+    color: listColor = "primary",
+    divider,
+  } = useSummaryList();
   const color = colorProp ?? listColor;
   const cls = item({ striped, divider, class: className });
 
@@ -118,9 +121,6 @@ const Title = ({ className, ...rest }: Omit<HeadingProps, "size">) => {
   return <Heading className={title({ color, class: className })} {...rest} />;
 };
 
-interface MetaProps
-  extends ComponentPropsWithRef<"div">, VariantProps<typeof meta> {}
-
 const meta = tv({
   base: "mt-3 flex flex-col gap-3 justify-self-start sm:flex-row",
   variants: {
@@ -129,6 +129,9 @@ const meta = tv({
     },
   },
 });
+
+interface MetaProps
+  extends ComponentPropsWithRef<"div">, VariantProps<typeof meta> {}
 
 /**
  * Secondary metadata row rendered below the item body.

--- a/packages/ui/src/components/SummaryList/SummaryItem.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryItem.tsx
@@ -1,6 +1,5 @@
 import type { ComponentPropsWithRef } from "react";
 import { tv, type VariantProps } from "tailwind-variants";
-import type { Variant } from "@testing-library/react";
 
 import Action from "./SummaryAction";
 import Box from "../Box/Box";
@@ -21,7 +20,7 @@ const item = tv({
       true: "odd:bg-gray-100/20 dark:odd:bg-gray-700/40",
     },
     inList: {
-      true: "not-first:border-t not-first:border-t-gray-200 dark:not-first:border-t-black",
+      true: "not-first:border-t not-first:border-t-gray-200 dark:not-first:border-t-gray-700",
     },
     timeline: {
       true: "",

--- a/packages/ui/src/components/SummaryList/SummaryItem.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryItem.tsx
@@ -14,7 +14,7 @@ import type { SummaryColor } from "./SummaryContext";
 import TimelineMarker from "./TimelineMarker";
 
 const item = tv({
-  base: "group/item relative z-1 flex gap-x-3 px-9 py-7.5",
+  base: "group/item relative flex gap-x-3 px-9 py-7.5",
   variants: {
     striped: {
       true: "odd:bg-gray-100/20 dark:odd:bg-gray-700/40",

--- a/packages/ui/src/components/SummaryList/SummaryItem.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryItem.tsx
@@ -1,0 +1,135 @@
+import type { ComponentPropsWithRef } from "react";
+import { tv, type VariantProps } from "tailwind-variants";
+
+import Action from "./SummaryAction";
+import Box from "../Box/Box";
+import type { HeadingProps } from "../Heading";
+import Heading from "../Heading";
+import {
+  useSummaryItem,
+  useSummaryList,
+  SummaryItemContext,
+} from "./SummaryContext";
+import type { SummaryColor } from "./SummaryContext";
+import TimelineMarker from "./TimelineMarker";
+
+const item = tv({
+  base: "group/item relative flex gap-x-3 px-9 py-7.5",
+  variants: {
+    striped: {
+      true: "odd:bg-gray-100/20 dark:odd:bg-gray-700/40",
+    },
+    inList: {
+      true: "not-first:border-t not-first:border-t-gray-200 dark:not-first:border-t-black",
+    },
+    timeline: {
+      true: "",
+    },
+  },
+  compoundVariants: [
+    { timeline: true, inList: true, class: "not-first:border-t-0" },
+  ],
+  defaultVariants: {
+    striped: false,
+  },
+});
+
+// striped / inList / timeline are injected from context; not exposed as props
+type ItemVariants = Omit<
+  VariantProps<typeof item>,
+  "striped" | "inList" | "timeline"
+>;
+
+interface SummaryItemProps
+  extends
+    Omit<
+      ComponentPropsWithRef<"li"> & ComponentPropsWithRef<"div">,
+      "as" | "color"
+    >,
+    ItemVariants {
+  color?: SummaryColor;
+}
+
+function SummaryItem({
+  className,
+  color: colorProp,
+  children,
+  ...rest
+}: SummaryItemProps) {
+  const {
+    inList,
+    striped,
+    color: listColor = "primary",
+    timeline = false,
+  } = useSummaryList();
+  const color = colorProp ?? listColor;
+  const cls = item({ striped, inList, timeline, class: className });
+
+  return (
+    <SummaryItemContext.Provider value={{ color }}>
+      {inList ? (
+        <Box<"li"> as="li" className={cls} {...rest}>
+          {timeline && <TimelineMarker />}
+          {children}
+        </Box>
+      ) : (
+        <Box<"div"> as="div" className={cls} {...rest}>
+          {children}
+        </Box>
+      )}
+    </SummaryItemContext.Provider>
+  );
+}
+
+const content = tv({
+  base: "order-3 grow",
+});
+
+type ContentProps = ComponentPropsWithRef<"div">;
+
+const Content = ({ className, ...rest }: ContentProps) => {
+  return <div className={content({ class: className })} {...rest} />;
+};
+
+const title = tv({
+  base: "mt-0 mb-1 text-base/relaxed font-bold group-has-[.summary-action.expanded]/item:underline lg:text-base/relaxed",
+  variants: {
+    color: {
+      primary: [
+        "group-has-[.summary-action.expanded:hover]/item:text-primary-700",
+        "dark:group-has-[.summary-action.expanded:hover]/item:text-primary-100",
+      ],
+      secondary: [
+        "group-has-[.summary-action.expanded:hover]/item:text-secondary-700",
+        "dark:group-has-[.summary-action.expanded:hover]/item:text-secondary-100",
+      ],
+      success: [
+        "group-has-[.summary-action.expanded:hover]/item:text-success-700",
+        "dark:group-has-[.summary-action.expanded:hover]/item:text-success-100",
+      ],
+      warning: [
+        "group-has-[.summary-action.expanded:hover]/item:text-warning-700",
+        "dark:group-has-[.summary-action.expanded:hover]/item:text-warning-100",
+      ],
+      error: [
+        "group-has-[.summary-action.expanded:hover]/item:text-error-700",
+        "dark:group-has-[.summary-action.expanded:hover]/item:text-error-100",
+      ],
+    },
+  },
+});
+
+const Title = ({ className, ...rest }: Omit<HeadingProps, "size">) => {
+  const { color } = useSummaryItem();
+  return <Heading className={title({ color, class: className })} {...rest} />;
+};
+
+export default {
+  Root: SummaryItem,
+  Content,
+  Title,
+  Action: Action.Root,
+  ActionButton: Action.Button,
+  ActionLink: Action.Link,
+  ActionMenu: Action.Menu,
+};

--- a/packages/ui/src/components/SummaryList/SummaryItem.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryItem.tsx
@@ -39,11 +39,10 @@ interface SummaryItemProps
 }
 
 /**
- * A single row in a summary list (or a standalone card when used outside
- * `SummaryList.Root`).
+ * A single row inside a `SummaryList`, or a standalone card when used without one.
  *
- * Renders as `<li>` inside a list and `<div>` when standalone. Accepts an
- * optional `color` override that takes precedence over the list-level color.
+ * Renders as `<li>` inside a `SummaryList` and `<div>` when standalone. Accepts
+ * an optional `color` override that takes precedence over the list-level color.
  */
 function SummaryItem({
   className,
@@ -146,7 +145,7 @@ export default {
   Title,
   Meta,
   Action: Action.Root,
-  ActionButton: Action.Button,
-  ActionLink: Action.Link,
-  ActionMenu: Action.Menu,
+  Button: Action.Button,
+  Link: Action.Link,
+  Menu: Action.Menu,
 };

--- a/packages/ui/src/components/SummaryList/SummaryItem.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryItem.tsx
@@ -1,5 +1,6 @@
 import type { ComponentPropsWithRef } from "react";
 import { tv, type VariantProps } from "tailwind-variants";
+import type { Variant } from "@testing-library/react";
 
 import Action from "./SummaryAction";
 import Box from "../Box/Box";
@@ -124,10 +125,27 @@ const Title = ({ className, ...rest }: Omit<HeadingProps, "size">) => {
   return <Heading className={title({ color, class: className })} {...rest} />;
 };
 
+const meta = tv({
+  base: "mt-3 flex flex-col gap-3 justify-self-start sm:flex-row",
+  variants: {
+    separator: {
+      true: "sm:*:not-last:after:ml-3 sm:*:not-last:after:text-gray/50 sm:*:not-last:after:content-['•']",
+    },
+  },
+});
+
+interface MetaProps
+  extends ComponentPropsWithRef<"div">, VariantProps<typeof meta> {}
+
+const Meta = ({ className, separator, ...rest }: MetaProps) => (
+  <div className={meta({ separator, class: className })} {...rest} />
+);
+
 export default {
   Root: SummaryItem,
   Content,
   Title,
+  Meta,
   Action: Action.Root,
   ActionButton: Action.Button,
   ActionLink: Action.Link,

--- a/packages/ui/src/components/SummaryList/SummaryItem.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryItem.tsx
@@ -42,6 +42,13 @@ interface SummaryItemProps
   color?: SummaryColor;
 }
 
+/**
+ * A single row in a summary list (or a standalone card when used outside
+ * `SummaryList.Root`).
+ *
+ * Renders as `<li>` inside a list and `<div>` when standalone. Accepts an
+ * optional `color` override that takes precedence over the list-level color.
+ */
 function SummaryItem({
   className,
   color: colorProp,
@@ -74,6 +81,7 @@ const content = tv({
 
 type ContentProps = ComponentPropsWithRef<"div">;
 
+/** Primary content area of a summary item. Grows to fill available horizontal space. */
 const Content = ({ className, ...rest }: ContentProps) => {
   return <div className={content({ class: className })} {...rest} />;
 };
@@ -106,6 +114,10 @@ const title = tv({
   },
 });
 
+/**
+ * Heading for a summary item. Underlines and changes color on hover when the
+ * item contains an `expand` action button, turning the whole item into a link.
+ */
 const Title = ({ className, ...rest }: Omit<HeadingProps, "size">) => {
   const { color } = useSummaryItem();
   return <Heading className={title({ color, class: className })} {...rest} />;
@@ -123,6 +135,11 @@ const meta = tv({
 interface MetaProps
   extends ComponentPropsWithRef<"div">, VariantProps<typeof meta> {}
 
+/**
+ * Secondary metadata row rendered below the item body.
+ *
+ * Pass `separator` to add a bullet (`•`) between children on wider viewports.
+ */
 const Meta = ({ className, separator, ...rest }: MetaProps) => (
   <div className={meta({ separator, class: className })} {...rest} />
 );

--- a/packages/ui/src/components/SummaryList/SummaryList.stories.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryList.stories.tsx
@@ -1,0 +1,253 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { action } from "storybook/actions";
+import { useState } from "react";
+import ArrowTopRightOnSquareIcon from "@heroicons/react/20/solid/ArrowTopRightOnSquareIcon";
+import MagnifyingGlassPlusIcon from "@heroicons/react/20/solid/MagnifyingGlassPlusIcon";
+import PencilSquareIcon from "@heroicons/react/20/solid/PencilSquareIcon";
+import XMarkIcon from "@heroicons/react/20/solid/XMarkIcon";
+
+import { allModes } from "@gc-digital-talent/storybook-helpers";
+
+import SummaryList from "./SummaryList";
+import SummaryItem from "./SummaryItem";
+import type { Color } from "../../types";
+
+const Text = () => (
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam quam dui,
+    efficitur sed tempus at, luctus sit amet lacus. Cras accumsan massa vitae
+    eros iaculis ullamcorper. Praesent a libero ipsum. Nullam at velit in turpis
+    varius luctus. Phasellus quis lacus congue, scelerisque eros quis,
+    condimentum elit.
+  </p>
+);
+
+const ItemWithAction = () => {
+  const [menuOpen, setMenuOpen] = useState<boolean>(false);
+
+  return (
+    <SummaryList.Item>
+      <SummaryList.Item.Action align="start" justify="start">
+        <SummaryList.Item.ActionMenu.Root
+          open={menuOpen}
+          onOpenChange={setMenuOpen}
+        >
+          <SummaryList.Item.ActionMenu.Trigger
+            icon={menuOpen ? XMarkIcon : PencilSquareIcon}
+            label="Action menu"
+          />
+          <SummaryList.Item.ActionMenu.Popup>
+            <SummaryList.Item.ActionMenu.Item
+              onClick={() => {
+                action("Clicked edit")();
+              }}
+            >
+              Edit
+            </SummaryList.Item.ActionMenu.Item>
+            <SummaryList.Item.ActionMenu.Item
+              onClick={() => {
+                action("Clicked delete")();
+              }}
+            >
+              Delete
+            </SummaryList.Item.ActionMenu.Item>
+          </SummaryList.Item.ActionMenu.Popup>
+        </SummaryList.Item.ActionMenu.Root>
+      </SummaryList.Item.Action>
+      <SummaryList.Item.Content>
+        <SummaryList.Item.Title>
+          Item with a dropdown action menu
+        </SummaryList.Item.Title>
+        <Text />
+      </SummaryList.Item.Content>
+    </SummaryList.Item>
+  );
+};
+
+export default {
+  component: SummaryList.Root,
+  parameters: {
+    chromatic: {
+      modes: {
+        light: allModes.light,
+        "light mobile": allModes["light mobile"],
+        dark: allModes.dark,
+      },
+    },
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/guHeIIh8dqFVCks310Wv0G/Component-library?node-id=3353-78109&p=f",
+    },
+  },
+  argTypes: {
+    striped: {
+      control: "boolean",
+    },
+  },
+  args: {
+    striped: false,
+  },
+  render: (args) => {
+    return (
+      <SummaryList.Root {...args}>
+        <SummaryList.Item>
+          <SummaryList.Item.Content>
+            <SummaryList.Item.Title>Item 1</SummaryList.Item.Title>
+            <Text />
+          </SummaryList.Item.Content>
+        </SummaryList.Item>
+        <SummaryList.Item>
+          <SummaryList.Item.Content>
+            <SummaryList.Item.Title>
+              Item with action button
+            </SummaryList.Item.Title>
+            <Text />
+          </SummaryList.Item.Content>
+          <SummaryList.Item.Action align="middle" justify="end" expand>
+            <SummaryList.Item.ActionButton
+              icon={MagnifyingGlassPlusIcon}
+              onClick={() => {
+                action("Click action")();
+              }}
+            />
+          </SummaryList.Item.Action>
+        </SummaryList.Item>
+        <ItemWithAction />
+      </SummaryList.Root>
+    );
+  },
+} satisfies Meta<typeof SummaryList.Root>;
+
+type Story = StoryObj<typeof SummaryList.Root>;
+
+export const Default: Story = {};
+
+export const Striped: Story = {
+  args: {
+    striped: true,
+  },
+};
+
+export const Timeline: Story = {
+  args: {
+    timeline: true,
+  },
+};
+
+export const TimelineSingle: Story = {
+  args: {
+    timeline: true,
+  },
+  render: (args) => (
+    <SummaryList.Root {...args}>
+      <SummaryList.Item>
+        <SummaryList.Item.Content>
+          <SummaryList.Item.Title>Single timeline item</SummaryList.Item.Title>
+          <Text />
+        </SummaryList.Item.Content>
+      </SummaryList.Item>
+    </SummaryList.Root>
+  ),
+};
+
+export const TimelineWithActions: Story = {
+  args: {
+    timeline: true,
+  },
+  render: (args) => (
+    <SummaryList.Root {...args}>
+      {Array.from({ length: 3 }).map((_, index) => (
+        <SummaryList.Item key={index}>
+          <SummaryList.Item.Content>
+            <SummaryList.Item.Title>Item {index}</SummaryList.Item.Title>
+            <Text />
+          </SummaryList.Item.Content>
+          <SummaryList.Item.Action align="middle" justify="end" expand>
+            <SummaryList.Item.ActionButton
+              icon={MagnifyingGlassPlusIcon}
+              label={`Item ${index}`}
+              onClick={() => {
+                action(`Clicked: ${index + 1}`)();
+              }}
+            />
+          </SummaryList.Item.Action>
+        </SummaryList.Item>
+      ))}
+    </SummaryList.Root>
+  ),
+};
+
+const colors = [
+  "primary",
+  "secondary",
+  "success",
+  "warning",
+  "error",
+] satisfies Color[];
+
+export const WithActionLink: Story = {
+  render: (args) => (
+    <SummaryList.Root {...args}>
+      {colors.map((color) => (
+        <SummaryList.Item key={color} color={color}>
+          <SummaryList.Item.Content>
+            <SummaryList.Item.Title>{color}</SummaryList.Item.Title>
+            <Text />
+          </SummaryList.Item.Content>
+          <SummaryList.Item.Action align="middle" justify="end" expand>
+            <SummaryList.Item.ActionLink
+              icon={ArrowTopRightOnSquareIcon}
+              label={`View ${color}`}
+              href="#"
+              external
+            />
+          </SummaryList.Item.Action>
+        </SummaryList.Item>
+      ))}
+    </SummaryList.Root>
+  ),
+};
+
+export const WithColor: Story = {
+  render: (args) => (
+    <SummaryList.Root {...args}>
+      {colors.map((color) => (
+        <SummaryList.Item key={color} color={color}>
+          <SummaryList.Item.Content>
+            <SummaryList.Item.Title>{color}</SummaryList.Item.Title>
+            <Text />
+          </SummaryList.Item.Content>
+          <SummaryList.Item.Action justify="end" align="middle" expand>
+            <SummaryList.Item.ActionButton
+              icon={MagnifyingGlassPlusIcon}
+              onClick={() => {
+                action(`Clicked: ${color}`)();
+              }}
+              label={color}
+            />
+          </SummaryList.Item.Action>
+        </SummaryList.Item>
+      ))}
+    </SummaryList.Root>
+  ),
+};
+
+export const StandaloneItem: Story = {
+  render: () => (
+    <SummaryItem.Root>
+      <SummaryItem.Content>
+        <SummaryItem.Title>Standalone item</SummaryItem.Title>
+        <Text />
+      </SummaryItem.Content>
+      <SummaryItem.Action align="middle" justify="end" expand>
+        <SummaryItem.ActionButton
+          icon={MagnifyingGlassPlusIcon}
+          label="View"
+          onClick={() => {
+            action("Clicked")();
+          }}
+        />
+      </SummaryItem.Action>
+    </SummaryItem.Root>
+  ),
+};

--- a/packages/ui/src/components/SummaryList/SummaryList.stories.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryList.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { action } from "storybook/actions";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import ArrowTopRightOnSquareIcon from "@heroicons/react/20/solid/ArrowTopRightOnSquareIcon";
+import EllipsisHorizontalIcon from "@heroicons/react/20/solid/EllipsisHorizontalIcon";
 import MagnifyingGlassPlusIcon from "@heroicons/react/20/solid/MagnifyingGlassPlusIcon";
 import PencilSquareIcon from "@heroicons/react/20/solid/PencilSquareIcon";
 import XMarkIcon from "@heroicons/react/20/solid/XMarkIcon";
@@ -10,6 +11,7 @@ import { allModes } from "@gc-digital-talent/storybook-helpers";
 
 import SummaryList from "./SummaryList";
 import SummaryItem from "./SummaryItem";
+import Dialog from "../Dialog/Dialog";
 import type { Color } from "../../types";
 
 const Text = () => (
@@ -206,6 +208,107 @@ export const WithActionLink: Story = {
       ))}
     </SummaryList.Root>
   ),
+};
+
+/**
+ * Two patterns for opening dialogs from summary item actions.
+ *
+ * ActionButton: wrap with Dialog.Trigger (asChild by default) — Radix
+ * restores focus to the button automatically on close.
+ *
+ * Menu item (detached trigger): the menu item unmounts when the menu closes,
+ * so Radix cannot restore focus to it. Store a ref to the menu trigger button
+ * and use onCloseAutoFocus to focus it manually instead.
+ */
+const WithDialogsExample = () => {
+  const [menuDialogOpen, setMenuDialogOpen] = useState(false);
+  const menuTriggerRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <>
+      {/* Detached dialog — sits outside the list, opened via controlled state */}
+      <Dialog.Root open={menuDialogOpen} onOpenChange={setMenuDialogOpen}>
+        <Dialog.Content
+          onCloseAutoFocus={(e) => {
+            e.preventDefault();
+            menuTriggerRef.current?.focus();
+          }}
+        >
+          <Dialog.Header>Edit item</Dialog.Header>
+          <Dialog.Body>
+            <p>
+              This dialog was opened from a menu item. When it closes, focus
+              returns to the menu trigger button via the ref.
+            </p>
+          </Dialog.Body>
+        </Dialog.Content>
+      </Dialog.Root>
+
+      <SummaryList.Root>
+        {/* Pattern 1: Dialog.Trigger wraps ActionButton — focus is automatic */}
+        <Dialog.Root>
+          <SummaryList.Item>
+            <SummaryList.Item.Content>
+              <SummaryList.Item.Title>Action button trigger</SummaryList.Item.Title>
+              <p>
+                Dialog.Trigger (asChild) merges onto the button. Radix tracks the
+                trigger and restores focus automatically when the dialog closes.
+              </p>
+            </SummaryList.Item.Content>
+            <SummaryList.Item.Action align="middle" justify="end">
+              <Dialog.Trigger>
+                <SummaryList.Item.ActionButton
+                  icon={PencilSquareIcon}
+                  label="Edit"
+                />
+              </Dialog.Trigger>
+            </SummaryList.Item.Action>
+          </SummaryList.Item>
+          <Dialog.Content>
+            <Dialog.Header>Edit item</Dialog.Header>
+            <Dialog.Body>
+              <p>
+                Focus will return to the edit button automatically when this
+                dialog closes.
+              </p>
+            </Dialog.Body>
+          </Dialog.Content>
+        </Dialog.Root>
+
+        {/* Pattern 2: menu item opens dialog — focus restored manually via ref */}
+        <SummaryList.Item>
+          <SummaryList.Item.Content>
+            <SummaryList.Item.Title>Menu item trigger</SummaryList.Item.Title>
+            <p>
+              The menu item unmounts when the menu closes, so Radix cannot track
+              it. A ref on the menu trigger combined with onCloseAutoFocus
+              handles focus restoration instead.
+            </p>
+          </SummaryList.Item.Content>
+          <SummaryList.Item.Action align="start" justify="start">
+            <SummaryList.Item.ActionMenu.Root>
+              <SummaryList.Item.ActionMenu.Trigger
+                ref={menuTriggerRef}
+                icon={EllipsisHorizontalIcon}
+                label="Options"
+              />
+              <SummaryList.Item.ActionMenu.Popup>
+                <SummaryList.Item.ActionMenu.Item
+                  onClick={() => setMenuDialogOpen(true)}
+                >
+                  Edit
+                </SummaryList.Item.ActionMenu.Item>
+              </SummaryList.Item.ActionMenu.Popup>
+            </SummaryList.Item.ActionMenu.Root>
+          </SummaryList.Item.Action>
+        </SummaryList.Item>
+      </SummaryList.Root>
+    </>
+  );
+};
+
+export const WithDialogs: Story = {
+  render: () => <WithDialogsExample />,
 };
 
 export const WithColor: Story = {

--- a/packages/ui/src/components/SummaryList/SummaryList.stories.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryList.stories.tsx
@@ -12,7 +12,9 @@ import { allModes } from "@gc-digital-talent/storybook-helpers";
 import SummaryList from "./SummaryList";
 import SummaryItem from "./SummaryItem";
 import Dialog from "../Dialog/Dialog";
-import type { Color } from "../../types";
+import { COLOR, type Color } from "../../types";
+import Button from "../Button";
+import type { SummaryColor } from "./SummaryContext";
 
 const Text = () => (
   <p>
@@ -85,6 +87,12 @@ export default {
     striped: {
       control: "boolean",
     },
+    color: {
+      control: "select",
+      options: Object.values(COLOR).filter(
+        (color) => ![COLOR.BLACK, COLOR.WHITE].includes(color),
+      ),
+    },
   },
   args: {
     striped: false,
@@ -115,6 +123,32 @@ export default {
           </SummaryList.Item.Action>
         </SummaryList.Item>
         <ItemWithAction />
+        <SummaryList.Item>
+          <SummaryList.Item.Content>
+            <SummaryList.Item.Title>Item 1</SummaryList.Item.Title>
+            <Text />
+            <SummaryList.Item.Meta separator>
+              <Button
+                mode="inline"
+                color={args.color}
+                onClick={() => {
+                  action("Click: meta one")();
+                }}
+              >
+                Meta one
+              </Button>
+              <Button
+                mode="inline"
+                color={args.color}
+                onClick={() => {
+                  action("Click: meta two")();
+                }}
+              >
+                Meta two
+              </Button>
+            </SummaryList.Item.Meta>
+          </SummaryList.Item.Content>
+        </SummaryList.Item>
       </SummaryList.Root>
     );
   },
@@ -249,10 +283,13 @@ const WithDialogsExample = () => {
         <Dialog.Root>
           <SummaryList.Item>
             <SummaryList.Item.Content>
-              <SummaryList.Item.Title>Action button trigger</SummaryList.Item.Title>
+              <SummaryList.Item.Title>
+                Action button trigger
+              </SummaryList.Item.Title>
               <p>
-                Dialog.Trigger (asChild) merges onto the button. Radix tracks the
-                trigger and restores focus automatically when the dialog closes.
+                Dialog.Trigger (asChild) merges onto the button. Radix tracks
+                the trigger and restores focus automatically when the dialog
+                closes.
               </p>
             </SummaryList.Item.Content>
             <SummaryList.Item.Action align="middle" justify="end">

--- a/packages/ui/src/components/SummaryList/SummaryList.stories.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryList.stories.tsx
@@ -16,7 +16,7 @@ import { COLOR, type Color } from "../../types";
 import Button from "../Button";
 
 const Text = () => (
-  <p>
+  <p className="not-last:mb-3">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam quam dui,
     efficitur sed tempus at, luctus sit amet lacus. Cras accumsan massa vitae
     eros iaculis ullamcorper. Praesent a libero ipsum. Nullam at velit in turpis
@@ -29,46 +29,41 @@ const ItemWithAction = () => {
   const [menuOpen, setMenuOpen] = useState<boolean>(false);
 
   return (
-    <SummaryList.Item>
-      <SummaryList.Item.Action align="start" justify="start">
-        <SummaryList.Item.ActionMenu.Root
-          open={menuOpen}
-          onOpenChange={setMenuOpen}
-        >
-          <SummaryList.Item.ActionMenu.Trigger
+    <SummaryItem.Root>
+      <SummaryItem.Action align="start" justify="start">
+        <SummaryItem.Menu open={menuOpen} onOpenChange={setMenuOpen}>
+          <SummaryItem.Menu.Trigger
             icon={menuOpen ? XMarkIcon : PencilSquareIcon}
             label="Action menu"
           />
-          <SummaryList.Item.ActionMenu.Popup>
-            <SummaryList.Item.ActionMenu.Item
+          <SummaryItem.Menu.Popup>
+            <SummaryItem.Menu.Item
               onClick={() => {
                 action("Clicked edit")();
               }}
             >
               Edit
-            </SummaryList.Item.ActionMenu.Item>
-            <SummaryList.Item.ActionMenu.Item
+            </SummaryItem.Menu.Item>
+            <SummaryItem.Menu.Item
               onClick={() => {
                 action("Clicked delete")();
               }}
             >
               Delete
-            </SummaryList.Item.ActionMenu.Item>
-          </SummaryList.Item.ActionMenu.Popup>
-        </SummaryList.Item.ActionMenu.Root>
-      </SummaryList.Item.Action>
-      <SummaryList.Item.Content>
-        <SummaryList.Item.Title>
-          Item with a dropdown action menu
-        </SummaryList.Item.Title>
+            </SummaryItem.Menu.Item>
+          </SummaryItem.Menu.Popup>
+        </SummaryItem.Menu>
+      </SummaryItem.Action>
+      <SummaryItem.Content>
+        <SummaryItem.Title>Item with a dropdown action menu</SummaryItem.Title>
         <Text />
-      </SummaryList.Item.Content>
-    </SummaryList.Item>
+      </SummaryItem.Content>
+    </SummaryItem.Root>
   );
 };
 
 export default {
-  component: SummaryList.Root,
+  component: SummaryList,
   parameters: {
     chromatic: {
       modes: {
@@ -107,35 +102,41 @@ export default {
   },
   render: (args) => {
     return (
-      <SummaryList.Root {...args}>
-        <SummaryList.Item>
-          <SummaryList.Item.Content>
-            <SummaryList.Item.Title>Item 1</SummaryList.Item.Title>
+      <SummaryList {...args}>
+        <SummaryItem.Root>
+          <SummaryItem.Content>
+            <SummaryItem.Title>Item 1</SummaryItem.Title>
             <Text />
-          </SummaryList.Item.Content>
-        </SummaryList.Item>
-        <SummaryList.Item>
-          <SummaryList.Item.Content>
-            <SummaryList.Item.Title>
-              Item with action button
-            </SummaryList.Item.Title>
+          </SummaryItem.Content>
+        </SummaryItem.Root>
+        <SummaryItem.Root>
+          <SummaryItem.Content>
+            <SummaryItem.Title>Item with action button</SummaryItem.Title>
             <Text />
-          </SummaryList.Item.Content>
-          <SummaryList.Item.Action align="middle" justify="end" expand>
-            <SummaryList.Item.ActionButton
+          </SummaryItem.Content>
+          <SummaryItem.Action align="middle" justify="end" expand>
+            <SummaryItem.Button
               icon={MagnifyingGlassPlusIcon}
               onClick={() => {
                 action("Click action")();
               }}
             />
-          </SummaryList.Item.Action>
-        </SummaryList.Item>
-        <ItemWithAction />
-        <SummaryList.Item>
-          <SummaryList.Item.Content>
-            <SummaryList.Item.Title>Item 1</SummaryList.Item.Title>
+          </SummaryItem.Action>
+        </SummaryItem.Root>
+        <SummaryItem.Root>
+          <SummaryItem.Content>
+            <SummaryItem.Title>Item with a lot of text</SummaryItem.Title>
             <Text />
-            <SummaryList.Item.Meta separator>
+            <Text />
+            <Text />
+          </SummaryItem.Content>
+        </SummaryItem.Root>
+        <ItemWithAction />
+        <SummaryItem.Root>
+          <SummaryItem.Content>
+            <SummaryItem.Title>Item 1</SummaryItem.Title>
+            <Text />
+            <SummaryItem.Meta separator>
               <Button
                 mode="inline"
                 color={args.color}
@@ -154,15 +155,15 @@ export default {
               >
                 Meta two
               </Button>
-            </SummaryList.Item.Meta>
-          </SummaryList.Item.Content>
-        </SummaryList.Item>
-      </SummaryList.Root>
+            </SummaryItem.Meta>
+          </SummaryItem.Content>
+        </SummaryItem.Root>
+      </SummaryList>
     );
   },
-} satisfies Meta<typeof SummaryList.Root>;
+} satisfies Meta<typeof SummaryList>;
 
-type Story = StoryObj<typeof SummaryList.Root>;
+type Story = StoryObj<typeof SummaryList>;
 
 export const Default: Story = {};
 
@@ -189,14 +190,14 @@ export const TimelineSingle: Story = {
     divider: "timeline",
   },
   render: (args) => (
-    <SummaryList.Root {...args}>
-      <SummaryList.Item>
-        <SummaryList.Item.Content>
-          <SummaryList.Item.Title>Single timeline item</SummaryList.Item.Title>
+    <SummaryList {...args}>
+      <SummaryItem.Root>
+        <SummaryItem.Content>
+          <SummaryItem.Title>Single timeline item</SummaryItem.Title>
           <Text />
-        </SummaryList.Item.Content>
-      </SummaryList.Item>
-    </SummaryList.Root>
+        </SummaryItem.Content>
+      </SummaryItem.Root>
+    </SummaryList>
   ),
 };
 
@@ -205,25 +206,25 @@ export const TimelineWithActions: Story = {
     divider: "timeline",
   },
   render: (args) => (
-    <SummaryList.Root {...args}>
+    <SummaryList {...args}>
       {Array.from({ length: 3 }).map((_, index) => (
-        <SummaryList.Item key={index}>
-          <SummaryList.Item.Content>
-            <SummaryList.Item.Title>Item {index}</SummaryList.Item.Title>
+        <SummaryItem.Root key={index}>
+          <SummaryItem.Content>
+            <SummaryItem.Title>Item {index}</SummaryItem.Title>
             <Text />
-          </SummaryList.Item.Content>
-          <SummaryList.Item.Action align="middle" justify="end" expand>
-            <SummaryList.Item.ActionButton
+          </SummaryItem.Content>
+          <SummaryItem.Action align="middle" justify="end" expand>
+            <SummaryItem.Button
               icon={MagnifyingGlassPlusIcon}
               label={`Item ${index}`}
               onClick={() => {
                 action(`Clicked: ${index + 1}`)();
               }}
             />
-          </SummaryList.Item.Action>
-        </SummaryList.Item>
+          </SummaryItem.Action>
+        </SummaryItem.Root>
       ))}
-    </SummaryList.Root>
+    </SummaryList>
   ),
 };
 
@@ -237,32 +238,32 @@ const colors = [
 
 export const WithActionLink: Story = {
   render: (args) => (
-    <SummaryList.Root {...args}>
+    <SummaryList {...args}>
       {colors.map((color) => (
-        <SummaryList.Item key={color} color={color}>
-          <SummaryList.Item.Content>
-            <SummaryList.Item.Title>{color}</SummaryList.Item.Title>
+        <SummaryItem.Root key={color} color={color}>
+          <SummaryItem.Content>
+            <SummaryItem.Title>{color}</SummaryItem.Title>
             <Text />
-          </SummaryList.Item.Content>
-          <SummaryList.Item.Action align="middle" justify="end" expand>
-            <SummaryList.Item.ActionLink
+          </SummaryItem.Content>
+          <SummaryItem.Action align="middle" justify="end" expand>
+            <SummaryItem.Link
               icon={ArrowTopRightOnSquareIcon}
               label={`View ${color}`}
               href="#"
               external
             />
-          </SummaryList.Item.Action>
-        </SummaryList.Item>
+          </SummaryItem.Action>
+        </SummaryItem.Root>
       ))}
-    </SummaryList.Root>
+    </SummaryList>
   ),
 };
 
 /**
  * Two patterns for opening dialogs from summary item actions.
  *
- * ActionButton: wrap with Dialog.Trigger (asChild by default) — Radix
- * restores focus to the button automatically on close.
+ * Button: wrap with Dialog.Trigger (asChild by default) — Radix restores focus
+ * to the button automatically on close.
  *
  * Menu item (detached trigger): the menu item unmounts when the menu closes,
  * so Radix cannot restore focus to it. Store a ref to the menu trigger button
@@ -292,29 +293,24 @@ const WithDialogsExample = () => {
         </Dialog.Content>
       </Dialog.Root>
 
-      <SummaryList.Root>
-        {/* Pattern 1: Dialog.Trigger wraps ActionButton — focus is automatic */}
+      <SummaryList>
+        {/* Pattern 1: Dialog.Trigger wraps Button — focus is automatic */}
         <Dialog.Root>
-          <SummaryList.Item>
-            <SummaryList.Item.Content>
-              <SummaryList.Item.Title>
-                Action button trigger
-              </SummaryList.Item.Title>
+          <SummaryItem.Root>
+            <SummaryItem.Content>
+              <SummaryItem.Title>Action button trigger</SummaryItem.Title>
               <p>
                 Dialog.Trigger (asChild) merges onto the button. Radix tracks
                 the trigger and restores focus automatically when the dialog
                 closes.
               </p>
-            </SummaryList.Item.Content>
-            <SummaryList.Item.Action align="middle" justify="end">
+            </SummaryItem.Content>
+            <SummaryItem.Action align="middle" justify="end">
               <Dialog.Trigger>
-                <SummaryList.Item.ActionButton
-                  icon={PencilSquareIcon}
-                  label="Edit"
-                />
+                <SummaryItem.Button icon={PencilSquareIcon} label="Edit" />
               </Dialog.Trigger>
-            </SummaryList.Item.Action>
-          </SummaryList.Item>
+            </SummaryItem.Action>
+          </SummaryItem.Root>
           <Dialog.Content>
             <Dialog.Header>Edit item</Dialog.Header>
             <Dialog.Body>
@@ -327,33 +323,31 @@ const WithDialogsExample = () => {
         </Dialog.Root>
 
         {/* Pattern 2: menu item opens dialog — focus restored manually via ref */}
-        <SummaryList.Item>
-          <SummaryList.Item.Content>
-            <SummaryList.Item.Title>Menu item trigger</SummaryList.Item.Title>
+        <SummaryItem.Root>
+          <SummaryItem.Content>
+            <SummaryItem.Title>Menu item trigger</SummaryItem.Title>
             <p>
               The menu item unmounts when the menu closes, so Radix cannot track
               it. A ref on the menu trigger combined with onCloseAutoFocus
               handles focus restoration instead.
             </p>
-          </SummaryList.Item.Content>
-          <SummaryList.Item.Action align="start" justify="start">
-            <SummaryList.Item.ActionMenu.Root>
-              <SummaryList.Item.ActionMenu.Trigger
+          </SummaryItem.Content>
+          <SummaryItem.Action align="start" justify="start">
+            <SummaryItem.Menu>
+              <SummaryItem.Menu.Trigger
                 ref={menuTriggerRef}
                 icon={EllipsisHorizontalIcon}
                 label="Options"
               />
-              <SummaryList.Item.ActionMenu.Popup>
-                <SummaryList.Item.ActionMenu.Item
-                  onClick={() => setMenuDialogOpen(true)}
-                >
+              <SummaryItem.Menu.Popup>
+                <SummaryItem.Menu.Item onClick={() => setMenuDialogOpen(true)}>
                   Edit
-                </SummaryList.Item.ActionMenu.Item>
-              </SummaryList.Item.ActionMenu.Popup>
-            </SummaryList.Item.ActionMenu.Root>
-          </SummaryList.Item.Action>
-        </SummaryList.Item>
-      </SummaryList.Root>
+                </SummaryItem.Menu.Item>
+              </SummaryItem.Menu.Popup>
+            </SummaryItem.Menu>
+          </SummaryItem.Action>
+        </SummaryItem.Root>
+      </SummaryList>
     </>
   );
 };
@@ -364,25 +358,25 @@ export const WithDialogs: Story = {
 
 export const WithColor: Story = {
   render: (args) => (
-    <SummaryList.Root {...args}>
+    <SummaryList {...args}>
       {colors.map((color) => (
-        <SummaryList.Item key={color} color={color}>
-          <SummaryList.Item.Content>
-            <SummaryList.Item.Title>{color}</SummaryList.Item.Title>
+        <SummaryItem.Root key={color} color={color}>
+          <SummaryItem.Content>
+            <SummaryItem.Title>{color}</SummaryItem.Title>
             <Text />
-          </SummaryList.Item.Content>
-          <SummaryList.Item.Action justify="end" align="middle" expand>
-            <SummaryList.Item.ActionButton
+          </SummaryItem.Content>
+          <SummaryItem.Action justify="end" align="middle" expand>
+            <SummaryItem.Button
               icon={MagnifyingGlassPlusIcon}
               onClick={() => {
                 action(`Clicked: ${color}`)();
               }}
               label={color}
             />
-          </SummaryList.Item.Action>
-        </SummaryList.Item>
+          </SummaryItem.Action>
+        </SummaryItem.Root>
       ))}
-    </SummaryList.Root>
+    </SummaryList>
   ),
 };
 
@@ -394,7 +388,7 @@ export const StandaloneItem: Story = {
         <Text />
       </SummaryItem.Content>
       <SummaryItem.Action align="middle" justify="end" expand>
-        <SummaryItem.ActionButton
+        <SummaryItem.Button
           icon={MagnifyingGlassPlusIcon}
           label="View"
           onClick={() => {

--- a/packages/ui/src/components/SummaryList/SummaryList.stories.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryList.stories.tsx
@@ -14,7 +14,6 @@ import SummaryItem from "./SummaryItem";
 import Dialog from "../Dialog/Dialog";
 import { COLOR, type Color } from "../../types";
 import Button from "../Button";
-import type { SummaryColor } from "./SummaryContext";
 
 const Text = () => (
   <p>
@@ -87,10 +86,14 @@ export default {
     striped: {
       control: "boolean",
     },
+    mode: {
+      control: "inline-radio",
+      options: ["simple", "card"],
+    },
     color: {
       control: "select",
       options: Object.values(COLOR).filter(
-        (color) => ![COLOR.BLACK, COLOR.WHITE].includes(color),
+        (color) => color !== COLOR.WHITE && color !== COLOR.BLACK,
       ),
     },
   },
@@ -167,6 +170,12 @@ export const Striped: Story = {
 export const Timeline: Story = {
   args: {
     timeline: true,
+  },
+};
+
+export const AsCard: Story = {
+  args: {
+    mode: "card",
   },
 };
 

--- a/packages/ui/src/components/SummaryList/SummaryList.stories.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryList.stories.tsx
@@ -116,6 +116,7 @@ export default {
           </SummaryItem.Content>
           <SummaryItem.Action align="middle" justify="end" expand>
             <SummaryItem.Button
+              label="Action button"
               icon={MagnifyingGlassPlusIcon}
               onClick={() => {
                 action("Click action")();
@@ -173,15 +174,15 @@ export const Striped: Story = {
   },
 };
 
-export const Timeline: Story = {
-  args: {
-    divider: "timeline",
-  },
-};
-
 export const AsCard: Story = {
   args: {
     mode: "card",
+  },
+};
+
+export const Timeline: Story = {
+  args: {
+    divider: "timeline",
   },
 };
 

--- a/packages/ui/src/components/SummaryList/SummaryList.stories.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryList.stories.tsx
@@ -86,6 +86,10 @@ export default {
     striped: {
       control: "boolean",
     },
+    divider: {
+      control: "select",
+      options: [undefined, "line", "timeline"],
+    },
     mode: {
       control: "inline-radio",
       options: ["simple", "card"],
@@ -99,6 +103,7 @@ export default {
   },
   args: {
     striped: false,
+    divider: "line",
   },
   render: (args) => {
     return (
@@ -169,7 +174,7 @@ export const Striped: Story = {
 
 export const Timeline: Story = {
   args: {
-    timeline: true,
+    divider: "timeline",
   },
 };
 
@@ -181,7 +186,7 @@ export const AsCard: Story = {
 
 export const TimelineSingle: Story = {
   args: {
-    timeline: true,
+    divider: "timeline",
   },
   render: (args) => (
     <SummaryList.Root {...args}>
@@ -197,7 +202,7 @@ export const TimelineSingle: Story = {
 
 export const TimelineWithActions: Story = {
   args: {
-    timeline: true,
+    divider: "timeline",
   },
   render: (args) => (
     <SummaryList.Root {...args}>

--- a/packages/ui/src/components/SummaryList/SummaryList.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryList.tsx
@@ -1,7 +1,6 @@
 import { type ComponentPropsWithRef } from "react";
 import { tv, type VariantProps } from "tailwind-variants";
 
-import SummaryItem from "./SummaryItem";
 import { SummaryListContext } from "./SummaryContext";
 import type { SummaryListContextValue } from "./SummaryContext";
 
@@ -18,23 +17,24 @@ const root = tv({
   },
 });
 
-interface RootProps
-  extends ComponentPropsWithRef<"ul">,
+interface SummaryListProps
+  extends
+    Omit<ComponentPropsWithRef<"ul">, "color">,
     VariantProps<typeof root>,
     Omit<SummaryListContextValue, "inList"> {}
 
 /**
- * Container for a list of summary items.
+ * Container for a list of `SummaryItem.Root` elements.
  *
  * Renders a `<ul>` and provides color, striped, and divider context to all
- * child `SummaryList.Item` elements.
+ * child items.
  *
  * @example
- * <SummaryList.Root color="primary" divider="timeline">
- *   <SummaryList.Item>…</SummaryList.Item>
- * </SummaryList.Root>
+ * <SummaryList color="primary" divider="timeline">
+ *   <SummaryItem.Root>…</SummaryItem.Root>
+ * </SummaryList>
  */
-const Root = ({
+const SummaryList = ({
   children,
   className,
   striped,
@@ -42,24 +42,15 @@ const Root = ({
   color = "primary",
   divider,
   ref,
-}: RootProps) => (
+  ...rest
+}: SummaryListProps) => (
   <SummaryListContext.Provider
     value={{ striped, color, divider, inList: true }}
   >
-    <ul ref={ref} className={root({ mode, class: className })}>
+    <ul ref={ref} className={root({ mode, class: className })} {...rest}>
       {children}
     </ul>
   </SummaryListContext.Provider>
 );
 
-const Item = Object.assign(SummaryItem.Root, {
-  Content: SummaryItem.Content,
-  Title: SummaryItem.Title,
-  Action: SummaryItem.Action,
-  Meta: SummaryItem.Meta,
-  ActionButton: SummaryItem.ActionButton,
-  ActionLink: SummaryItem.ActionLink,
-  ActionMenu: SummaryItem.ActionMenu,
-});
-
-export default { Root, Item };
+export default SummaryList;

--- a/packages/ui/src/components/SummaryList/SummaryList.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryList.tsx
@@ -39,6 +39,7 @@ const Item = Object.assign(SummaryItem.Root, {
   Content: SummaryItem.Content,
   Title: SummaryItem.Title,
   Action: SummaryItem.Action,
+  Meta: SummaryItem.Meta,
   ActionButton: SummaryItem.ActionButton,
   ActionLink: SummaryItem.ActionLink,
   ActionMenu: SummaryItem.ActionMenu,

--- a/packages/ui/src/components/SummaryList/SummaryList.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryList.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, type RefObject } from "react";
+import { type ComponentPropsWithRef } from "react";
 import { tv, type VariantProps } from "tailwind-variants";
 
 import SummaryItem from "./SummaryItem";
@@ -19,11 +19,9 @@ const root = tv({
 });
 
 interface RootProps
-  extends VariantProps<typeof root>, Omit<SummaryListContextValue, "inList"> {
-  children: ReactNode;
-  className?: string;
-  ref?: RefObject<HTMLUListElement>;
-}
+  extends ComponentPropsWithRef<"ul">,
+    VariantProps<typeof root>,
+    Omit<SummaryListContextValue, "inList"> {}
 
 /**
  * Container for a list of summary items.

--- a/packages/ui/src/components/SummaryList/SummaryList.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryList.tsx
@@ -3,7 +3,7 @@ import { tv, type VariantProps } from "tailwind-variants";
 
 import SummaryItem from "./SummaryItem";
 import { SummaryListContext } from "./SummaryContext";
-import type { SummaryColor } from "./SummaryContext";
+import type { SummaryListContextValue } from "./SummaryContext";
 
 const root = tv({
   base: "bg-white dark:bg-gray-600",
@@ -18,13 +18,11 @@ const root = tv({
   },
 });
 
-interface RootProps extends VariantProps<typeof root> {
+interface RootProps
+  extends VariantProps<typeof root>, Omit<SummaryListContextValue, "inList"> {
   children: ReactNode;
   className?: string;
   ref?: RefObject<HTMLUListElement>;
-  timeline?: boolean;
-  color?: SummaryColor;
-  striped?: boolean;
 }
 
 const Root = ({
@@ -33,11 +31,11 @@ const Root = ({
   striped,
   mode,
   color = "primary",
-  timeline = false,
+  divider,
   ref,
 }: RootProps) => (
   <SummaryListContext.Provider
-    value={{ striped, color, timeline, inList: true }}
+    value={{ striped, color, divider, inList: true }}
   >
     <ul ref={ref} className={root({ mode, class: className })}>
       {children}

--- a/packages/ui/src/components/SummaryList/SummaryList.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryList.tsx
@@ -25,6 +25,17 @@ interface RootProps
   ref?: RefObject<HTMLUListElement>;
 }
 
+/**
+ * Container for a list of summary items.
+ *
+ * Renders a `<ul>` and provides color, striped, and divider context to all
+ * child `SummaryList.Item` elements.
+ *
+ * @example
+ * <SummaryList.Root color="primary" divider="timeline">
+ *   <SummaryList.Item>…</SummaryList.Item>
+ * </SummaryList.Root>
+ */
 const Root = ({
   children,
   className,

--- a/packages/ui/src/components/SummaryList/SummaryList.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryList.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, type RefObject } from "react";
-import { tv } from "tailwind-variants";
+import { tv, type VariantProps } from "tailwind-variants";
 
 import SummaryItem from "./SummaryItem";
 import { SummaryListContext } from "./SummaryContext";
@@ -7,9 +7,18 @@ import type { SummaryColor } from "./SummaryContext";
 
 const root = tv({
   base: "bg-white dark:bg-gray-600",
+  variants: {
+    mode: {
+      simple: "",
+      card: "rounded-md shadow-xl",
+    },
+  },
+  defaultVariants: {
+    mode: "simple",
+  },
 });
 
-interface RootProps {
+interface RootProps extends VariantProps<typeof root> {
   children: ReactNode;
   className?: string;
   ref?: RefObject<HTMLUListElement>;
@@ -22,6 +31,7 @@ const Root = ({
   children,
   className,
   striped,
+  mode,
   color = "primary",
   timeline = false,
   ref,
@@ -29,7 +39,7 @@ const Root = ({
   <SummaryListContext.Provider
     value={{ striped, color, timeline, inList: true }}
   >
-    <ul ref={ref} className={root({ class: className })}>
+    <ul ref={ref} className={root({ mode, class: className })}>
       {children}
     </ul>
   </SummaryListContext.Provider>

--- a/packages/ui/src/components/SummaryList/SummaryList.tsx
+++ b/packages/ui/src/components/SummaryList/SummaryList.tsx
@@ -1,0 +1,47 @@
+import { type ReactNode, type RefObject } from "react";
+import { tv } from "tailwind-variants";
+
+import SummaryItem from "./SummaryItem";
+import { SummaryListContext } from "./SummaryContext";
+import type { SummaryColor } from "./SummaryContext";
+
+const root = tv({
+  base: "bg-white dark:bg-gray-600",
+});
+
+interface RootProps {
+  children: ReactNode;
+  className?: string;
+  ref?: RefObject<HTMLUListElement>;
+  timeline?: boolean;
+  color?: SummaryColor;
+  striped?: boolean;
+}
+
+const Root = ({
+  children,
+  className,
+  striped,
+  color = "primary",
+  timeline = false,
+  ref,
+}: RootProps) => (
+  <SummaryListContext.Provider
+    value={{ striped, color, timeline, inList: true }}
+  >
+    <ul ref={ref} className={root({ class: className })}>
+      {children}
+    </ul>
+  </SummaryListContext.Provider>
+);
+
+const Item = Object.assign(SummaryItem.Root, {
+  Content: SummaryItem.Content,
+  Title: SummaryItem.Title,
+  Action: SummaryItem.Action,
+  ActionButton: SummaryItem.ActionButton,
+  ActionLink: SummaryItem.ActionLink,
+  ActionMenu: SummaryItem.ActionMenu,
+});
+
+export default { Root, Item };

--- a/packages/ui/src/components/SummaryList/TimelineMarker.tsx
+++ b/packages/ui/src/components/SummaryList/TimelineMarker.tsx
@@ -1,0 +1,58 @@
+import { tv } from "tailwind-variants";
+
+import { useSummaryItem } from "./SummaryContext";
+
+// h-9.5 on the upper line = py-7.5 (1.875rem) + half of text-base/relaxed line-height (0.8125rem) − dot radius (0.3125rem)
+// This centres the dot on the title's first line regardless of item height.
+// invisible (not hidden) preserves the height so the dot never shifts position on first/last/only items.
+const timelineMarker = tv({
+  slots: {
+    root: "pointer-events-none absolute inset-y-0 left-0 flex w-9 flex-col items-center",
+    upper: "h-9.5 w-px group-first/item:invisible",
+    dot: "size-2.5 shrink-0 rounded-full",
+    lower: "w-px flex-1 group-last/item:invisible",
+  },
+  variants: {
+    color: {
+      primary: {
+        upper: "bg-primary-600 dark:bg-primary-200",
+        dot: "bg-primary-600 dark:bg-primary-200",
+        lower: "bg-primary-600 dark:bg-primary-200",
+      },
+      secondary: {
+        upper: "bg-secondary-600 dark:bg-secondary-200",
+        dot: "bg-secondary-600 dark:bg-secondary-200",
+        lower: "bg-secondary-600 dark:bg-secondary-200",
+      },
+      success: {
+        upper: "bg-success-600 dark:bg-success-200",
+        dot: "bg-success-600 dark:bg-success-200",
+        lower: "bg-success-600 dark:bg-success-200",
+      },
+      warning: {
+        upper: "bg-warning-600 dark:bg-warning-200",
+        dot: "bg-warning-600 dark:bg-warning-200",
+        lower: "bg-warning-600 dark:bg-warning-200",
+      },
+      error: {
+        upper: "bg-error-600 dark:bg-error-200",
+        dot: "bg-error-600 dark:bg-error-200",
+        lower: "bg-error-600 dark:bg-error-200",
+      },
+    },
+  },
+});
+
+const TimelineMarker = () => {
+  const { color } = useSummaryItem();
+  const { root, upper, dot, lower } = timelineMarker({ color });
+  return (
+    <div aria-hidden className={root()}>
+      <div className={upper()} />
+      <div className={dot()} />
+      <div className={lower()} />
+    </div>
+  );
+};
+
+export default TimelineMarker;

--- a/packages/ui/src/components/SummaryList/TimelineMarker.tsx
+++ b/packages/ui/src/components/SummaryList/TimelineMarker.tsx
@@ -7,7 +7,7 @@ import { useSummaryItem } from "./SummaryContext";
 // invisible (not hidden) preserves the height so the dot never shifts position on first/last/only items.
 const timelineMarker = tv({
   slots: {
-    root: "pointer-events-none absolute inset-y-0 left-0 flex w-9 flex-col items-center",
+    root: "pointer-events-none absolute inset-y-0 left-0 z-10 flex w-9 flex-col items-center",
     upper: "h-9.5 w-px group-first/item:invisible",
     dot: "size-2.5 shrink-0 rounded-full",
     lower: "w-px flex-1 group-last/item:invisible",

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,6 +1,7 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 
 import type { Color, HeadingRank, IconType, IconProps } from "./types";
+import { COLOR } from "./types";
 import Accordion, {
   type AccordionMetaData,
 } from "./components/Accordion/Accordion";
@@ -226,4 +227,5 @@ export {
   hrefToString,
   wrapParens,
   UNICODE_CHAR,
+  COLOR,
 };

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -10,17 +10,11 @@ import type {
 export type Color =
   | "primary"
   | "secondary"
-  | "secondaryDarkFixed"
-  | "tertiary"
-  | "quaternary"
-  | "quinary"
   | "success"
   | "warning"
   | "error"
   | "black"
-  | "blackFixed"
-  | "white"
-  | "whiteFixed";
+  | "white";
 
 export type HeadingRank = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -7,14 +7,18 @@ import type {
   JSX,
 } from "react";
 
-export type Color =
-  | "primary"
-  | "secondary"
-  | "success"
-  | "warning"
-  | "error"
-  | "black"
-  | "white";
+export const COLOR = {
+  PRIMARY: "primary",
+  SECONDARY: "secondary",
+  SUCCESS: "success",
+  WARNING: "warning",
+  ERROR: "error",
+  BLACK: "black",
+  WHITE: "white",
+};
+
+type ObjectValues<T> = T[keyof T];
+export type Color = ObjectValues<typeof COLOR>;
 
 export type HeadingRank = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -15,7 +15,7 @@ export const COLOR = {
   ERROR: "error",
   BLACK: "black",
   WHITE: "white",
-};
+} as const;
 
 type ObjectValues<T> = T[keyof T];
 export type Color = ObjectValues<typeof COLOR>;


### PR DESCRIPTION
## 👋 Introduction

This PR is a spike illustrating one approach to component consolidation. It builds a generic compound component from smaller, composable pieces rather than one-off bespoke components.

The concrete goal is to replace `PreviewList` (a read-only list of summary tiles) and `DevelopmentProgramCard` (an editible repeater component) with a single `SummaryList`/`SummaryItem` system that can be composed to achieve both and more. I'm pushing this up as PR rather than an RFC so people can interact with it in Storybook and read the actual code.

> [!NOTE]
> This is experimental — the API is open for feedback. How we resolve this could inform how we approach compound components going forward, so input from both designers and developers is welcome.

## 🕵️ Details
The system is split into two imports:

- `SummaryList`: the `<ul>` container. Provides color, striping, and divider context to all items inside it.
- `SummaryItem`: everything inside a row. Sub-components are composed to build up the item.

`SummaryItem` can also be used outside a `SummaryList` as a standalone card, it renders as a `<div>` instead of a `<li>` and receives no list context.

The hierarchy looks like this:

```sh
SummaryList                         the <ul>
└── SummaryItem.Root                the <li> (or <div> when used standalone)
    ├── SummaryItem.Content         grows to fill available space
    │   ├── SummaryItem.Title       heading, reacts to expand hover
    │   └── SummaryItem.Meta        optional metadata row
    └── SummaryItem.Action          action slot (positioned start or end)
        ├── SummaryItem.Button      icon button
        ├── SummaryItem.Link        icon link
        └── SummaryItem.Menu        dropdown menu root
            ├── SummaryItem.Menu.Trigger
            ├── SummaryItem.Menu.Popup
            ├── SummaryItem.Menu.Item
            ├── SummaryItem.Menu.CheckboxItem
            └── … (full DropdownMenu API)
```

## :hammer_and_wrench: Usage

### Props

```ts
interface SummaryListProps {
  /**
   * Controls the look of the container.
   * Default: "simple"
   */
  mode?: "simple" | "card";

  /**
   * Visual separator between items.
   * "line" draws a border; "timeline" renders a connected dot-and-line track.
   * Default: none
   */
  divider?: "line" | "timeline";

  /**
   * Accent color applied to timeline markers, action buttons, and title hover states.
   * Inherited by all items unless overridden.
   * Default: "primary" 
   */
    color?: "primary" | "secondary" | "success" | "warning" | "error";

  /**
   * Alternates item background for improved scannability.
   * Default: false
   */
  striped?: boolean;
}

interface ItemProps {
  /** Overrides the list-level color for this item only. */
  color?: "primary" | "secondary" | "success" | "warning" | "error";
}

/** Accepts all Heading props except size, which is fixed. */
interface TitleProps extends Omit<HeadingProps, "size"> {}

interface MetaProps {
  /** Adds a bullet (•) separator between children on wider viewports. */
  separator?: boolean;
}

interface ActionProps {
  /**
   * Controls position relative to content.
   * Default: "end"
   */
  justify?: "start" | "end";

  /**
   * Controls vertical alignment on wider screens.
   * Default: "middle"
   */
  align?: "start" | "middle";

  /**
   * Stretches an ::after overlay across the entire item, making the action's
   * child a full-card click target. Combine with Title for link-style hover treatment.
   * Default: false
   */
  expand?: boolean;

  /** Overrides the inherited color for this action slot. */
  color?: "primary" | "secondary" | "success" | "warning" | "error";
}
```

### Recreating a `PreviewList`

```tsx
<SummaryList>
  <SummaryItem.Root>
    <SummaryItem.Content>
      <SummaryItem.Title as="h3">Title</SummaryItem.Title>
      <p>Any content can go here for flexibility.</p>
      <SummaryItem.Meta separator>
        <Button>Button meta</Button>
        <Chip>Chip meta</Chip>
      </SummaryItem.Meta>
    </SummaryItem.Content>
    <SummaryItem.Action align="middle" justify="end" expand>
      <SummaryItem.Link href="#" icon={MagnifyingGlassIcon} label="View" />
    </SummaryItem.Action>
  </SummaryItem.Root>
</SummaryList>
```

### Recreating a DevelopmentProgramCard

```tsx
const DevelopementProgramCard = ({ query }) => {
 const program = getFragment(Fragment, query);
 
 // Component body logic
 
 return (
    <SummaryList color="secondary">
      <SummaryItem.Root>
        <SummaryItem.Content>
          <SummaryItem.Title as="h3">{program.title.localized}</SummaryItem.Title>
          <p>{program.description.localized}</p>
        </SummaryItem.Content>
        <SummaryItem.Action align="middle" justify="end">
          <SummaryItem.Menu>
            <SummaryItem.Menu.Trigger icon={EllipsisHorizontalIcon} label="Actions" />
            <SummaryItem.Menu.Popup>
              <SummaryItem.Menu.Item>Edit</SummaryItem.Menu.Item>
              <SummaryItem.Menu.Item color="error">Remove</SummaryItem.Menu.Item>
            </SummaryItem.Menu.Popup>
          </SummaryItem.Menu>
        </SummaryItem.Action>
      </SummaryItem.Root>
    </SummaryList>
  );
}
```

### Opening dialogs from actions

Two patterns are supported and both are shown in the WithDialogs story:

  - `SummaryItem.Button` wrapped in `Dialog.Trigger`, Radix tracks the trigger and restores focus automatically when the dialog closes.
  - Menu item opening a dialog, the menu item unmounts when the menu closes, so Radix can't track it. Store a ref on `SummaryItem.Menu.Trigger` and pass it to `Dialog.Content`'s `onCloseAutoFocus` to restore focus manually.

## 🧪 Testing

  1. Open Storybook and navigate to **SummaryList**
  2. **Default**: verify line dividers, action button, dropdown menu, and meta separator all render correctly
  3. **Timeline / Timeline Single**: confirm the dot aligns with the title's first line; single item shows only the dot with no connecting lines
  4. **Striped**: alternating row backgrounds
  5. **As Card**: rounded corners and shadow on the container
  6. **With Action Link / With Color**: each color variant renders correctly in light and dark mode
  7. WithDialogs: open both dialogs and close them; confirm focus returns to the correct trigger button in both cases
  8. StandaloneItem: renders as a <div> outside a list with no list context

## 📸 Screenshot

<img width="1600" height="999" alt="swappy-20260509_113554" src="https://github.com/user-attachments/assets/b17c0e5c-05de-47cb-9c2f-0abd6879de5a" />

<img width="1597" height="1001" alt="swappy-20260509_113610" src="https://github.com/user-attachments/assets/83163035-1d80-4583-a399-e71c18db9709" />
