### PR TITLE
[Bug] Set `<FieldDisplay />` to wrap anywhere

### DIFF
--- a/apps/web/src/components/FieldDisplay/FieldDisplay.tsx
+++ b/apps/web/src/components/FieldDisplay/FieldDisplay.tsx
@@ -50,7 +50,7 @@ const FieldDisplay = ({
       ) : (
         <span className="block font-bold">{label}</span>
       )}
-      {children && <span>{children}</span>}
+      {children && <span className="wrap-anywhere">{children}</span>}
     </div>
   );
 };


### PR DESCRIPTION
🤖 Resolves #16849

## 👋 Introduction

Small visual issue that was spun off from a different PR. 
Adjust wrapping to prevent overflow text in certain cases 

## 🧪 Testing

1. Check a bunch of pages rendering values
2. Check Chromatic
3. Exercise it yourself (Ensure the tested value is nested within the effected component)

## 📸 Screenshot

<img width="394" height="263" alt="image" src="https://github.com/user-attachments/assets/b83e5f77-0ec7-4a47-8122-d095d6d7a824" />

