### PR TITLE
[Fix] Replaces `p` with `div`

### DIFF
--- a/apps/web/src/components/EmployeeVerificationSection/EmployeeVerificationSection.tsx
+++ b/apps/web/src/components/EmployeeVerificationSection/EmployeeVerificationSection.tsx
@@ -289,7 +289,7 @@ const EmployeeVerificationSection = ({
                   description: "Label for functional communities field",
                 })}
               </p>
-              <p>
+              <div>
                 {user.isVerifiedGovEmployee ? (
                   communityInterests.length > 0 ? (
                     <Ul unStyled space="md">
@@ -349,7 +349,7 @@ const EmployeeVerificationSection = ({
                     </span>
                   </span>
                 )}
-              </p>
+              </div>
             </div>
             <div className="mt-auto">
               <Card.Separator space="xs" />


### PR DESCRIPTION
🤖 Resolves #16845.

## 👋 Introduction

This PR fixes a HTML hierarchy issue where a paragraph had been a descendant of an unordered list.

## 🧪 Testing

1. `pnpm watch`
2. Open browser console
3. Navigate to http://localhost:3000/en/applicant/employee-profile#career-development-section
4. Verify nothing has changed visually and no errors in console