### PR TITLE
[Bug] Fix unique email constraint

### DIFF
--- a/api/app/GraphQL/Mutations/VerifyUserEmails.php
+++ b/api/app/GraphQL/Mutations/VerifyUserEmails.php
@@ -5,6 +5,7 @@ namespace App\GraphQL\Mutations;
 use App\Enums\EmailType;
 use App\Enums\ErrorCode;
 use App\Models\User;
+use App\Rules\CaseInsensitiveUnique;
 use App\Rules\GovernmentEmailRegex;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
@@ -31,6 +32,7 @@ final class VerifyUserEmails
             throw ValidationException::withMessages(['code' => ErrorCode::VERIFICATION_FAILED->name]);
         }
 
+        // these rules should stay similar to api/app/GraphQL/Validators/SendUserEmailsVerificationInputValidator.php
         $validator = Validator::make($token, [
             'code' => [
                 'required',
@@ -53,12 +55,12 @@ final class VerifyUserEmails
                     [new GovernmentEmailRegex()],
                     ['email']
                 ),
-                Rule::unique('users', 'email')->ignore($user->id, 'id'),
-                Rule::unique('users', 'work_email')->ignore($user->id, 'id'),
+                (new CaseInsensitiveUnique('users', 'email'))->ignore($user?->id, 'id'),
+                (new CaseInsensitiveUnique('users', 'work_email'))->ignore($user?->id, 'id'),
             ],
         ],
             [
-                'emailAddress.unique' => ErrorCode::EMAIL_ADDRESS_IN_USE->name,
+                'emailAddress.case_insensitive_unique' => ErrorCode::EMAIL_ADDRESS_IN_USE->name,
             ]);
 
         if ($validator->fails()) {

--- a/api/app/GraphQL/Validators/SendUserEmailsVerificationInputValidator.php
+++ b/api/app/GraphQL/Validators/SendUserEmailsVerificationInputValidator.php
@@ -29,8 +29,8 @@ final class SendUserEmailsVerificationInputValidator extends Validator
                     [new GovernmentEmailRegex()],
                     ['email']
                 ),
-                (new CaseInsensitiveUnique('users', 'email'))->ignore($user?->id, 'id'),
-                (new CaseInsensitiveUnique('users', 'work_email'))->ignore($user?->id, 'id'),
+                (new CaseInsensitiveUnique('users', 'email', ErrorCode::EMAIL_ADDRESS_IN_USE->name))->ignore($user?->id, 'id'),
+                (new CaseInsensitiveUnique('users', 'work_email', ErrorCode::EMAIL_ADDRESS_IN_USE->name))->ignore($user?->id, 'id'),
             ],
             'emailTypes' => [
                 'array',

--- a/api/app/GraphQL/Validators/SendUserEmailsVerificationInputValidator.php
+++ b/api/app/GraphQL/Validators/SendUserEmailsVerificationInputValidator.php
@@ -23,22 +23,27 @@ final class SendUserEmailsVerificationInputValidator extends Validator
     {
         $user = Auth::user();
 
+        // these rules should stay similar to api/app/GraphQL/Mutations/VerifyUserEmails.php
         return [
+            'emailTypes' => [
+                'required',
+                'array',
+                'min:1',
+            ],
+            'emailTypes.*' => [
+                'required',
+                'distinct',
+                Rule::in(array_column(EmailType::cases(), 'name')),
+            ],
             'emailAddress' => [
+                'required',
+                'string',
                 Rule::when(fn () => in_array(EmailType::WORK->name, $this->arg('emailTypes')),
                     [new GovernmentEmailRegex()],
                     ['email']
                 ),
                 (new CaseInsensitiveUnique('users', 'email'))->ignore($user?->id, 'id'),
                 (new CaseInsensitiveUnique('users', 'work_email'))->ignore($user?->id, 'id'),
-            ],
-            'emailTypes' => [
-                'array',
-                'min:1',
-            ],
-            'emailTypes.*' => [
-                'distinct',
-                Rule::in(array_column(EmailType::cases(), 'name')),
             ],
         ];
     }
@@ -49,7 +54,6 @@ final class SendUserEmailsVerificationInputValidator extends Validator
     public function messages(): array
     {
         return [
-            'emailAddress.unique' => ErrorCode::EMAIL_ADDRESS_IN_USE->name,
             'emailAddress.case_insensitive_unique' => ErrorCode::EMAIL_ADDRESS_IN_USE->name,
         ];
     }

--- a/api/app/GraphQL/Validators/SendUserEmailsVerificationInputValidator.php
+++ b/api/app/GraphQL/Validators/SendUserEmailsVerificationInputValidator.php
@@ -29,8 +29,8 @@ final class SendUserEmailsVerificationInputValidator extends Validator
                     [new GovernmentEmailRegex()],
                     ['email']
                 ),
-                (new CaseInsensitiveUnique('users', 'email', ErrorCode::EMAIL_ADDRESS_IN_USE->name))->ignore($user?->id, 'id'),
-                (new CaseInsensitiveUnique('users', 'work_email', ErrorCode::EMAIL_ADDRESS_IN_USE->name))->ignore($user?->id, 'id'),
+                (new CaseInsensitiveUnique('users', 'email'))->ignore($user?->id, 'id'),
+                (new CaseInsensitiveUnique('users', 'work_email'))->ignore($user?->id, 'id'),
             ],
             'emailTypes' => [
                 'array',
@@ -50,6 +50,7 @@ final class SendUserEmailsVerificationInputValidator extends Validator
     {
         return [
             'emailAddress.unique' => ErrorCode::EMAIL_ADDRESS_IN_USE->name,
+            'emailAddress.case_insensitive_unique' => ErrorCode::EMAIL_ADDRESS_IN_USE->name,
         ];
     }
 }

--- a/api/app/GraphQL/Validators/SendUserEmailsVerificationInputValidator.php
+++ b/api/app/GraphQL/Validators/SendUserEmailsVerificationInputValidator.php
@@ -4,6 +4,7 @@ namespace App\GraphQL\Validators;
 
 use App\Enums\EmailType;
 use App\Enums\ErrorCode;
+use App\Rules\CaseInsensitiveUnique;
 use App\Rules\GovernmentEmailRegex;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
@@ -28,8 +29,8 @@ final class SendUserEmailsVerificationInputValidator extends Validator
                     [new GovernmentEmailRegex()],
                     ['email']
                 ),
-                Rule::unique('users', 'email')->ignore($user?->id, 'id'),
-                Rule::unique('users', 'work_email')->ignore($user?->id, 'id'),
+                (new CaseInsensitiveUnique('users', 'email'))->ignore($user?->id, 'id'),
+                (new CaseInsensitiveUnique('users', 'work_email'))->ignore($user?->id, 'id'),
             ],
             'emailTypes' => [
                 'array',

--- a/api/app/Rules/CaseInsensitiveUnique.php
+++ b/api/app/Rules/CaseInsensitiveUnique.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule as RuleContract;
+use Illuminate\Support\Facades\DB;
+
+class CaseInsensitiveUnique implements RuleContract
+{
+    protected string $table;
+
+    protected string $column;
+
+    protected mixed $ignoreId = null;
+
+    protected $ignoreColumn = 'id';
+
+    public function __construct(string $table, string $column)
+    {
+        $this->table = $table;
+        $this->column = $column;
+    }
+
+    public function ignore(mixed $id, $column = 'id')
+    {
+        $this->ignoreId = $id;
+        $this->ignoreColumn = $column;
+
+        return $this;
+    }
+
+    public function passes($attribute, $value): bool
+    {
+        $query = DB::table($this->table)
+            ->whereRaw('LOWER('.$this->column.') = ?', [mb_strtolower($value)]);
+
+        if ($this->ignoreId !== null) {
+            $query->where($this->ignoreColumn, '!=', $this->ignoreId);
+        }
+
+        return ! $query->exists();
+    }
+
+    public function message(): string
+    {
+        return __('validation.unique');
+    }
+}

--- a/api/app/Rules/CaseInsensitiveUnique.php
+++ b/api/app/Rules/CaseInsensitiveUnique.php
@@ -2,10 +2,11 @@
 
 namespace App\Rules;
 
-use Illuminate\Contracts\Validation\Rule as RuleContract;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\DB;
 
-class CaseInsensitiveUnique implements RuleContract
+class CaseInsensitiveUnique implements ValidationRule
 {
     protected string $table;
 
@@ -13,15 +14,18 @@ class CaseInsensitiveUnique implements RuleContract
 
     protected mixed $ignoreId = null;
 
-    protected $ignoreColumn = 'id';
+    protected string $ignoreColumn = 'id';
 
-    public function __construct(string $table, string $column)
+    protected string $message;
+
+    public function __construct(string $table, string $column, string $message = 'validation.unique')
     {
         $this->table = $table;
         $this->column = $column;
+        $this->message = $message;
     }
 
-    public function ignore(mixed $id, $column = 'id')
+    public function ignore(mixed $id, string $column = 'id'): self
     {
         $this->ignoreId = $id;
         $this->ignoreColumn = $column;
@@ -29,8 +33,12 @@ class CaseInsensitiveUnique implements RuleContract
         return $this;
     }
 
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
+        if (! is_string($value)) {
+            return;
+        }
+
         $query = DB::table($this->table)
             ->whereRaw('LOWER('.$this->column.') = ?', [mb_strtolower($value)]);
 
@@ -38,11 +46,8 @@ class CaseInsensitiveUnique implements RuleContract
             $query->where($this->ignoreColumn, '!=', $this->ignoreId);
         }
 
-        return ! $query->exists();
-    }
-
-    public function message(): string
-    {
-        return __('validation.unique');
+        if ($query->exists()) {
+            $fail($this->message);
+        }
     }
 }

--- a/api/app/Rules/CaseInsensitiveUnique.php
+++ b/api/app/Rules/CaseInsensitiveUnique.php
@@ -36,8 +36,9 @@ class CaseInsensitiveUnique implements ValidationRule
             return;
         }
 
+        $column = DB::getQueryGrammar()->wrap($this->column);
         $query = DB::table($this->table)
-            ->whereRaw('LOWER('.$this->column.') = ?', [mb_strtolower($value)]);
+            ->whereRaw("LOWER($column) = ?", [mb_strtolower($value)]);
 
         if ($this->ignoreId !== null) {
             $query->where($this->ignoreColumn, '!=', $this->ignoreId);

--- a/api/app/Rules/CaseInsensitiveUnique.php
+++ b/api/app/Rules/CaseInsensitiveUnique.php
@@ -16,13 +16,10 @@ class CaseInsensitiveUnique implements ValidationRule
 
     protected string $ignoreColumn = 'id';
 
-    protected string $message;
-
-    public function __construct(string $table, string $column, string $message = 'validation.unique')
+    public function __construct(string $table, string $column)
     {
         $this->table = $table;
         $this->column = $column;
-        $this->message = $message;
     }
 
     public function ignore(mixed $id, string $column = 'id'): self
@@ -47,7 +44,7 @@ class CaseInsensitiveUnique implements ValidationRule
         }
 
         if ($query->exists()) {
-            $fail($this->message);
+            $fail('validation.unique');
         }
     }
 }

--- a/api/tests/Feature/UserVerifyEmailsTest.php
+++ b/api/tests/Feature/UserVerifyEmailsTest.php
@@ -387,4 +387,79 @@ class UserVerifyEmailsTest extends TestCase
             ]
         )->assertGraphQLValidationError('sendUserEmailsVerificationInput.emailAddress', ErrorCode::EMAIL_ADDRESS_IN_USE->name);
     }
+
+    public function testCannotVerifyWithDuplicateContactEmail()
+    {
+        // Create another user with a contact email
+        User::factory()->create([
+            'email' => 'contact.duplicate@example.org',
+        ]);
+
+        Cache::put(
+            'email-verification-00000000-0000-0000-0000-000000000001',
+            [
+                'code' => '5678',
+                'emailTypes' => [EmailType::CONTACT->name],
+                'emailAddress' => 'contact.duplicate@example.org',
+            ],
+            now()->addHours(2)
+        );
+
+        $this->actingAs($this->regularUser, 'api')->graphQL(
+            $this->verifyEmailsMutation,
+            [
+                'code' => '5678',
+            ]
+        )->assertGraphQLValidationError('emailAddress', ErrorCode::EMAIL_ADDRESS_IN_USE->name);
+    }
+
+    public function testCannotVerifyWithDuplicateWorkEmail()
+    {
+        // Create another user with a work email
+        User::factory()->create([
+            'work_email' => 'work.duplicate@example.org',
+        ]);
+
+        Cache::put(
+            'email-verification-00000000-0000-0000-0000-000000000001',
+            [
+                'code' => '5679',
+                'emailTypes' => [EmailType::WORK->name],
+                'emailAddress' => 'work.duplicate@example.org',
+            ],
+            now()->addHours(2)
+        );
+
+        $this->actingAs($this->regularUser, 'api')->graphQL(
+            $this->verifyEmailsMutation,
+            [
+                'code' => '5679',
+            ]
+        )->assertGraphQLValidationError('emailAddress', ErrorCode::EMAIL_ADDRESS_IN_USE->name);
+    }
+
+    public function testCannotVerifyWithDuplicateWorkEmailCaseInsensitive()
+    {
+        // Create another user with a work email
+        User::factory()->create([
+            'work_email' => 'work.duplicate@example.org',
+        ]);
+
+        Cache::put(
+            'email-verification-00000000-0000-0000-0000-000000000001',
+            [
+                'code' => '5680',
+                'emailTypes' => [EmailType::CONTACT->name],
+                'emailAddress' => 'WORK.DUPLICATE@EXAMPLE.ORG',
+            ],
+            now()->addHours(2)
+        );
+
+        $this->actingAs($this->regularUser, 'api')->graphQL(
+            $this->verifyEmailsMutation,
+            [
+                'code' => '5680',
+            ]
+        )->assertGraphQLValidationError('emailAddress', ErrorCode::EMAIL_ADDRESS_IN_USE->name);
+    }
 }

--- a/api/tests/Feature/UserVerifyEmailsTest.php
+++ b/api/tests/Feature/UserVerifyEmailsTest.php
@@ -333,4 +333,58 @@ class UserVerifyEmailsTest extends TestCase
         // check that verification was cleared
         assertNull($this->regularUser->work_email_verified_at);
     }
+
+    public function testCannotRequestCodeForDuplicateEmail()
+    {
+        // Create another user with their own email
+        User::factory()->create([
+            'email' => 'regular.user.2@example.org',
+        ]);
+
+        $this->actingAs($this->regularUser, 'api')->graphQL(
+            $this->sendVerificationEmailsMutation,
+            [
+                'input' => [
+                    'emailAddress' => 'regular.user.2@example.org',
+                    'emailTypes' => [EmailType::CONTACT->name],
+                ],
+            ]
+        )->assertGraphQLValidationError('sendUserEmailsVerificationInput.emailAddress', ErrorCode::EMAIL_ADDRESS_IN_USE->name);
+    }
+
+    public function testCannotRequestCodeForDuplicateEmailWithWork()
+    {
+        // Create another user with their own email
+        User::factory()->create([
+            'work_email' => 'regular.user.2@example.org',
+        ]);
+
+        $this->actingAs($this->regularUser, 'api')->graphQL(
+            $this->sendVerificationEmailsMutation,
+            [
+                'input' => [
+                    'emailAddress' => 'regular.user.2@example.org',
+                    'emailTypes' => [EmailType::CONTACT->name],
+                ],
+            ]
+        )->assertGraphQLValidationError('sendUserEmailsVerificationInput.emailAddress', ErrorCode::EMAIL_ADDRESS_IN_USE->name);
+    }
+
+    public function testCannotRequestCodeForDuplicateEmailCaseInsensitive()
+    {
+        // Create another user with their own email
+        User::factory()->create([
+            'work_email' => 'regular.user.2@example.org',
+        ]);
+
+        $this->actingAs($this->regularUser, 'api')->graphQL(
+            $this->sendVerificationEmailsMutation,
+            [
+                'input' => [
+                    'emailAddress' => 'REGULAR.USER.2@EXAMPLE.ORG',
+                    'emailTypes' => [EmailType::CONTACT->name],
+                ],
+            ]
+        )->assertGraphQLValidationError('sendUserEmailsVerificationInput.emailAddress', ErrorCode::EMAIL_ADDRESS_IN_USE->name);
+    }
 }


### PR DESCRIPTION
🤖 Resolves #13874 

## 👋 Introduction

Fixes the email validation to enforce uniqueness across both contact and work email columns in a case-insensitive way.

## 🕵️ Details

Main changes:
- Added a new validation rule that uses the SQL lower function to perform case-insensitive comparison.
- Uses the new rule when generating verification codes.
- Uses the new rule when redeeming verification codes.

Note:
No changes were made to the mutations used by admins or testing.  Just the user-facing mutations were updated.

## 🧪 Testing

> [!TIP]
> If you don't want to mess with GCNotify you can pull a verification code out of the cache with `grep -Rni "api/storage/framework/cache" -e "trey"`

1. Log in as a user and note their contact and work email addresses
2. Navigate to the account settings page to update email addresses

- [ ] can use contact email unused by anyone else
- [ ] can use work email unused by anyone else
- [ ] can use email used by self (for example, setting contact email to address already used by work email)
- [ ] can't use exact email used another user
- [ ] can't use email used by another user that's different only in casing
- [ ] all the above rules apply to requesting verification codes
- [ ] all the above rules apply to submitting codes (for example, other emails change between requesting a code and submitting it)
