### PR TITLE
[Platform] Add cooldown config for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
+    cooldown:
+      default-days: 7
+      semver-patch-days: 5
+      semver-minor-days: 7
+      semver-major-days: 14
     exclude-paths:
       - "tc-report"
     open-pull-requests-limit: 50
@@ -122,6 +127,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
+    cooldown:
+      default-days: 7
+      semver-patch-days: 5
+      semver-minor-days: 7
+      semver-major-days: 14
     open-pull-requests-limit: 15
 
   # DOCKER image updates


### PR DESCRIPTION
🤖 Resolves #16816 

## 👋 Introduction

Adds basic cooldown to dependabot as one mechanism to attempt to avoid supply chain attacks.

## 🕵️ Details

This sets dependabot to only update dependencies when they are a certain age so we can hopefully avoid uopdating packages that could be compromised, giving package authors time address any supply chain attacks.

## 🧪 Testing

> [!NOTE]
> Can't really test this and just need to hope it works once merged.

1. Confirm cooldown set for `pnpm`
2. Confirm cooldown set for `composer`
3. Confirm values make sense 