### PR TITLE
[Dep] Upgrade activty log to v5

### DIFF
--- a/api/app/Models/Activity.php
+++ b/api/app/Models/Activity.php
@@ -17,13 +17,13 @@ class Activity extends SpatieActivity
 
     protected function properties(): Attribute
     {
-        return Attribute::get(function ($value) {
-            $data = is_array($value) ? $value : json_decode($value, true);
+        return Attribute::get(function () {
+            $changes = $this->attribute_changes;
 
-            return [
-                'attributes' => $data['attributes'] ?? null,
-                'old' => $data['old'] ?? null,
-            ];
+            return collect([
+                'attributes' => $changes?->get('attributes'),
+                'old' => $changes?->get('old'),
+            ]);
         });
     }
 
@@ -47,7 +47,7 @@ class Activity extends SpatieActivity
                     $poolQuery->where('subject_type', Pool::class)
                         ->where('subject_id', $poolId);
                 })
-                    ->orWhereJsonContains('properties->attributes->pool_id', $poolId);
+                    ->orWhereJsonContains('attribute_changes->attributes->pool_id', $poolId);
             });
 
     }
@@ -201,7 +201,7 @@ class Activity extends SpatieActivity
             return $query;
         }
 
-        return $query->whereRaw('properties::text ILIKE ?', ["%$searchTerm%"]);
+        return $query->whereRaw('(properties::text ILIKE ? OR attribute_changes::text ILIKE ?)', ["%$searchTerm%", "%$searchTerm%"]);
     }
 
     public function scopeAuthorizedToViewPoolActivity(Builder $query)
@@ -231,7 +231,7 @@ class Activity extends SpatieActivity
                 })
                     ->orWhere(function ($q) use ($authorizedPoolIds) {
                         foreach ($authorizedPoolIds->get() as $pool) {
-                            $q->orWhereJsonContains('properties->attributes', ['pool_id' => $pool->id]);
+                            $q->orWhereJsonContains('attribute_changes->attributes', ['pool_id' => $pool->id]);
                         }
                     });
             });

--- a/api/app/Models/AssessmentResult.php
+++ b/api/app/Models/AssessmentResult.php
@@ -57,7 +57,7 @@ class AssessmentResult extends Model
         return LogOptions::defaults()
             ->logOnly(['*'])
             ->logOnlyDirty()
-            ->dontSubmitEmptyLogs();
+            ->dontLogEmptyChanges();
     }
 
     /** @return BelongsTo<AssessmentStep, $this> */

--- a/api/app/Models/AssessmentResult.php
+++ b/api/app/Models/AssessmentResult.php
@@ -8,8 +8,8 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
-use Spatie\Activitylog\LogOptions;
-use Spatie\Activitylog\Traits\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
+use Spatie\Activitylog\Models\Concerns\LogsActivity;
 
 /**
  * Class AssessmentResult

--- a/api/app/Models/AssessmentResult.php
+++ b/api/app/Models/AssessmentResult.php
@@ -8,8 +8,8 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
-use Spatie\Activitylog\Support\LogOptions;
 use Spatie\Activitylog\Models\Concerns\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
 
 /**
  * Class AssessmentResult

--- a/api/app/Models/AssessmentStep.php
+++ b/api/app/Models/AssessmentStep.php
@@ -64,7 +64,7 @@ class AssessmentStep extends Model
         return LogOptions::defaults()
             ->logOnly((['*']))
             ->logOnlyDirty()
-            ->dontSubmitEmptyLogs();
+            ->dontLogEmptyChanges();
     }
 
     protected function customizeActivityProperties(array &$properties, ActivityEvent $event): void

--- a/api/app/Models/AssessmentStep.php
+++ b/api/app/Models/AssessmentStep.php
@@ -17,8 +17,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
-use Spatie\Activitylog\Support\LogOptions;
 use Spatie\Activitylog\Models\Concerns\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
 
 /**
  * Class AssessmentStep

--- a/api/app/Models/AssessmentStep.php
+++ b/api/app/Models/AssessmentStep.php
@@ -17,8 +17,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
-use Spatie\Activitylog\LogOptions;
-use Spatie\Activitylog\Traits\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
+use Spatie\Activitylog\Models\Concerns\LogsActivity;
 
 /**
  * Class AssessmentStep

--- a/api/app/Models/AssessmentStepPoolSkill.php
+++ b/api/app/Models/AssessmentStepPoolSkill.php
@@ -3,8 +3,8 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Relations\Pivot;
-use Spatie\Activitylog\LogOptions;
-use Spatie\Activitylog\Traits\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
+use Spatie\Activitylog\Models\Concerns\LogsActivity;
 
 class AssessmentStepPoolSkill extends Pivot
 {

--- a/api/app/Models/AssessmentStepPoolSkill.php
+++ b/api/app/Models/AssessmentStepPoolSkill.php
@@ -3,8 +3,8 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Relations\Pivot;
-use Spatie\Activitylog\Support\LogOptions;
 use Spatie\Activitylog\Models\Concerns\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
 
 class AssessmentStepPoolSkill extends Pivot
 {

--- a/api/app/Models/AssessmentStepPoolSkill.php
+++ b/api/app/Models/AssessmentStepPoolSkill.php
@@ -24,6 +24,6 @@ class AssessmentStepPoolSkill extends Pivot
         return LogOptions::defaults()
             ->logOnly(['*'])
             ->logOnlyDirty()
-            ->dontSubmitEmptyLogs();
+            ->dontLogEmptyChanges();
     }
 }

--- a/api/app/Models/GeneralQuestion.php
+++ b/api/app/Models/GeneralQuestion.php
@@ -8,8 +8,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
-use Spatie\Activitylog\Support\LogOptions;
 use Spatie\Activitylog\Models\Concerns\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
 
 /**
  * Class General Question

--- a/api/app/Models/GeneralQuestion.php
+++ b/api/app/Models/GeneralQuestion.php
@@ -48,7 +48,7 @@ class GeneralQuestion extends Model
         return LogOptions::defaults()
             ->logOnly((['*']))
             ->logOnlyDirty()
-            ->dontSubmitEmptyLogs();
+            ->dontLogEmptyChanges();
     }
 
     /** @return BelongsTo<Pool, $this> */

--- a/api/app/Models/GeneralQuestion.php
+++ b/api/app/Models/GeneralQuestion.php
@@ -8,8 +8,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
-use Spatie\Activitylog\LogOptions;
-use Spatie\Activitylog\Traits\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
+use Spatie\Activitylog\Models\Concerns\LogsActivity;
 
 /**
  * Class General Question

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -28,8 +28,8 @@ use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Validator;
-use Spatie\Activitylog\Support\LogOptions;
 use Spatie\Activitylog\Models\Concerns\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
 
 /**
  * Class Pool

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -202,7 +202,7 @@ class Pool extends Model
         return LogOptions::defaults()
             ->logOnly(['*'])
             ->logOnlyDirty()
-            ->dontSubmitEmptyLogs();
+            ->dontLogEmptyChanges();
     }
 
     public function user(): BelongsTo

--- a/api/app/Models/Pool.php
+++ b/api/app/Models/Pool.php
@@ -28,8 +28,8 @@ use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Validator;
-use Spatie\Activitylog\LogOptions;
-use Spatie\Activitylog\Traits\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
+use Spatie\Activitylog\Models\Concerns\LogsActivity;
 
 /**
  * Class Pool

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -42,8 +42,8 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Lang;
-use Spatie\Activitylog\LogOptions;
-use Spatie\Activitylog\Traits\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
+use Spatie\Activitylog\Models\Concerns\LogsActivity;
 
 /**
  * Class PoolCandidate

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -198,7 +198,7 @@ class PoolCandidate extends Model
         return LogOptions::defaults()
             ->logOnly(['*'])
             ->logOnlyDirty()
-            ->dontSubmitEmptyLogs();
+            ->dontLogEmptyChanges();
     }
 
     /** @return BelongsTo<User, $this> */

--- a/api/app/Models/PoolCandidate.php
+++ b/api/app/Models/PoolCandidate.php
@@ -42,8 +42,8 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Lang;
-use Spatie\Activitylog\Support\LogOptions;
 use Spatie\Activitylog\Models\Concerns\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
 
 /**
  * Class PoolCandidate

--- a/api/app/Models/PoolCandidateSearchRequest.php
+++ b/api/app/Models/PoolCandidateSearchRequest.php
@@ -11,8 +11,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
-use Spatie\Activitylog\LogOptions;
-use Spatie\Activitylog\Traits\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
+use Spatie\Activitylog\Models\Concerns\LogsActivity;
 
 /**
  * Class PoolCandidateSearchRequest

--- a/api/app/Models/PoolCandidateSearchRequest.php
+++ b/api/app/Models/PoolCandidateSearchRequest.php
@@ -99,7 +99,7 @@ class PoolCandidateSearchRequest extends Model
                 'applicantFilter.qualified_streams',
             ])
             ->logOnlyDirty()
-            ->dontSubmitEmptyLogs();
+            ->dontLogEmptyChanges();
     }
 
     /** @return BelongsTo<Department, $this> */

--- a/api/app/Models/PoolCandidateSearchRequest.php
+++ b/api/app/Models/PoolCandidateSearchRequest.php
@@ -11,8 +11,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
-use Spatie\Activitylog\Support\LogOptions;
 use Spatie\Activitylog\Models\Concerns\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
 
 /**
  * Class PoolCandidateSearchRequest

--- a/api/app/Models/PoolSkill.php
+++ b/api/app/Models/PoolSkill.php
@@ -78,7 +78,7 @@ class PoolSkill extends Model
         return LogOptions::defaults()
             ->logOnly(['*'])
             ->logOnlyDirty()
-            ->dontSubmitEmptyLogs();
+            ->dontLogEmptyChanges();
     }
 
     /** @return BelongsTo<Skill, $this> */

--- a/api/app/Models/PoolSkill.php
+++ b/api/app/Models/PoolSkill.php
@@ -10,8 +10,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Spatie\Activitylog\Support\LogOptions;
 use Spatie\Activitylog\Models\Concerns\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
 
 /**
  * Class PoolSkill

--- a/api/app/Models/PoolSkill.php
+++ b/api/app/Models/PoolSkill.php
@@ -10,8 +10,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Spatie\Activitylog\LogOptions;
-use Spatie\Activitylog\Traits\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
+use Spatie\Activitylog\Models\Concerns\LogsActivity;
 
 /**
  * Class PoolSkill

--- a/api/app/Models/ScreeningQuestion.php
+++ b/api/app/Models/ScreeningQuestion.php
@@ -8,8 +8,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
-use Spatie\Activitylog\Support\LogOptions;
 use Spatie\Activitylog\Models\Concerns\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
 
 /**
  * Class Screening Question

--- a/api/app/Models/ScreeningQuestion.php
+++ b/api/app/Models/ScreeningQuestion.php
@@ -8,8 +8,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
-use Spatie\Activitylog\LogOptions;
-use Spatie\Activitylog\Traits\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
+use Spatie\Activitylog\Models\Concerns\LogsActivity;
 
 /**
  * Class Screening Question

--- a/api/app/Models/ScreeningQuestion.php
+++ b/api/app/Models/ScreeningQuestion.php
@@ -49,7 +49,7 @@ class ScreeningQuestion extends Model
         return LogOptions::defaults()
             ->logOnly((['*']))
             ->logOnlyDirty()
-            ->dontSubmitEmptyLogs();
+            ->dontLogEmptyChanges();
     }
 
     /** @return BelongsTo<Pool, $this> */

--- a/api/app/Models/TalentNomination.php
+++ b/api/app/Models/TalentNomination.php
@@ -11,8 +11,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Carbon;
-use Spatie\Activitylog\Support\LogOptions;
 use Spatie\Activitylog\Models\Concerns\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
 use Staudenmeir\EloquentHasManyDeep\HasManyDeep;
 use Staudenmeir\EloquentHasManyDeep\HasRelationships;
 

--- a/api/app/Models/TalentNomination.php
+++ b/api/app/Models/TalentNomination.php
@@ -11,8 +11,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Carbon;
-use Spatie\Activitylog\LogOptions;
-use Spatie\Activitylog\Traits\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
+use Spatie\Activitylog\Models\Concerns\LogsActivity;
 use Staudenmeir\EloquentHasManyDeep\HasManyDeep;
 use Staudenmeir\EloquentHasManyDeep\HasRelationships;
 

--- a/api/app/Models/TalentNomination.php
+++ b/api/app/Models/TalentNomination.php
@@ -93,7 +93,7 @@ class TalentNomination extends Model
         return LogOptions::defaults()
             ->logOnly(['*'])
             ->logOnlyDirty()
-            ->dontSubmitEmptyLogs();
+            ->dontLogEmptyChanges();
     }
 
     /**

--- a/api/app/Models/TalentNominationEvent.php
+++ b/api/app/Models/TalentNominationEvent.php
@@ -14,8 +14,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Auth;
-use Spatie\Activitylog\LogOptions;
-use Spatie\Activitylog\Traits\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
+use Spatie\Activitylog\Models\Concerns\LogsActivity;
 use Staudenmeir\EloquentHasManyDeep\HasManyDeep;
 use Staudenmeir\EloquentHasManyDeep\HasRelationships;
 

--- a/api/app/Models/TalentNominationEvent.php
+++ b/api/app/Models/TalentNominationEvent.php
@@ -61,7 +61,7 @@ class TalentNominationEvent extends Model
         return LogOptions::defaults()
             ->logOnly(['*'])
             ->logOnlyDirty()
-            ->dontSubmitEmptyLogs();
+            ->dontLogEmptyChanges();
     }
 
     /** @return BelongsTo<Community, $this> */

--- a/api/app/Models/TalentNominationEvent.php
+++ b/api/app/Models/TalentNominationEvent.php
@@ -14,8 +14,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Auth;
-use Spatie\Activitylog\Support\LogOptions;
 use Spatie\Activitylog\Models\Concerns\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
 use Staudenmeir\EloquentHasManyDeep\HasManyDeep;
 use Staudenmeir\EloquentHasManyDeep\HasRelationships;
 

--- a/api/app/Models/TalentNominationGroup.php
+++ b/api/app/Models/TalentNominationGroup.php
@@ -14,8 +14,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
-use Spatie\Activitylog\LogOptions;
-use Spatie\Activitylog\Traits\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
+use Spatie\Activitylog\Models\Concerns\LogsActivity;
 
 /**
  * Class TalentNominationGroup

--- a/api/app/Models/TalentNominationGroup.php
+++ b/api/app/Models/TalentNominationGroup.php
@@ -66,7 +66,7 @@ class TalentNominationGroup extends Model
         return LogOptions::defaults()
             ->logOnly(['*'])
             ->logOnlyDirty()
-            ->dontSubmitEmptyLogs();
+            ->dontLogEmptyChanges();
     }
 
     /**

--- a/api/app/Models/TalentNominationGroup.php
+++ b/api/app/Models/TalentNominationGroup.php
@@ -14,8 +14,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
-use Spatie\Activitylog\Support\LogOptions;
 use Spatie\Activitylog\Models\Concerns\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
 
 /**
  * Class TalentNominationGroup

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -37,9 +37,9 @@ use Illuminate\Support\Str;
 use Laratrust\Contracts\LaratrustUser;
 use Laratrust\Traits\HasRolesAndPermissions;
 use Laravel\Scout\Searchable;
-use Spatie\Activitylog\Support\LogOptions;
 use Spatie\Activitylog\Models\Concerns\CausesActivity;
 use Spatie\Activitylog\Models\Concerns\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
 use Staudenmeir\EloquentHasManyDeep\HasManyDeep;
 use Staudenmeir\EloquentHasManyDeep\HasRelationships;
 

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -37,9 +37,9 @@ use Illuminate\Support\Str;
 use Laratrust\Contracts\LaratrustUser;
 use Laratrust\Traits\HasRolesAndPermissions;
 use Laravel\Scout\Searchable;
-use Spatie\Activitylog\LogOptions;
-use Spatie\Activitylog\Traits\CausesActivity;
-use Spatie\Activitylog\Traits\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
+use Spatie\Activitylog\Models\Concerns\CausesActivity;
+use Spatie\Activitylog\Models\Concerns\LogsActivity;
 use Staudenmeir\EloquentHasManyDeep\HasManyDeep;
 use Staudenmeir\EloquentHasManyDeep\HasRelationships;
 

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -262,7 +262,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
         return LogOptions::defaults()
             ->logOnly(['*'])
             ->logOnlyDirty()
-            ->dontSubmitEmptyLogs();
+            ->dontLogEmptyChanges();
     }
 
     /**
@@ -687,7 +687,7 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
         activity()
             ->causedBy(Auth::user())
             ->performedOn($user)
-            ->withProperties(['attributes' => $properties])
+            ->withChanges(['attributes' => $properties])
             ->event($eventName)
             ->log($eventName);
     }

--- a/api/app/Traits/LogsCustomActivity.php
+++ b/api/app/Traits/LogsCustomActivity.php
@@ -96,7 +96,7 @@ trait LogsCustomActivity
             ->causedBy(Auth::user())
             ->performedOn($this)
             ->event($event->value)
-            ->withProperties($properties)
+            ->withChanges($properties)
             ->log($event->value);
 
         // Reset temporary override

--- a/api/composer.json
+++ b/api/composer.json
@@ -27,7 +27,7 @@
     "phpoffice/phpspreadsheet": "^5.0",
     "phpoffice/phpword": "^1.2",
     "santigarcor/laratrust": "^8.3.0",
-    "spatie/laravel-activitylog": "^4.7",
+    "spatie/laravel-activitylog": "^5.0",
     "spatie/php-structure-discoverer": "^2.1",
     "staudenmeir/eloquent-has-many-deep": "^1.18",
     "staudenmeir/eloquent-json-relations": "^1.13.1",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "ec07678b4cf9f621f5b31c81cb126108",
+  "content-hash": "1137fa9bf722762f103d0c0a9f128e8d",
   "packages": [
     {
       "name": "beyondcode/laravel-server-timing",
@@ -6137,29 +6137,31 @@
     },
     {
       "name": "spatie/laravel-activitylog",
-      "version": "4.12.3",
+      "version": "5.0.0",
       "source": {
         "type": "git",
         "url": "https://github.com/spatie/laravel-activitylog.git",
-        "reference": "2a2024fcac05628b0d1bfdbb1b94dda8b0661dc0"
+        "reference": "0e00fe74fd071cc572a045459f6d4c9de33130bd"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/spatie/laravel-activitylog/zipball/2a2024fcac05628b0d1bfdbb1b94dda8b0661dc0",
-        "reference": "2a2024fcac05628b0d1bfdbb1b94dda8b0661dc0",
+        "url": "https://api.github.com/repos/spatie/laravel-activitylog/zipball/0e00fe74fd071cc572a045459f6d4c9de33130bd",
+        "reference": "0e00fe74fd071cc572a045459f6d4c9de33130bd",
         "shasum": ""
       },
       "require": {
-        "illuminate/config": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
-        "illuminate/database": "^8.69 || ^9.27 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
-        "illuminate/support": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
-        "php": "^8.1",
+        "illuminate/config": "^12.0 || ^13.0",
+        "illuminate/database": "^12.0 || ^13.0",
+        "illuminate/support": "^12.0 || ^13.0",
+        "php": "^8.4",
         "spatie/laravel-package-tools": "^1.6.3"
       },
       "require-dev": {
         "ext-json": "*",
-        "orchestra/testbench": "^6.23 || ^7.0 || ^8.0 || ^9.6 || ^10.0 || ^11.0",
-        "pestphp/pest": "^1.20 || ^2.0 || ^3.0 || ^4.0"
+        "larastan/larastan": "^3.0",
+        "laravel/pint": "^1.29",
+        "orchestra/testbench": "^10.0 || ^11.0",
+        "pestphp/pest": "^4.0"
       },
       "type": "library",
       "extra": {
@@ -6212,7 +6214,7 @@
       ],
       "support": {
         "issues": "https://github.com/spatie/laravel-activitylog/issues",
-        "source": "https://github.com/spatie/laravel-activitylog/tree/4.12.3"
+        "source": "https://github.com/spatie/laravel-activitylog/tree/5.0.0"
       },
       "funding": [
         {
@@ -6224,7 +6226,7 @@
           "type": "github"
         }
       ],
-      "time": "2026-03-24T12:33:53+00:00"
+      "time": "2026-03-25T10:04:54+00:00"
     },
     {
       "name": "spatie/laravel-package-tools",
@@ -13420,15 +13422,15 @@
   ],
   "aliases": [],
   "minimum-stability": "stable",
-  "stability-flags": [],
+  "stability-flags": {},
   "prefer-stable": true,
   "prefer-lowest": false,
   "platform": {
     "php": "^8.4"
   },
-  "platform-dev": [],
+  "platform-dev": {},
   "platform-overrides": {
     "php": "8.4.10"
   },
-  "plugin-api-version": "2.6.0"
+  "plugin-api-version": "2.9.0"
 }

--- a/api/config/activitylog.php
+++ b/api/config/activitylog.php
@@ -1,19 +1,21 @@
 <?php
 
 use App\Models\Activity;
+use Spatie\Activitylog\Actions\CleanActivityLogAction;
+use Spatie\Activitylog\Actions\LogActivityAction;
 
 return [
 
     /*
      * If set to false, no activities will be saved to the database.
      */
-    'enabled' => env('ACTIVITY_LOGGER_ENABLED', true),
+    'enabled' => env('ACTIVITYLOG_ENABLED', true),
 
     /*
      * When the clean-command is executed, all recording activities older than
      * the number of days specified here will be deleted.
      */
-    'delete_records_older_than_days' => 365,
+    'clean_after_days' => 365,
 
     /*
      * If no log name is passed to the activity() helper
@@ -30,7 +32,7 @@ return [
     /*
      * If set to true, the subject returns soft deleted models.
      */
-    'subject_returns_soft_deleted_models' => false,
+    'include_soft_deleted_subjects' => false,
 
     /*
      * This model will be used to log activity.
@@ -40,15 +42,26 @@ return [
     'activity_model' => Activity::class,
 
     /*
-     * This is the name of the table that will be created by the migration and
-     * used by the Activity model shipped with this package.
+     * These attributes will be excluded from logging for all models.
+     * Model-specific exclusions via logExcept() are merged with these.
      */
-    'table_name' => 'activity_log',
+    'default_except_attributes' => [],
 
     /*
-     * This is the database connection that will be used by the migration and
-     * the Activity model shipped with this package. In case it's not set
-     * Laravel's database.default will be used instead.
+     * When enabled, activities are buffered in memory and inserted in a
+     * single bulk query after the response has been sent to the client.
      */
-    'database_connection' => env('ACTIVITY_LOGGER_DB_CONNECTION'),
+    'buffer' => [
+        'enabled' => env('ACTIVITYLOG_BUFFER_ENABLED', false),
+    ],
+
+    /*
+     * These action classes can be overridden to customize how activities
+     * are logged and cleaned. Your custom classes must extend the originals.
+     */
+    'actions' => [
+        'log_activity' => LogActivityAction::class,
+        'clean_log' => CleanActivityLogAction::class,
+    ],
+
 ];

--- a/api/database/migrations/2026_05_21_000000_upgrade_activity_log_v5.php
+++ b/api/database/migrations/2026_05_21_000000_upgrade_activity_log_v5.php
@@ -5,7 +5,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+return new class() extends Migration
 {
     public function up(): void
     {

--- a/api/database/migrations/2026_05_21_000000_upgrade_activity_log_v5.php
+++ b/api/database/migrations/2026_05_21_000000_upgrade_activity_log_v5.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('activity_log', function (Blueprint $table) {
+            $table->json('attribute_changes')->nullable()->after('causer_id');
+            $table->dropColumn('batch_uuid');
+        });
+
+        DB::table('activity_log')->whereNotNull('properties')->eachById(function ($row) {
+            $properties = json_decode($row->properties, true);
+            $changes = array_intersect_key($properties, array_flip(['attributes', 'old']));
+            $remaining = array_diff_key($properties, array_flip(['attributes', 'old']));
+
+            DB::table('activity_log')->where('id', $row->id)->update([
+                'attribute_changes' => empty($changes) ? null : json_encode($changes),
+                'properties' => empty($remaining) ? null : json_encode($remaining),
+            ]);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('activity_log', function (Blueprint $table) {
+            $table->uuid('batch_uuid')->nullable();
+            $table->dropColumn('attribute_changes');
+        });
+    }
+};

--- a/api/tests/Feature/ActivityLogTest.php
+++ b/api/tests/Feature/ActivityLogTest.php
@@ -6,6 +6,7 @@ use App\Enums\ActivityLog;
 use App\Enums\ApplicationStatus;
 use App\Enums\PoolCandidateSearchPositionType;
 use App\Enums\PoolCandidateSearchRequestReason;
+use App\Models\Activity;
 use App\Models\Community;
 use App\Models\Department;
 use App\Models\Pool;
@@ -14,7 +15,6 @@ use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
-use App\Models\Activity;
 use Tests\TestCase;
 use Tests\UsesProtectedGraphqlEndpoint;
 

--- a/api/tests/Feature/ActivityLogTest.php
+++ b/api/tests/Feature/ActivityLogTest.php
@@ -14,7 +14,7 @@ use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
-use Spatie\Activitylog\Models\Activity;
+use App\Models\Activity;
 use Tests\TestCase;
 use Tests\UsesProtectedGraphqlEndpoint;
 
@@ -227,7 +227,7 @@ class ActivityLogTest extends TestCase
 
         // assert can query all the actions undertaken or caused by a user
         $actingUser = User::where('email', 'admin-user@test.com')->sole();
-        $actions = $actingUser->actions;
+        $actions = $actingUser->activitiesAsCauser;
         assertEquals(4, count($actions)); // total
         assertEquals(2, count($actions->where('description', 'updated'))); // two update actions
         assertEquals(2, count($actions->where('subject_type', 'App\Models\PoolCandidate'))); // two events on PoolCandidate


### PR DESCRIPTION
🤖 Resolves #16264 

## 👋 Introduction

Upgrades the activity log to version 5.

## 🧪 Testing

1. Make sure you have some logs present in `activity_log` table
2. Install new dpes and run migration `make composer CMD="update spatie/laravel-activitylog"; make artisan CMD="migrate"`
3. Confirm the migration runs successfully
4. Create a process, make a few changes, publish it and then edit after publishing
5. Confirm the activity log still appears
6. Confirm other activity is still logged
7. Confirm no more legacy methods, namespaces mentioned in [the upgrade guide](https://github.com/spatie/laravel-activitylog/blob/main/UPGRADING.md) are called
