### PR TITLE
[Refactor] Hide search request candidate columns

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -437,6 +437,7 @@ const PoolCandidatesTable = ({
   doNotUseBookmark = false,
   doNotUseFlag = false,
   availableSteps,
+  hiddenColumnIds: hiddenColumnIdsProp,
 }: {
   initialFilterInput?: PoolCandidateSearchInput;
   currentPool?: Maybe<Pick<Pool, "id" | "displayName">>;
@@ -445,6 +446,7 @@ const PoolCandidatesTable = ({
   doNotUseBookmark?: boolean;
   doNotUseFlag?: boolean;
   availableSteps?: Maybe<PoolCandidateFilterDialogProps["availableSteps"]>;
+  hiddenColumnIds?: string[];
 }) => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -1143,7 +1145,11 @@ const PoolCandidatesTable = ({
     ),
   ] as ColumnDef<CandidatesTableCandidatesPaginatedQueryDataType>[];
 
-  const hiddenColumnIds = ["candidacyStatus", "notes", "flexibleWorkLocations"];
+  const hiddenColumnIds = hiddenColumnIdsProp ?? [
+    "candidacyStatus",
+    "notes",
+    "flexibleWorkLocations",
+  ];
   const hasSelectedRows = selectedRows.length > 0;
 
   return (

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/SearchRequestCandidatesTable.tsx
@@ -100,6 +100,22 @@ const SingleSearchRequestTableApi = ({
             }
       }
       title={intl.formatMessage(adminMessages.poolCandidates)}
+      hiddenColumnIds={[
+        "process",
+        "processNumber",
+        "priority",
+        "screeningStage",
+        "assessmentStep",
+        "screeningResult",
+        "applicationStatus",
+        "candidateFacingStatus",
+        "candidacyStatus",
+        "notes",
+        "preferredLang",
+        "languageAbility",
+        "flexibleWorkLocations",
+        "dateReceived",
+      ]}
       doNotUseBookmark
       doNotUseFlag
     />


### PR DESCRIPTION
🤖 Resolves #16767 

## 👋 Introduction

Hides columns that are rarely used on the candidates table within the context of a search request.

## 🕵️ Details

Users who use this table have identified the columns that they deemed unecessary in this table. We are starting by hiding them to get some early feedback while we work on a more permanent transition to a new table for the talent requests refactor.

## 🧪 Testing

> [!TIP]
> Most search requests are seeded with filters that result in no candidates. You may need to zero them out or submit your own request that does contain candidates to best test this. 

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to  a talent request `/admin/talent-requests/{id}`
4. Confirm that the only columns displayed by defualt are the ones listed in the ticket
5. Confirm you can still renable other columns

## 📸 Screenshot

<img width="1405" height="245" alt="swappy-20260514_074518" src="https://github.com/user-attachments/assets/c54932ab-5d49-41e8-8594-e9b264af2645" />
<img width="552" height="691" alt="swappy-20260514_074524" src="https://github.com/user-attachments/assets/d2113e41-c996-440a-82f9-c396cd5301e2" />
