### PR TITLE
[Fix] Nominations filename sanitization

### DIFF
--- a/api/app/GraphQL/Mutations/DownloadNominationsExcel.php
+++ b/api/app/GraphQL/Mutations/DownloadNominationsExcel.php
@@ -5,6 +5,7 @@ namespace App\GraphQL\Mutations;
 use App\Generators\NominationsExcelGenerator;
 use App\Jobs\GenerateUserFile;
 use App\Models\TalentNominationEvent;
+use App\Support\FilePath;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Lang;
@@ -32,7 +33,7 @@ final class DownloadNominationsExcel
 
         try {
             $generator = new NominationsExcelGenerator(
-                fileName: sprintf('%s_%s_%s', str_replace(' ', '', $talentNominationEventName), strtolower(Lang::get('common.nominations')), date('Y-m-d_His')),
+                fileName: FilePath::sanitize(sprintf('%s_%s_%s', str_replace(' ', '', $talentNominationEventName), strtolower(Lang::get('common.nominations')), date('Y-m-d_His'))),
                 talentNominationEventId: $talentNominationEventId,
                 dir: $user->id,
                 lang: App::getLocale(),

--- a/api/app/Support/FilePath.php
+++ b/api/app/Support/FilePath.php
@@ -12,13 +12,13 @@ class FilePath
     {
         // Remove dots to prevent directory traversal and double extensions
         if ($preserveExtension && str_contains($input, '.')) {
-            $parts = explode('.', $input);
-            $extension = array_pop($parts);
-            // Replace internal dots with spaces, then join back to the extension
-            $name = implode(' ', $parts).'.'.$extension;
+            $lastDot = strrpos($input, '.');
+            $extension = substr($input, $lastDot + 1);
+            // Replace internal dots (e.g. version numbers like 2.72.2) with underscores
+            $name = str_replace('.', '_', substr($input, 0, $lastDot)).'.'.$extension;
         } else {
             // No dots allowed at all (prevents double extensions)
-            $name = str_replace('.', ' ', $input);
+            $name = str_replace('.', '_', $input);
         }
 
         // Keep French letters, numbers, spaces, and dashes


### PR DESCRIPTION
🤖 Resolves #16831 

## 👋 Introduction

Updates the file path santitization helper to replace periods with underscores for a safer filename.

## 🕵️ Details

The santization was messing up and creating filenames that could not be safely retrieved. This did two things:

1. Replaces all periods but the extension delimiter with underscores in the filename
2. Updates the file generation to use santization to strip out unwanted characters

## 🧪 Testing

1. Login as `community@test.com`
2. Create a talent event with periods in its title
3. Seed some nominees for that talrent event
4. Confirm you can download the nominees without error