### PR TITLE
[Copy] Updates `contractDuration` label

### DIFF
--- a/api/lang/en/headings.php
+++ b/api/lang/en/headings.php
@@ -43,7 +43,7 @@ return [
     'location_preferences' => 'Work location preferences',
     'flexible_work_locations' => 'Flexible work location options',
     'location_exemptions' => 'Location exemptions',
-    'contract_duration' => 'Employment duration preference',
+    'contract_duration' => 'Duration of positions you would like to be considered for',
     'accept_temporary' => 'Accept temporary',
     'accepted_operational_requirements' => 'Acceptable job requirements',
     'rejected_operational_requirements' => 'Would not consider a job that requires: ',

--- a/api/lang/fr/headings.php
+++ b/api/lang/fr/headings.php
@@ -43,7 +43,7 @@ return [
     'location_preferences' => 'Préférences pour le lieu de travail',
     'flexible_work_locations' => 'Options de lieu de travail flexible',
     'location_exemptions' => 'Exemptions de lieux',
-    'contract_duration' => '',
+    'contract_duration' => 'Durée des postes pour lesquels vous souhaitez être pris en considération',
     'accept_temporary' => 'Accepter les temporaires',
     'accepted_operational_requirements' => 'Exigences de poste acceptables',
     'rejected_operational_requirements' => 'N\'envisagerait pas d\'accepter un emploi qui : ',

--- a/api/lang/fr/headings.php
+++ b/api/lang/fr/headings.php
@@ -43,7 +43,7 @@ return [
     'location_preferences' => 'Préférences pour le lieu de travail',
     'flexible_work_locations' => 'Options de lieu de travail flexible',
     'location_exemptions' => 'Exemptions de lieux',
-    'contract_duration' => 'Préférence pour la durée de l\'emploi',
+    'contract_duration' => '',
     'accept_temporary' => 'Accepter les temporaires',
     'accepted_operational_requirements' => 'Exigences de poste acceptables',
     'rejected_operational_requirements' => 'N\'envisagerait pas d\'accepter un emploi qui : ',

--- a/api/tests/Feature/Generators/__snapshots__/ApplicationDocGeneratorTest__testApplicationDocSnapshot__1.html
+++ b/api/tests/Feature/Generators/__snapshots__/ApplicationDocGeneratorTest__testApplicationDocSnapshot__1.html
@@ -90,7 +90,7 @@ div > *:first-child {page-break-before: auto;}
 <p>Classification: XX-01</p>
 <p>Priority entitlement: </p>
 <h4>Work preferences</h4>
-<p><span style="font-weight: bold;">Employment duration preference</span></p>
+<p><span style="font-weight: bold;">Duration of positions you would like to be considered for</span></p>
 <p>Any duration. (short term, long term, or indeterminate duration)</p>
 <p>Permanent duration</p>
 <p><span style="font-weight: bold;">Acceptable job requirements</span></p>

--- a/api/tests/Feature/Generators/__snapshots__/UserDocGeneratorTest__testUserProfileDocSnapshot__1.html
+++ b/api/tests/Feature/Generators/__snapshots__/UserDocGeneratorTest__testUserProfileDocSnapshot__1.html
@@ -66,7 +66,7 @@ div > *:first-child {page-break-before: auto;}
 <p>Classification: BL-01</p>
 <p>Priority entitlement: No</p>
 <h4>Work preferences</h4>
-<p><span style="font-weight: bold;">Employment duration preference</span></p>
+<p><span style="font-weight: bold;">Duration of positions you would like to be considered for</span></p>
 <p>Permanent duration</p>
 <p><span style="font-weight: bold;">Current location</span></p>
 <p>City: North Mary, Northwest Territories</p>

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -7747,10 +7747,6 @@
     "defaultMessage": "Ce rôle n’avait aucun lien avec le gouvernement du Canada.",
     "description": "Description for the external employment category option in work experience"
   },
-  "TfEUPu": {
-    "defaultMessage": "Préférence pour la durée de l'emploi",
-    "description": "Legend Text for required work preferences options in work preferences form"
-  },
   "TfYpv3": {
     "defaultMessage": "Titre du poste",
     "description": "The job title for a job poster template"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -8046,6 +8046,10 @@
     "defaultMessage": "Participation de la collectivité",
     "description": "Title for community experience section"
   },
+  "V/bSTW": {
+    "defaultMessage": "Durée des postes pour lesquels vous souhaitez être pris en considération",
+    "description": "Legend Text for required work preferences options in work preferences form"
+  },
   "V0+Pk/": {
     "defaultMessage": "Consulter les talents de la collectivité",
     "description": "Permissions related to viewing users interested in users community"

--- a/apps/web/src/messages/profileMessages.ts
+++ b/apps/web/src/messages/profileMessages.ts
@@ -34,8 +34,8 @@ const messages = defineMessages({
     description: "Title for priority status",
   },
   contractDuration: {
-    defaultMessage: "Employment duration preference",
-    id: "TfEUPu",
+    defaultMessage: "Duration of positions you would like to be considered for",
+    id: "V/bSTW",
     description:
       "Legend Text for required work preferences options in work preferences form",
   },


### PR DESCRIPTION
🤖 Resolves #16480.

## 👋 Introduction

This PR updates the `contractDuration` label.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/applicant/personal-information#work-preferences-section
3. Verify label uses updated copy in English and French

## 📸 Screenshots

<img width="1492" height="907" alt="Screenshot 2026-05-19 at 11 52 38" src="https://github.com/user-attachments/assets/bcd989b0-6263-4cf5-9ad8-4db95655fa04" />

<img width="1505" height="830" alt="Screenshot 2026-05-19 at 11 52 46" src="https://github.com/user-attachments/assets/367c2705-8e81-40a5-884f-227cc7809143" />