### PR TITLE
Standardize SDO terminology

### DIFF
--- a/api/lang/en/finance_chief_role.php
+++ b/api/lang/en/finance_chief_role.php
@@ -5,6 +5,6 @@ return [
     'chief_information_officer' => 'Chief Information Officer (CIO)',
     'head_of_human_resources' => 'Head of Human Resources (HHR)',
     'head_of_procurement' => 'Head of Procurement',
-    'other' => 'Other senior delegated official (SDO) position',
+    'other' => 'Other senior designated official (SDO) position',
 
 ];

--- a/api/lang/fr/finance_chief_role.php
+++ b/api/lang/fr/finance_chief_role.php
@@ -5,5 +5,5 @@ return [
     'chief_information_officer' => 'Dirigeante principale ou dirigeant principal de l\'information (DPI)',
     'head_of_human_resources' => 'Chef des ressources humaines',
     'head_of_procurement' => 'Responsable de l\'approvisionnement',
-    'other' => 'Autre poste de cadre supérieur délégué (CSD)',
+    'other' => 'Autre poste de cadre supérieur désigné (CSD)',
 ];

--- a/apps/web/src/components/CommunityInterest/CommunityInterest.tsx
+++ b/apps/web/src/components/CommunityInterest/CommunityInterest.tsx
@@ -361,8 +361,8 @@ const CommunityInterest = ({
                     <p className="mb-1.5 font-bold">
                       {intl.formatMessage({
                         defaultMessage:
-                          "Other senior delegated official (SDO) position",
-                        id: "qQYO+V",
+                          "Other senior designated official (SDO) position",
+                        id: "q8ztSV",
                         description: "Label for the 'Other role' input",
                       })}
                     </p>
@@ -381,8 +381,8 @@ const CommunityInterest = ({
         <>
           <p className="mb-1.5 font-bold">
             {intl.formatMessage({
-              defaultMessage: "Senior Designated Officer (SDO) role",
-              id: "voOIR0",
+              defaultMessage: "Senior Designated Official (SDO) role",
+              id: "U1GjYG",
               description: "Bounding box label for the SDO checkbox",
             })}
           </p>
@@ -392,16 +392,16 @@ const CommunityInterest = ({
           >
             {communityInterest.procurementIsSDO
               ? intl.formatMessage({
-                  defaultMessage: "I'm a Senior Designated Officer (SDO).",
-                  id: "MoehVY",
+                  defaultMessage: "I'm a Senior Designated Official (SDO).",
+                  id: "oAC+SM",
                   description:
-                    "Message when user is a Senior Designated Officer",
+                    "Message when user is a Senior Designated Official",
                 })
               : intl.formatMessage({
-                  defaultMessage: "I'm not a Senior Designated Officer (SDO).",
-                  id: "uhtPZi",
+                  defaultMessage: "I'm not a Senior Designated Official (SDO).",
+                  id: "WWJRlj",
                   description:
-                    "Message when user is not a Senior Designated Officer",
+                    "Message when user is not a Senior Designated Official",
                 })}
           </BoolCheckIcon>
           {communityInterest.procurementIsSDO ? (

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -23,6 +23,10 @@
     "defaultMessage": "Statut de priorité",
     "description": "Title for priority status"
   },
+  "+2vO9m": {
+    "defaultMessage": "J’occupe actuellement un rôle de cadre supérieur désigné",
+    "description": "Message when user is a Senior Designated Official"
+  },
   "+2z44i": {
     "defaultMessage": "Il s’agit du nom d’utilisateur et du mot de passe que vous utilisez habituellement pour vous connecter à Talents numériques du GC.",
     "description": "Text for step two link your GCKey account."
@@ -2186,10 +2190,6 @@
   "6bGWe5": {
     "defaultMessage": "<strong>{name}</strong> a publié",
     "description": "Label for activity log item published action"
-  },
-  "6bjQWW": {
-    "defaultMessage": "Veuillez indiquer si vous exercez l’une des fonctions supplémentaires suivantes dans le cadre de votre rôle de CSD.",
-    "description": "Description for additional duties referencing a Senior Designated Officer (SDO) role"
   },
   "6bvAQ+": {
     "defaultMessage": "Rétroaction et coordonnées",
@@ -6143,10 +6143,6 @@
     "defaultMessage": "Sélectionnez un ou plusieurs programmes, certifications ou accréditations dont cette personne bénéficierait en y participant.",
     "description": "Description for development program options section in nominations details step"
   },
-  "MoehVY": {
-    "defaultMessage": "Je suis une personne occupant un rôle de cadre supérieur désigné (CSD).",
-    "description": "Message when user is a Senior Designated Officer"
-  },
   "MptxTu": {
     "defaultMessage": "Cette section vous permet de présenter des informations sur vous-même et sur votre façon de travailler, y compris sur vos objectifs pour l'avenir et sur les environnements qui vous permettent de donner le meilleur de vous-même.",
     "description": "Describes the goals and work style section of employee profile"
@@ -7851,6 +7847,10 @@
     "defaultMessage": "À quoi vous attendre après avoir soumis votre demande",
     "description": "Title for the what to expect section"
   },
+  "U1GjYG": {
+    "defaultMessage": "Rôle de cadre supérieur désigné (CSD)",
+    "description": "Bounding box label for the SDO checkbox"
+  },
   "U56T9c": {
     "defaultMessage": "Non vérifiée",
     "description": "The email address has not been verified to be owned by user"
@@ -8405,6 +8405,10 @@
   "WT+5to": {
     "defaultMessage": "Autre grade avec spécialisation",
     "description": "Heading for the `other education with specialization` option for EC education requirements"
+  },
+  "WWJRlj": {
+    "defaultMessage": "Je n'occupe pas de rôle de cadre supérieur désigné (CSD).",
+    "description": "Message when user is not a Senior Designated Official"
   },
   "WWrQYI": {
     "defaultMessage": "Erreur : la mise à jour de la possibilité de formation a échoué",
@@ -10342,6 +10346,10 @@
     "defaultMessage": "Informations sur le ministère",
     "description": "Heading for the 'create a department' form"
   },
+  "eO6RfE": {
+    "defaultMessage": "Veuillez indiquer si vous exercez l’une des fonctions supplémentaires suivantes dans le cadre de votre rôle de CSD.",
+    "description": "Description for additional duties referencing a Senior Designated Official (SDO) role"
+  },
   "eO9buR": {
     "defaultMessage": "4. Félicitations! <strong>Vous vous êtes connecté avec une CléGC</strong> et vous serez redirigé vers la <strong>plateforme de talents numériques du GC</strong>.",
     "description": "Text for final sign in step."
@@ -10877,10 +10885,6 @@
   "gIvlZk": {
     "defaultMessage": "Le <link>Fonds de formation et de perfectionnement de la collectivité de la TI</link> peut vous aider à acquérir la certification en payant le coût des examens.",
     "description": "Second paragraph of certification exam vouchers section"
-  },
-  "gIwkgl": {
-    "defaultMessage": "J’occupe actuellement un rôle de cadre supérieur désigné",
-    "description": "Message when user is a Senior Designated Officer"
   },
   "gIzUDr": {
     "defaultMessage": "Modifier les questions générales",
@@ -12874,6 +12878,10 @@
     "defaultMessage": "Vous n'avez rejoint aucune collectivité fonctionnelle.",
     "description": "Label for when user has not expressed interest in any communities"
   },
+  "oAC+SM": {
+    "defaultMessage": "Je suis une personne occupant un rôle de cadre supérieur désigné (CSD).",
+    "description": "Message when user is a Senior Designated Official"
+  },
   "oCFoWU": {
     "defaultMessage": "Informations sur la compétence",
     "description": "Heading for the 'create a skill' form"
@@ -13370,6 +13378,10 @@
     "defaultMessage": "Actuellement non vérifié",
     "description": "Label for the unverified claim option"
   },
+  "q8ztSV": {
+    "defaultMessage": "Autre poste de cadre supérieur désigné (CSD)",
+    "description": "Label for the 'Other role' input"
+  },
   "q9LrNV": {
     "defaultMessage": "Se connecter avec ConnexionCanada",
     "description": "Page title for the sign in page using CanadaLogin"
@@ -13433,10 +13445,6 @@
   "qQ9ziR": {
     "defaultMessage": "Les personnes choisies devront travailler sur place dans la région de la capitale nationale.",
     "description": "Note for innovation corps candidates about location"
-  },
-  "qQYO+V": {
-    "defaultMessage": "Autre poste de cadre supérieur délégué (CSD)",
-    "description": "Label for the 'Other role' input"
   },
   "qSNLSc": {
     "defaultMessage": "Acceptez le résumé des conditions d'utilisation.",
@@ -14386,10 +14394,6 @@
     "defaultMessage": "Réglementation",
     "description": "Label for a regulatory department"
   },
-  "uhtPZi": {
-    "defaultMessage": "Je n'occupe pas de rôle de cadre supérieur désigné (CSD).",
-    "description": "Message when user is not a Senior Designated Officer"
-  },
   "ukcsxj": {
     "defaultMessage": "Si vous choisissez de vous autodéclarer dans votre profil et que vous postulez un emploi chez Talents numériques du GC, ces renseignements peuvent être utilisés à n’importe quelle étape du processus d’emploi, de la demande initiale à l’évaluation en passant par la nomination. Les gestionnaires d’embauche ou l’équipe de recrutement de Talents numériques du GC pourraient utiliser ces renseignements",
     "description": "Paragraph 2, how self-declaration data is used"
@@ -14681,10 +14685,6 @@
   "voMSDe": {
     "defaultMessage": "Les informations sur les objectifs et le style de travail ont été mises à jour avec succès!",
     "description": "Message displayed when a user successfully updates employee profile information"
-  },
-  "voOIR0": {
-    "defaultMessage": "Rôle de cadre supérieur désigné (CSD)",
-    "description": "Bounding box label for the SDO checkbox"
   },
   "voqC0s": {
     "defaultMessage": "Gestion des talents",

--- a/apps/web/src/pages/CommunityInterests/sections/AdditionalInformation.tsx
+++ b/apps/web/src/pages/CommunityInterests/sections/AdditionalInformation.tsx
@@ -247,8 +247,8 @@ const AdditionalInformation = ({
                     type="text"
                     label={intl.formatMessage({
                       defaultMessage:
-                        "Other senior delegated official (SDO) position",
-                      id: "qQYO+V",
+                        "Other senior designated official (SDO) position",
+                      id: "q8ztSV",
                       description: "Label for the 'Other role' input",
                     })}
                     disabled={formDisabled}
@@ -269,15 +269,16 @@ const AdditionalInformation = ({
               name="procurementIsSDO"
               label={intl.formatMessage({
                 defaultMessage:
-                  "I am currently in a Senior Designated Officer role",
-                id: "gIwkgl",
-                description: "Message when user is a Senior Designated Officer",
+                  "I am currently in a Senior Designated Official role",
+                id: "+2vO9m",
+                description:
+                  "Message when user is a Senior Designated Official",
               })}
               disabled={formDisabled}
               boundingBox={true}
               boundingBoxLabel={intl.formatMessage({
-                defaultMessage: "Senior Designated Officer (SDO) role",
-                id: "voOIR0",
+                defaultMessage: "Senior Designated Official (SDO) role",
+                id: "U1GjYG",
                 description: "Bounding box label for the SDO checkbox",
               })}
             />
@@ -288,9 +289,9 @@ const AdditionalInformation = ({
                   {intl.formatMessage({
                     defaultMessage:
                       "Please indicate if you perform any of the following additional duties in your SDO role.",
-                    id: "6bjQWW",
+                    id: "eO6RfE",
                     description:
-                      "Description for additional duties referencing a Senior Designated Officer (SDO) role",
+                      "Description for additional duties referencing a Senior Designated Official (SDO) role",
                   })}
                 </p>
                 <Checklist


### PR DESCRIPTION
🤖 Resolves #16749.

## 👋 Introduction

Standardizes meaning of SDO in copy to "Senior Designated Official" and "Cadre supérieur désigné".

## 🧪 Testing

1. Confirm all instances of “Senior Delegated Official” and “Senior Designated Officer” are replaced with “Senior Designated Official”.
2. Confirm all instances of “Cadre supérieur délégué” are replaced with “Cadre supérieur désigné”