### PR TITLE
[Fix] React hooks refs

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -1184,6 +1184,7 @@ const PoolCandidatesTable = ({
       }}
       filter={{
         initialState: initialFilterInput,
+        // eslint-disable-next-line react-hooks/refs
         state: filterRef.current,
         component: (
           <PoolCandidateFilterDialog

--- a/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
+++ b/apps/web/src/components/SearchRequestTable/SearchRequestTable.tsx
@@ -492,6 +492,7 @@ const SearchRequestTable = ({ title }: SearchRequestTableProps) => {
         },
       }}
       filter={{
+        // eslint-disable-next-line react-hooks/refs
         state: filterRef.current,
         component: (
           <SearchRequestFilterDialog

--- a/apps/web/src/components/Table/ResponsiveTable/RowSelection.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/RowSelection.tsx
@@ -405,6 +405,8 @@ export const useRowSelection = <T,>(
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const rowSelectionCallbackRef = useRef<RowSelectionCallback>(() => undefined);
 
+  // Latest-ref pattern: store fresh callback so the effect avoids a re-render cycle.
+  // eslint-disable-next-line react-hooks/refs
   rowSelectionCallbackRef.current = (newRows: RowSelectionState) => {
     if (rowSelect?.onRowSelection) {
       const selectedRows = Object.keys(newRows)

--- a/apps/web/src/components/Table/ResponsiveTable/RowSelection.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/RowSelection.tsx
@@ -405,7 +405,7 @@ export const useRowSelection = <T,>(
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const rowSelectionCallbackRef = useRef<RowSelectionCallback>(() => undefined);
 
-  // Latest-ref pattern: store fresh callback so the effect avoids a re-render cycle.
+  // Keep the newest callback in the ref for the effect to call
   // eslint-disable-next-line react-hooks/refs
   rowSelectionCallbackRef.current = (newRows: RowSelectionState) => {
     if (rowSelect?.onRowSelection) {

--- a/apps/web/src/hooks/useDeepCompareEffect.ts
+++ b/apps/web/src/hooks/useDeepCompareEffect.ts
@@ -4,7 +4,7 @@ import { useRef, useEffect } from "react";
 
 function useDeepCompareMemoize(value: DependencyList): DependencyList {
   const ref = useRef<DependencyList>([]);
-  // Ref-based memoization by design; ref access during render is intentional.
+  // Reading the ref during render is intentional here
   // eslint-disable-next-line react-hooks/refs
   if (!isEqual(value, ref.current)) {
     // eslint-disable-next-line react-hooks/refs

--- a/apps/web/src/hooks/useDeepCompareEffect.ts
+++ b/apps/web/src/hooks/useDeepCompareEffect.ts
@@ -4,9 +4,13 @@ import { useRef, useEffect } from "react";
 
 function useDeepCompareMemoize(value: DependencyList): DependencyList {
   const ref = useRef<DependencyList>([]);
+  // Ref-based memoization by design; ref access during render is intentional.
+  // eslint-disable-next-line react-hooks/refs
   if (!isEqual(value, ref.current)) {
+    // eslint-disable-next-line react-hooks/refs
     ref.current = value;
   }
+  // eslint-disable-next-line react-hooks/refs
   return ref.current;
 }
 

--- a/apps/web/src/hooks/useSelectedRows.ts
+++ b/apps/web/src/hooks/useSelectedRows.ts
@@ -1,5 +1,5 @@
 import type { Dispatch, SetStateAction } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 interface UseSelectedRowsReturn<T> {
   setSelectedRows: Dispatch<SetStateAction<T[]>>;
@@ -8,24 +8,19 @@ interface UseSelectedRowsReturn<T> {
 }
 
 function useSelectedRows<T>(defaultSelected?: T[]): UseSelectedRowsReturn<T> {
-  const hasSelected = useRef<boolean>(false);
+  const [hasSelected, setHasSelected] = useState<boolean>(false);
   const [selectedRows, setSelectedRows] = useState<T[]>(defaultSelected ?? []);
 
   useEffect(() => {
-    if (selectedRows.length > 0 && !hasSelected.current) {
-      hasSelected.current = true;
+    if (selectedRows.length > 0 && !hasSelected) {
+      setHasSelected(true);
     }
-  }, [selectedRows]);
-
-  let pause = !hasSelected.current;
-  if (selectedRows.length > 0) {
-    pause = false;
-  }
+  }, [selectedRows, hasSelected]);
 
   return {
     selectedRows,
     setSelectedRows,
-    hasSelected: !pause,
+    hasSelected: hasSelected || selectedRows.length > 0,
   };
 }
 

--- a/apps/web/src/hooks/useSelectedRows.ts
+++ b/apps/web/src/hooks/useSelectedRows.ts
@@ -1,5 +1,5 @@
 import type { Dispatch, SetStateAction } from "react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 interface UseSelectedRowsReturn<T> {
   setSelectedRows: Dispatch<SetStateAction<T[]>>;
@@ -11,16 +11,14 @@ function useSelectedRows<T>(defaultSelected?: T[]): UseSelectedRowsReturn<T> {
   const [hasSelected, setHasSelected] = useState<boolean>(false);
   const [selectedRows, setSelectedRows] = useState<T[]>(defaultSelected ?? []);
 
-  useEffect(() => {
-    if (selectedRows.length > 0 && !hasSelected) {
-      setHasSelected(true);
-    }
-  }, [selectedRows, hasSelected]);
+  if (selectedRows.length > 0 && !hasSelected) {
+    setHasSelected(true);
+  }
 
   return {
     selectedRows,
     setSelectedRows,
-    hasSelected: hasSelected || selectedRows.length > 0,
+    hasSelected,
   };
 }
 

--- a/apps/web/src/pages/CommunityInterests/CommunityTalentPage/CommunityTalentTable.tsx
+++ b/apps/web/src/pages/CommunityInterests/CommunityTalentPage/CommunityTalentTable.tsx
@@ -689,6 +689,7 @@ const CommunityTalentTable = ({ title }: CommunityTalentTableProps) => {
         },
       }}
       filter={{
+        // eslint-disable-next-line react-hooks/refs
         state: filterRef.current,
         component: (
           <CommunityTalentFilterDialog

--- a/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
+++ b/apps/web/src/pages/CreateApplicationPage/CreateApplicationPage.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/refs -- SEE: #16944 */
 import { useRef } from "react";
 import { useIntl } from "react-intl";
 import { useNavigate } from "react-router";

--- a/apps/web/src/pages/CreateTalentNominationPage/CreateTalentNominationPage.tsx
+++ b/apps/web/src/pages/CreateTalentNominationPage/CreateTalentNominationPage.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/refs */
 import { useRef } from "react";
 import { useIntl } from "react-intl";
 import { useNavigate } from "react-router";

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -391,6 +391,7 @@ const PoolTable = ({ title, initialFilterInput }: PoolTableProps) => {
       }}
       filter={{
         initialState: initialFilterInput,
+        // eslint-disable-next-line react-hooks/refs
         state: filterRef.current,
         component: (
           <PoolFilterDialog

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
@@ -496,6 +496,7 @@ const UserTable = ({ title }: UserTableProps) => {
         initialState: defaultState.sortState,
       }}
       filter={{
+        // eslint-disable-next-line react-hooks/refs
         state: filterRef.current,
         component: (
           <UserFilterDialog

--- a/packages/eslint-config-custom/react.mjs
+++ b/packages/eslint-config-custom/react.mjs
@@ -32,8 +32,6 @@ export default [
 
       // TO DO: Enable in #16676
       "react-hooks/static-components": "off",
-      // TO DO: Enable in #16677
-      "react-hooks/refs": "off",
 
       ...vitest.configs.recommended.rules,
       "vitest/expect-expect": [

--- a/packages/forms/src/components/Combobox/Multi.tsx
+++ b/packages/forms/src/components/Combobox/Multi.tsx
@@ -209,6 +209,11 @@ const Multi = ({
     },
   });
 
+  const downshiftInputProps = getInputProps(
+    // eslint-disable-next-line react-hooks/refs -- downshift's prop getter needs the ref to wire up the input; it is not read during render
+    getDropdownProps({ preventKeyAction: isOpen, ref: inputRef }),
+  );
+
   const handleClear = () => {
     handleInputChanged("");
     inputRef?.current?.focus();
@@ -231,9 +236,7 @@ const Multi = ({
           <Input.Search />
           <input
             {...inputProps}
-            {...getInputProps(
-              getDropdownProps({ preventKeyAction: isOpen, ref: inputRef }),
-            )}
+            {...downshiftInputProps}
             className={comboboxInput({
               state: fieldState,
               hasSelectedItems: inputValue.length > 0,

--- a/packages/forms/src/components/Combobox/Single.tsx
+++ b/packages/forms/src/components/Combobox/Single.tsx
@@ -82,6 +82,9 @@ const Single = ({
     },
   });
 
+  // eslint-disable-next-line react-hooks/refs -- downshift's prop getter needs the ref to wire up the input; it is not read during render
+  const downshiftInputProps = getInputProps({ ref: inputRef });
+
   const handleClear = () => {
     selectItem(null);
     inputRef?.current?.focus();
@@ -103,9 +106,7 @@ const Single = ({
           <Input.Search />
           <input
             {...inputProps}
-            {...getInputProps({
-              ref: inputRef,
-            })}
+            {...downshiftInputProps}
             className={comboboxInput({
               state: fieldState,
               hasSelectedItems: inputValue.length > 0,


### PR DESCRIPTION
🤖 Resolves #16677 

## 👋 Introduction

Fixes errors related to `react-hooks/ref` eslint rule.

## 🕵️ Details

Most of this was just supressing errors since the use of refs are intentional. I left notes explaining why we are supressing them.

The main issues were in:

 - `useSelectedRows` where we removed the ref entirely
 - Both of the `Create*` pages for applications and nominations

For the create pages, there are true anti-patterns we should fix. These probably should not be links and instead should be forms where the creation happens in a callback.

Ticket created: https://github.com/GCTC-NTGC/gc-digital-talent/issues/16944

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Confirm no lint errors `pnpm lint --force`
3. Confirm the `useSelectedRows` hook still functions as expected (you can download only selected rows and the download buttons activate when any number of rows is selected)