### PR TITLE
[Tooling] Add codespace setup script for sharing with designers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down logs setup clean-modules refresh refresh-frontend refresh-api seed-fresh migrate artisan phpstan queue-work composer optimize-api reverb-start start-services
+.PHONY: up down logs setup codespace-setup clean-modules refresh refresh-frontend refresh-api seed-fresh migrate artisan phpstan queue-work composer optimize-api reverb-start start-services
 
 # Environment selection: use `make up ENV=dev` for development with hot reloading
 ifeq ($(ENV),dev)
@@ -22,6 +22,9 @@ logs:
 
 setup:
 	$(DOCKER_RUN) setup.sh
+
+codespace-setup:
+	bash maintenance/scripts/setup-codespace.sh
 
 refresh:
 	$(DOCKER_RUN) refresh_all.sh

--- a/maintenance/scripts/setup-codespace.sh
+++ b/maintenance/scripts/setup-codespace.sh
@@ -1,0 +1,147 @@
+#! /bin/bash
+
+# Configures a GitHub Codespace for external sharing.
+#
+# Patches api/.env, apps/web/.env, and the nginx mock-auth proxy to use the
+# Codespace's forwarded-port URL instead of localhost:8000, then rebuilds the
+# frontend (API_HOST is baked into the JS bundle at Vite build time), reloads
+# nginx, and clears Laravel's config cache so the changes take effect.
+#
+# Usage (run from repo root inside the Codespace terminal):
+#   bash maintenance/scripts/setup-codespace.sh
+#
+# Or via make:
+#   make codespace-setup
+
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+source ${parent_path}/lib/common.sh
+
+# ---------------------------------------------------------------------------
+# Resolve the Codespace app URL
+# ---------------------------------------------------------------------------
+
+if [ -z "${CODESPACE_NAME:-}" ]; then
+  echo "Error: CODESPACE_NAME is not set."
+  echo "This script must be run inside a GitHub Codespace terminal."
+  exit 1
+fi
+
+FORWARDING_DOMAIN="${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN:-app.github.dev}"
+APP_URL="https://${CODESPACE_NAME}-8000.${FORWARDING_DOMAIN}"
+APP_HOST="${CODESPACE_NAME}-8000.${FORWARDING_DOMAIN}"
+
+echo "Configuring Codespace for external access"
+echo "  App URL: ${APP_URL}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# api/.env
+# ---------------------------------------------------------------------------
+
+API_ENV="api/.env"
+if [ ! -f "${API_ENV}" ]; then
+  echo "api/.env not found — copying from api/.env.example"
+  cp api/.env.example "${API_ENV}"
+fi
+
+sed -i "s|APP_URL=.*|APP_URL=\"${APP_URL}\"|" "${API_ENV}"
+sed -i "s|OAUTH_REDIRECT_URI=.*|OAUTH_REDIRECT_URI=\"${APP_URL}/auth-callback\"|" "${API_ENV}"
+sed -i "s|OAUTH_POST_LOGIN_REDIRECT=.*|OAUTH_POST_LOGIN_REDIRECT=\"${APP_URL}/applicant\"|" "${API_ENV}"
+sed -i "s|OAUTH_POST_LOGIN_REGISTRATION_REDIRECT=.*|OAUTH_POST_LOGIN_REGISTRATION_REDIRECT=\"${APP_URL}/registration/account\"|" "${API_ENV}"
+sed -i "s|OAUTH_URI=.*|OAUTH_URI=\"${APP_URL}/oxauth/authorize\"|" "${API_ENV}"
+
+echo "✓ api/.env updated"
+
+# ---------------------------------------------------------------------------
+# apps/web/.env
+# ---------------------------------------------------------------------------
+
+WEB_ENV="apps/web/.env"
+if [ ! -f "${WEB_ENV}" ]; then
+  echo "apps/web/.env not found — copying from apps/web/.env.example"
+  cp apps/web/.env.example "${WEB_ENV}"
+fi
+
+sed -i "s|API_HOST=.*|API_HOST=\"${APP_URL}\"|" "${WEB_ENV}"
+sed -i "s|OAUTH_POST_LOGOUT_REDIRECT_EN=.*|OAUTH_POST_LOGOUT_REDIRECT_EN=\"${APP_URL}/en/logged-out\"|" "${WEB_ENV}"
+sed -i "s|OAUTH_POST_LOGOUT_REDIRECT_FR=.*|OAUTH_POST_LOGOUT_REDIRECT_FR=\"${APP_URL}/fr/logged-out\"|" "${WEB_ENV}"
+sed -i "s|OAUTH_LOGOUT_URI=.*|OAUTH_LOGOUT_URI=\"${APP_URL}/oxauth/endsession\"|" "${WEB_ENV}"
+
+echo "✓ apps/web/.env updated"
+
+# ---------------------------------------------------------------------------
+# nginx mock-auth proxy headers
+#
+# The mock OAuth server reads X-Forwarded-Proto + Host to construct URLs in
+# its OpenID Connect discovery document. Without this change the discovery
+# doc returns http://localhost:8000/oxauth/... which breaks login from an
+# external browser.
+# ---------------------------------------------------------------------------
+
+NGINX_CONF="infrastructure/conf/nginx-conf-local/default"
+
+sed -i "s|proxy_set_header X-Forwarded-Proto http;|proxy_set_header X-Forwarded-Proto https;|" "${NGINX_CONF}"
+sed -i "s|proxy_set_header Host localhost:8000;|proxy_set_header Host ${APP_HOST};|" "${NGINX_CONF}"
+
+echo "✓ nginx mock-auth proxy updated"
+
+# ---------------------------------------------------------------------------
+# Start containers (skip rebuild if already running)
+# ---------------------------------------------------------------------------
+
+if ! docker compose ps --status running | grep -q webserver; then
+  echo "Starting containers..."
+  docker compose up --detach
+else
+  echo "✓ Containers already running"
+fi
+
+# ---------------------------------------------------------------------------
+# Rebuild frontend
+#
+# API_HOST is injected by Vite's define config at build time, so updating
+# apps/web/.env alone has no effect — the bundle must be rebuilt.
+# ---------------------------------------------------------------------------
+
+echo "Rebuilding frontend (this takes a few minutes)..."
+docker compose run --rm maintenance bash refresh_frontend.sh
+
+echo "✓ Frontend rebuilt"
+
+# ---------------------------------------------------------------------------
+# Clear Laravel config cache + reload nginx
+# ---------------------------------------------------------------------------
+
+docker compose exec webserver sh -c \
+  "php /home/site/wwwroot/api/artisan config:clear && php /home/site/wwwroot/api/artisan cache:clear"
+
+docker compose exec webserver nginx -s reload
+
+echo "✓ Laravel cache cleared, nginx reloaded"
+
+# ---------------------------------------------------------------------------
+# Make port 8000 public (requires gh CLI, non-fatal if unavailable)
+# ---------------------------------------------------------------------------
+
+if command -v gh &>/dev/null; then
+  gh codespace ports visibility 8000:public --codespace "${CODESPACE_NAME}" 2>/dev/null \
+    && echo "✓ Port 8000 set to Public" \
+    || echo "Note: Could not set port visibility via gh CLI — set it manually in the Ports tab"
+else
+  echo "Note: gh CLI not found — set port 8000 to Public manually in the Ports tab"
+fi
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "========================================================"
+echo "  Codespace ready to share with designers"
+echo ""
+echo "  URL:  ${APP_URL}"
+echo ""
+echo "  Login (no password needed):"
+echo "    Admin:     admin@test.com"
+echo "    Applicant: applicant@test.com"
+echo "========================================================"

--- a/maintenance/scripts/setup-codespace.sh
+++ b/maintenance/scripts/setup-codespace.sh
@@ -42,6 +42,13 @@ API_ENV="api/.env"
 if [ ! -f "${API_ENV}" ]; then
   echo "api/.env not found — copying from api/.env.example"
   cp api/.env.example "${API_ENV}"
+  ${parent_path}/update_env_secrets.sh "${API_ENV}"
+fi
+
+# Generate APP_KEY if missing (e.g. freshly copied from .env.example)
+if ! grep -q "^APP_KEY=.\+" "${API_ENV}"; then
+  echo "Generating APP_KEY..."
+  docker compose run --rm maintenance sh -c "cd /var/www/html/api && php artisan key:generate"
 fi
 
 sed -i "s|APP_URL=.*|APP_URL=\"${APP_URL}\"|" "${API_ENV}"

--- a/maintenance/scripts/setup-codespace.sh
+++ b/maintenance/scripts/setup-codespace.sh
@@ -3,9 +3,9 @@
 # Configures a GitHub Codespace for external sharing.
 #
 # Patches api/.env, apps/web/.env, and the nginx mock-auth proxy to use the
-# Codespace's forwarded-port URL instead of localhost:8000, then rebuilds the
-# frontend (API_HOST is baked into the JS bundle at Vite build time), reloads
-# nginx, and clears Laravel's config cache so the changes take effect.
+# Codespace's forwarded-port URL instead of localhost:8000, then refreshes
+# the API, seeds the database, and rebuilds the frontend (API_HOST is baked
+# into the JS bundle at Vite build time so a rebuild is required).
 #
 # Usage (run from repo root inside the Codespace terminal):
 #   bash maintenance/scripts/setup-codespace.sh
@@ -97,6 +97,22 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Refresh API + seed database
+#
+# Runs inside the maintenance container (same as make refresh-api).
+# Clears config/route/view caches, re-runs migrations, and seeds test data
+# so designers can log in with admin@test.com / applicant@test.com.
+# ---------------------------------------------------------------------------
+
+echo "Refreshing API..."
+docker compose run --rm maintenance bash refresh_api.sh
+
+echo "Seeding database..."
+docker compose run --rm maintenance sh -c "cd /var/www/html/api && php artisan migrate:fresh --seed"
+
+echo "✓ API refreshed and database seeded"
+
+# ---------------------------------------------------------------------------
 # Rebuild frontend
 #
 # API_HOST is injected by Vite's define config at build time, so updating
@@ -109,15 +125,12 @@ docker compose run --rm maintenance bash refresh_frontend.sh
 echo "✓ Frontend rebuilt"
 
 # ---------------------------------------------------------------------------
-# Clear Laravel config cache + reload nginx
+# Reload nginx
 # ---------------------------------------------------------------------------
-
-docker compose exec webserver sh -c \
-  "php /home/site/wwwroot/api/artisan config:clear && php /home/site/wwwroot/api/artisan cache:clear"
 
 docker compose exec webserver nginx -s reload
 
-echo "✓ Laravel cache cleared, nginx reloaded"
+echo "✓ nginx reloaded"
 
 # ---------------------------------------------------------------------------
 # Make port 8000 public (requires gh CLI, non-fatal if unavailable)


### PR DESCRIPTION
## Summary

- Adds `maintenance/scripts/setup-codespace.sh` to configure a GitHub Codespace for external sharing
- Adds `make codespace-setup` target to the Makefile

## What it does

Running `make codespace-setup` inside a Codespace terminal will:

1. Patch `api/.env` — updates `APP_URL` and all OAuth redirect URIs to the Codespace URL
2. Patch `apps/web/.env` — updates `API_HOST` and logout redirect URLs
3. Patch nginx — fixes the mock OAuth server's `Host` header so login works from an external browser
4. Start containers if not running
5. Rebuild the frontend (`API_HOST` is baked into the JS bundle by Vite at build time, so a rebuild is required)
6. Clear Laravel config cache and reload nginx
7. Set port 8000 to Public via `gh` CLI if available

## Why

By default the app is configured for `localhost:8000`. Sharing a Codespace with designers requires all URLs to point to the Codespace's forwarded-port URL (`https://{name}-8000.app.github.dev`). Several of these are runtime config but `API_HOST` is compile-time, which is why a frontend rebuild is needed.

## Testing

- [ ] Run `make codespace-setup` inside a Codespace
- [ ] Confirm the app loads at the printed URL
- [ ] Confirm GCKey sign-in reaches the mock auth login page
- [ ] Confirm login with `admin@test.com` works and lands on the admin dashboard and do the same for other logins as well 
