### PR TITLE
[Fix] Update site background colour

### DIFF
--- a/apps/web/src/root.tsx
+++ b/apps/web/src/root.tsx
@@ -146,7 +146,7 @@ export function Layout({ children }: LayoutProps) {
         <Meta />
         <Links nonce="**CSP_NONCE**" />
       </head>
-      <body className="bg-gray-100 font-sans text-black dark:bg-gray-700 dark:text-white">
+      <body className="bg-[#EEF1F9] font-sans text-black dark:bg-gray-700 dark:text-white">
         <div className="isolate">{children}</div>
 
         <ScrollRestoration


### PR DESCRIPTION
🤖 Resolves #16348 

## 👋 Introduction

Updates the site background colour to `#EEF1F9`.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Navigate to any page
3. Confirm the following:
    a. Light mode background colour is `#EEF1F9`
    b. Dark mode background colour remains the same (`#252A37`)

## 📸 Screenshot

<img width="1658" height="1202" alt="swappy-20260528_080710" src="https://github.com/user-attachments/assets/34f39837-e695-4adc-a098-84353c66419f" />
