### PR TITLE
[Refactor] Community pages middleware addition

### DIFF
--- a/apps/web/src/pages/Communities/CommunityLayout.tsx
+++ b/apps/web/src/pages/Communities/CommunityLayout.tsx
@@ -79,6 +79,11 @@ const CommunityLayout = () => {
       [ROLE_NAME.CommunityTalentCoordinator],
       roleAssignmentsFiltered,
       communityId,
+    ) ||
+    checkRole(
+      [ROLE_NAME.CommunityRecruiter],
+      roleAssignmentsFiltered,
+      communityId,
     );
 
   const pages = new Map<PageNavKeys, PageNavInfo>([
@@ -98,7 +103,7 @@ const CommunityLayout = () => {
     ],
   ]);
 
-  if (canViewManageAccess) {
+  if (canAdminManageAccessAndEditCommunity) {
     pages.set("professionalization", {
       icon: CheckBadgeIcon,
       title: intl.formatMessage(adminMessages.professionalization),
@@ -106,6 +111,9 @@ const CommunityLayout = () => {
         url: paths.communityProfessionalization(communityId),
       },
     });
+  }
+
+  if (canViewManageAccess) {
     pages.set("manage-access", {
       icon: ClipboardDocumentListIcon,
       title: intl.formatMessage({

--- a/apps/web/src/pages/Communities/CommunityLayout.tsx
+++ b/apps/web/src/pages/Communities/CommunityLayout.tsx
@@ -68,13 +68,13 @@ const CommunityLayout = () => {
 
   const roleAssignmentsFiltered =
     data?.myAuth?.roleAssignments?.filter(notEmpty) ?? [];
-  const canAdminManageAccess = checkRole(
+  const canAdminManageAccessAndEditCommunity = checkRole(
     [ROLE_NAME.PlatformAdmin, ROLE_NAME.CommunityAdmin],
     roleAssignmentsFiltered,
     communityId,
   );
   const canViewManageAccess =
-    canAdminManageAccess ||
+    canAdminManageAccessAndEditCommunity ||
     checkRole(
       [ROLE_NAME.CommunityTalentCoordinator],
       roleAssignmentsFiltered,
@@ -142,7 +142,7 @@ const CommunityLayout = () => {
       url: page.link.url,
     })),
     navigationCrumbs: navigationCrumbs,
-    canAdminManageAccess,
+    canAdminManageAccessAndEditCommunity,
   };
 
   // No actual shared UI - this is just used as a context provider

--- a/apps/web/src/pages/Communities/CommunityMembersPage/CommunityMembersPage.test.ts
+++ b/apps/web/src/pages/Communities/CommunityMembersPage/CommunityMembersPage.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
+import type { RouterContextProvider } from "react-router";
 
 import { ROLE_NAME } from "@gc-digital-talent/auth";
 import { UnauthorizedError } from "@gc-digital-talent/helpers";
@@ -28,20 +29,27 @@ describe("CommunityMembersPage clientMiddleware", () => {
     communityId: "community-123",
   };
 
-  const mockNext = vi.fn(() => Promise.resolve("next-result"));
+  const mockUrl = new URL(mockRequest.url);
+  const mockPattern = "/:locale/admin/communities/:communityId/members";
+
+  const mockNext = vi.fn(() => Promise.resolve({})) as unknown as Parameters<
+    (typeof clientMiddleware)[0]
+  >[1];
 
   const createContext = (
     user: unknown,
     intl: unknown,
     graphqlClient: unknown = {},
-  ) => ({
-    get: vi.fn((token: unknown) => {
-      if (token === "userContext") return user;
-      if (token === "intlContext") return intl;
-      if (token === "graphqlClientContext") return graphqlClient;
-      return null;
-    }),
-  });
+  ): Readonly<RouterContextProvider> =>
+    ({
+      get: vi.fn((token: unknown) => {
+        if (token === "userContext") return user;
+        if (token === "intlContext") return intl;
+        if (token === "graphqlClientContext") return graphqlClient;
+        return null;
+      }),
+      set: vi.fn(),
+    }) as unknown as Readonly<RouterContextProvider>;
 
   const mockIntl = {
     locale: "en",
@@ -64,7 +72,13 @@ describe("CommunityMembersPage clientMiddleware", () => {
       );
 
       await clientMiddleware[0](
-        { context, request: mockRequest, params: mockParams },
+        {
+          context,
+          request: mockRequest,
+          params: mockParams,
+          url: mockUrl,
+          pattern: mockPattern,
+        },
         mockNext,
       );
 
@@ -82,7 +96,13 @@ describe("CommunityMembersPage clientMiddleware", () => {
       );
 
       await clientMiddleware[0](
-        { context, request: mockRequest, params: mockParams },
+        {
+          context,
+          request: mockRequest,
+          params: mockParams,
+          url: mockUrl,
+          pattern: mockPattern,
+        },
         mockNext,
       );
 
@@ -100,7 +120,13 @@ describe("CommunityMembersPage clientMiddleware", () => {
       );
 
       await clientMiddleware[0](
-        { context, request: mockRequest, params: mockParams },
+        {
+          context,
+          request: mockRequest,
+          params: mockParams,
+          url: mockUrl,
+          pattern: mockPattern,
+        },
         mockNext,
       );
 
@@ -121,7 +147,13 @@ describe("CommunityMembersPage clientMiddleware", () => {
       );
 
       await clientMiddleware[0](
-        { context, request: mockRequest, params: mockParams },
+        {
+          context,
+          request: mockRequest,
+          params: mockParams,
+          url: mockUrl,
+          pattern: mockPattern,
+        },
         mockNext,
       );
 
@@ -142,7 +174,13 @@ describe("CommunityMembersPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -163,7 +201,13 @@ describe("CommunityMembersPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -184,7 +228,13 @@ describe("CommunityMembersPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -202,7 +252,13 @@ describe("CommunityMembersPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -220,7 +276,13 @@ describe("CommunityMembersPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -234,7 +296,13 @@ describe("CommunityMembersPage clientMiddleware", () => {
       // requireUser throws a redirect Response when user is null
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toBeDefined();

--- a/apps/web/src/pages/Communities/CommunityMembersPage/CommunityMembersPage.test.ts
+++ b/apps/web/src/pages/Communities/CommunityMembersPage/CommunityMembersPage.test.ts
@@ -24,12 +24,17 @@ describe("CommunityMembersPage clientMiddleware", () => {
   } as Request;
 
   const mockParams = {
+    locale: "en",
     communityId: "community-123",
   };
 
   const mockNext = vi.fn(() => Promise.resolve("next-result"));
 
-  const createContext = (user: unknown, intl: unknown, graphqlClient: unknown = {}) => ({
+  const createContext = (
+    user: unknown,
+    intl: unknown,
+    graphqlClient: unknown = {},
+  ) => ({
     get: vi.fn((token: unknown) => {
       if (token === "userContext") return user;
       if (token === "intlContext") return intl;
@@ -53,9 +58,7 @@ describe("CommunityMembersPage clientMiddleware", () => {
     test("allows PlatformAdmin access (global role, no team needed)", async () => {
       const context = createContext(
         {
-          roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.PlatformAdmin),
-          ],
+          roleAssignments: [createMockRoleAssignment(ROLE_NAME.PlatformAdmin)],
         },
         mockIntl,
       );
@@ -108,7 +111,10 @@ describe("CommunityMembersPage clientMiddleware", () => {
       const context = createContext(
         {
           roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.CommunityTalentCoordinator, "team-123"),
+            createMockRoleAssignment(
+              ROLE_NAME.CommunityTalentCoordinator,
+              "team-123",
+            ),
           ],
         },
         mockIntl,
@@ -146,7 +152,10 @@ describe("CommunityMembersPage clientMiddleware", () => {
       const context = createContext(
         {
           roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.CommunityRecruiter, "wrong-team"),
+            createMockRoleAssignment(
+              ROLE_NAME.CommunityRecruiter,
+              "wrong-team",
+            ),
           ],
         },
         mockIntl,
@@ -164,7 +173,10 @@ describe("CommunityMembersPage clientMiddleware", () => {
       const context = createContext(
         {
           roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.CommunityTalentCoordinator, "wrong-team"),
+            createMockRoleAssignment(
+              ROLE_NAME.CommunityTalentCoordinator,
+              "wrong-team",
+            ),
           ],
         },
         mockIntl,
@@ -183,9 +195,7 @@ describe("CommunityMembersPage clientMiddleware", () => {
     test("throws UnauthorizedError for Applicant role", async () => {
       const context = createContext(
         {
-          roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.Applicant),
-          ],
+          roleAssignments: [createMockRoleAssignment(ROLE_NAME.Applicant)],
         },
         mockIntl,
       );

--- a/apps/web/src/pages/Communities/CommunityMembersPage/CommunityMembersPage.test.ts
+++ b/apps/web/src/pages/Communities/CommunityMembersPage/CommunityMembersPage.test.ts
@@ -1,0 +1,235 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+import { UnauthorizedError } from "@gc-digital-talent/helpers";
+
+import { clientMiddleware } from "./CommunityMembersPage";
+import { createMockRoleAssignment } from "../testUtils";
+
+// Mock the userContext and intlContext to return our test values
+vi.mock("~/routing/context", () => ({
+  userContext: "userContext",
+  intlContext: "intlContext",
+  graphqlClientContext: "graphqlClientContext",
+}));
+
+// Mock getCommunityTeamIdInMiddleware
+vi.mock("../utils", () => ({
+  getCommunityTeamIdInMiddleware: vi.fn(() => Promise.resolve("team-123")),
+}));
+
+describe("CommunityMembersPage clientMiddleware", () => {
+  const mockRequest = {
+    url: "http://localhost:3000/en/admin/communities/community-123/members",
+  } as Request;
+
+  const mockParams = {
+    communityId: "community-123",
+  };
+
+  const mockNext = vi.fn(() => Promise.resolve("next-result"));
+
+  const createContext = (user: unknown, intl: unknown, graphqlClient: unknown = {}) => ({
+    get: vi.fn((token: unknown) => {
+      if (token === "userContext") return user;
+      if (token === "intlContext") return intl;
+      if (token === "graphqlClientContext") return graphqlClient;
+      return null;
+    }),
+  });
+
+  const mockIntl = {
+    locale: "en",
+    formatMessage: vi.fn(
+      (descriptor: { defaultMessage: string }) => descriptor.defaultMessage,
+    ),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("allows access for authorized roles with matching team", () => {
+    test("allows PlatformAdmin access (global role, no team needed)", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.PlatformAdmin),
+          ],
+        },
+        mockIntl,
+      );
+
+      await clientMiddleware[0](
+        { context, request: mockRequest, params: mockParams },
+        mockNext,
+      );
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    test("allows CommunityAdmin with matching teamId", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityAdmin, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await clientMiddleware[0](
+        { context, request: mockRequest, params: mockParams },
+        mockNext,
+      );
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    test("allows CommunityRecruiter with matching teamId", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityRecruiter, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await clientMiddleware[0](
+        { context, request: mockRequest, params: mockParams },
+        mockNext,
+      );
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    test("allows CommunityTalentCoordinator with matching teamId", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityTalentCoordinator, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await clientMiddleware[0](
+        { context, request: mockRequest, params: mockParams },
+        mockNext,
+      );
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+  });
+
+  describe("denies access for community roles with wrong team", () => {
+    test("throws UnauthorizedError for CommunityAdmin with wrong teamId", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityAdmin, "wrong-team"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    test("throws UnauthorizedError for CommunityRecruiter with wrong teamId", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityRecruiter, "wrong-team"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    test("throws UnauthorizedError for CommunityTalentCoordinator with wrong teamId", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityTalentCoordinator, "wrong-team"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+  });
+
+  describe("denies access for other unauthorized roles", () => {
+    test("throws UnauthorizedError for Applicant role", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.Applicant),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    test("throws UnauthorizedError for ProcessOperator role", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.ProcessOperator, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+  });
+
+  describe("redirects when user is not logged in", () => {
+    test("throws redirect when user is null", async () => {
+      const context = createContext(null, mockIntl);
+
+      // requireUser throws a redirect Response when user is null
+      await expect(
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
+      ).rejects.toBeDefined();
+
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/pages/Communities/CommunityMembersPage/CommunityMembersPage.tsx
+++ b/apps/web/src/pages/Communities/CommunityMembersPage/CommunityMembersPage.tsx
@@ -21,12 +21,13 @@ import type { CommunityMember } from "~/utils/communityUtils";
 import { groupRoleAssignmentsByUser, checkRole } from "~/utils/communityUtils";
 import useRequiredParams from "~/hooks/useRequiredParams";
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
-import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import tableMessages from "~/components/Table/tableMessages";
 import Hero from "~/components/Hero";
 import useRoutes from "~/hooks/useRoutes";
+import { requireUser } from "~/routing/auth";
 import adminMessages from "~/messages/adminMessages";
 
+import type { Route } from "./+types/CommunityMembersPage";
 import AddCommunityMemberDialog from "./components/AddCommunityMemberDialog";
 import { actionCell, emailLinkCell, roleAccessor, roleCell } from "./helpers";
 import type {
@@ -34,6 +35,7 @@ import type {
   ContextType,
 } from "./components/types";
 import { CommunityMembersPage_CommunityFragment } from "./components/operations";
+import { getCommunityTeamIdInMiddleware } from "../utils";
 
 const pageTitle = defineMessage({
   defaultMessage: "Community members",
@@ -53,7 +55,8 @@ const CommunityMembers = ({ communityQuery }: CommunityMembersProps) => {
     CommunityMembersPage_CommunityFragment,
     communityQuery,
   );
-  const { canAdminManageAccess } = useOutletContext<ContextType>();
+  const { canAdminManageAccessAndEditCommunity } =
+    useOutletContext<ContextType>();
 
   const { userAuthInfo } = useAuthorization();
   const roleAssignments = unpackMaybes(userAuthInfo?.roleAssignments);
@@ -97,7 +100,7 @@ const CommunityMembers = ({ communityQuery }: CommunityMembersProps) => {
     }),
   ] as ColumnDef<CommunityMember>[];
 
-  if (canAdminManageAccess) {
+  if (canAdminManageAccessAndEditCommunity) {
     columns.splice(
       1,
       0,
@@ -136,7 +139,7 @@ const CommunityMembers = ({ communityQuery }: CommunityMembersProps) => {
           internal: true,
           label: intl.formatMessage(adminMessages.searchByKeyword),
         }}
-        {...(canAdminManageAccess && {
+        {...(canAdminManageAccessAndEditCommunity && {
           add: {
             component: <AddCommunityMemberDialog community={community} />,
           },
@@ -206,8 +209,30 @@ const CommunityMembersPage = ({ community }: CommunityMembersPageProps) => {
   );
 };
 
+export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
+  async ({ context, request, params }, next) => {
+    const teamId = await getCommunityTeamIdInMiddleware(
+      context,
+      params.communityId,
+    );
+
+    requireUser(
+      context,
+      request,
+      [
+        { name: ROLE_NAME.PlatformAdmin },
+        { name: ROLE_NAME.CommunityAdmin, teamId: teamId },
+        { name: ROLE_NAME.CommunityRecruiter, teamId: teamId },
+        { name: ROLE_NAME.CommunityTalentCoordinator, teamId: teamId },
+      ],
+      true,
+    );
+    return await next();
+  },
+];
+
 // Since the SEO and Hero need API-loaded data, we wrap the entire page in a Pending
-const CommunityMembersPageApiWrapper = () => {
+const Component = () => {
   const { communityId } = useRequiredParams<RouteParams>("communityId");
   const [{ data, fetching, error }] = useQuery({
     query: CommunityMembersTeam_Query,
@@ -223,19 +248,6 @@ const CommunityMembersPageApiWrapper = () => {
     </Pending>
   );
 };
-
-export const Component = () => (
-  <RequireAuth
-    roles={[
-      ROLE_NAME.CommunityAdmin,
-      ROLE_NAME.CommunityRecruiter,
-      ROLE_NAME.CommunityTalentCoordinator,
-      ROLE_NAME.PlatformAdmin,
-    ]}
-  >
-    <CommunityMembersPageApiWrapper />
-  </RequireAuth>
-);
 
 Component.displayName = "AdminCommunityMembersPage";
 

--- a/apps/web/src/pages/Communities/CommunityMembersPage/components/types.ts
+++ b/apps/web/src/pages/Communities/CommunityMembersPage/components/types.ts
@@ -20,5 +20,5 @@ export interface ContextType {
   teamId: Scalars["UUID"]["output"] | null | undefined;
   navTabs: React.ComponentProps<typeof Hero>["navTabs"];
   navigationCrumbs: React.ComponentProps<typeof Hero>["crumbs"];
-  canAdminManageAccess: boolean;
+  canAdminManageAccessAndEditCommunity: boolean;
 }

--- a/apps/web/src/pages/Communities/CommunityProfessionalizationPage/CommunityProfessionalizationPage.test.ts
+++ b/apps/web/src/pages/Communities/CommunityProfessionalizationPage/CommunityProfessionalizationPage.test.ts
@@ -24,12 +24,17 @@ describe("CommunityProfessionalizationPage clientMiddleware", () => {
   } as Request;
 
   const mockParams = {
+    locale: "en",
     communityId: "community-123",
   };
 
   const mockNext = vi.fn(() => Promise.resolve("next-result"));
 
-  const createContext = (user: unknown, intl: unknown, graphqlClient: unknown = {}) => ({
+  const createContext = (
+    user: unknown,
+    intl: unknown,
+    graphqlClient: unknown = {},
+  ) => ({
     get: vi.fn((token: unknown) => {
       if (token === "userContext") return user;
       if (token === "intlContext") return intl;
@@ -53,9 +58,7 @@ describe("CommunityProfessionalizationPage clientMiddleware", () => {
     test("allows PlatformAdmin access (global role, no team needed)", async () => {
       const context = createContext(
         {
-          roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.PlatformAdmin),
-          ],
+          roleAssignments: [createMockRoleAssignment(ROLE_NAME.PlatformAdmin)],
         },
         mockIntl,
       );
@@ -110,7 +113,10 @@ describe("CommunityProfessionalizationPage clientMiddleware", () => {
       const context = createContext(
         {
           roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.CommunityTalentCoordinator, "team-123"),
+            createMockRoleAssignment(
+              ROLE_NAME.CommunityTalentCoordinator,
+              "team-123",
+            ),
           ],
         },
         mockIntl,
@@ -149,9 +155,7 @@ describe("CommunityProfessionalizationPage clientMiddleware", () => {
     test("throws UnauthorizedError for Applicant role", async () => {
       const context = createContext(
         {
-          roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.Applicant),
-          ],
+          roleAssignments: [createMockRoleAssignment(ROLE_NAME.Applicant)],
         },
         mockIntl,
       );
@@ -185,9 +189,7 @@ describe("CommunityProfessionalizationPage clientMiddleware", () => {
     test("throws UnauthorizedError for BaseUser role", async () => {
       const context = createContext(
         {
-          roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.BaseUser),
-          ],
+          roleAssignments: [createMockRoleAssignment(ROLE_NAME.BaseUser)],
         },
         mockIntl,
       );

--- a/apps/web/src/pages/Communities/CommunityProfessionalizationPage/CommunityProfessionalizationPage.test.ts
+++ b/apps/web/src/pages/Communities/CommunityProfessionalizationPage/CommunityProfessionalizationPage.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
+import type { RouterContextProvider } from "react-router";
 
 import { ROLE_NAME } from "@gc-digital-talent/auth";
 import { UnauthorizedError } from "@gc-digital-talent/helpers";
@@ -28,20 +29,28 @@ describe("CommunityProfessionalizationPage clientMiddleware", () => {
     communityId: "community-123",
   };
 
-  const mockNext = vi.fn(() => Promise.resolve("next-result"));
+  const mockUrl = new URL(mockRequest.url);
+  const mockPattern =
+    "/:locale/admin/communities/:communityId/professionalization";
+
+  const mockNext = vi.fn(() => Promise.resolve({})) as unknown as Parameters<
+    (typeof clientMiddleware)[0]
+  >[1];
 
   const createContext = (
     user: unknown,
     intl: unknown,
     graphqlClient: unknown = {},
-  ) => ({
-    get: vi.fn((token: unknown) => {
-      if (token === "userContext") return user;
-      if (token === "intlContext") return intl;
-      if (token === "graphqlClientContext") return graphqlClient;
-      return null;
-    }),
-  });
+  ): Readonly<RouterContextProvider> =>
+    ({
+      get: vi.fn((token: unknown) => {
+        if (token === "userContext") return user;
+        if (token === "intlContext") return intl;
+        if (token === "graphqlClientContext") return graphqlClient;
+        return null;
+      }),
+      set: vi.fn(),
+    }) as unknown as Readonly<RouterContextProvider>;
 
   const mockIntl = {
     locale: "en",
@@ -64,7 +73,13 @@ describe("CommunityProfessionalizationPage clientMiddleware", () => {
       );
 
       await clientMiddleware[0](
-        { context, request: mockRequest, params: mockParams },
+        {
+          context,
+          request: mockRequest,
+          params: mockParams,
+          url: mockUrl,
+          pattern: mockPattern,
+        },
         mockNext,
       );
 
@@ -82,7 +97,13 @@ describe("CommunityProfessionalizationPage clientMiddleware", () => {
       );
 
       await clientMiddleware[0](
-        { context, request: mockRequest, params: mockParams },
+        {
+          context,
+          request: mockRequest,
+          params: mockParams,
+          url: mockUrl,
+          pattern: mockPattern,
+        },
         mockNext,
       );
 
@@ -103,7 +124,13 @@ describe("CommunityProfessionalizationPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -124,7 +151,13 @@ describe("CommunityProfessionalizationPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -144,7 +177,13 @@ describe("CommunityProfessionalizationPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -162,7 +201,13 @@ describe("CommunityProfessionalizationPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -180,7 +225,13 @@ describe("CommunityProfessionalizationPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -196,7 +247,13 @@ describe("CommunityProfessionalizationPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -210,7 +267,13 @@ describe("CommunityProfessionalizationPage clientMiddleware", () => {
       // requireUser throws a redirect Response when user is null
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toBeDefined();

--- a/apps/web/src/pages/Communities/CommunityProfessionalizationPage/CommunityProfessionalizationPage.test.ts
+++ b/apps/web/src/pages/Communities/CommunityProfessionalizationPage/CommunityProfessionalizationPage.test.ts
@@ -1,0 +1,219 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+import { UnauthorizedError } from "@gc-digital-talent/helpers";
+
+import { clientMiddleware } from "./CommunityProfessionalizationPage";
+import { createMockRoleAssignment } from "../testUtils";
+
+// Mock the userContext and intlContext to return our test values
+vi.mock("~/routing/context", () => ({
+  userContext: "userContext",
+  intlContext: "intlContext",
+  graphqlClientContext: "graphqlClientContext",
+}));
+
+// Mock getCommunityTeamIdInMiddleware
+vi.mock("../utils", () => ({
+  getCommunityTeamIdInMiddleware: vi.fn(() => Promise.resolve("team-123")),
+}));
+
+describe("CommunityProfessionalizationPage clientMiddleware", () => {
+  const mockRequest = {
+    url: "http://localhost:3000/en/admin/communities/community-123/professionalization",
+  } as Request;
+
+  const mockParams = {
+    communityId: "community-123",
+  };
+
+  const mockNext = vi.fn(() => Promise.resolve("next-result"));
+
+  const createContext = (user: unknown, intl: unknown, graphqlClient: unknown = {}) => ({
+    get: vi.fn((token: unknown) => {
+      if (token === "userContext") return user;
+      if (token === "intlContext") return intl;
+      if (token === "graphqlClientContext") return graphqlClient;
+      return null;
+    }),
+  });
+
+  const mockIntl = {
+    locale: "en",
+    formatMessage: vi.fn(
+      (descriptor: { defaultMessage: string }) => descriptor.defaultMessage,
+    ),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("allows access for authorized roles", () => {
+    test("allows PlatformAdmin access (global role, no team needed)", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.PlatformAdmin),
+          ],
+        },
+        mockIntl,
+      );
+
+      await clientMiddleware[0](
+        { context, request: mockRequest, params: mockParams },
+        mockNext,
+      );
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    test("allows CommunityAdmin with matching teamId", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityAdmin, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await clientMiddleware[0](
+        { context, request: mockRequest, params: mockParams },
+        mockNext,
+      );
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+  });
+
+  describe("denies access for CommunityRecruiter and CommunityTalentCoordinator (not authorized)", () => {
+    test("throws UnauthorizedError for CommunityRecruiter even with matching teamId", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityRecruiter, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    test("throws UnauthorizedError for CommunityTalentCoordinator even with matching teamId", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityTalentCoordinator, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+  });
+
+  describe("denies access for CommunityAdmin with wrong team", () => {
+    test("throws UnauthorizedError for CommunityAdmin with wrong teamId", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityAdmin, "wrong-team"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+  });
+
+  describe("denies access for other unauthorized roles", () => {
+    test("throws UnauthorizedError for Applicant role", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.Applicant),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    test("throws UnauthorizedError for ProcessOperator role", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.ProcessOperator, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    test("throws UnauthorizedError for BaseUser role", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.BaseUser),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+  });
+
+  describe("redirects when user is not logged in", () => {
+    test("throws redirect when user is null", async () => {
+      const context = createContext(null, mockIntl);
+
+      // requireUser throws a redirect Response when user is null
+      await expect(
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
+      ).rejects.toBeDefined();
+
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/pages/Communities/CommunityProfessionalizationPage/CommunityProfessionalizationPage.tsx
+++ b/apps/web/src/pages/Communities/CommunityProfessionalizationPage/CommunityProfessionalizationPage.tsx
@@ -22,15 +22,17 @@ import { MAX_DATE } from "@gc-digital-talent/date-helpers";
 
 import SEO from "~/components/SEO/SEO";
 import useRequiredParams from "~/hooks/useRequiredParams";
-import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import Hero from "~/components/Hero";
 import DevelopmentProgramCard from "~/components/DevelopmentProgramCard/DevelopmentProgramCard";
 import adminMessages from "~/messages/adminMessages";
+import { requireUser } from "~/routing/auth";
 
 import type { ContextType } from "../CommunityMembersPage/components/types";
 import AddDialog from "./components/AddDialog";
 import EditDialog from "./components/EditDialog";
 import RemoveDialog from "./components/RemoveDialog";
+import { getCommunityTeamIdInMiddleware } from "../utils";
+import type { Route } from "./+types/CommunityProfessionalizationPage";
 
 type SortValues = "recentlyAdded" | "name";
 
@@ -260,17 +262,37 @@ const CommunityProfessionalization_Query = graphql(/* GraphQL */ `
   }
 `);
 
-const context: Partial<OperationContext> = {
+const operationContext: Partial<OperationContext> = {
   additionalTypenames: ["CommunityDevelopmentProgram"], // This lets urql know when to invalidate cache if request returns empty list. https://formidable.com/open-source/urql/docs/basics/document-caching/#document-cache-gotchas
 };
 
-const CommunityProfessionalizationPage = () => {
+export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
+  async ({ context, request, params }, next) => {
+    const teamId = await getCommunityTeamIdInMiddleware(
+      context,
+      params.communityId,
+    );
+
+    requireUser(
+      context,
+      request,
+      [
+        { name: ROLE_NAME.PlatformAdmin },
+        { name: ROLE_NAME.CommunityAdmin, teamId: teamId },
+      ],
+      true,
+    );
+    return await next();
+  },
+];
+
+const Component = () => {
   const intl = useIntl();
   const { communityId } = useRequiredParams<RouteParams>("communityId");
   const [{ data, fetching, error }] = useQuery({
     query: CommunityProfessionalization_Query,
     variables: { id: communityId },
-    context,
+    context: operationContext,
   });
 
   return (
@@ -294,19 +316,6 @@ const CommunityProfessionalizationPage = () => {
     </Pending>
   );
 };
-
-export const Component = () => (
-  <RequireAuth
-    roles={[
-      ROLE_NAME.CommunityAdmin,
-      ROLE_NAME.CommunityRecruiter,
-      ROLE_NAME.CommunityTalentCoordinator,
-      ROLE_NAME.PlatformAdmin,
-    ]}
-  >
-    <CommunityProfessionalizationPage />
-  </RequireAuth>
-);
 
 Component.displayName = "CommunityProfessionalizationPage";
 

--- a/apps/web/src/pages/Communities/CreateCommunityPage/CreateCommunityPage.test.ts
+++ b/apps/web/src/pages/Communities/CreateCommunityPage/CreateCommunityPage.test.ts
@@ -18,6 +18,10 @@ describe("CreateCommunityPage clientMiddleware", () => {
     url: "http://localhost:3000/en/admin/communities/create",
   } as Request;
 
+  const mockParams = {
+    locale: "en",
+  };
+
   const mockNext = vi.fn(() => Promise.resolve("next-result"));
 
   const createContext = (user: unknown, intl: unknown) => ({
@@ -43,14 +47,15 @@ describe("CreateCommunityPage clientMiddleware", () => {
     test("allows PlatformAdmin access", async () => {
       const context = createContext(
         {
-          roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.PlatformAdmin),
-          ],
+          roleAssignments: [createMockRoleAssignment(ROLE_NAME.PlatformAdmin)],
         },
         mockIntl,
       );
 
-      await clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext);
+      await clientMiddleware[0](
+        { context, request: mockRequest, params: mockParams },
+        mockNext,
+      );
 
       expect(mockNext).toHaveBeenCalled();
     });
@@ -68,7 +73,10 @@ describe("CreateCommunityPage clientMiddleware", () => {
       );
 
       await expect(
-        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
       ).rejects.toThrow(UnauthorizedError);
     });
 
@@ -83,7 +91,10 @@ describe("CreateCommunityPage clientMiddleware", () => {
       );
 
       await expect(
-        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
       ).rejects.toThrow(UnauthorizedError);
     });
 
@@ -91,14 +102,20 @@ describe("CreateCommunityPage clientMiddleware", () => {
       const context = createContext(
         {
           roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.CommunityTalentCoordinator, "team-123"),
+            createMockRoleAssignment(
+              ROLE_NAME.CommunityTalentCoordinator,
+              "team-123",
+            ),
           ],
         },
         mockIntl,
       );
 
       await expect(
-        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
       ).rejects.toThrow(UnauthorizedError);
     });
   });
@@ -107,30 +124,32 @@ describe("CreateCommunityPage clientMiddleware", () => {
     test("throws UnauthorizedError for Applicant role", async () => {
       const context = createContext(
         {
-          roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.Applicant),
-          ],
+          roleAssignments: [createMockRoleAssignment(ROLE_NAME.Applicant)],
         },
         mockIntl,
       );
 
       await expect(
-        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
       ).rejects.toThrow(UnauthorizedError);
     });
 
     test("throws UnauthorizedError for BaseUser role", async () => {
       const context = createContext(
         {
-          roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.BaseUser),
-          ],
+          roleAssignments: [createMockRoleAssignment(ROLE_NAME.BaseUser)],
         },
         mockIntl,
       );
 
       await expect(
-        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
       ).rejects.toThrow(UnauthorizedError);
     });
 
@@ -145,7 +164,10 @@ describe("CreateCommunityPage clientMiddleware", () => {
       );
 
       await expect(
-        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
       ).rejects.toThrow(UnauthorizedError);
     });
   });
@@ -156,7 +178,10 @@ describe("CreateCommunityPage clientMiddleware", () => {
 
       // requireUser throws a redirect Response when user is null
       await expect(
-        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
       ).rejects.toBeDefined();
 
       expect(mockNext).not.toHaveBeenCalled();

--- a/apps/web/src/pages/Communities/CreateCommunityPage/CreateCommunityPage.test.ts
+++ b/apps/web/src/pages/Communities/CreateCommunityPage/CreateCommunityPage.test.ts
@@ -1,0 +1,165 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+import { UnauthorizedError } from "@gc-digital-talent/helpers";
+
+import { clientMiddleware } from "./CreateCommunityPage";
+import { createMockRoleAssignment } from "../testUtils";
+
+// Mock the userContext and intlContext to return our test values
+vi.mock("~/routing/context", () => ({
+  userContext: "userContext",
+  intlContext: "intlContext",
+  graphqlClientContext: "graphqlClientContext",
+}));
+
+describe("CreateCommunityPage clientMiddleware", () => {
+  const mockRequest = {
+    url: "http://localhost:3000/en/admin/communities/create",
+  } as Request;
+
+  const mockNext = vi.fn(() => Promise.resolve("next-result"));
+
+  const createContext = (user: unknown, intl: unknown) => ({
+    get: vi.fn((token: unknown) => {
+      if (token === "userContext") return user;
+      if (token === "intlContext") return intl;
+      return null;
+    }),
+  });
+
+  const mockIntl = {
+    locale: "en",
+    formatMessage: vi.fn(
+      (descriptor: { defaultMessage: string }) => descriptor.defaultMessage,
+    ),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("allows access for authorized roles", () => {
+    test("allows PlatformAdmin access", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.PlatformAdmin),
+          ],
+        },
+        mockIntl,
+      );
+
+      await clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+  });
+
+  describe("denies access for community roles (not authorized to create)", () => {
+    test("throws UnauthorizedError for CommunityAdmin role", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityAdmin, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    test("throws UnauthorizedError for CommunityRecruiter role", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityRecruiter, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    test("throws UnauthorizedError for CommunityTalentCoordinator role", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityTalentCoordinator, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+  });
+
+  describe("denies access for other unauthorized roles", () => {
+    test("throws UnauthorizedError for Applicant role", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.Applicant),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    test("throws UnauthorizedError for BaseUser role", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.BaseUser),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    test("throws UnauthorizedError for ProcessOperator role", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.ProcessOperator, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+  });
+
+  describe("redirects when user is not logged in", () => {
+    test("throws redirect when user is null", async () => {
+      const context = createContext(null, mockIntl);
+
+      // requireUser throws a redirect Response when user is null
+      await expect(
+        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+      ).rejects.toBeDefined();
+
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/pages/Communities/CreateCommunityPage/CreateCommunityPage.test.ts
+++ b/apps/web/src/pages/Communities/CreateCommunityPage/CreateCommunityPage.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
+import type { RouterContextProvider } from "react-router";
 
 import { ROLE_NAME } from "@gc-digital-talent/auth";
 import { UnauthorizedError } from "@gc-digital-talent/helpers";
@@ -22,15 +23,25 @@ describe("CreateCommunityPage clientMiddleware", () => {
     locale: "en",
   };
 
-  const mockNext = vi.fn(() => Promise.resolve("next-result"));
+  const mockUrl = new URL(mockRequest.url);
+  const mockPattern = "/:locale/admin/communities/create";
 
-  const createContext = (user: unknown, intl: unknown) => ({
-    get: vi.fn((token: unknown) => {
-      if (token === "userContext") return user;
-      if (token === "intlContext") return intl;
-      return null;
-    }),
-  });
+  const mockNext = vi.fn(() => Promise.resolve({})) as unknown as Parameters<
+    (typeof clientMiddleware)[0]
+  >[1];
+
+  const createContext = (
+    user: unknown,
+    intl: unknown,
+  ): Readonly<RouterContextProvider> =>
+    ({
+      get: vi.fn((token: unknown) => {
+        if (token === "userContext") return user;
+        if (token === "intlContext") return intl;
+        return null;
+      }),
+      set: vi.fn(),
+    }) as unknown as Readonly<RouterContextProvider>;
 
   const mockIntl = {
     locale: "en",
@@ -53,7 +64,13 @@ describe("CreateCommunityPage clientMiddleware", () => {
       );
 
       await clientMiddleware[0](
-        { context, request: mockRequest, params: mockParams },
+        {
+          context,
+          request: mockRequest,
+          params: mockParams,
+          url: mockUrl,
+          pattern: mockPattern,
+        },
         mockNext,
       );
 
@@ -74,7 +91,13 @@ describe("CreateCommunityPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -92,7 +115,13 @@ describe("CreateCommunityPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -113,7 +142,13 @@ describe("CreateCommunityPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -131,7 +166,13 @@ describe("CreateCommunityPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -147,7 +188,13 @@ describe("CreateCommunityPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -165,7 +212,13 @@ describe("CreateCommunityPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -179,7 +232,13 @@ describe("CreateCommunityPage clientMiddleware", () => {
       // requireUser throws a redirect Response when user is null
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toBeDefined();

--- a/apps/web/src/pages/Communities/CreateCommunityPage/CreateCommunityPage.tsx
+++ b/apps/web/src/pages/Communities/CreateCommunityPage/CreateCommunityPage.tsx
@@ -8,10 +8,11 @@ import { ROLE_NAME } from "@gc-digital-talent/auth";
 import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
-import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import pageTitles from "~/messages/pageTitles";
 import Hero from "~/components/Hero";
+import { requireUser } from "~/routing/auth";
 
+import type { Route } from "./+types/CreateCommunityPage";
 import CreateCommunityForm from "./components/CreateCommunityForm";
 
 const CreateCommunity_Mutation = graphql(/* GraphQL */ `
@@ -28,7 +29,14 @@ const pageTitle = defineMessage({
   description: "Page title for the create community page",
 });
 
-const CreateCommunityPage = () => {
+export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
+  async ({ context, request }, next) => {
+    requireUser(context, request, [{ name: ROLE_NAME.PlatformAdmin }], false);
+    return await next();
+  },
+];
+
+const Component = () => {
   const intl = useIntl();
   const routes = useRoutes();
 
@@ -80,12 +88,6 @@ const CreateCommunityPage = () => {
     </>
   );
 };
-
-export const Component = () => (
-  <RequireAuth roles={[ROLE_NAME.PlatformAdmin]}>
-    <CreateCommunityPage />
-  </RequireAuth>
-);
 
 Component.displayName = "AdminCreateCommunityPage";
 

--- a/apps/web/src/pages/Communities/IndexCommunityPage/IndexCommunityPage.test.ts
+++ b/apps/web/src/pages/Communities/IndexCommunityPage/IndexCommunityPage.test.ts
@@ -1,0 +1,178 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+import { UnauthorizedError } from "@gc-digital-talent/helpers";
+
+import { clientMiddleware } from "./IndexCommunityPage";
+import { createMockRoleAssignment } from "../testUtils";
+
+// Mock the userContext and intlContext to return our test values
+vi.mock("~/routing/context", () => ({
+  userContext: "userContext",
+  intlContext: "intlContext",
+  graphqlClientContext: "graphqlClientContext",
+}));
+
+describe("IndexCommunityPage clientMiddleware", () => {
+  const mockRequest = {
+    url: "http://localhost:3000/en/admin/communities",
+  } as Request;
+
+  const mockNext = vi.fn(() => Promise.resolve("next-result"));
+
+  const createContext = (user: unknown, intl: unknown) => ({
+    get: vi.fn((token: unknown) => {
+      if (token === "userContext") return user;
+      if (token === "intlContext") return intl;
+      return null;
+    }),
+  });
+
+  const mockIntl = {
+    locale: "en",
+    formatMessage: vi.fn(
+      (descriptor: { defaultMessage: string }) => descriptor.defaultMessage,
+    ),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("allows access for authorized roles", () => {
+    test("allows PlatformAdmin access", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.PlatformAdmin),
+          ],
+        },
+        mockIntl,
+      );
+
+      await clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    test("allows CommunityAdmin access", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityAdmin, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    test("allows CommunityRecruiter access", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityRecruiter, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    test("allows CommunityTalentCoordinator access", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityTalentCoordinator, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+  });
+
+  describe("denies access for unauthorized roles", () => {
+    test("throws UnauthorizedError for Applicant role", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.Applicant),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    test("throws UnauthorizedError for BaseUser role", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.BaseUser),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    test("throws UnauthorizedError for Guest role", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.Guest),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    test("throws UnauthorizedError for ProcessOperator role", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.ProcessOperator, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+  });
+
+  describe("redirects when user is not logged in", () => {
+    test("throws redirect when user is null", async () => {
+      const context = createContext(null, mockIntl);
+
+      // requireUser throws a redirect Response when user is null
+      await expect(
+        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+      ).rejects.toBeDefined();
+
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/pages/Communities/IndexCommunityPage/IndexCommunityPage.test.ts
+++ b/apps/web/src/pages/Communities/IndexCommunityPage/IndexCommunityPage.test.ts
@@ -18,6 +18,10 @@ describe("IndexCommunityPage clientMiddleware", () => {
     url: "http://localhost:3000/en/admin/communities",
   } as Request;
 
+  const mockParams = {
+    locale: "en",
+  };
+
   const mockNext = vi.fn(() => Promise.resolve("next-result"));
 
   const createContext = (user: unknown, intl: unknown) => ({
@@ -43,14 +47,15 @@ describe("IndexCommunityPage clientMiddleware", () => {
     test("allows PlatformAdmin access", async () => {
       const context = createContext(
         {
-          roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.PlatformAdmin),
-          ],
+          roleAssignments: [createMockRoleAssignment(ROLE_NAME.PlatformAdmin)],
         },
         mockIntl,
       );
 
-      await clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext);
+      await clientMiddleware[0](
+        { context, request: mockRequest, params: mockParams },
+        mockNext,
+      );
 
       expect(mockNext).toHaveBeenCalled();
     });
@@ -65,7 +70,10 @@ describe("IndexCommunityPage clientMiddleware", () => {
         mockIntl,
       );
 
-      await clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext);
+      await clientMiddleware[0](
+        { context, request: mockRequest, params: mockParams },
+        mockNext,
+      );
 
       expect(mockNext).toHaveBeenCalled();
     });
@@ -80,7 +88,10 @@ describe("IndexCommunityPage clientMiddleware", () => {
         mockIntl,
       );
 
-      await clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext);
+      await clientMiddleware[0](
+        { context, request: mockRequest, params: mockParams },
+        mockNext,
+      );
 
       expect(mockNext).toHaveBeenCalled();
     });
@@ -89,13 +100,19 @@ describe("IndexCommunityPage clientMiddleware", () => {
       const context = createContext(
         {
           roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.CommunityTalentCoordinator, "team-123"),
+            createMockRoleAssignment(
+              ROLE_NAME.CommunityTalentCoordinator,
+              "team-123",
+            ),
           ],
         },
         mockIntl,
       );
 
-      await clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext);
+      await clientMiddleware[0](
+        { context, request: mockRequest, params: mockParams },
+        mockNext,
+      );
 
       expect(mockNext).toHaveBeenCalled();
     });
@@ -105,45 +122,48 @@ describe("IndexCommunityPage clientMiddleware", () => {
     test("throws UnauthorizedError for Applicant role", async () => {
       const context = createContext(
         {
-          roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.Applicant),
-          ],
+          roleAssignments: [createMockRoleAssignment(ROLE_NAME.Applicant)],
         },
         mockIntl,
       );
 
       await expect(
-        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
       ).rejects.toThrow(UnauthorizedError);
     });
 
     test("throws UnauthorizedError for BaseUser role", async () => {
       const context = createContext(
         {
-          roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.BaseUser),
-          ],
+          roleAssignments: [createMockRoleAssignment(ROLE_NAME.BaseUser)],
         },
         mockIntl,
       );
 
       await expect(
-        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
       ).rejects.toThrow(UnauthorizedError);
     });
 
     test("throws UnauthorizedError for Guest role", async () => {
       const context = createContext(
         {
-          roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.Guest),
-          ],
+          roleAssignments: [createMockRoleAssignment(ROLE_NAME.Guest)],
         },
         mockIntl,
       );
 
       await expect(
-        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
       ).rejects.toThrow(UnauthorizedError);
     });
 
@@ -158,7 +178,10 @@ describe("IndexCommunityPage clientMiddleware", () => {
       );
 
       await expect(
-        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
       ).rejects.toThrow(UnauthorizedError);
     });
   });
@@ -169,7 +192,10 @@ describe("IndexCommunityPage clientMiddleware", () => {
 
       // requireUser throws a redirect Response when user is null
       await expect(
-        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
       ).rejects.toBeDefined();
 
       expect(mockNext).not.toHaveBeenCalled();

--- a/apps/web/src/pages/Communities/IndexCommunityPage/IndexCommunityPage.test.ts
+++ b/apps/web/src/pages/Communities/IndexCommunityPage/IndexCommunityPage.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
+import type { RouterContextProvider } from "react-router";
 
 import { ROLE_NAME } from "@gc-digital-talent/auth";
 import { UnauthorizedError } from "@gc-digital-talent/helpers";
@@ -22,15 +23,25 @@ describe("IndexCommunityPage clientMiddleware", () => {
     locale: "en",
   };
 
-  const mockNext = vi.fn(() => Promise.resolve("next-result"));
+  const mockUrl = new URL(mockRequest.url);
+  const mockPattern = "/:locale/admin/communities";
 
-  const createContext = (user: unknown, intl: unknown) => ({
-    get: vi.fn((token: unknown) => {
-      if (token === "userContext") return user;
-      if (token === "intlContext") return intl;
-      return null;
-    }),
-  });
+  const mockNext = vi.fn(() => Promise.resolve({})) as unknown as Parameters<
+    (typeof clientMiddleware)[0]
+  >[1];
+
+  const createContext = (
+    user: unknown,
+    intl: unknown,
+  ): Readonly<RouterContextProvider> =>
+    ({
+      get: vi.fn((token: unknown) => {
+        if (token === "userContext") return user;
+        if (token === "intlContext") return intl;
+        return null;
+      }),
+      set: vi.fn(),
+    }) as unknown as Readonly<RouterContextProvider>;
 
   const mockIntl = {
     locale: "en",
@@ -53,7 +64,13 @@ describe("IndexCommunityPage clientMiddleware", () => {
       );
 
       await clientMiddleware[0](
-        { context, request: mockRequest, params: mockParams },
+        {
+          context,
+          request: mockRequest,
+          params: mockParams,
+          url: mockUrl,
+          pattern: mockPattern,
+        },
         mockNext,
       );
 
@@ -71,7 +88,13 @@ describe("IndexCommunityPage clientMiddleware", () => {
       );
 
       await clientMiddleware[0](
-        { context, request: mockRequest, params: mockParams },
+        {
+          context,
+          request: mockRequest,
+          params: mockParams,
+          url: mockUrl,
+          pattern: mockPattern,
+        },
         mockNext,
       );
 
@@ -89,7 +112,13 @@ describe("IndexCommunityPage clientMiddleware", () => {
       );
 
       await clientMiddleware[0](
-        { context, request: mockRequest, params: mockParams },
+        {
+          context,
+          request: mockRequest,
+          params: mockParams,
+          url: mockUrl,
+          pattern: mockPattern,
+        },
         mockNext,
       );
 
@@ -110,7 +139,13 @@ describe("IndexCommunityPage clientMiddleware", () => {
       );
 
       await clientMiddleware[0](
-        { context, request: mockRequest, params: mockParams },
+        {
+          context,
+          request: mockRequest,
+          params: mockParams,
+          url: mockUrl,
+          pattern: mockPattern,
+        },
         mockNext,
       );
 
@@ -129,7 +164,13 @@ describe("IndexCommunityPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -145,7 +186,13 @@ describe("IndexCommunityPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -161,7 +208,13 @@ describe("IndexCommunityPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -179,7 +232,13 @@ describe("IndexCommunityPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -193,7 +252,13 @@ describe("IndexCommunityPage clientMiddleware", () => {
       // requireUser throws a redirect Response when user is null
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toBeDefined();

--- a/apps/web/src/pages/Communities/IndexCommunityPage/IndexCommunityPage.tsx
+++ b/apps/web/src/pages/Communities/IndexCommunityPage/IndexCommunityPage.tsx
@@ -5,14 +5,32 @@ import { ROLE_NAME } from "@gc-digital-talent/auth";
 import useRoutes from "~/hooks/useRoutes";
 import SEO from "~/components/SEO/SEO";
 import useBreadcrumbs from "~/hooks/useBreadcrumbs";
-import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import pageTitles from "~/messages/pageTitles";
 import Hero from "~/components/Hero";
 import AdminContentWrapper from "~/components/AdminContentWrapper/AdminContentWrapper";
+import { requireUser } from "~/routing/auth";
 
+import type { Route } from "./+types/IndexCommunityPage";
 import CommunityTableApi from "./components/CommunityTable/CommunityTable";
 
-const IndexCommunityPage = () => {
+export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
+  async ({ context, request }, next) => {
+    requireUser(
+      context,
+      request,
+      [
+        { name: ROLE_NAME.PlatformAdmin },
+        { name: ROLE_NAME.CommunityAdmin },
+        { name: ROLE_NAME.CommunityRecruiter },
+        { name: ROLE_NAME.CommunityTalentCoordinator },
+      ],
+      false,
+    );
+    return await next();
+  },
+];
+
+const Component = () => {
   const intl = useIntl();
   const routes = useRoutes();
 
@@ -36,19 +54,6 @@ const IndexCommunityPage = () => {
     </>
   );
 };
-
-export const Component = () => (
-  <RequireAuth
-    roles={[
-      ROLE_NAME.CommunityAdmin,
-      ROLE_NAME.CommunityRecruiter,
-      ROLE_NAME.CommunityTalentCoordinator,
-      ROLE_NAME.PlatformAdmin,
-    ]}
-  >
-    <IndexCommunityPage />
-  </RequireAuth>
-);
 
 Component.displayName = "AdminIndexCommunityPage";
 

--- a/apps/web/src/pages/Communities/UpdateCommunityPage/UpdateCommunityPage.test.ts
+++ b/apps/web/src/pages/Communities/UpdateCommunityPage/UpdateCommunityPage.test.ts
@@ -1,0 +1,235 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+import { UnauthorizedError } from "@gc-digital-talent/helpers";
+
+import { clientMiddleware } from "./UpdateCommunityPage";
+import { createMockRoleAssignment } from "../testUtils";
+
+// Mock the userContext and intlContext to return our test values
+vi.mock("~/routing/context", () => ({
+  userContext: "userContext",
+  intlContext: "intlContext",
+  graphqlClientContext: "graphqlClientContext",
+}));
+
+// Mock getCommunityTeamIdInMiddleware
+vi.mock("../utils", () => ({
+  getCommunityTeamIdInMiddleware: vi.fn(() => Promise.resolve("team-123")),
+}));
+
+describe("UpdateCommunityPage clientMiddleware", () => {
+  const mockRequest = {
+    url: "http://localhost:3000/en/admin/communities/community-123/edit",
+  } as Request;
+
+  const mockParams = {
+    communityId: "community-123",
+  };
+
+  const mockNext = vi.fn(() => Promise.resolve("next-result"));
+
+  const createContext = (user: unknown, intl: unknown, graphqlClient: unknown = {}) => ({
+    get: vi.fn((token: unknown) => {
+      if (token === "userContext") return user;
+      if (token === "intlContext") return intl;
+      if (token === "graphqlClientContext") return graphqlClient;
+      return null;
+    }),
+  });
+
+  const mockIntl = {
+    locale: "en",
+    formatMessage: vi.fn(
+      (descriptor: { defaultMessage: string }) => descriptor.defaultMessage,
+    ),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("allows access for authorized roles with matching team", () => {
+    test("allows PlatformAdmin access (global role, no team needed)", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.PlatformAdmin),
+          ],
+        },
+        mockIntl,
+      );
+
+      await clientMiddleware[0](
+        { context, request: mockRequest, params: mockParams },
+        mockNext,
+      );
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    test("allows CommunityAdmin with matching teamId", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityAdmin, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await clientMiddleware[0](
+        { context, request: mockRequest, params: mockParams },
+        mockNext,
+      );
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    test("allows CommunityRecruiter with matching teamId", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityRecruiter, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await clientMiddleware[0](
+        { context, request: mockRequest, params: mockParams },
+        mockNext,
+      );
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    test("allows CommunityTalentCoordinator with matching teamId", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityTalentCoordinator, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await clientMiddleware[0](
+        { context, request: mockRequest, params: mockParams },
+        mockNext,
+      );
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+  });
+
+  describe("denies access for community roles with wrong team", () => {
+    test("throws UnauthorizedError for CommunityAdmin with wrong teamId", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityAdmin, "wrong-team"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    test("throws UnauthorizedError for CommunityRecruiter with wrong teamId", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityRecruiter, "wrong-team"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    test("throws UnauthorizedError for CommunityTalentCoordinator with wrong teamId", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityTalentCoordinator, "wrong-team"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+  });
+
+  describe("denies access for other unauthorized roles", () => {
+    test("throws UnauthorizedError for Applicant role", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.Applicant),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    test("throws UnauthorizedError for ProcessOperator role", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.ProcessOperator, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+  });
+
+  describe("redirects when user is not logged in", () => {
+    test("throws redirect when user is null", async () => {
+      const context = createContext(null, mockIntl);
+
+      // requireUser throws a redirect Response when user is null
+      await expect(
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
+      ).rejects.toBeDefined();
+
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/pages/Communities/UpdateCommunityPage/UpdateCommunityPage.test.ts
+++ b/apps/web/src/pages/Communities/UpdateCommunityPage/UpdateCommunityPage.test.ts
@@ -109,7 +109,7 @@ describe("UpdateCommunityPage clientMiddleware", () => {
       expect(mockNext).toHaveBeenCalled();
     });
 
-    test("allows CommunityRecruiter with matching teamId", async () => {
+    test("blocks CommunityRecruiter even with matching teamId", async () => {
       const context = createContext(
         {
           roleAssignments: [
@@ -119,21 +119,21 @@ describe("UpdateCommunityPage clientMiddleware", () => {
         mockIntl,
       );
 
-      await clientMiddleware[0](
-        {
-          context,
-          request: mockRequest,
-          params: mockParams,
-          url: mockUrl,
-          pattern: mockPattern,
-        },
-        mockNext,
-      );
-
-      expect(mockNext).toHaveBeenCalled();
+      await expect(
+        clientMiddleware[0](
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
+          mockNext,
+        ),
+      ).rejects.toThrow(UnauthorizedError);
     });
 
-    test("allows CommunityTalentCoordinator with matching teamId", async () => {
+    test("blocks CommunityTalentCoordinator even with matching teamId", async () => {
       const context = createContext(
         {
           roleAssignments: [
@@ -146,18 +146,18 @@ describe("UpdateCommunityPage clientMiddleware", () => {
         mockIntl,
       );
 
-      await clientMiddleware[0](
-        {
-          context,
-          request: mockRequest,
-          params: mockParams,
-          url: mockUrl,
-          pattern: mockPattern,
-        },
-        mockNext,
-      );
-
-      expect(mockNext).toHaveBeenCalled();
+      await expect(
+        clientMiddleware[0](
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
+          mockNext,
+        ),
+      ).rejects.toThrow(UnauthorizedError);
     });
   });
 

--- a/apps/web/src/pages/Communities/UpdateCommunityPage/UpdateCommunityPage.test.ts
+++ b/apps/web/src/pages/Communities/UpdateCommunityPage/UpdateCommunityPage.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
+import type { RouterContextProvider } from "react-router";
 
 import { ROLE_NAME } from "@gc-digital-talent/auth";
 import { UnauthorizedError } from "@gc-digital-talent/helpers";
@@ -28,20 +29,27 @@ describe("UpdateCommunityPage clientMiddleware", () => {
     communityId: "community-123",
   };
 
-  const mockNext = vi.fn(() => Promise.resolve("next-result"));
+  const mockUrl = new URL(mockRequest.url);
+  const mockPattern = "/:locale/admin/communities/:communityId/edit";
+
+  const mockNext = vi.fn(() => Promise.resolve({})) as unknown as Parameters<
+    (typeof clientMiddleware)[0]
+  >[1];
 
   const createContext = (
     user: unknown,
     intl: unknown,
     graphqlClient: unknown = {},
-  ) => ({
-    get: vi.fn((token: unknown) => {
-      if (token === "userContext") return user;
-      if (token === "intlContext") return intl;
-      if (token === "graphqlClientContext") return graphqlClient;
-      return null;
-    }),
-  });
+  ): Readonly<RouterContextProvider> =>
+    ({
+      get: vi.fn((token: unknown) => {
+        if (token === "userContext") return user;
+        if (token === "intlContext") return intl;
+        if (token === "graphqlClientContext") return graphqlClient;
+        return null;
+      }),
+      set: vi.fn(),
+    }) as unknown as Readonly<RouterContextProvider>;
 
   const mockIntl = {
     locale: "en",
@@ -64,7 +72,13 @@ describe("UpdateCommunityPage clientMiddleware", () => {
       );
 
       await clientMiddleware[0](
-        { context, request: mockRequest, params: mockParams },
+        {
+          context,
+          request: mockRequest,
+          params: mockParams,
+          url: mockUrl,
+          pattern: mockPattern,
+        },
         mockNext,
       );
 
@@ -82,7 +96,13 @@ describe("UpdateCommunityPage clientMiddleware", () => {
       );
 
       await clientMiddleware[0](
-        { context, request: mockRequest, params: mockParams },
+        {
+          context,
+          request: mockRequest,
+          params: mockParams,
+          url: mockUrl,
+          pattern: mockPattern,
+        },
         mockNext,
       );
 
@@ -100,7 +120,13 @@ describe("UpdateCommunityPage clientMiddleware", () => {
       );
 
       await clientMiddleware[0](
-        { context, request: mockRequest, params: mockParams },
+        {
+          context,
+          request: mockRequest,
+          params: mockParams,
+          url: mockUrl,
+          pattern: mockPattern,
+        },
         mockNext,
       );
 
@@ -121,7 +147,13 @@ describe("UpdateCommunityPage clientMiddleware", () => {
       );
 
       await clientMiddleware[0](
-        { context, request: mockRequest, params: mockParams },
+        {
+          context,
+          request: mockRequest,
+          params: mockParams,
+          url: mockUrl,
+          pattern: mockPattern,
+        },
         mockNext,
       );
 
@@ -142,7 +174,13 @@ describe("UpdateCommunityPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -163,7 +201,13 @@ describe("UpdateCommunityPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -184,7 +228,13 @@ describe("UpdateCommunityPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -202,7 +252,13 @@ describe("UpdateCommunityPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -220,7 +276,13 @@ describe("UpdateCommunityPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -234,7 +296,13 @@ describe("UpdateCommunityPage clientMiddleware", () => {
       // requireUser throws a redirect Response when user is null
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toBeDefined();

--- a/apps/web/src/pages/Communities/UpdateCommunityPage/UpdateCommunityPage.test.ts
+++ b/apps/web/src/pages/Communities/UpdateCommunityPage/UpdateCommunityPage.test.ts
@@ -24,12 +24,17 @@ describe("UpdateCommunityPage clientMiddleware", () => {
   } as Request;
 
   const mockParams = {
+    locale: "en",
     communityId: "community-123",
   };
 
   const mockNext = vi.fn(() => Promise.resolve("next-result"));
 
-  const createContext = (user: unknown, intl: unknown, graphqlClient: unknown = {}) => ({
+  const createContext = (
+    user: unknown,
+    intl: unknown,
+    graphqlClient: unknown = {},
+  ) => ({
     get: vi.fn((token: unknown) => {
       if (token === "userContext") return user;
       if (token === "intlContext") return intl;
@@ -53,9 +58,7 @@ describe("UpdateCommunityPage clientMiddleware", () => {
     test("allows PlatformAdmin access (global role, no team needed)", async () => {
       const context = createContext(
         {
-          roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.PlatformAdmin),
-          ],
+          roleAssignments: [createMockRoleAssignment(ROLE_NAME.PlatformAdmin)],
         },
         mockIntl,
       );
@@ -108,7 +111,10 @@ describe("UpdateCommunityPage clientMiddleware", () => {
       const context = createContext(
         {
           roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.CommunityTalentCoordinator, "team-123"),
+            createMockRoleAssignment(
+              ROLE_NAME.CommunityTalentCoordinator,
+              "team-123",
+            ),
           ],
         },
         mockIntl,
@@ -146,7 +152,10 @@ describe("UpdateCommunityPage clientMiddleware", () => {
       const context = createContext(
         {
           roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.CommunityRecruiter, "wrong-team"),
+            createMockRoleAssignment(
+              ROLE_NAME.CommunityRecruiter,
+              "wrong-team",
+            ),
           ],
         },
         mockIntl,
@@ -164,7 +173,10 @@ describe("UpdateCommunityPage clientMiddleware", () => {
       const context = createContext(
         {
           roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.CommunityTalentCoordinator, "wrong-team"),
+            createMockRoleAssignment(
+              ROLE_NAME.CommunityTalentCoordinator,
+              "wrong-team",
+            ),
           ],
         },
         mockIntl,
@@ -183,9 +195,7 @@ describe("UpdateCommunityPage clientMiddleware", () => {
     test("throws UnauthorizedError for Applicant role", async () => {
       const context = createContext(
         {
-          roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.Applicant),
-          ],
+          roleAssignments: [createMockRoleAssignment(ROLE_NAME.Applicant)],
         },
         mockIntl,
       );

--- a/apps/web/src/pages/Communities/UpdateCommunityPage/UpdateCommunityPage.tsx
+++ b/apps/web/src/pages/Communities/UpdateCommunityPage/UpdateCommunityPage.tsx
@@ -32,11 +32,13 @@ import SEO from "~/components/SEO/SEO";
 import useRoutes from "~/hooks/useRoutes";
 import useRequiredParams from "~/hooks/useRequiredParams";
 import adminMessages from "~/messages/adminMessages";
-import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import Hero from "~/components/Hero";
 import { FRENCH_WORDS_PER_ENGLISH_WORD } from "~/constants/talentSearchConstants";
+import { requireUser } from "~/routing/auth";
 
+import type { Route } from "./+types/UpdateCommunityPage";
 import type { ContextType } from "../CommunityMembersPage/components/types";
+import { getCommunityTeamIdInMiddleware } from "../utils";
 
 const TEXT_AREA_MAX_WORDS_EN = 200;
 const TEXT_AREA_MAX_WORDS_FR = Math.round(
@@ -331,7 +333,29 @@ const UpdateCommunity_Mutation = graphql(/* GraphQL */ `
   }
 `);
 
-export const UpdateCommunity = () => {
+export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
+  async ({ context, request, params }, next) => {
+    const teamId = await getCommunityTeamIdInMiddleware(
+      context,
+      params.communityId,
+    );
+
+    requireUser(
+      context,
+      request,
+      [
+        { name: ROLE_NAME.PlatformAdmin },
+        { name: ROLE_NAME.CommunityAdmin, teamId: teamId },
+        { name: ROLE_NAME.CommunityRecruiter, teamId: teamId },
+        { name: ROLE_NAME.CommunityTalentCoordinator, teamId: teamId },
+      ],
+      true,
+    );
+    return await next();
+  },
+];
+
+export const Component = () => {
   const intl = useIntl();
   const paths = useRoutes();
   const { communityId } = useRequiredParams<RouteParams>("communityId");
@@ -409,12 +433,6 @@ export const UpdateCommunity = () => {
     </>
   );
 };
-
-export const Component = () => (
-  <RequireAuth roles={[ROLE_NAME.PlatformAdmin, ROLE_NAME.CommunityAdmin]}>
-    <UpdateCommunity />
-  </RequireAuth>
-);
 
 Component.displayName = "AdminUpdateCommunityPage";
 

--- a/apps/web/src/pages/Communities/UpdateCommunityPage/UpdateCommunityPage.tsx
+++ b/apps/web/src/pages/Communities/UpdateCommunityPage/UpdateCommunityPage.tsx
@@ -346,8 +346,6 @@ export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
       [
         { name: ROLE_NAME.PlatformAdmin },
         { name: ROLE_NAME.CommunityAdmin, teamId: teamId },
-        { name: ROLE_NAME.CommunityRecruiter, teamId: teamId },
-        { name: ROLE_NAME.CommunityTalentCoordinator, teamId: teamId },
       ],
       true,
     );

--- a/apps/web/src/pages/Communities/ViewCommunityPage/ViewCommunityPage.test.ts
+++ b/apps/web/src/pages/Communities/ViewCommunityPage/ViewCommunityPage.test.ts
@@ -1,0 +1,163 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+import { UnauthorizedError } from "@gc-digital-talent/helpers";
+
+import { clientMiddleware } from "./ViewCommunityPage";
+import { createMockRoleAssignment } from "../testUtils";
+
+// Mock the userContext and intlContext to return our test values
+vi.mock("~/routing/context", () => ({
+  userContext: "userContext",
+  intlContext: "intlContext",
+  graphqlClientContext: "graphqlClientContext",
+}));
+
+describe("ViewCommunityPage clientMiddleware", () => {
+  const mockRequest = {
+    url: "http://localhost:3000/en/admin/communities/123",
+  } as Request;
+
+  const mockNext = vi.fn(() => Promise.resolve("next-result"));
+
+  const createContext = (user: unknown, intl: unknown) => ({
+    get: vi.fn((token: unknown) => {
+      if (token === "userContext") return user;
+      if (token === "intlContext") return intl;
+      return null;
+    }),
+  });
+
+  const mockIntl = {
+    locale: "en",
+    formatMessage: vi.fn(
+      (descriptor: { defaultMessage: string }) => descriptor.defaultMessage,
+    ),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("allows access for authorized roles", () => {
+    test("allows PlatformAdmin access", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.PlatformAdmin),
+          ],
+        },
+        mockIntl,
+      );
+
+      await clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    test("allows CommunityAdmin access", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityAdmin, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    test("allows CommunityRecruiter access", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityRecruiter, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    test("allows CommunityTalentCoordinator access", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.CommunityTalentCoordinator, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+  });
+
+  describe("denies access for unauthorized roles", () => {
+    test("throws UnauthorizedError for Applicant role", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.Applicant),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    test("throws UnauthorizedError for BaseUser role", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.BaseUser),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+
+    test("throws UnauthorizedError for ProcessOperator role", async () => {
+      const context = createContext(
+        {
+          roleAssignments: [
+            createMockRoleAssignment(ROLE_NAME.ProcessOperator, "team-123"),
+          ],
+        },
+        mockIntl,
+      );
+
+      await expect(
+        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+      ).rejects.toThrow(UnauthorizedError);
+    });
+  });
+
+  describe("redirects when user is not logged in", () => {
+    test("throws redirect when user is null", async () => {
+      const context = createContext(null, mockIntl);
+
+      // requireUser throws a redirect Response when user is null
+      await expect(
+        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+      ).rejects.toBeDefined();
+
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/pages/Communities/ViewCommunityPage/ViewCommunityPage.test.ts
+++ b/apps/web/src/pages/Communities/ViewCommunityPage/ViewCommunityPage.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
+import type { RouterContextProvider } from "react-router";
 
 import { ROLE_NAME } from "@gc-digital-talent/auth";
 import { UnauthorizedError } from "@gc-digital-talent/helpers";
@@ -23,15 +24,25 @@ describe("ViewCommunityPage clientMiddleware", () => {
     communityId: "community-123",
   };
 
-  const mockNext = vi.fn(() => Promise.resolve("next-result"));
+  const mockUrl = new URL(mockRequest.url);
+  const mockPattern = "/:locale/admin/communities/:communityId";
 
-  const createContext = (user: unknown, intl: unknown) => ({
-    get: vi.fn((token: unknown) => {
-      if (token === "userContext") return user;
-      if (token === "intlContext") return intl;
-      return null;
-    }),
-  });
+  const mockNext = vi.fn(() => Promise.resolve({})) as unknown as Parameters<
+    (typeof clientMiddleware)[0]
+  >[1];
+
+  const createContext = (
+    user: unknown,
+    intl: unknown,
+  ): Readonly<RouterContextProvider> =>
+    ({
+      get: vi.fn((token: unknown) => {
+        if (token === "userContext") return user;
+        if (token === "intlContext") return intl;
+        return null;
+      }),
+      set: vi.fn(),
+    }) as unknown as Readonly<RouterContextProvider>;
 
   const mockIntl = {
     locale: "en",
@@ -54,7 +65,13 @@ describe("ViewCommunityPage clientMiddleware", () => {
       );
 
       await clientMiddleware[0](
-        { context, request: mockRequest, params: mockParams },
+        {
+          context,
+          request: mockRequest,
+          params: mockParams,
+          url: mockUrl,
+          pattern: mockPattern,
+        },
         mockNext,
       );
 
@@ -72,7 +89,13 @@ describe("ViewCommunityPage clientMiddleware", () => {
       );
 
       await clientMiddleware[0](
-        { context, request: mockRequest, params: mockParams },
+        {
+          context,
+          request: mockRequest,
+          params: mockParams,
+          url: mockUrl,
+          pattern: mockPattern,
+        },
         mockNext,
       );
 
@@ -90,7 +113,13 @@ describe("ViewCommunityPage clientMiddleware", () => {
       );
 
       await clientMiddleware[0](
-        { context, request: mockRequest, params: mockParams },
+        {
+          context,
+          request: mockRequest,
+          params: mockParams,
+          url: mockUrl,
+          pattern: mockPattern,
+        },
         mockNext,
       );
 
@@ -111,7 +140,13 @@ describe("ViewCommunityPage clientMiddleware", () => {
       );
 
       await clientMiddleware[0](
-        { context, request: mockRequest, params: mockParams },
+        {
+          context,
+          request: mockRequest,
+          params: mockParams,
+          url: mockUrl,
+          pattern: mockPattern,
+        },
         mockNext,
       );
 
@@ -130,7 +165,13 @@ describe("ViewCommunityPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -146,7 +187,13 @@ describe("ViewCommunityPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -164,7 +211,13 @@ describe("ViewCommunityPage clientMiddleware", () => {
 
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toThrow(UnauthorizedError);
@@ -178,7 +231,13 @@ describe("ViewCommunityPage clientMiddleware", () => {
       // requireUser throws a redirect Response when user is null
       await expect(
         clientMiddleware[0](
-          { context, request: mockRequest, params: mockParams },
+          {
+            context,
+            request: mockRequest,
+            params: mockParams,
+            url: mockUrl,
+            pattern: mockPattern,
+          },
           mockNext,
         ),
       ).rejects.toBeDefined();

--- a/apps/web/src/pages/Communities/ViewCommunityPage/ViewCommunityPage.test.ts
+++ b/apps/web/src/pages/Communities/ViewCommunityPage/ViewCommunityPage.test.ts
@@ -18,6 +18,11 @@ describe("ViewCommunityPage clientMiddleware", () => {
     url: "http://localhost:3000/en/admin/communities/123",
   } as Request;
 
+  const mockParams = {
+    locale: "en",
+    communityId: "community-123",
+  };
+
   const mockNext = vi.fn(() => Promise.resolve("next-result"));
 
   const createContext = (user: unknown, intl: unknown) => ({
@@ -43,14 +48,15 @@ describe("ViewCommunityPage clientMiddleware", () => {
     test("allows PlatformAdmin access", async () => {
       const context = createContext(
         {
-          roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.PlatformAdmin),
-          ],
+          roleAssignments: [createMockRoleAssignment(ROLE_NAME.PlatformAdmin)],
         },
         mockIntl,
       );
 
-      await clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext);
+      await clientMiddleware[0](
+        { context, request: mockRequest, params: mockParams },
+        mockNext,
+      );
 
       expect(mockNext).toHaveBeenCalled();
     });
@@ -65,7 +71,10 @@ describe("ViewCommunityPage clientMiddleware", () => {
         mockIntl,
       );
 
-      await clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext);
+      await clientMiddleware[0](
+        { context, request: mockRequest, params: mockParams },
+        mockNext,
+      );
 
       expect(mockNext).toHaveBeenCalled();
     });
@@ -80,7 +89,10 @@ describe("ViewCommunityPage clientMiddleware", () => {
         mockIntl,
       );
 
-      await clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext);
+      await clientMiddleware[0](
+        { context, request: mockRequest, params: mockParams },
+        mockNext,
+      );
 
       expect(mockNext).toHaveBeenCalled();
     });
@@ -89,13 +101,19 @@ describe("ViewCommunityPage clientMiddleware", () => {
       const context = createContext(
         {
           roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.CommunityTalentCoordinator, "team-123"),
+            createMockRoleAssignment(
+              ROLE_NAME.CommunityTalentCoordinator,
+              "team-123",
+            ),
           ],
         },
         mockIntl,
       );
 
-      await clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext);
+      await clientMiddleware[0](
+        { context, request: mockRequest, params: mockParams },
+        mockNext,
+      );
 
       expect(mockNext).toHaveBeenCalled();
     });
@@ -105,30 +123,32 @@ describe("ViewCommunityPage clientMiddleware", () => {
     test("throws UnauthorizedError for Applicant role", async () => {
       const context = createContext(
         {
-          roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.Applicant),
-          ],
+          roleAssignments: [createMockRoleAssignment(ROLE_NAME.Applicant)],
         },
         mockIntl,
       );
 
       await expect(
-        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
       ).rejects.toThrow(UnauthorizedError);
     });
 
     test("throws UnauthorizedError for BaseUser role", async () => {
       const context = createContext(
         {
-          roleAssignments: [
-            createMockRoleAssignment(ROLE_NAME.BaseUser),
-          ],
+          roleAssignments: [createMockRoleAssignment(ROLE_NAME.BaseUser)],
         },
         mockIntl,
       );
 
       await expect(
-        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
       ).rejects.toThrow(UnauthorizedError);
     });
 
@@ -143,7 +163,10 @@ describe("ViewCommunityPage clientMiddleware", () => {
       );
 
       await expect(
-        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
       ).rejects.toThrow(UnauthorizedError);
     });
   });
@@ -154,7 +177,10 @@ describe("ViewCommunityPage clientMiddleware", () => {
 
       // requireUser throws a redirect Response when user is null
       await expect(
-        clientMiddleware[0]({ context, request: mockRequest, params: {} }, mockNext),
+        clientMiddleware[0](
+          { context, request: mockRequest, params: mockParams },
+          mockNext,
+        ),
       ).rejects.toBeDefined();
 
       expect(mockNext).not.toHaveBeenCalled();

--- a/apps/web/src/pages/Communities/ViewCommunityPage/ViewCommunityPage.tsx
+++ b/apps/web/src/pages/Communities/ViewCommunityPage/ViewCommunityPage.tsx
@@ -24,12 +24,13 @@ import { htmlToRichTextJSON, RichTextRenderer } from "@gc-digital-talent/forms";
 
 import SEO from "~/components/SEO/SEO";
 import useRequiredParams from "~/hooks/useRequiredParams";
-import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import useRoutes from "~/hooks/useRoutes";
 import FieldDisplay from "~/components/FieldDisplay/FieldDisplay";
 import adminMessages from "~/messages/adminMessages";
 import Hero from "~/components/Hero";
+import { requireUser } from "~/routing/auth";
 
+import type { Route } from "./+types/ViewCommunityPage";
 import type { ContextType } from "../CommunityMembersPage/components/types";
 
 interface RouteParams extends Record<string, string> {
@@ -68,6 +69,8 @@ export const ViewCommunityForm = ({ query }: ViewCommunityProps) => {
   const intl = useIntl();
   const paths = useRoutes();
   const community = getFragment(ViewCommunityPage_CommunityFragment, query);
+  const { canAdminManageAccessAndEditCommunity } =
+    useOutletContext<ContextType>();
 
   const notProvided = intl.formatMessage(commonMessages.notProvided);
   return (
@@ -197,19 +200,23 @@ export const ViewCommunityForm = ({ query }: ViewCommunityProps) => {
             </FieldDisplay>
           </div>
         </div>
-        <CardSeparator />
-        <div className="flex justify-center xs:justify-start">
-          <Link
-            href={paths.communityUpdate(community.id)}
-            className="font-bold"
-          >
-            {intl.formatMessage({
-              defaultMessage: "Edit community information",
-              id: "phS+TP",
-              description: "Link to edit the currently viewed community",
-            })}
-          </Link>
-        </div>
+        {canAdminManageAccessAndEditCommunity && (
+          <>
+            <CardSeparator />
+            <div className="flex justify-center xs:justify-start">
+              <Link
+                href={paths.communityUpdate(community.id)}
+                className="font-bold"
+              >
+                {intl.formatMessage({
+                  defaultMessage: "Edit community information",
+                  id: "phS+TP",
+                  description: "Link to edit the currently viewed community",
+                })}
+              </Link>
+            </div>
+          </>
+        )}
       </Card>
     </>
   );
@@ -249,8 +256,25 @@ const ViewCommunityPage = ({ community }: ViewCommunityPageProps) => {
   );
 };
 
+export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
+  async ({ context, request }, next) => {
+    requireUser(
+      context,
+      request,
+      [
+        { name: ROLE_NAME.PlatformAdmin },
+        { name: ROLE_NAME.CommunityAdmin },
+        { name: ROLE_NAME.CommunityRecruiter },
+        { name: ROLE_NAME.CommunityTalentCoordinator },
+      ],
+      false,
+    );
+    return await next();
+  },
+];
+
 // Since the SEO and Hero need API-loaded data, we wrap the entire page in a Pending
-const ViewCommunityPageApiWrapper = () => {
+const Component = () => {
   const intl = useIntl();
   const { communityId } = useRequiredParams<RouteParams>("communityId");
   const [{ data, fetching, error }] = useQuery({
@@ -278,19 +302,6 @@ const ViewCommunityPageApiWrapper = () => {
     </Pending>
   );
 };
-
-export const Component = () => (
-  <RequireAuth
-    roles={[
-      ROLE_NAME.CommunityAdmin,
-      ROLE_NAME.CommunityRecruiter,
-      ROLE_NAME.CommunityTalentCoordinator,
-      ROLE_NAME.PlatformAdmin,
-    ]}
-  >
-    <ViewCommunityPageApiWrapper />
-  </RequireAuth>
-);
 
 Component.displayName = "AdminViewCommunityPage";
 

--- a/apps/web/src/pages/Communities/testUtils.ts
+++ b/apps/web/src/pages/Communities/testUtils.ts
@@ -4,21 +4,26 @@
 import { vi } from "vitest";
 
 import type { RoleAssignment } from "@gc-digital-talent/graphql";
-import { ROLE_NAME, type RoleName } from "@gc-digital-talent/auth";
+import { ROLE_NAME } from "@gc-digital-talent/auth";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const RoleNameValues = Object.values(ROLE_NAME);
 
 // Re-usable mock role assignments
 export const createMockRoleAssignment = (
-  roleName: RoleName,
+  roleName: (typeof RoleNameValues)[number],
   teamId?: string,
 ): RoleAssignment => {
-  const isTeamBased = [
+  const teamRoleArray: string[] = [
     ROLE_NAME.CommunityAdmin,
     ROLE_NAME.CommunityRecruiter,
     ROLE_NAME.CommunityTalentCoordinator,
     ROLE_NAME.ProcessOperator,
     ROLE_NAME.DepartmentAdmin,
     ROLE_NAME.DepartmentHRAdvisor,
-  ].includes(roleName);
+  ];
+
+  const isTeamBased = teamRoleArray.includes(roleName);
 
   return {
     id: `assignment-${roleName}`,
@@ -113,11 +118,14 @@ export const createMockNext = () => vi.fn(() => Promise.resolve("next-result"));
  * Test helper to verify middleware allows access
  */
 export const expectMiddlewareToAllow = async (
-  middleware: (args: {
-    context: ReturnType<typeof createMockContext>;
-    request: Request;
-    params: Record<string, string>;
-  }, next: ReturnType<typeof createMockNext>) => Promise<unknown>,
+  middleware: (
+    args: {
+      context: ReturnType<typeof createMockContext>;
+      request: Request;
+      params: Record<string, string>;
+    },
+    next: ReturnType<typeof createMockNext>,
+  ) => Promise<unknown>,
   context: ReturnType<typeof createMockContext>,
   request: Request,
   params: Record<string, string> = {},

--- a/apps/web/src/pages/Communities/testUtils.ts
+++ b/apps/web/src/pages/Communities/testUtils.ts
@@ -1,0 +1,128 @@
+/**
+ * Shared test utilities for middleware authorization testing
+ */
+import { vi } from "vitest";
+
+import type { RoleAssignment } from "@gc-digital-talent/graphql";
+import { ROLE_NAME, type RoleName } from "@gc-digital-talent/auth";
+
+// Re-usable mock role assignments
+export const createMockRoleAssignment = (
+  roleName: RoleName,
+  teamId?: string,
+): RoleAssignment => {
+  const isTeamBased = [
+    ROLE_NAME.CommunityAdmin,
+    ROLE_NAME.CommunityRecruiter,
+    ROLE_NAME.CommunityTalentCoordinator,
+    ROLE_NAME.ProcessOperator,
+    ROLE_NAME.DepartmentAdmin,
+    ROLE_NAME.DepartmentHRAdvisor,
+  ].includes(roleName);
+
+  return {
+    id: `assignment-${roleName}`,
+    role: {
+      id: `role-${roleName}`,
+      name: roleName,
+      isTeamBased,
+    },
+    team: teamId ? { id: teamId, name: `Team ${teamId}` } : null,
+  };
+};
+
+interface CreateMockContextOptions {
+  roleAssignments?: RoleAssignment[];
+  locale?: string;
+}
+
+/**
+ * Creates a mock context for middleware testing
+ * Simulates the router context with user, intl, and graphql client
+ */
+export const createMockContext = (options: CreateMockContextOptions = {}) => {
+  const { roleAssignments = [], locale = "en" } = options;
+
+  const mockUser = roleAssignments.length > 0 ? { roleAssignments } : null;
+
+  const mockIntl = {
+    formatMessage: (
+      descriptor: { defaultMessage: string },
+      values?: Record<string, string>,
+    ) => {
+      let message = descriptor.defaultMessage;
+      if (values) {
+        Object.entries(values).forEach(([key, value]) => {
+          message = message.replace(`{${key}}`, value);
+        });
+      }
+      return message;
+    },
+    locale,
+  };
+
+  // We need to simulate context.get() calls by token reference
+  // The order is: userContext, intlContext (for redirect path)
+  const contextValues: Record<string, unknown> = {
+    user: mockUser,
+    intl: mockIntl,
+    graphql: {},
+  };
+
+  return {
+    get: vi.fn((token: unknown) => {
+      // Match based on what the token represents
+      // In production, these are actual context objects
+      const tokenStr = String(token);
+      if (
+        tokenStr.includes("user") ||
+        tokenStr.includes("User") ||
+        token === "userContext"
+      ) {
+        return contextValues.user;
+      }
+      if (
+        tokenStr.includes("intl") ||
+        tokenStr.includes("Intl") ||
+        token === "intlContext"
+      ) {
+        return contextValues.intl;
+      }
+      // Default - return user for the first context call in requireUser
+      return contextValues.user;
+    }),
+    _values: contextValues,
+  };
+};
+
+/**
+ * Creates a mock Request object for middleware testing
+ */
+export const createMockRequest = (path = "/en/admin/communities") => {
+  return {
+    url: `http://localhost:3000${path}`,
+  } as Request;
+};
+
+/**
+ * Creates a mock next function for middleware testing
+ */
+export const createMockNext = () => vi.fn(() => Promise.resolve("next-result"));
+
+/**
+ * Test helper to verify middleware allows access
+ */
+export const expectMiddlewareToAllow = async (
+  middleware: (args: {
+    context: ReturnType<typeof createMockContext>;
+    request: Request;
+    params: Record<string, string>;
+  }, next: ReturnType<typeof createMockNext>) => Promise<unknown>,
+  context: ReturnType<typeof createMockContext>,
+  request: Request,
+  params: Record<string, string> = {},
+) => {
+  const mockNext = createMockNext();
+  const result = await middleware({ context, request, params }, mockNext);
+  return { result, mockNext };
+};

--- a/apps/web/src/pages/Communities/utils.test.ts
+++ b/apps/web/src/pages/Communities/utils.test.ts
@@ -1,0 +1,133 @@
+import { describe, test, expect, vi } from "vitest";
+
+import { NotFoundError } from "@gc-digital-talent/helpers";
+
+import { getCommunityTeamIdInMiddleware } from "./utils";
+
+// Mock the graphqlClientContext and intlContext
+const createMockContext = (queryResult: {
+  data?: { community?: { teamIdForRoleAssignment?: string | null } | null };
+  error?: Error;
+}) => {
+  const mockQuery = vi.fn().mockReturnValue({
+    toPromise: () => Promise.resolve(queryResult),
+  });
+
+  const mockClient = {
+    query: mockQuery,
+  };
+
+  const mockIntl = {
+    formatMessage: (
+      descriptor: { defaultMessage: string },
+      values?: Record<string, string>,
+    ) => {
+      let message = descriptor.defaultMessage;
+      if (values) {
+        Object.entries(values).forEach(([key, value]) => {
+          message = message.replace(`{${key}}`, value);
+        });
+      }
+      return message;
+    },
+    locale: "en",
+  };
+
+  const mockContext = {
+    get: vi.fn((token: unknown) => {
+      if (token === "graphqlClientContext") {
+        return mockClient;
+      }
+      if (token === "intlContext") {
+        return mockIntl;
+      }
+      // Return appropriate mock based on the token reference
+      // Since we can't access the actual context symbols, we match by order
+      return mockClient;
+    }),
+  };
+
+  // Override get to work with the actual context tokens
+  let callCount = 0;
+  mockContext.get = vi.fn(() => {
+    callCount++;
+    // First call is for intlContext, second is for graphqlClientContext
+    if (callCount === 1) {
+      return mockIntl;
+    }
+    return mockClient;
+  });
+
+  return mockContext;
+};
+
+describe("getCommunityTeamIdInMiddleware", () => {
+  const communityId = "test-community-id";
+  const teamId = "test-team-id";
+
+  test("returns teamIdForRoleAssignment when community exists", async () => {
+    const mockContext = createMockContext({
+      data: {
+        community: {
+          teamIdForRoleAssignment: teamId,
+        },
+      },
+    });
+
+    const result = await getCommunityTeamIdInMiddleware(
+      mockContext as never,
+      communityId,
+    );
+
+    expect(result).toBe(teamId);
+  });
+
+  test("throws NotFoundError when community is null", async () => {
+    const mockContext = createMockContext({
+      data: {
+        community: null,
+      },
+    });
+
+    await expect(
+      getCommunityTeamIdInMiddleware(mockContext as never, communityId),
+    ).rejects.toThrow(NotFoundError);
+  });
+
+  test("throws NotFoundError when teamIdForRoleAssignment is null", async () => {
+    const mockContext = createMockContext({
+      data: {
+        community: {
+          teamIdForRoleAssignment: null,
+        },
+      },
+    });
+
+    await expect(
+      getCommunityTeamIdInMiddleware(mockContext as never, communityId),
+    ).rejects.toThrow(NotFoundError);
+  });
+
+  test("throws NotFoundError when data is undefined", async () => {
+    const mockContext = createMockContext({
+      data: undefined,
+    });
+
+    await expect(
+      getCommunityTeamIdInMiddleware(mockContext as never, communityId),
+    ).rejects.toThrow(NotFoundError);
+  });
+
+  test("error message includes communityId", async () => {
+    const specificCommunityId = "specific-test-id";
+    const mockContext = createMockContext({
+      data: {
+        community: null,
+      },
+    });
+
+    await expect(
+      getCommunityTeamIdInMiddleware(mockContext as never, specificCommunityId),
+    ).rejects.toThrow(specificCommunityId);
+  });
+});

--- a/apps/web/src/pages/Communities/utils.ts
+++ b/apps/web/src/pages/Communities/utils.ts
@@ -1,0 +1,41 @@
+import type { RouterContextProvider } from "react-router";
+
+import { graphql } from "@gc-digital-talent/graphql";
+import { NotFoundError } from "@gc-digital-talent/helpers";
+
+import { graphqlClientContext, intlContext } from "~/routing/context";
+
+const CommunityTeamMiddleware_Query = graphql(/** GraphQL */ `
+  query CommunityTeamMiddleware($id: UUID!) {
+    community(id: $id) {
+      teamIdForRoleAssignment
+    }
+  }
+`);
+
+export async function getCommunityTeamIdInMiddleware(
+  context: Readonly<RouterContextProvider>,
+  communityId: string,
+) {
+  const intl = context.get(intlContext);
+  const client = context.get(graphqlClientContext);
+
+  const res = await client
+    .query(CommunityTeamMiddleware_Query, { id: communityId })
+    .toPromise();
+
+  if (!res.data?.community?.teamIdForRoleAssignment) {
+    throw new NotFoundError(
+      intl.formatMessage(
+        {
+          defaultMessage: "Community {communityId} not found.",
+          id: "TfbBB7",
+          description: "Message displayed for community not found.",
+        },
+        { communityId },
+      ),
+    );
+  }
+
+  return res.data.community.teamIdForRoleAssignment;
+}


### PR DESCRIPTION
🤖 Resolves #16461 

## 👋 Introduction

Use the new middleware stuff to handle frontend role checks, and a few changes alongside 

## 🕵️ Details

Issue A/C wanted some unit testing, used Claude in Agents to put together some stuff. Went decently, for the most part

## 🧪 Testing

Assert the roles behaviour per issue body

1. Platform admin access all
2. Community admin view all three tabs for own community and can edit
3. Recruiter views two tabs for own community
4. Coordinator view two tabs for own community
5. All four can view the communities table and the information view of any community

Edit restricted to platform admin and community admin (own community)
Only platform can create communities 

## 📸 Screenshot

Edit link now conditionally rendered 😮 

<img width="1103" height="307" alt="image" src="https://github.com/user-attachments/assets/7f7bc64f-8202-4fe9-acc2-b8a64901db56" />


