### PR TITLE
[Fix] Clear space for vitest workflow

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -28,11 +28,10 @@ jobs:
           rm -rf /usr/share/dotnet
           rm -rf /usr/local/share/boost
           rm -rf /opt/ghc
-          rm -rf /usr/local/share/powershell
-          rm -rf /usr/share/swift
-          rm -rf /usr/local/.ghcup
-          rm -rf /usr/lib/jvm
-          # Display free space for future diagnosis
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/lib/jvm
           df -h
 
       - uses: actions/checkout@v6

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -22,12 +22,20 @@ jobs:
         uses: SimenB/github-actions-cpu-cores@v3
         id: cpu-cores
 
-      - uses: actions/checkout@v6
-
-      - name: Remove unused deps
+      - name: Reclaim space on runner
         run: |
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/share/dotnet
+          rm -rf /usr/local/android
+          rm -rf /usr/share/dotnet
+          rm -rf /usr/local/share/boost
+          rm -rf /opt/ghc
+          rm -rf /usr/local/share/powershell
+          rm -rf /usr/share/swift
+          rm -rf /usr/local/.ghcup
+          rm -rf /usr/lib/jvm
+          # Display free space for future diagnosis
+          df -h
+
+      - uses: actions/checkout@v6
 
       - name: "Copy .env"
         working-directory: "./apps/web"


### PR DESCRIPTION
🤖 Resolves #16806 

## 👋 Introduction

Updates the vitest workflow to delete unused files from the base image so we have space for coverage reports.

## 🕵️ Details

This also appends on `df -h` for a human readable printout of the free space on the runner in the workflow so we have info to better diagnose issues in the future.

SEE: https://man7.org/linux/man-pages/man1/df.1.html

## 🧪 Testing

> [!NOTE]
> This may be difficult to test since the space error is a little flaky. 

1. Run the workflow multiple times
2. Confirm no space errors
3. Confirm free space with the `df -h` command