### PR TITLE
[Fix] Removes `Heading` variant color black

### DIFF
--- a/apps/web/src/pages/Communities/CommunityProfessionalizationPage/components/AddDialog.tsx
+++ b/apps/web/src/pages/Communities/CommunityProfessionalizationPage/components/AddDialog.tsx
@@ -236,12 +236,7 @@ const AddDialog = ({ community: communityFragment }: AddDialogProps) => {
                 className="mb-6"
               />
               <div className="mb-6">
-                <Heading
-                  level="h3"
-                  color="black"
-                  size="h6"
-                  className="mt-0 font-bold"
-                >
+                <Heading level="h3" size="h6" className="mt-0 font-bold">
                   {intl.formatMessage({
                     defaultMessage: "Classification restrictions",
                     id: "V3zpN4",

--- a/apps/web/src/pages/Communities/CommunityProfessionalizationPage/components/EditDialog.tsx
+++ b/apps/web/src/pages/Communities/CommunityProfessionalizationPage/components/EditDialog.tsx
@@ -138,12 +138,7 @@ const EditDialog = ({
         <Dialog.Body>
           <FormProvider {...methods}>
             <form onSubmit={handleSubmit(onSubmit)}>
-              <Heading
-                level="h3"
-                color="black"
-                size="h6"
-                className="mt-0 font-bold"
-              >
+              <Heading level="h3" size="h6" className="mt-0 font-bold">
                 {intl.formatMessage({
                   defaultMessage: "Classification restrictions",
                   id: "V3zpN4",

--- a/apps/web/src/pages/EmployeeProfile/EmployeeProfilePage.tsx
+++ b/apps/web/src/pages/EmployeeProfile/EmployeeProfilePage.tsx
@@ -274,7 +274,7 @@ export const EmployeeProfile = ({
                       ? ChartBarSquareIcon
                       : LockClosedIcon
                   }
-                  color={user.isVerifiedGovEmployee ? "primary" : "black"}
+                  {...(user.isVerifiedGovEmployee && { color: "primary" })}
                   className="mt-0 font-normal sm:text-left"
                 >
                   {intl.formatMessage(commonMessages.careerPlanning)}

--- a/apps/web/src/pages/EmployeeProfile/components/CareerDevelopmentSection/CareerDevelopmentSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerDevelopmentSection/CareerDevelopmentSection.tsx
@@ -184,7 +184,6 @@ const CareerDevelopmentSection = ({
     ? verifiedIcon
     : {
         icon: LockClosedIcon,
-        color: "black",
       };
 
   const handleError = () => {

--- a/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerObjective/CareerObjectiveSection.tsx
@@ -224,7 +224,6 @@ const CareerObjectiveSection = ({
     ? verifiedIcon
     : {
         icon: LockClosedIcon,
-        color: "black",
       };
 
   const handleError = () => {

--- a/apps/web/src/pages/EmployeeProfile/components/GoalsWorkStyleSection/GoalsWorkStyleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/GoalsWorkStyleSection/GoalsWorkStyleSection.tsx
@@ -104,7 +104,6 @@ const GoalsWorkStyleSection = ({
     ? verifiedIcon
     : {
         icon: LockClosedIcon,
-        color: "black",
       };
 
   const handleError = () => {

--- a/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/NextRoleSection/NextRoleSection.tsx
@@ -220,7 +220,6 @@ const NextRoleSection = ({
     ? verifiedIcon
     : {
         icon: LockClosedIcon,
-        color: "black",
       };
 
   const handleError = () => {

--- a/packages/ui/src/components/Heading/Heading.tsx
+++ b/packages/ui/src/components/Heading/Heading.tsx
@@ -56,9 +56,6 @@ const heading = tv({
       error: {
         icon: "text-error",
       },
-      black: {
-        icon: "text-black",
-      },
     },
     // Center align text
     center: {


### PR DESCRIPTION
🤖 Resolves #16742.

## 👋 Introduction

This PR removes `Heading` variant color black and any instances where it was used.

## 🧪 Testing

1. `pnpm build:fresh`
2. Verify no instances of `Heading` variant color black remain in codebase
3. Verify any instances where variant color black was removed from a `Heading` instance render in the intended style

## 📸 Screenshots

<details><summary>Employee profile</summary>
<p>
<img width="1804" height="3238" alt="localhost_8000_en_applicant_employee-profile" src="https://github.com/user-attachments/assets/df46c8f0-a28a-4b96-b791-cfedf9730fe0" />
<img width="1804" height="3238" alt="localhost_8000_en_applicant_employee-profile (1)" src="https://github.com/user-attachments/assets/3eda6ed7-a30a-4468-b0dc-6dab80650fa6" />

</p>
</details> 

<details><summary>Community professionalization</summary>
<p>

<img width="1228" height="468" alt="Screenshot 2026-05-13 at 14 10 24" src="https://github.com/user-attachments/assets/6bf9ce8e-93f9-4b1c-b59c-1b8d040cdcf5" />
<img width="1220" height="676" alt="Screenshot 2026-05-13 at 14 10 46" src="https://github.com/user-attachments/assets/4df043f2-e25b-4020-8983-5ce4e51dcadd" />
<img width="1207" height="675" alt="Screenshot 2026-05-13 at 14 10 57" src="https://github.com/user-attachments/assets/14b91f7d-339f-4ac4-bf5e-c1a273d3cf02" />
<img width="1210" height="675" alt="Screenshot 2026-05-13 at 14 11 07" src="https://github.com/user-attachments/assets/bcaf0883-129f-4281-91e7-15d27674817b" />

</p>
</details> 


