### PR TITLE
[Fix] French `common.successfully_placed`

### DIFF
--- a/api/lang/fr/common.php
+++ b/api/lang/fr/common.php
@@ -52,5 +52,5 @@ return [
     'currently_enrolled' => 'Programme en cours',
     'completed_in' => 'Achevé en ',
     'successfully_completed' => 'Complété avec succès',
-    'successfully_placed' => 'Candidate has been successfully placed',
+    'successfully_placed' => 'Placement effectué avec succès',
 ];


### PR DESCRIPTION
🤖 Resolves #16735.

## 👋 Introduction

This PR adds the correct French translation for `common.successfully_placed` that was previously the English value.

## 🧪 Testing

Verify database string that `pool_candidates` table `pause_referrals_reason` column saves a French value when saved using French version of site.