### PR TITLE
[Fix] community dashboard community admin

### DIFF
--- a/apps/web/src/constants/permissionConstants.ts
+++ b/apps/web/src/constants/permissionConstants.ts
@@ -36,6 +36,7 @@ const permissionConstants: Readonly<Record<string, RoleName[]>> = {
     ROLE_NAME.PlatformAdmin,
   ],
   viewCommunityTalent: [
+    ROLE_NAME.CommunityAdmin,
     ROLE_NAME.CommunityRecruiter,
     ROLE_NAME.CommunityTalentCoordinator,
     ROLE_NAME.PlatformAdmin,

--- a/apps/web/src/pages/AdminDashboardPage/AdminDashboard.test.tsx
+++ b/apps/web/src/pages/AdminDashboardPage/AdminDashboard.test.tsx
@@ -147,6 +147,11 @@ describe("Render dashboard page", () => {
         name: "Candidates",
       }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: "Community talent",
+      }),
+    ).toBeInTheDocument();
 
     // resources links
     expect(


### PR DESCRIPTION
🤖 Resolves #16736.

## 👋 Introduction

This PR allows the community admin role to view the **Community talent** link on the community dashboard.

## 🧪 Testing

1. `pnpm build:fresh`
2. Sign in as community@test.com
3. Navigate to http://localhost:8000/en/community
4. Verify **Community talent** link is rendered in the recruitment section

## 📸 Screenshot

<img width="717" height="903" alt="Screenshot 2026-05-12 at 12 41 17" src="https://github.com/user-attachments/assets/ab09a09c-3a82-4b99-81ac-b47922548e63" />
