### PR TITLE
[Fix] `heavyWarning` color

### DIFF
--- a/packages/rich-text-elements/src/index.tsx
+++ b/packages/rich-text-elements/src/index.tsx
@@ -86,7 +86,7 @@ const warning = (text: ReactNode) => (
  * @param text  text to wrap
  */
 const heavyWarning = (text: ReactNode) => (
-  <span className="font-bold text-warning-500 dark:text-warning-300">
+  <span className="font-bold text-warning-600 dark:text-warning-300">
     {text}
   </span>
 );


### PR DESCRIPTION
🤖 Resolves #16597.

## 👋 Introduction

This PR updates the `heavyWarning` color in light mode to avoid low colour contrast.

## 🧪 Testing

1. `pnpm storybook`
2. Navigate to http://localhost:6006/?path=/story/pages-pools-viewpoolpage--draft-complete-process
3. Verify accessibility tab does not show any issues with the **draft** text related to low colour contrast

## 📸 Screenshot

<img width="1694" height="920" alt="Screenshot 2026-05-21 at 11 59 15" src="https://github.com/user-attachments/assets/62b9c382-4eec-48e9-9e46-0678d78d818a" />
