### PR TITLE
[Refactor] Validate `aud` in bearer token services

### DIFF
--- a/api/app/Services/CanadaLoginBearerTokenService.php
+++ b/api/app/Services/CanadaLoginBearerTokenService.php
@@ -21,9 +21,11 @@ use Jose\Component\Core\Util\RSAKey;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer;
 use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Token\DataSet;
 use Lcobucci\JWT\UnencryptedToken;
 use Lcobucci\JWT\Validation\Constraint\IssuedBy;
 use Lcobucci\JWT\Validation\Constraint\LooseValidAt;
+use Lcobucci\JWT\Validation\Constraint\PermittedFor;
 use Lcobucci\JWT\Validation\Constraint\RelatedTo;
 use Lcobucci\JWT\Validation\Constraint\SignedWith;
 use Psr\Clock\ClockInterface;
@@ -197,7 +199,7 @@ class CanadaLoginBearerTokenService implements BearerTokenService
     /*
     * @returns Lcobucci\JWT\Token\DataSet
     */
-    public function validateAndGetClaims(string $bearerToken)
+    public function validateAndGetClaims(string $bearerToken): DataSet
     {
         $unsecuredToken = $this->unsecuredConfig->parser()->parse($bearerToken);
 
@@ -209,6 +211,7 @@ class CanadaLoginBearerTokenService implements BearerTokenService
         assert($token instanceof UnencryptedToken);
         $config = $config->withValidationConstraints(
             new IssuedBy($this->getConfigProperty('issuer')),
+            new PermittedFor(strval(config('oauth.client_id'))),
             new RelatedTo($token->claims()->get('sub')),
             new LooseValidAt($this->clock, $this->allowableClockSkew),
             new SignedWith($config->signer(), $config->verificationKey()),

--- a/api/app/Services/SignInCanadaBearerTokenService.php
+++ b/api/app/Services/SignInCanadaBearerTokenService.php
@@ -22,6 +22,7 @@ use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\UnencryptedToken;
 use Lcobucci\JWT\Validation\Constraint\IssuedBy;
 use Lcobucci\JWT\Validation\Constraint\LooseValidAt;
+use Lcobucci\JWT\Validation\Constraint\PermittedFor;
 use Lcobucci\JWT\Validation\Constraint\RelatedTo;
 use Lcobucci\JWT\Validation\Constraint\SignedWith;
 use Psr\Clock\ClockInterface;
@@ -206,6 +207,7 @@ class SignInCanadaBearerTokenService implements BearerTokenService
         assert($token instanceof UnencryptedToken);
         $config = $config->withValidationConstraints(
             new IssuedBy($this->getConfigProperty('issuer')),
+            new PermittedFor(strval(config('oauth.client_id'))),
             new RelatedTo($token->claims()->get('sub')),
             new LooseValidAt($this->clock, $this->allowableClockSkew),
             new SignedWith($config->signer(), $config->verificationKey()),

--- a/api/tests/Unit/CanadaLoginBearerTokenTest.php
+++ b/api/tests/Unit/CanadaLoginBearerTokenTest.php
@@ -7,6 +7,9 @@ use DateTimeImmutable;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer;
+use Lcobucci\JWT\Signer\Key\InMemory;
 use Psr\Clock\ClockInterface;
 use Tests\TestCase;
 
@@ -25,6 +28,38 @@ class CanadaLoginBearerTokenTest extends TestCase
 
     const fakeJwksUrl = self::fakeRootUrl.'/jwks';
 
+    const fakeAudience = 'fake-development-client-key';
+
+    private function getToken(
+        string $subject = '1234567890',
+        string $issuer = self::fakeRootUrl,
+        string|array|null $audience = self::fakeAudience,
+        int $expiresAt = 2147483647,
+        int $issuedAt = 0,
+        string $keyId = 'key1',
+        string $privateKeyResource = 'key1.pem',
+    ): string {
+        $config = Configuration::forAsymmetricSigner(
+            new Signer\Rsa\Sha256(),
+            InMemory::file(__DIR__.'/resources/'.$privateKeyResource),
+            InMemory::file(__DIR__.'/resources/'.str_replace('.pem', '-cert.pem', $privateKeyResource)),
+        );
+
+        $builder = $config->builder()
+            ->withHeader('kid', $keyId)
+            ->withHeader('typ', 'JWT')
+            ->relatedTo($subject)
+            ->issuedBy($issuer)
+            ->issuedAt((new DateTimeImmutable())->setTimestamp($issuedAt))
+            ->expiresAt((new DateTimeImmutable())->setTimestamp($expiresAt));
+
+        foreach ((array) $audience as $audienceValue) {
+            $builder = $builder->permittedFor(strval($audienceValue));
+        }
+
+        return $builder->getToken($config->signer(), $config->signingKey())->toString();
+    }
+
     protected bool $fakeIntrospectionIsActive;
 
     protected DateTimeImmutable $fakeIntrospectionExpiry;
@@ -33,6 +68,7 @@ class CanadaLoginBearerTokenTest extends TestCase
     {
         parent::setUp(); // initializes Http facade
         Cache::flush(); // Start with fresh cache
+        config(['oauth.client_id' => self::fakeAudience]);
 
         $fakeIntrospectionUrl = self::fakeRootUrl.'/introspection';
 
@@ -83,7 +119,7 @@ class CanadaLoginBearerTokenTest extends TestCase
      */
     public function testAcceptsGoodTokenAndReturnsCorrectSub()
     {
-        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoyMTQ3NDgzNjQ3LCJpYXQiOjB9.qiOmlGVi-7K0B8eeZNYY21yZnXDn5pZWFMSLM6UH2uHUQ8mdcN0Ocd36Sq1vKvWeOgTvEm_MCl5GGCert16huUoEiILnlmf9F4i7L7wa1HIgPZnXKxKFbShbUUFMSn-6WxEQxF5g-s6cr77Lu6H_y2_osD39MFcpxTy5k5zJE8EXwQ2FGxmYhW4_qpNF3WQcMge5dfhaPaLpxH1lSrYHkCqnfGJkcTMRg3TPkQe1KWV4VUf2uGl06FleWCXuPgO__LSWeA2YHsyCV7tMPVDlOIOtiyZA1Pk4G_p2ur8a403NyIjdcXOscwIHd55vw--GOdMGSurLMS_rHfz0FD6bRSzW_6AWfBa4KQJVkoM_U6aUZ5yBEbzbsNh2u1H-OyEVBgu4R5XoyXfcn8-Z8nq_ciER8UyvVXTj9WnU--ELEZ_0Qxn4ovKqjXdL7eGwwQ5YercEh-iGiaHikEi2pD1YpfbpXE_uS3Wl2Acd8f_4sIzyQfbBfGoqIZb_cPKIm-gRhJlJn-dRdO_Hzy0rCkDngbSEg_VAeQQv-JAvOlQimI73scyWyLGLzuyOZV33Sy0NAsdOJ0xiM0C5HT_-Wc-ZFHW3uYWzixu60c0yRiJ2vV0-o-VTvpkALYPmy5n8SXSKKP59psvGzSydiX4dq5bk2XGq8wTsUGBOObTVZEN_j9E';
+        $token = $this->getToken();
         /** analyze token at https://jwt.io/
         {
         "kid": "key1",               -- should be validated by key1 (see the resources directory)
@@ -128,7 +164,7 @@ class CanadaLoginBearerTokenTest extends TestCase
     public function testRejectsIncorrectIssuer()
     {
         $this->expectException(\Exception::class);
-        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3dyb25nZG9tYWluLmNvbSIsImV4cCI6MjE0NzQ4MzY0NywiaWF0IjowfQ.xtr4Xolvxryi6_vMLquynGmbi0v925e6wC5hPUYgUXxVXaiZ8IoMHW5hR7sG916ZrsE52IRZXKWXv8sbebUdiavJVav94nyRJTtcp24FoefB_yLck930xZgHLSl5WmqMf7jhy8OBhBIgVCNQY9kj2BzAgrqJ0RCY-9F95unwSPfQHm9rryILY2DlgduReoDIpO1u1E-Lwyw3rVt-hKChsyP1tcc1GyVXNFPfd3YyeAO6Mez6yV8mcTAnsHdrYSrp8XHTbEb5tmF3QQQR-WjftmAMFjq1UA0e70WjfKh0ZNzHMCJt2W0ElWIL8pkliop68Y-STNqZnZStemq0PaRfX1jhfek-To6J1UfuAfiiYjaJoCoOxECdY_xb0UCyLLcG-g2roAeqKQgrEp7PCbjdXE8Xe_e4Yc4gNWDidOoV0vqrxx05h1KCmIy8u1W8xbdXTOVH39yIt7_JKWM_g8ySO5x0fQHdIqgNgW5CWPoYel45k23bnfqq7bOCIULj3SeKMrrP-WBAWaJs0Z6noKql08HcQYOFoqaYPj8wFF1T4IzVyYbcOxWY_L9pAzxU19WOa01Me2oDA9SCBKGszZMgYVEkayL40J0MB5qpMYjR9x-Dd1xifyr9zlNEy7-jlOyM6BopZrovWbIEI1w1XqqCmXQoXfxhD3ZYrSbX5k6l-bc';
+        $token = $this->getToken(issuer: 'http://wrongdomain.com');
         /** analyze token at https://jwt.io/
         {
         "kid": "key1",
@@ -146,12 +182,22 @@ class CanadaLoginBearerTokenTest extends TestCase
     }
 
     /**
+     * A token is provided but has the wrong audience and should be rejected.
+     */
+    public function testRejectsIncorrectAudience()
+    {
+        $this->expectException(\Exception::class);
+        $token = $this->getToken(audience: 'wrong-client-id');
+        $this->service_provider->validateAndGetClaims($token);
+    }
+
+    /**
      * A token is provided but has expired and should be rejected.
      */
     public function testRejectsExpiredToken()
     {
         $this->expectException(\Exception::class);
-        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoxLCJpYXQiOjB9.hfY-0wyAaBL9GDysfc33VMou1pEuGbbwL6oSKzjLdBUtZ5-x--ROaFgUf4NbnSYR7erSggsGMq9Z15gtZVRnYNu1n2QiLYq3mhh83peBH0zdhAB7K_GO_Tpe6dswMGg0esgcp4odH1mlxHYb2RzHkAbYbrYeCYvG537HcoTXFhfltFHpZq7nVMxxbLC0QnSkDSO0vUfyYXiFBe-s5Jxb3UMuStpdPpvrl3OtCh7i-P91BJl5RFN1h7Xd6je1qwcYhQi6aKrPex9sXbdQ3ywzYmxCSHMmIGtYGpbNf_A9WdDKe2SMUW9Q6XWrWCuvTM-SEGUsV1ezrncn21CZfPUREQ_wl7wEdYo2R2W6Ybhgw4Wu0hJEsRxPfP-oNAV4HsVzOh2XRVVYrJ-Y0v_ij6JprDovddXNHFhB4ITeLbB0lSN1pA2qFvPySvPwfNcMNCK5cNY0WVfJmPjgrlxSPCMOIjlCJIaIkPj2QxWbdsMeiASXCKPvrmCiTsrbzxydPprrL6pbdNE_ILPsyf0DpCitMvKtGBmtgr3hv-XP3pjOm2To_bspp-R59Z2pYA_Rav0HdqCPpTC6MZBsf-oF3CSzYviMAxFDq20DUPflT9mzcLGmPtmCVshjfQJ1i9iH55S7TWAhDGT50rVGUje0ZSFVDU1nFYThcVZqb787BN417x8';
+        $token = $this->getToken(expiresAt: 1);
         /** analyze token at https://jwt.io/
         {
         "kid": "key1",
@@ -174,7 +220,7 @@ class CanadaLoginBearerTokenTest extends TestCase
     public function testRejectsFutureToken()
     {
         $this->expectException(\Exception::class);
-        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoyMTQ3NDgzNjQ3LCJpYXQiOjIxNDc0ODM2NDZ9.NGbN9gRz_duLXrziyFc3tg_8YtebqWUR0iuoiUElCi3KNOlJjvwPERUWbhYfEgx-FmN7u-FfGjgZoIsK9i745IxHvgunaP3xbZlq-M2FGRd2gMNMMX7n1hnrtuNR43ULmAMleU5ps8l4ey4-FjJCBHoRK0tG_BLkzdbbh-eqU16StIDwzfeJblMUFk78j7gKHS0g15udkNwXm2YawxlqH8ihCf3Ty0E3Jedpmo83L67EI5VKNy2ab7lauEk1xvJUoteUK0ugwpYMPm54LPXYUeWPXI2JpzdlNNZkPdlAhaM3nVPHrYBAPWdWPR83E9R4svc5anva73TtOnDH_8blb3dFkHKTdANbRLWv8kkFL-QogY4sJazzn_v61ZgjS5Q7tqXrQgim6_7871-bbdDO6zYGIQnDWecCXqMJLrXjkkRhs8-euEsXmZm5LaSIEcHSb05XU2rgb6LwFeKdQE7DuZcVWJ0gEFI_13ciOOe1ltFWbUhSppHSfiQ320H3lldlIHuh_gDLWTjyWcCffveV_I3fUF2E0z83926hvwycPH3qcRVyOz5lr_o6SaH8ogmFnhNea-qIgQX-Uo3MZVeiVHKmthiod-p_lF8xMLAao--z_cfPxSe7YC4yBehfRQW3Hnzo13D9M9avHUtNxAEfy89naaTa6LO8GK8EZlHndtU';
+        $token = $this->getToken(issuedAt: 2147483646);
         /** analyze token at https://jwt.io/
         {
         "kid": "key1",
@@ -198,7 +244,7 @@ class CanadaLoginBearerTokenTest extends TestCase
     {
         $this->expectException(\Exception::class);
         // this token actually signed with key2
-        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoyMTQ3NDgzNjQ3LCJpYXQiOjB9.o-gz2gQSJ7frAfJq6H9DYWqxPmeptsbnAKUJpg7V5OdJVV3cmN5S4Ask0B9RoutlFix8jjBX0tYksyCxJ97Rz2wcFZNh_FpDyE9oQ3xgApfnHzerIiyfpxYWIzg-LWixuObha2aLN15CwxfBoFACbZ0SN_PeXkw9NWGmy_FUAmoLbf6K1NYmZY85eqGvyOifXf8VFXMFj0Wd0XlH1fR_dXiUn7oud_9FDIrTfr9eWXRriRleQTGcnkTns7VnddXp6qo6NQchcIvejg1L4Zukpe_YZ37T2fQUDR6ctRGeZj1qmNKHTiUUfiiMoHAfBz0Hx9EW_BTaasUWt0kbv8Xym26bwg-UXj4v6GA2YcwimPHi4rhs6bKOfgNiNqllqkF7Xf-Q86GDicaiV_kuP8JQa68svv4NdUCyfY9AVsV19PjoPClQdKzqSZtl1Ng9i6CujHNzCsqZDHZvvfhHHFlVovLJZjKEX5hQas6SdBV5pjPkJCC-Kwiin9NJb4l-nVIBkRvt5DRbXNF2xQDloQPPhSrJcT6TF2kaMbKOxMbXJ9aOnMLraAoXaImWlYc3JTiGotvovmtv5gPjs2Q_9-AuuQIkhluy2NF-pXuKMtcZB0qopsC8pG_6JhsE9NE8sgWxDeXOW6FC5tY7hix3bocy5oDN3kxUZ-dLhtR6d7eBulc';
+        $token = $this->getToken(privateKeyResource: 'key2.pem');
         /** analyze token at https://jwt.io/
         {
         "kid": "key1",
@@ -220,7 +266,7 @@ class CanadaLoginBearerTokenTest extends TestCase
      */
     public function testAcceptsExpiredTokenWithinAllowableSkew()
     {
-        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoxNTc3ODM2ODYwLCJpYXQiOjB9.zI4EHjfWyZP3G8DFRAMJXF9mZrA65RizQMrnQGVuKFYm0cwMusBToaH5k4feB0b2WPfBkl3-gHOJ5qKoNcR50RI_t5LEZbBVZrGhCDfpCDVlO5ZnwABhQo48NUi2ZbMb1ZoDTa_802hifvpjhOtEE0V9_zCsDZ1pcA9G4rsqEv5T3N35JV_xwgD_PqToZrxCMNuJOG5k8suoIKazzN5eJm3adKi7UsOqh-DJTni7-z88A95UycS0ONw5APFYU-IE3kL5UL1K6OwvXEgpD0md06qB3GUmkkjXeGumDefokT8RouAIbX8p37cfvxeuctJ1WtKZJ3IrJx0E4y-15JCLaPQ3tmv4XQ7lfHf9Yblith7Sw4T4upO7wtynogg2Y_Oget7zLksvaza77SRkXLf8Si3lGJ9ydqSlkLKqo8aX5nQJAkUnRY72eIz5jEEdBBrkpTQdQRG4g2-R9xXd9rGCscdAt2S3COJEFhO2FrgwUiD0piHah-PlMVN5fw3wr2ISN9OYfd5_e15UxLgo0Qw99_mKaakXBf20umTkk2TGi8YmMZLvbOS6yI7eS1wo3rFPzdTOPT7WoW6iPl_kW0FdGZYQQb1GxI2RrjFl6Ud4axKqJbtv1dV9ml1Z9PPawBcIP2B702uLwc9RZrX8b3S3Cnq72-7iCWJVvET9IQr1ess';
+        $token = $this->getToken(expiresAt: 1577836860);
         /** analyze token at https://jwt.io/
         {
         "kid": "key1",
@@ -247,7 +293,7 @@ class CanadaLoginBearerTokenTest extends TestCase
      */
     public function testThatIntrospectionCanRejectAValidToken()
     {
-        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoyMTQ3NDgzNjQ3LCJpYXQiOjB9.qiOmlGVi-7K0B8eeZNYY21yZnXDn5pZWFMSLM6UH2uHUQ8mdcN0Ocd36Sq1vKvWeOgTvEm_MCl5GGCert16huUoEiILnlmf9F4i7L7wa1HIgPZnXKxKFbShbUUFMSn-6WxEQxF5g-s6cr77Lu6H_y2_osD39MFcpxTy5k5zJE8EXwQ2FGxmYhW4_qpNF3WQcMge5dfhaPaLpxH1lSrYHkCqnfGJkcTMRg3TPkQe1KWV4VUf2uGl06FleWCXuPgO__LSWeA2YHsyCV7tMPVDlOIOtiyZA1Pk4G_p2ur8a403NyIjdcXOscwIHd55vw--GOdMGSurLMS_rHfz0FD6bRSzW_6AWfBa4KQJVkoM_U6aUZ5yBEbzbsNh2u1H-OyEVBgu4R5XoyXfcn8-Z8nq_ciER8UyvVXTj9WnU--ELEZ_0Qxn4ovKqjXdL7eGwwQ5YercEh-iGiaHikEi2pD1YpfbpXE_uS3Wl2Acd8f_4sIzyQfbBfGoqIZb_cPKIm-gRhJlJn-dRdO_Hzy0rCkDngbSEg_VAeQQv-JAvOlQimI73scyWyLGLzuyOZV33Sy0NAsdOJ0xiM0C5HT_-Wc-ZFHW3uYWzixu60c0yRiJ2vV0-o-VTvpkALYPmy5n8SXSKKP59psvGzSydiX4dq5bk2XGq8wTsUGBOObTVZEN_j9E';
+        $token = $this->getToken();
         /** analyze token at https://jwt.io/
         {
         "kid": "key1",               -- should be validated by key1 (see the resources directory)
@@ -271,7 +317,7 @@ class CanadaLoginBearerTokenTest extends TestCase
      */
     public function testThatASecondQuickIntrospectionRequestIsCached()
     {
-        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoyMTQ3NDgzNjQ3LCJpYXQiOjB9.qiOmlGVi-7K0B8eeZNYY21yZnXDn5pZWFMSLM6UH2uHUQ8mdcN0Ocd36Sq1vKvWeOgTvEm_MCl5GGCert16huUoEiILnlmf9F4i7L7wa1HIgPZnXKxKFbShbUUFMSn-6WxEQxF5g-s6cr77Lu6H_y2_osD39MFcpxTy5k5zJE8EXwQ2FGxmYhW4_qpNF3WQcMge5dfhaPaLpxH1lSrYHkCqnfGJkcTMRg3TPkQe1KWV4VUf2uGl06FleWCXuPgO__LSWeA2YHsyCV7tMPVDlOIOtiyZA1Pk4G_p2ur8a403NyIjdcXOscwIHd55vw--GOdMGSurLMS_rHfz0FD6bRSzW_6AWfBa4KQJVkoM_U6aUZ5yBEbzbsNh2u1H-OyEVBgu4R5XoyXfcn8-Z8nq_ciER8UyvVXTj9WnU--ELEZ_0Qxn4ovKqjXdL7eGwwQ5YercEh-iGiaHikEi2pD1YpfbpXE_uS3Wl2Acd8f_4sIzyQfbBfGoqIZb_cPKIm-gRhJlJn-dRdO_Hzy0rCkDngbSEg_VAeQQv-JAvOlQimI73scyWyLGLzuyOZV33Sy0NAsdOJ0xiM0C5HT_-Wc-ZFHW3uYWzixu60c0yRiJ2vV0-o-VTvpkALYPmy5n8SXSKKP59psvGzSydiX4dq5bk2XGq8wTsUGBOObTVZEN_j9E';
+        $token = $this->getToken();
         /** analyze token at https://jwt.io/
         {
         "kid": "key1",               -- should be validated by key1 (see the resources directory)
@@ -301,7 +347,7 @@ class CanadaLoginBearerTokenTest extends TestCase
      */
     public function testThatASecondLongIntrospectionRequestIsNotCached()
     {
-        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoyMTQ3NDgzNjQ3LCJpYXQiOjB9.qiOmlGVi-7K0B8eeZNYY21yZnXDn5pZWFMSLM6UH2uHUQ8mdcN0Ocd36Sq1vKvWeOgTvEm_MCl5GGCert16huUoEiILnlmf9F4i7L7wa1HIgPZnXKxKFbShbUUFMSn-6WxEQxF5g-s6cr77Lu6H_y2_osD39MFcpxTy5k5zJE8EXwQ2FGxmYhW4_qpNF3WQcMge5dfhaPaLpxH1lSrYHkCqnfGJkcTMRg3TPkQe1KWV4VUf2uGl06FleWCXuPgO__LSWeA2YHsyCV7tMPVDlOIOtiyZA1Pk4G_p2ur8a403NyIjdcXOscwIHd55vw--GOdMGSurLMS_rHfz0FD6bRSzW_6AWfBa4KQJVkoM_U6aUZ5yBEbzbsNh2u1H-OyEVBgu4R5XoyXfcn8-Z8nq_ciER8UyvVXTj9WnU--ELEZ_0Qxn4ovKqjXdL7eGwwQ5YercEh-iGiaHikEi2pD1YpfbpXE_uS3Wl2Acd8f_4sIzyQfbBfGoqIZb_cPKIm-gRhJlJn-dRdO_Hzy0rCkDngbSEg_VAeQQv-JAvOlQimI73scyWyLGLzuyOZV33Sy0NAsdOJ0xiM0C5HT_-Wc-ZFHW3uYWzixu60c0yRiJ2vV0-o-VTvpkALYPmy5n8SXSKKP59psvGzSydiX4dq5bk2XGq8wTsUGBOObTVZEN_j9E';
+        $token = $this->getToken();
         /** analyze token at https://jwt.io/
         {
         "kid": "key1",               -- should be validated by key1 (see the resources directory)
@@ -332,7 +378,7 @@ class CanadaLoginBearerTokenTest extends TestCase
      */
     public function testThatASecondQuickIntrospectionRequestIsNotCachedWhenExpired()
     {
-        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoxNTc3ODM2ODA1LCJpYXQiOjB9.G_gs9jaBUUiew520AZMmthTb-Ykj75BoB2AL-Qh7_wfNjZCTeS89jciPLp_Uh1CQJSK64yW3IyVd8XqZjSSVOARlZox5LlcXdHwdkqAyGa2_iiMOdk8E_ILX0gKWn1KaJyuuAMVnIocMMR8NN3T-m5NT8aYBXUEYF9XRaXcQL1ZfdE_E2JO-6pPZW55SEytQwRpi_mshs-EPolyxenWrNRRCP9xxUiO_FJ8wN0zaeheeCWo2t6z6TGT9VVEqojpfM-N6dGkrZyyFYpoxwksSeGp4clIBDb4aN7tysz0oXxZuNbF7Ex9wv9oRslb9MaMTc1FR5hDZNRiCVlCLTqF4Bb2rF6x2UlVRN48xCQOhRN54psOxuYQL_BQUUXxYHDdRLdzfG-GgHyzkQbgYedWKx6oip--OoFD-P-PVcdyRiG7iBqAXqINUsDDLB5HvlCPXkBL4fRlG789ct25MnKCEcTJE1KMku9ge5QIz7wMume19bO-rgFZTufQI_lko6rfPqAKmn5__pZqACO56IaEMGR7Zw9gGXU9clPfn5s3M8yKV0w4x1cTXsfb4ad6MQvOrAFhpGMF0Q820QMAGa85dNCM5xQzAzfeJn7W4MeHIei02CuDGLfqMJF2IL3A2oxv4QvOfrDGlkneWa6yj0uQUd_HpSnMDihxMwos5svA7blQ';
+        $token = $this->getToken(expiresAt: 1577836805);
         /** analyze token at https://jwt.io/
         {
         "kid": "key1",               -- should be validated by key1 (see the resources directory)

--- a/api/tests/Unit/SignInCanadaBearerTokenTest.php
+++ b/api/tests/Unit/SignInCanadaBearerTokenTest.php
@@ -7,6 +7,9 @@ use DateTimeImmutable;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer;
+use Lcobucci\JWT\Signer\Key\InMemory;
 use Psr\Clock\ClockInterface;
 use Tests\TestCase;
 
@@ -25,6 +28,38 @@ class SignInCanadaBearerTokenTest extends TestCase
 
     const fakeJwksUrl = self::fakeRootUrl.'/jwks';
 
+    const fakeAudience = 'fake-development-client-key';
+
+    private function getToken(
+        string $subject = '1234567890',
+        string $issuer = self::fakeRootUrl,
+        string|array|null $audience = self::fakeAudience,
+        int $expiresAt = 2147483647,
+        int $issuedAt = 0,
+        string $keyId = 'key1',
+        string $privateKeyResource = 'key1.pem',
+    ): string {
+        $config = Configuration::forAsymmetricSigner(
+            new Signer\Rsa\Sha256(),
+            InMemory::file(__DIR__.'/resources/'.$privateKeyResource),
+            InMemory::file(__DIR__.'/resources/'.str_replace('.pem', '-cert.pem', $privateKeyResource)),
+        );
+
+        $builder = $config->builder()
+            ->withHeader('kid', $keyId)
+            ->withHeader('typ', 'JWT')
+            ->relatedTo($subject)
+            ->issuedBy($issuer)
+            ->issuedAt((new DateTimeImmutable())->setTimestamp($issuedAt))
+            ->expiresAt((new DateTimeImmutable())->setTimestamp($expiresAt));
+
+        foreach ((array) $audience as $audienceValue) {
+            $builder = $builder->permittedFor(strval($audienceValue));
+        }
+
+        return $builder->getToken($config->signer(), $config->signingKey())->toString();
+    }
+
     protected bool $fakeIntrospectionIsActive;
 
     protected DateTimeImmutable $fakeIntrospectionExpiry;
@@ -33,6 +68,7 @@ class SignInCanadaBearerTokenTest extends TestCase
     {
         parent::setUp(); // initializes Http facade
         Cache::flush(); // Start with fresh cache
+        config(['oauth.client_id' => self::fakeAudience]);
 
         $fakeIntrospectionUrl = self::fakeRootUrl.'/introspection';
 
@@ -83,7 +119,7 @@ class SignInCanadaBearerTokenTest extends TestCase
      */
     public function testAcceptsGoodTokenAndReturnsCorrectSub()
     {
-        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoyMTQ3NDgzNjQ3LCJpYXQiOjB9.qiOmlGVi-7K0B8eeZNYY21yZnXDn5pZWFMSLM6UH2uHUQ8mdcN0Ocd36Sq1vKvWeOgTvEm_MCl5GGCert16huUoEiILnlmf9F4i7L7wa1HIgPZnXKxKFbShbUUFMSn-6WxEQxF5g-s6cr77Lu6H_y2_osD39MFcpxTy5k5zJE8EXwQ2FGxmYhW4_qpNF3WQcMge5dfhaPaLpxH1lSrYHkCqnfGJkcTMRg3TPkQe1KWV4VUf2uGl06FleWCXuPgO__LSWeA2YHsyCV7tMPVDlOIOtiyZA1Pk4G_p2ur8a403NyIjdcXOscwIHd55vw--GOdMGSurLMS_rHfz0FD6bRSzW_6AWfBa4KQJVkoM_U6aUZ5yBEbzbsNh2u1H-OyEVBgu4R5XoyXfcn8-Z8nq_ciER8UyvVXTj9WnU--ELEZ_0Qxn4ovKqjXdL7eGwwQ5YercEh-iGiaHikEi2pD1YpfbpXE_uS3Wl2Acd8f_4sIzyQfbBfGoqIZb_cPKIm-gRhJlJn-dRdO_Hzy0rCkDngbSEg_VAeQQv-JAvOlQimI73scyWyLGLzuyOZV33Sy0NAsdOJ0xiM0C5HT_-Wc-ZFHW3uYWzixu60c0yRiJ2vV0-o-VTvpkALYPmy5n8SXSKKP59psvGzSydiX4dq5bk2XGq8wTsUGBOObTVZEN_j9E';
+        $token = $this->getToken();
         /** analyze token at https://jwt.io/
         {
         "kid": "key1",               -- should be validated by key1 (see the resources directory)
@@ -128,7 +164,7 @@ class SignInCanadaBearerTokenTest extends TestCase
     public function testRejectsIncorrectIssuer()
     {
         $this->expectException(\Exception::class);
-        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3dyb25nZG9tYWluLmNvbSIsImV4cCI6MjE0NzQ4MzY0NywiaWF0IjowfQ.xtr4Xolvxryi6_vMLquynGmbi0v925e6wC5hPUYgUXxVXaiZ8IoMHW5hR7sG916ZrsE52IRZXKWXv8sbebUdiavJVav94nyRJTtcp24FoefB_yLck930xZgHLSl5WmqMf7jhy8OBhBIgVCNQY9kj2BzAgrqJ0RCY-9F95unwSPfQHm9rryILY2DlgduReoDIpO1u1E-Lwyw3rVt-hKChsyP1tcc1GyVXNFPfd3YyeAO6Mez6yV8mcTAnsHdrYSrp8XHTbEb5tmF3QQQR-WjftmAMFjq1UA0e70WjfKh0ZNzHMCJt2W0ElWIL8pkliop68Y-STNqZnZStemq0PaRfX1jhfek-To6J1UfuAfiiYjaJoCoOxECdY_xb0UCyLLcG-g2roAeqKQgrEp7PCbjdXE8Xe_e4Yc4gNWDidOoV0vqrxx05h1KCmIy8u1W8xbdXTOVH39yIt7_JKWM_g8ySO5x0fQHdIqgNgW5CWPoYel45k23bnfqq7bOCIULj3SeKMrrP-WBAWaJs0Z6noKql08HcQYOFoqaYPj8wFF1T4IzVyYbcOxWY_L9pAzxU19WOa01Me2oDA9SCBKGszZMgYVEkayL40J0MB5qpMYjR9x-Dd1xifyr9zlNEy7-jlOyM6BopZrovWbIEI1w1XqqCmXQoXfxhD3ZYrSbX5k6l-bc';
+        $token = $this->getToken(issuer: 'http://wrongdomain.com');
         /** analyze token at https://jwt.io/
         {
         "kid": "key1",
@@ -146,12 +182,22 @@ class SignInCanadaBearerTokenTest extends TestCase
     }
 
     /**
+     * A token is provided but has the wrong audience and should be rejected.
+     */
+    public function testRejectsIncorrectAudience()
+    {
+        $this->expectException(\Exception::class);
+        $token = $this->getToken(audience: 'wrong-client-id');
+        $this->service_provider->validateAndGetClaims($token);
+    }
+
+    /**
      * A token is provided but has expired and should be rejected.
      */
     public function testRejectsExpiredToken()
     {
         $this->expectException(\Exception::class);
-        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoxLCJpYXQiOjB9.hfY-0wyAaBL9GDysfc33VMou1pEuGbbwL6oSKzjLdBUtZ5-x--ROaFgUf4NbnSYR7erSggsGMq9Z15gtZVRnYNu1n2QiLYq3mhh83peBH0zdhAB7K_GO_Tpe6dswMGg0esgcp4odH1mlxHYb2RzHkAbYbrYeCYvG537HcoTXFhfltFHpZq7nVMxxbLC0QnSkDSO0vUfyYXiFBe-s5Jxb3UMuStpdPpvrl3OtCh7i-P91BJl5RFN1h7Xd6je1qwcYhQi6aKrPex9sXbdQ3ywzYmxCSHMmIGtYGpbNf_A9WdDKe2SMUW9Q6XWrWCuvTM-SEGUsV1ezrncn21CZfPUREQ_wl7wEdYo2R2W6Ybhgw4Wu0hJEsRxPfP-oNAV4HsVzOh2XRVVYrJ-Y0v_ij6JprDovddXNHFhB4ITeLbB0lSN1pA2qFvPySvPwfNcMNCK5cNY0WVfJmPjgrlxSPCMOIjlCJIaIkPj2QxWbdsMeiASXCKPvrmCiTsrbzxydPprrL6pbdNE_ILPsyf0DpCitMvKtGBmtgr3hv-XP3pjOm2To_bspp-R59Z2pYA_Rav0HdqCPpTC6MZBsf-oF3CSzYviMAxFDq20DUPflT9mzcLGmPtmCVshjfQJ1i9iH55S7TWAhDGT50rVGUje0ZSFVDU1nFYThcVZqb787BN417x8';
+        $token = $this->getToken(expiresAt: 1);
         /** analyze token at https://jwt.io/
         {
         "kid": "key1",
@@ -174,7 +220,7 @@ class SignInCanadaBearerTokenTest extends TestCase
     public function testRejectsFutureToken()
     {
         $this->expectException(\Exception::class);
-        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoyMTQ3NDgzNjQ3LCJpYXQiOjIxNDc0ODM2NDZ9.NGbN9gRz_duLXrziyFc3tg_8YtebqWUR0iuoiUElCi3KNOlJjvwPERUWbhYfEgx-FmN7u-FfGjgZoIsK9i745IxHvgunaP3xbZlq-M2FGRd2gMNMMX7n1hnrtuNR43ULmAMleU5ps8l4ey4-FjJCBHoRK0tG_BLkzdbbh-eqU16StIDwzfeJblMUFk78j7gKHS0g15udkNwXm2YawxlqH8ihCf3Ty0E3Jedpmo83L67EI5VKNy2ab7lauEk1xvJUoteUK0ugwpYMPm54LPXYUeWPXI2JpzdlNNZkPdlAhaM3nVPHrYBAPWdWPR83E9R4svc5anva73TtOnDH_8blb3dFkHKTdANbRLWv8kkFL-QogY4sJazzn_v61ZgjS5Q7tqXrQgim6_7871-bbdDO6zYGIQnDWecCXqMJLrXjkkRhs8-euEsXmZm5LaSIEcHSb05XU2rgb6LwFeKdQE7DuZcVWJ0gEFI_13ciOOe1ltFWbUhSppHSfiQ320H3lldlIHuh_gDLWTjyWcCffveV_I3fUF2E0z83926hvwycPH3qcRVyOz5lr_o6SaH8ogmFnhNea-qIgQX-Uo3MZVeiVHKmthiod-p_lF8xMLAao--z_cfPxSe7YC4yBehfRQW3Hnzo13D9M9avHUtNxAEfy89naaTa6LO8GK8EZlHndtU';
+        $token = $this->getToken(issuedAt: 2147483646);
         /** analyze token at https://jwt.io/
         {
         "kid": "key1",
@@ -198,7 +244,7 @@ class SignInCanadaBearerTokenTest extends TestCase
     {
         $this->expectException(\Exception::class);
         // this token actually signed with key2
-        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoyMTQ3NDgzNjQ3LCJpYXQiOjB9.o-gz2gQSJ7frAfJq6H9DYWqxPmeptsbnAKUJpg7V5OdJVV3cmN5S4Ask0B9RoutlFix8jjBX0tYksyCxJ97Rz2wcFZNh_FpDyE9oQ3xgApfnHzerIiyfpxYWIzg-LWixuObha2aLN15CwxfBoFACbZ0SN_PeXkw9NWGmy_FUAmoLbf6K1NYmZY85eqGvyOifXf8VFXMFj0Wd0XlH1fR_dXiUn7oud_9FDIrTfr9eWXRriRleQTGcnkTns7VnddXp6qo6NQchcIvejg1L4Zukpe_YZ37T2fQUDR6ctRGeZj1qmNKHTiUUfiiMoHAfBz0Hx9EW_BTaasUWt0kbv8Xym26bwg-UXj4v6GA2YcwimPHi4rhs6bKOfgNiNqllqkF7Xf-Q86GDicaiV_kuP8JQa68svv4NdUCyfY9AVsV19PjoPClQdKzqSZtl1Ng9i6CujHNzCsqZDHZvvfhHHFlVovLJZjKEX5hQas6SdBV5pjPkJCC-Kwiin9NJb4l-nVIBkRvt5DRbXNF2xQDloQPPhSrJcT6TF2kaMbKOxMbXJ9aOnMLraAoXaImWlYc3JTiGotvovmtv5gPjs2Q_9-AuuQIkhluy2NF-pXuKMtcZB0qopsC8pG_6JhsE9NE8sgWxDeXOW6FC5tY7hix3bocy5oDN3kxUZ-dLhtR6d7eBulc';
+        $token = $this->getToken(privateKeyResource: 'key2.pem');
         /** analyze token at https://jwt.io/
         {
         "kid": "key1",
@@ -220,7 +266,7 @@ class SignInCanadaBearerTokenTest extends TestCase
      */
     public function testAcceptsExpiredTokenWithinAllowableSkew()
     {
-        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoxNTc3ODM2ODYwLCJpYXQiOjB9.zI4EHjfWyZP3G8DFRAMJXF9mZrA65RizQMrnQGVuKFYm0cwMusBToaH5k4feB0b2WPfBkl3-gHOJ5qKoNcR50RI_t5LEZbBVZrGhCDfpCDVlO5ZnwABhQo48NUi2ZbMb1ZoDTa_802hifvpjhOtEE0V9_zCsDZ1pcA9G4rsqEv5T3N35JV_xwgD_PqToZrxCMNuJOG5k8suoIKazzN5eJm3adKi7UsOqh-DJTni7-z88A95UycS0ONw5APFYU-IE3kL5UL1K6OwvXEgpD0md06qB3GUmkkjXeGumDefokT8RouAIbX8p37cfvxeuctJ1WtKZJ3IrJx0E4y-15JCLaPQ3tmv4XQ7lfHf9Yblith7Sw4T4upO7wtynogg2Y_Oget7zLksvaza77SRkXLf8Si3lGJ9ydqSlkLKqo8aX5nQJAkUnRY72eIz5jEEdBBrkpTQdQRG4g2-R9xXd9rGCscdAt2S3COJEFhO2FrgwUiD0piHah-PlMVN5fw3wr2ISN9OYfd5_e15UxLgo0Qw99_mKaakXBf20umTkk2TGi8YmMZLvbOS6yI7eS1wo3rFPzdTOPT7WoW6iPl_kW0FdGZYQQb1GxI2RrjFl6Ud4axKqJbtv1dV9ml1Z9PPawBcIP2B702uLwc9RZrX8b3S3Cnq72-7iCWJVvET9IQr1ess';
+        $token = $this->getToken(expiresAt: 1577836860);
         /** analyze token at https://jwt.io/
         {
         "kid": "key1",
@@ -247,7 +293,7 @@ class SignInCanadaBearerTokenTest extends TestCase
      */
     public function testThatIntrospectionCanRejectAValidToken()
     {
-        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoyMTQ3NDgzNjQ3LCJpYXQiOjB9.qiOmlGVi-7K0B8eeZNYY21yZnXDn5pZWFMSLM6UH2uHUQ8mdcN0Ocd36Sq1vKvWeOgTvEm_MCl5GGCert16huUoEiILnlmf9F4i7L7wa1HIgPZnXKxKFbShbUUFMSn-6WxEQxF5g-s6cr77Lu6H_y2_osD39MFcpxTy5k5zJE8EXwQ2FGxmYhW4_qpNF3WQcMge5dfhaPaLpxH1lSrYHkCqnfGJkcTMRg3TPkQe1KWV4VUf2uGl06FleWCXuPgO__LSWeA2YHsyCV7tMPVDlOIOtiyZA1Pk4G_p2ur8a403NyIjdcXOscwIHd55vw--GOdMGSurLMS_rHfz0FD6bRSzW_6AWfBa4KQJVkoM_U6aUZ5yBEbzbsNh2u1H-OyEVBgu4R5XoyXfcn8-Z8nq_ciER8UyvVXTj9WnU--ELEZ_0Qxn4ovKqjXdL7eGwwQ5YercEh-iGiaHikEi2pD1YpfbpXE_uS3Wl2Acd8f_4sIzyQfbBfGoqIZb_cPKIm-gRhJlJn-dRdO_Hzy0rCkDngbSEg_VAeQQv-JAvOlQimI73scyWyLGLzuyOZV33Sy0NAsdOJ0xiM0C5HT_-Wc-ZFHW3uYWzixu60c0yRiJ2vV0-o-VTvpkALYPmy5n8SXSKKP59psvGzSydiX4dq5bk2XGq8wTsUGBOObTVZEN_j9E';
+        $token = $this->getToken();
         /** analyze token at https://jwt.io/
         {
         "kid": "key1",               -- should be validated by key1 (see the resources directory)
@@ -271,7 +317,7 @@ class SignInCanadaBearerTokenTest extends TestCase
      */
     public function testThatASecondQuickIntrospectionRequestIsCached()
     {
-        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoyMTQ3NDgzNjQ3LCJpYXQiOjB9.qiOmlGVi-7K0B8eeZNYY21yZnXDn5pZWFMSLM6UH2uHUQ8mdcN0Ocd36Sq1vKvWeOgTvEm_MCl5GGCert16huUoEiILnlmf9F4i7L7wa1HIgPZnXKxKFbShbUUFMSn-6WxEQxF5g-s6cr77Lu6H_y2_osD39MFcpxTy5k5zJE8EXwQ2FGxmYhW4_qpNF3WQcMge5dfhaPaLpxH1lSrYHkCqnfGJkcTMRg3TPkQe1KWV4VUf2uGl06FleWCXuPgO__LSWeA2YHsyCV7tMPVDlOIOtiyZA1Pk4G_p2ur8a403NyIjdcXOscwIHd55vw--GOdMGSurLMS_rHfz0FD6bRSzW_6AWfBa4KQJVkoM_U6aUZ5yBEbzbsNh2u1H-OyEVBgu4R5XoyXfcn8-Z8nq_ciER8UyvVXTj9WnU--ELEZ_0Qxn4ovKqjXdL7eGwwQ5YercEh-iGiaHikEi2pD1YpfbpXE_uS3Wl2Acd8f_4sIzyQfbBfGoqIZb_cPKIm-gRhJlJn-dRdO_Hzy0rCkDngbSEg_VAeQQv-JAvOlQimI73scyWyLGLzuyOZV33Sy0NAsdOJ0xiM0C5HT_-Wc-ZFHW3uYWzixu60c0yRiJ2vV0-o-VTvpkALYPmy5n8SXSKKP59psvGzSydiX4dq5bk2XGq8wTsUGBOObTVZEN_j9E';
+        $token = $this->getToken();
         /** analyze token at https://jwt.io/
         {
         "kid": "key1",               -- should be validated by key1 (see the resources directory)
@@ -301,7 +347,7 @@ class SignInCanadaBearerTokenTest extends TestCase
      */
     public function testThatASecondLongIntrospectionRequestIsNotCached()
     {
-        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoyMTQ3NDgzNjQ3LCJpYXQiOjB9.qiOmlGVi-7K0B8eeZNYY21yZnXDn5pZWFMSLM6UH2uHUQ8mdcN0Ocd36Sq1vKvWeOgTvEm_MCl5GGCert16huUoEiILnlmf9F4i7L7wa1HIgPZnXKxKFbShbUUFMSn-6WxEQxF5g-s6cr77Lu6H_y2_osD39MFcpxTy5k5zJE8EXwQ2FGxmYhW4_qpNF3WQcMge5dfhaPaLpxH1lSrYHkCqnfGJkcTMRg3TPkQe1KWV4VUf2uGl06FleWCXuPgO__LSWeA2YHsyCV7tMPVDlOIOtiyZA1Pk4G_p2ur8a403NyIjdcXOscwIHd55vw--GOdMGSurLMS_rHfz0FD6bRSzW_6AWfBa4KQJVkoM_U6aUZ5yBEbzbsNh2u1H-OyEVBgu4R5XoyXfcn8-Z8nq_ciER8UyvVXTj9WnU--ELEZ_0Qxn4ovKqjXdL7eGwwQ5YercEh-iGiaHikEi2pD1YpfbpXE_uS3Wl2Acd8f_4sIzyQfbBfGoqIZb_cPKIm-gRhJlJn-dRdO_Hzy0rCkDngbSEg_VAeQQv-JAvOlQimI73scyWyLGLzuyOZV33Sy0NAsdOJ0xiM0C5HT_-Wc-ZFHW3uYWzixu60c0yRiJ2vV0-o-VTvpkALYPmy5n8SXSKKP59psvGzSydiX4dq5bk2XGq8wTsUGBOObTVZEN_j9E';
+        $token = $this->getToken();
         /** analyze token at https://jwt.io/
         {
         "kid": "key1",               -- should be validated by key1 (see the resources directory)
@@ -332,7 +378,7 @@ class SignInCanadaBearerTokenTest extends TestCase
      */
     public function testThatASecondQuickIntrospectionRequestIsNotCachedWhenExpired()
     {
-        $token = 'eyJraWQiOiJrZXkxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cDovL3Rlc3QuY29tIiwiZXhwIjoxNTc3ODM2ODA1LCJpYXQiOjB9.G_gs9jaBUUiew520AZMmthTb-Ykj75BoB2AL-Qh7_wfNjZCTeS89jciPLp_Uh1CQJSK64yW3IyVd8XqZjSSVOARlZox5LlcXdHwdkqAyGa2_iiMOdk8E_ILX0gKWn1KaJyuuAMVnIocMMR8NN3T-m5NT8aYBXUEYF9XRaXcQL1ZfdE_E2JO-6pPZW55SEytQwRpi_mshs-EPolyxenWrNRRCP9xxUiO_FJ8wN0zaeheeCWo2t6z6TGT9VVEqojpfM-N6dGkrZyyFYpoxwksSeGp4clIBDb4aN7tysz0oXxZuNbF7Ex9wv9oRslb9MaMTc1FR5hDZNRiCVlCLTqF4Bb2rF6x2UlVRN48xCQOhRN54psOxuYQL_BQUUXxYHDdRLdzfG-GgHyzkQbgYedWKx6oip--OoFD-P-PVcdyRiG7iBqAXqINUsDDLB5HvlCPXkBL4fRlG789ct25MnKCEcTJE1KMku9ge5QIz7wMume19bO-rgFZTufQI_lko6rfPqAKmn5__pZqACO56IaEMGR7Zw9gGXU9clPfn5s3M8yKV0w4x1cTXsfb4ad6MQvOrAFhpGMF0Q820QMAGa85dNCM5xQzAzfeJn7W4MeHIei02CuDGLfqMJF2IL3A2oxv4QvOfrDGlkneWa6yj0uQUd_HpSnMDihxMwos5svA7blQ';
+        $token = $this->getToken(expiresAt: 1577836805);
         /** analyze token at https://jwt.io/
         {
         "kid": "key1",               -- should be validated by key1 (see the resources directory)

--- a/infrastructure/conf/mock-oauth2-server.json
+++ b/infrastructure/conf/mock-oauth2-server.json
@@ -11,7 +11,7 @@
           "requestParam": "client_id",
           "match": "fake-development-client-key",
           "claims": {
-            "aud": "00000000-0000-0000-0123-456789abcdef",
+            "aud": "fake-development-client-key",
             "code": "00000000-0000-0000-0123-456789abcdef",
             "scope": [
               "openid",
@@ -26,7 +26,7 @@
           "match": "e2e",
           "claims": {
             "sub": "${sub}",
-            "aud": "00000000-0000-0000-0123-456789abcdef",
+            "aud": "fake-development-client-key",
             "code": "00000000-0000-0000-0123-456789abcdef",
             "scope": [
               "openid",


### PR DESCRIPTION
🤖 Resolves #16472 

## 👋 Introduction

Updates our bearer token services to validate the `aud` by adding the `PermittedFor` constraint in the `validateAndGetClaims` method.

## 🕵️ Details

This also added a helper in the tests so that we can be more explicit about creating tokens. This might make tests run a little longer but, avoids the need to hardcode an entire tokens into the test cases. 

## 🧪 Testing

> [!IMPORTANT]
> Run this test with all three auth services (SiC, CL and mock). If you need keys, let me know and I can get them to you. 

1. Ensure proper test oauth keys set in `.env`
2. Attempt to login
3. Cofirm you can
4. Repear for other auth service(s)

### Fail test

1. Modify `mock-oauth2-server.json` so that `aud` and `client_id` do not match
2. Rebuild `make down; make up;`
3. Confirm you cannot login