### PR TITLE
[Tooling] Adds a talent request sync script

### DIFF
--- a/api/app/Console/Commands/SyncTalentRequests.php
+++ b/api/app/Console/Commands/SyncTalentRequests.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+#[Signature('app:sync-talent-requests')]
+#[Description('Syncs search request rows to new talent requests table.')]
+class SyncTalentRequests extends Command
+{
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        if (Schema::hasTable('talent_requests') && Schema::hasTable('pool_candidate_search_requests')) {
+            // Rows without an applicant_filter_id pre-date that field and can't be represented in the new schema.
+            DB::statement(<<<'SQL'
+            INSERT INTO talent_requests (
+                id, full_name, email, job_title, hr_advisor_email, manager_job_title,
+                position_type, reason, additional_comments, was_empty, initial_result_count,
+                applicant_filter_id, department_id, community_id, user_id, admin_notes,
+                status, in_progress_details, completion_details, follow_up_date,
+                status_changed_at, created_at, updated_at, deleted_at
+            )
+            SELECT
+                id, full_name, email, job_title, hr_advisor_email, manager_job_title,
+                position_type, reason, additional_comments, was_empty, initial_result_count,
+                applicant_filter_id, department_id, community_id, user_id, admin_notes,
+                status, in_progress_details, completion_details, follow_up_date,
+                request_status_changed_at, created_at, updated_at, deleted_at
+            FROM pool_candidate_search_requests
+            WHERE applicant_filter_id IS NOT NULL
+            ON CONFLICT (id) DO NOTHING;
+            SQL
+            );
+
+            // Duplicated rather than moved — PoolCandidateSearchRequest history must remain intact during transition.
+            DB::statement(<<<'SQL'
+            INSERT INTO activity_log (
+                id, log_name, description, subject_type, subject_id,
+                causer_type, causer_id, properties, attribute_changes,
+                created_at, updated_at, event
+            )
+            SELECT
+                gen_random_uuid(),
+                source_log.log_name,
+                source_log.description,
+                'App\Models\TalentRequest',
+                source_log.subject_id,
+                source_log.causer_type,
+                source_log.causer_id,
+                source_log.properties,
+                source_log.attribute_changes,
+                source_log.created_at,
+                source_log.updated_at,
+                source_log.event
+            FROM activity_log AS source_log
+            WHERE source_log.subject_type = 'App\Models\PoolCandidateSearchRequest'
+            AND source_log.subject_id IN (SELECT id FROM talent_requests)
+            AND NOT EXISTS (
+                SELECT 1
+                FROM activity_log AS target_log
+                WHERE target_log.subject_type = 'App\Models\TalentRequest'
+                    AND target_log.subject_id = source_log.subject_id
+                    AND target_log.created_at = source_log.created_at
+            );
+            SQL
+            );
+        }
+    }
+}


### PR DESCRIPTION
🤖 Resolves #16928 

## 👋 Introduction

Adds a script to sync new `PoolCandidateSearchRequest` entities to the new `TalentRequest` entity.

## 🕵️ Details

We made an initial migration when the new table was introduced but, there will be a short period where new requests could come in that need to be synced over. This command was built to be ran as many times as needed and can be ran just before removing the old `PoolCandidateSearchRequest` mode.

## 🧪 Testing

1. Make sure all migrations ran `make refresh-api`
2. Login to DB and confirm the number and records in both `pool_candidate_search_requests` and `talent_requests` tables
3. Run the command `make artisan CMD="app:sync-talent-requests"`
4. Confirm that after running the command, the tables match (outside of deprecated fields)
5. Submit a new request for talent from `/search`
6. Run the same command from step 3
7. Confirm only the new record is synced and not others