### PR TITLE
[Test] e2e code coverage

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -38,6 +38,7 @@ jobs:
       PNPM_VERSION: "10.27.0"
       PLAYWRIGHT_WORKERS: "25%"
       PLAYWRIGHT_RETRIES: "1"
+      E2E_COVERAGE: "true"
       GCNOTIFY_API_KEY: ${{ secrets.GCNOTIFY_API_KEY }}
       GCNOTIFY_TEMPLATE_VERIFY_EMAIL_EN: ${{ vars.GCNOTIFY_TEMPLATE_VERIFY_EMAIL_EN }}
       GCNOTIFY_TEMPLATE_NOMINATION_RECEIVED_SUBMITTER_EN: ${{ vars.GCNOTIFY_TEMPLATE_NOMINATION_RECEIVED_SUBMITTER_EN }}
@@ -94,6 +95,16 @@ jobs:
 
       - name: Run Tests
         run: pnpm run e2e:playwright --project=${{ matrix.project }} --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+
+      - name: Upload E2E coverage to Codecov
+        if: ${{ !cancelled() && github.actor != 'dependabot[bot]' }}
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./apps/playwright/coverage
+          flags: e2etests
+          fail_ci_if_error: false
+
       - uses: actions/upload-artifact@v7
         if: always()
         with:

--- a/apps/playwright/.gitignore
+++ b/apps/playwright/.gitignore
@@ -3,4 +3,5 @@ node_modules/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+/coverage/
 .auth

--- a/apps/playwright/e2e-coverage-teardown.ts
+++ b/apps/playwright/e2e-coverage-teardown.ts
@@ -1,0 +1,13 @@
+import MCR from "monocart-coverage-reports";
+
+export default async () => {
+  const mcr = MCR({
+    name: "E2E Coverage",
+    outputDir: "./coverage",
+    reports: [["lcovonly", { file: "lcov.info" }]],
+    entryFilter: { "**/node_modules/**": false, "**/*": true },
+    sourceFilter: (sourcePath: string) =>
+      /(apps\/web|packages\/.+)\/src\//.test(sourcePath),
+  });
+  await mcr.generate();
+};

--- a/apps/playwright/e2e-coverage-teardown.ts
+++ b/apps/playwright/e2e-coverage-teardown.ts
@@ -3,7 +3,6 @@ import { CoverageReport } from "monocart-coverage-reports";
 export default async () => {
   const cr = new CoverageReport({
     name: "E2E Coverage",
-    cacheDir: "./coverage/.cache",
     outputDir: "./coverage",
     reports: [["lcovonly", { file: "lcov.info" }]],
     entryFilter: { "**/node_modules/**": false, "**/*": true },

--- a/apps/playwright/e2e-coverage-teardown.ts
+++ b/apps/playwright/e2e-coverage-teardown.ts
@@ -1,13 +1,14 @@
-import MCR from "monocart-coverage-reports";
+import { CoverageReport } from "monocart-coverage-reports";
 
 export default async () => {
-  const mcr = MCR({
+  const cr = new CoverageReport({
     name: "E2E Coverage",
+    cacheDir: "./coverage/.cache",
     outputDir: "./coverage",
     reports: [["lcovonly", { file: "lcov.info" }]],
     entryFilter: { "**/node_modules/**": false, "**/*": true },
     sourceFilter: (sourcePath: string) =>
       /(apps\/web|packages\/.+)\/src\//.test(sourcePath),
   });
-  await mcr.generate();
+  await cr.generate();
 };

--- a/apps/playwright/fixtures/index.ts
+++ b/apps/playwright/fixtures/index.ts
@@ -1,5 +1,6 @@
 import { test as base } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
+import { addCoverageReport } from "monocart-coverage-reports";
 
 import AppPage from "./AppPage";
 
@@ -8,10 +9,28 @@ interface AppFixtures {
   appPage: AppPage;
   // Axe test builder
   makeAxeBuilder: () => AxeBuilder;
+  // Auto V8 coverage — active when E2E_COVERAGE=true on chromium
+  autoCoverage: void;
 }
 
 // Extend base text with our fixtures
 export const test = base.extend<AppFixtures>({
+  autoCoverage: [
+    async ({ page }, use, testInfo) => {
+      const enabled =
+        process.env.E2E_COVERAGE === "true" &&
+        testInfo.project.name === "chromium";
+      if (enabled) {
+        await page.coverage.startJSCoverage({ resetOnNavigation: false });
+      }
+      await use();
+      if (enabled) {
+        const coverage = await page.coverage.stopJSCoverage();
+        await addCoverageReport(coverage, testInfo);
+      }
+    },
+    { scope: "test", auto: true },
+  ],
   appPage: async ({ page }, use) => {
     const app = new AppPage(page);
     await use(app);

--- a/apps/playwright/fixtures/index.ts
+++ b/apps/playwright/fixtures/index.ts
@@ -1,6 +1,6 @@
 import { test as base } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
-import { addCoverageReport } from "monocart-coverage-reports";
+import { CoverageReport } from "monocart-coverage-reports";
 
 import AppPage from "./AppPage";
 
@@ -26,7 +26,8 @@ export const test = base.extend<AppFixtures>({
       await use();
       if (enabled) {
         const coverage = await page.coverage.stopJSCoverage();
-        await addCoverageReport(coverage, testInfo);
+        const cr = new CoverageReport({ cacheDir: "./coverage/.cache" });
+        await cr.add(coverage);
       }
     },
     { scope: "test", auto: true },

--- a/apps/playwright/fixtures/index.ts
+++ b/apps/playwright/fixtures/index.ts
@@ -26,7 +26,7 @@ export const test = base.extend<AppFixtures>({
       await use();
       if (enabled) {
         const coverage = await page.coverage.stopJSCoverage();
-        const cr = new CoverageReport({ cacheDir: "./coverage/.cache" });
+        const cr = new CoverageReport({ outputDir: "./coverage" });
         await cr.add(coverage);
       }
     },

--- a/apps/playwright/package.json
+++ b/apps/playwright/package.json
@@ -29,6 +29,7 @@
     "eslint-plugin-playwright": "^2.10.2",
     "exceljs": "^4.4.0",
     "mammoth": "^1.12.0",
+    "monocart-coverage-reports": "^2.12.11",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.3"
   },

--- a/apps/playwright/playwright.config.ts
+++ b/apps/playwright/playwright.config.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 
 import { defineConfig, devices } from "@playwright/test";
 import dotenv from "dotenv";
-import MCR from "monocart-coverage-reports";
 
 dotenv.config({ path: path.resolve(__dirname, ".env"), quiet: true });
 
@@ -22,23 +21,11 @@ export default defineConfig({
   workers: process.env.CI ? (process.env.PLAYWRIGHT_WORKERS ?? "25%") : "25%",
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI
-    ? [
-        ["blob"],
-        [
-          MCR.PwCoverageReporter,
-          {
-            name: "E2E Coverage",
-            outputDir: "./coverage",
-            reports: [["lcovonly", { file: "lcov.info" }]],
-            // exclude dependencies and build artifacts
-            entryFilter: { "**/node_modules/**": false, "**/*": true },
-            // include only app and package source files
-            sourceFilter: (sourcePath: string) =>
-              /(apps\/web|packages\/.+)\/src\//.test(sourcePath),
-          },
-        ],
-      ]
+    ? "blob"
     : [["line"], ["html", { open: "on-failure" }]],
+  globalTeardown: process.env.E2E_COVERAGE === "true"
+    ? "./e2e-coverage-teardown"
+    : undefined,
   timeout: Number(process.env.TEST_TIMEOUT ?? 60 * 1000),
   expect: { timeout: Number(process.env.EXPECT_TIMEOUT ?? 15000) }, // 15 seconds
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/apps/playwright/playwright.config.ts
+++ b/apps/playwright/playwright.config.ts
@@ -23,9 +23,8 @@ export default defineConfig({
   reporter: process.env.CI
     ? "blob"
     : [["line"], ["html", { open: "on-failure" }]],
-  globalTeardown: process.env.E2E_COVERAGE === "true"
-    ? "./e2e-coverage-teardown"
-    : undefined,
+  globalTeardown:
+    process.env.E2E_COVERAGE === "true" ? "./e2e-coverage-teardown" : undefined,
   timeout: Number(process.env.TEST_TIMEOUT ?? 60 * 1000),
   expect: { timeout: Number(process.env.EXPECT_TIMEOUT ?? 15000) }, // 15 seconds
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/apps/playwright/playwright.config.ts
+++ b/apps/playwright/playwright.config.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import { defineConfig, devices } from "@playwright/test";
 import dotenv from "dotenv";
+import MCR from "monocart-coverage-reports";
 
 dotenv.config({ path: path.resolve(__dirname, ".env"), quiet: true });
 
@@ -21,7 +22,22 @@ export default defineConfig({
   workers: process.env.CI ? (process.env.PLAYWRIGHT_WORKERS ?? "25%") : "25%",
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI
-    ? "blob"
+    ? [
+        ["blob"],
+        [
+          MCR.PwCoverageReporter,
+          {
+            name: "E2E Coverage",
+            outputDir: "./coverage",
+            reports: [["lcovonly", { file: "lcov.info" }]],
+            // exclude dependencies and build artifacts
+            entryFilter: { "**/node_modules/**": false, "**/*": true },
+            // include only app and package source files
+            sourceFilter: (sourcePath: string) =>
+              /(apps\/web|packages\/.+)\/src\//.test(sourcePath),
+          },
+        ],
+      ]
     : [["line"], ["html", { open: "on-failure" }]],
   timeout: Number(process.env.TEST_TIMEOUT ?? 60 * 1000),
   expect: { timeout: Number(process.env.EXPECT_TIMEOUT ?? 15000) }, // 15 seconds

--- a/apps/playwright/tsconfig.json
+++ b/apps/playwright/tsconfig.json
@@ -12,6 +12,7 @@
     }
   },
   "include": [
+    "e2e-coverage-teardown.ts",
     "eslint.config.mjs",
     "playwright.config.ts",
     "constants",

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,11 @@
 ignore:
   - "**/*.stories.tsx"
 comment: false
+
+flags:
+  unittests:
+    carryforward: true
+  integrationtests:
+    carryforward: true
+  e2etests:
+    carryforward: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       mammoth:
         specifier: ^1.12.0
         version: 1.12.0
+      monocart-coverage-reports:
+        specifier: ^2.12.11
+        version: 2.12.11
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -4154,6 +4157,14 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  acorn-loose@8.5.2:
+    resolution: {integrity: sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==}
+    engines: {node: '>=0.4.0'}
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
@@ -4495,6 +4506,10 @@ packages:
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -4514,6 +4529,9 @@ packages:
 
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
+  console-grid@2.2.4:
+    resolution: {integrity: sha512-OLjCRTiHhOpTRo9lQp/2FgJDyq5uQHwkEmVJulEnQ6JVf27oKKzXHZnNOv/e72V4++UdMZCrDWtvXW5sx4lyQg==}
 
   constant-case@3.0.4:
     resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
@@ -4732,6 +4750,9 @@ packages:
 
   duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
+
+  eight-colors@1.3.3:
+    resolution: {integrity: sha512-4B54S2Qi4pJjeHmCbDIsveQZWQ/TSSQng4ixYJ9/SYHHpeS5nYK0pzcHvWzWUfRsvJQjwoIENhAwqg59thQceg==}
 
   electron-to-chromium@1.5.360:
     resolution: {integrity: sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==}
@@ -5102,6 +5123,10 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  foreground-child@4.0.3:
+    resolution: {integrity: sha512-yeXZaNbCBGaT9giTpLPBdtedzjwhlJBUoL/R4BVQU5mn0TQXOHwVIl1Q2DMuBIdNno4ktA1abZ7dQFVxD6uHxw==}
+    engines: {node: '>=16'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -5836,6 +5861,9 @@ packages:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
+  lz-utils@2.1.1:
+    resolution: {integrity: sha512-d3Thjos0PSJQAoyMj6vipSSrtrRHS7DImqUNR8x9NW3+zQIftPIbMJAWhi5nPdg5Q9zHz6lxtN8kp/VdMlhi/Q==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -5915,6 +5943,13 @@ packages:
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
+
+  monocart-coverage-reports@2.12.11:
+    resolution: {integrity: sha512-yo4/FdUdFIWoc9OjhBZCNXM95tYHS4e8nov9Q3AGbpvteT/W5aQSc4B+Q0nhmedZFvjvm3BUH/Xu9GT2n/0wkw==}
+    hasBin: true
+
+  monocart-locator@1.0.3:
+    resolution: {integrity: sha512-pe29W2XAoA1WQmZZqxXoP7s06ZEXUhcb81086v68cqjk1HnVL7Q/iU/WJnnetxjPcLqwb4qG8vaSGUOMQU602g==}
 
   motion-dom@12.38.0:
     resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
@@ -10387,6 +10422,14 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
+  acorn-loose@8.5.2:
+    dependencies:
+      acorn: 8.16.0
+
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.16.0
+
   acorn@8.15.0: {}
 
   acorn@8.16.0: {}
@@ -10783,6 +10826,8 @@ snapshots:
 
   colorette@2.0.20: {}
 
+  commander@14.0.3: {}
+
   commander@2.20.3:
     optional: true
 
@@ -10800,6 +10845,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   confbox@0.2.4: {}
+
+  console-grid@2.2.4: {}
 
   constant-case@3.0.4:
     dependencies:
@@ -10992,6 +11039,8 @@ snapshots:
   duplexer2@0.1.4:
     dependencies:
       readable-stream: 2.3.8
+
+  eight-colors@1.3.3: {}
 
   electron-to-chromium@1.5.360: {}
 
@@ -11516,6 +11565,10 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  foreground-child@4.0.3:
+    dependencies:
+      signal-exit: 4.1.0
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -12220,6 +12273,8 @@ snapshots:
 
   lz-string@1.5.0: {}
 
+  lz-utils@2.1.1: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -12295,6 +12350,23 @@ snapshots:
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
+
+  monocart-coverage-reports@2.12.11:
+    dependencies:
+      acorn: 8.16.0
+      acorn-loose: 8.5.2
+      acorn-walk: 8.3.5
+      commander: 14.0.3
+      console-grid: 2.2.4
+      eight-colors: 1.3.3
+      foreground-child: 4.0.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      lz-utils: 2.1.1
+      monocart-locator: 1.0.3
+
+  monocart-locator@1.0.3: {}
 
   motion-dom@12.38.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -156,7 +156,9 @@
     "clean": {
       "cache": false
     },
-    "e2e:playwright": {},
+    "e2e:playwright": {
+      "env": ["E2E_COVERAGE"]
+    },
     "lint": {
       "inputs": [
         "../../packages/eslint-config-custom/index.js",


### PR DESCRIPTION
🤖 Resolves #15726

## 👋 Introduction

Collects code coverage reports from playwright to be uploaded to codecov in CI.

## 🕵️ Details

Sets up the collection of code coveratge reports for playwright when `E2E_COVERAGE` is true.

Adds `monocard-coverage-reports` to collect coverage data and generate a report by extending the base fixture to run on every test.

Then,in a global teardown it generates the lcov file so it can be uploaded to codecov in CI.

## 🧪 Testing

1. Confirm tests still pass
2. Confirm reports uploaded to codecov
