### PR TITLE
[Feature] Edge cursors in cursor pagination

### DIFF
--- a/api/app/GraphQL/Directives/Pagination/ConnectionField.php
+++ b/api/app/GraphQL/Directives/Pagination/ConnectionField.php
@@ -8,6 +8,7 @@ use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ObjectType;
 use Illuminate\Contracts\Pagination\CursorPaginator;
+use Illuminate\Pagination\AbstractCursorPaginator;
 use Illuminate\Support\Collection;
 use Nuwave\Lighthouse\Execution\ResolveInfo;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
@@ -51,12 +52,16 @@ class ConnectionField
 
         $values = new Collection(array_values($paginator->items()));
 
-        return $values->map(static function ($item, int $index) use ($returnTypeFields): array {
+        return $values->map(static function ($item, int $index) use ($returnTypeFields, $paginator): array {
             $data = [];
             foreach ($returnTypeFields as $field) {
                 switch ($field->name) {
                     case 'cursor':
-                        $data['cursor'] = null; // Not available from CursorPaginator
+                        if ($paginator instanceof AbstractCursorPaginator) {
+                            $data['cursor'] = $paginator->getCursorForItem($item)->encode();
+                        } else {
+                            $data['cursor'] = '';
+                        }
                         break;
 
                     case 'node':

--- a/api/app/GraphQL/Directives/Pagination/ConnectionField.php
+++ b/api/app/GraphQL/Directives/Pagination/ConnectionField.php
@@ -64,6 +64,14 @@ class ConnectionField
                         }
                         break;
 
+                    case 'reverseCursor':
+                        if ($paginator instanceof AbstractCursorPaginator) {
+                            $data['reverseCursor'] = $paginator->getCursorForItem($item, false)->encode();
+                        } else {
+                            $data['reverseCursor'] = '';
+                        }
+                        break;
+
                     case 'node':
                         $data['node'] = $item;
                         break;

--- a/api/app/GraphQL/Directives/Pagination/ConnectionField.php
+++ b/api/app/GraphQL/Directives/Pagination/ConnectionField.php
@@ -56,19 +56,19 @@ class ConnectionField
             $data = [];
             foreach ($returnTypeFields as $field) {
                 switch ($field->name) {
-                    case 'cursor':
+                    case 'nextCursor':
                         if ($paginator instanceof AbstractCursorPaginator) {
-                            $data['cursor'] = $paginator->getCursorForItem($item)->encode();
+                            $data['nextCursor'] = $paginator->getCursorForItem($item)->encode();
                         } else {
-                            $data['cursor'] = '';
+                            $data['nextCursor'] = '';
                         }
                         break;
 
-                    case 'reverseCursor':
+                    case 'previousCursor':
                         if ($paginator instanceof AbstractCursorPaginator) {
-                            $data['reverseCursor'] = $paginator->getCursorForItem($item, false)->encode();
+                            $data['previousCursor'] = $paginator->getCursorForItem($item, false)->encode();
                         } else {
-                            $data['reverseCursor'] = '';
+                            $data['previousCursor'] = '';
                         }
                         break;
 

--- a/api/app/GraphQL/Directives/Pagination/PaginationArgs.php
+++ b/api/app/GraphQL/Directives/Pagination/PaginationArgs.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\GraphQL\Directives\Pagination;
 
+use Exception;
 use GraphQL\Error\Error;
 use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
@@ -12,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Pagination\Cursor;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
 use Nuwave\Lighthouse\Exceptions\ValidationException;
 use Nuwave\Lighthouse\Execution\ResolveInfo;
@@ -83,6 +85,17 @@ class PaginationArgs
     {
         if ($this->perPage === 0) {
             return new ZeroPerPagePaginator();
+        }
+
+        $query = match (true) {
+            $builder instanceof QueryBuilder => $builder,
+            $builder instanceof EloquentBuilder => $builder->getQuery(),
+            $builder instanceof Relation => $builder->getQuery()->getQuery(),
+            default => null,
+        };
+        // Builder->ensureOrderForCursorPagination filters out any ordering that does not include a `direction` property.
+        if (! Arr::every($query?->orders, fn ($o) => array_key_exists('direction', $o))) {
+            throw new Exception('This directive does not support ordering without directions, like orderByRaw.');
         }
 
         return $builder->cursorPaginate(perPage: $this->perPage, columns: ['*'], cursorName: 'cursor', cursor: $this->cursor);

--- a/api/app/GraphQL/Directives/Pagination/PaginationArgs.php
+++ b/api/app/GraphQL/Directives/Pagination/PaginationArgs.php
@@ -90,11 +90,10 @@ class PaginationArgs
         $query = match (true) {
             $builder instanceof QueryBuilder => $builder,
             $builder instanceof EloquentBuilder => $builder->getQuery(),
-            $builder instanceof Relation => $builder->getQuery()->getQuery(),
-            default => null,
+            $builder instanceof Relation => $builder->getQuery()->getQuery()
         };
         // Builder->ensureOrderForCursorPagination filters out any ordering that does not include a `direction` property.
-        if (! Arr::every($query?->orders, fn ($o) => array_key_exists('direction', $o))) {
+        if (! Arr::every($query->orders, fn ($o) => array_key_exists('direction', $o))) {
             throw new Exception('This directive does not support ordering without directions, like orderByRaw.');
         }
 

--- a/api/app/GraphQL/Directives/Pagination/PaginationManipulator.php
+++ b/api/app/GraphQL/Directives/Pagination/PaginationManipulator.php
@@ -112,6 +112,9 @@ GRAPHQL
 
                     "A unique cursor that can be used for pagination."
                     cursor: String!
+
+                    "A reverse cursor for the same node, suitable for backward pagination."
+                    reverseCursor: String!
                 }
 GRAPHQL
             );

--- a/api/app/GraphQL/Directives/Pagination/PaginationManipulator.php
+++ b/api/app/GraphQL/Directives/Pagination/PaginationManipulator.php
@@ -110,11 +110,11 @@ GRAPHQL
                     "The {$fieldTypeName} node."
                     node: {$fieldTypeName}!
 
-                    "A unique cursor that can be used for pagination."
-                    cursor: String!
+                    "A unique cursor that can be used for forward pagination."
+                    nextCursor: String!
 
-                    "A reverse cursor for the same node, suitable for backward pagination."
-                    reverseCursor: String!
+                    "A unique cursor that can be used for reverse pagination."
+                    previousCursor: String!
                 }
 GRAPHQL
             );

--- a/api/tests/Unit/Directives/CursorPaginationTest.php
+++ b/api/tests/Unit/Directives/CursorPaginationTest.php
@@ -310,4 +310,65 @@ final class CursorPaginationTest extends TestCase
             }
         }')->assertGraphQLValidationKeys(['last']);
     }
+
+    public function testEdgesHaveWorkingCursors(): void
+    {
+        // Fetch first 3 edges and check their cursors
+        $response = $this->graphQL(/** @lang GraphQL */ '
+        {
+            classifications(orderBy: { column: "level", order: ASC }, first: 3) {
+                edges {
+                    cursor
+                    reverseCursor
+                    node { level }
+                }
+                pageInfo { hasNextPage }
+            }
+        }
+        ');
+
+        $response->assertGraphQLErrorFree();
+        $edges = Arr::get($response, 'data.classifications.edges');
+        $this->assertCount(3, $edges);
+
+        // the next tests reference the second (middle) cursors
+        $secondCursor = $edges[1]['cursor'];
+        $secondReverseCursor = $edges[1]['reverseCursor'];
+
+        // navigating forwards from the edge cursor of the second item returns the third item
+        $responseForward = $this->graphQL(/** @lang GraphQL */ '
+            query Classifications($after: String) {
+                classifications(orderBy: { column: "level", order: ASC }, first: 1, after: $after) {
+                    edges {
+                        cursor
+                        reverseCursor
+                        node { level }
+                    }
+                }
+            }
+        ', ['after' => $secondCursor]);
+
+        $responseForward->assertGraphQLErrorFree();
+        $edgesForward = Arr::get($responseForward, 'data.classifications.edges');
+        $this->assertCount(1, $edgesForward);
+        $this->assertEquals(3, $edgesForward[0]['node']['level']);
+
+        // navigating backwards from the edge cursor of the second item returns the first item
+        $responseBack = $this->graphQL(/** @lang GraphQL */ '
+            query Classifications($before: String) {
+                classifications(orderBy: { column: "level", order: ASC }, last: 1, before: $before) {
+                    edges {
+                        cursor
+                        reverseCursor
+                        node { level }
+                    }
+                }
+            }
+        ', ['before' => $secondReverseCursor]);
+
+        $responseBack->assertGraphQLErrorFree();
+        $edgesBack = Arr::get($responseBack, 'data.classifications.edges');
+        $this->assertCount(1, $edgesBack);
+        $this->assertEquals(1, $edgesBack[0]['node']['level']);
+    }
 }

--- a/api/tests/Unit/Directives/CursorPaginationTest.php
+++ b/api/tests/Unit/Directives/CursorPaginationTest.php
@@ -318,8 +318,8 @@ final class CursorPaginationTest extends TestCase
         {
             classifications(orderBy: { column: "level", order: ASC }, first: 3) {
                 edges {
-                    cursor
-                    reverseCursor
+                    nextCursor
+                    previousCursor
                     node { level }
                 }
                 pageInfo { hasNextPage }
@@ -331,22 +331,17 @@ final class CursorPaginationTest extends TestCase
         $edges = Arr::get($response, 'data.classifications.edges');
         $this->assertCount(3, $edges);
 
-        // the next tests reference the second (middle) cursors
-        $secondCursor = $edges[1]['cursor'];
-        $secondReverseCursor = $edges[1]['reverseCursor'];
-
         // navigating forwards from the edge cursor of the second item returns the third item
+        $secondForwardCursor = $edges[1]['nextCursor'];
         $responseForward = $this->graphQL(/** @lang GraphQL */ '
             query Classifications($after: String) {
                 classifications(orderBy: { column: "level", order: ASC }, first: 1, after: $after) {
                     edges {
-                        cursor
-                        reverseCursor
                         node { level }
                     }
                 }
             }
-        ', ['after' => $secondCursor]);
+        ', ['after' => $secondForwardCursor]);
 
         $responseForward->assertGraphQLErrorFree();
         $edgesForward = Arr::get($responseForward, 'data.classifications.edges');
@@ -354,12 +349,11 @@ final class CursorPaginationTest extends TestCase
         $this->assertEquals(3, $edgesForward[0]['node']['level']);
 
         // navigating backwards from the edge cursor of the second item returns the first item
+        $secondReverseCursor = $edges[1]['previousCursor'];
         $responseBack = $this->graphQL(/** @lang GraphQL */ '
             query Classifications($before: String) {
                 classifications(orderBy: { column: "level", order: ASC }, last: 1, before: $before) {
                     edges {
-                        cursor
-                        reverseCursor
                         node { level }
                     }
                 }


### PR DESCRIPTION
🤖 Resolves #16153 

## 👋 Introduction

Adds forward and reverse cursors to individual edges in the result sets.  I think the relay spec only wants one cursor on each edge that can be used in each direction but Laravel uses separate cursors for each direction.

## 🕵️ Details

The cursor pagination contract in Laravel didn't provide the needed method to get a cursor for each item but it was provided on the underlying AbstractCursorPaginator.

## 🧪 Testing

> [!CAUTION]
> This is a bit tricky to test since the directive isn't in use in the schema currently.  I suggest using the PHPUnit test as a model.  Modify the classifications query in our schema like what is present in the tests and then run similar ad-hoc queries. 

1. Query a list of items with the cursor directive, including edge cursors.
2. Pick an item in the middle and query forward from that point.
3. Pick an item in the middle and query backwards from that point.

> [!CAUTION]
> As noted in [the docs](https://laravel.com/docs/13.x/pagination#cursor-pagination): 
It requires that the ordering is based on at least one unique column or a combination of columns that are unique.

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

## 🚚 Deployment

<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the PR if deployment steps are needed

 -->
