### PR TITLE
[Copy] Replaces continuez with continuer in French string Enregistrer et continuer

### DIFF
--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -620,7 +620,7 @@
     "description": "Name of the skill showcase page"
   },
   "MQB4IA": {
-    "defaultMessage": "Enregistrer et continuez",
+    "defaultMessage": "Enregistrer et continuer",
     "description": "Button text to save a form step and continue to the next one"
   },
   "Mco0Km": {


### PR DESCRIPTION
🤖 Resolves #16801.

## 👋 Introduction

This PR replaces _continuez_ with _continuer_ in French string _Enregistrer et continuer_ (which is a common string used elsewhere in the codebase and in English is Save and continue).

## 🧪 Testing

1. `pnpm build:fresh`
2. http://localhost:8000/en/register-info
3. Sign up with an email that does not exist in the database
4. Switch to French
5. Verify button label is _Enregistrer et continuer_

## 📸 Screenshots

## Instance from linked issue
<img width="1188" height="745" alt="Screenshot 2026-05-15 at 15 44 17" src="https://github.com/user-attachments/assets/2d1114b1-a1ef-4d7e-b148-bd5adc2c47e8" />

## Instance not referenced in linked issue
<img width="1241" height="677" alt="Screenshot 2026-05-15 at 15 48 39" src="https://github.com/user-attachments/assets/e269f37e-3c5e-4398-8390-b9a886f360c9" />