### PR TITLE
[Fix] Excel user input crashing generation

### DIFF
--- a/api/app/Generators/CommunityInterestUserExcelGenerator.php
+++ b/api/app/Generators/CommunityInterestUserExcelGenerator.php
@@ -17,7 +17,6 @@ use App\Traits\Generator\Filterable;
 use App\Traits\Generator\GeneratesFile;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 class CommunityInterestUserExcelGenerator extends ExcelGenerator implements FileGeneratorInterface
 {
@@ -68,7 +67,7 @@ class CommunityInterestUserExcelGenerator extends ExcelGenerator implements File
 
     public function generate(): self
     {
-        $this->spreadsheet = new Spreadsheet();
+        $this->spreadsheet = $this->newSpreadsheet();
 
         $sheet = $this->spreadsheet->getActiveSheet();
         $localizedHeaders = array_map(function ($key) {

--- a/api/app/Generators/ExcelGenerator.php
+++ b/api/app/Generators/ExcelGenerator.php
@@ -3,6 +3,8 @@
 namespace App\Generators;
 
 use Illuminate\Support\Facades\Log;
+use PhpOffice\PhpSpreadsheet\Cell\Cell;
+use PhpOffice\PhpSpreadsheet\Cell\IValueBinder;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 
@@ -12,13 +14,22 @@ abstract class ExcelGenerator extends FileGenerator implements FileGeneratorInte
 
     protected string $extension = 'xlsx';
 
+    private IValueBinder $previousValueBinder;
+
     public function __construct(public string $fileName, protected ?string $dir)
     {
         parent::__construct($fileName, $dir);
+
+        // The value binder is process-global, so save the current one and
+        // restore it on destruct to keep the override scoped to this generator.
+        $this->previousValueBinder = Cell::getValueBinder();
+        Cell::setValueBinder(new NonFormulaValueBinder);
     }
 
     public function __destruct()
     {
+        Cell::setValueBinder($this->previousValueBinder);
+
         // https://phpspreadsheet.readthedocs.io/en/latest/topics/creating-spreadsheet/#clearing-a-workbook-from-memory
         if ($this->spreadsheet) {
             $this->spreadsheet->disconnectWorksheets();

--- a/api/app/Generators/ExcelGenerator.php
+++ b/api/app/Generators/ExcelGenerator.php
@@ -23,7 +23,7 @@ abstract class ExcelGenerator extends FileGenerator implements FileGeneratorInte
         // The value binder is process-global, so save the current one and
         // restore it on destruct to keep the override scoped to this generator.
         $this->previousValueBinder = Cell::getValueBinder();
-        Cell::setValueBinder(new NonFormulaValueBinder);
+        Cell::setValueBinder(new NonFormulaValueBinder());
     }
 
     public function __destruct()

--- a/api/app/Generators/ExcelGenerator.php
+++ b/api/app/Generators/ExcelGenerator.php
@@ -3,8 +3,6 @@
 namespace App\Generators;
 
 use Illuminate\Support\Facades\Log;
-use PhpOffice\PhpSpreadsheet\Cell\Cell;
-use PhpOffice\PhpSpreadsheet\Cell\IValueBinder;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 
@@ -14,22 +12,13 @@ abstract class ExcelGenerator extends FileGenerator implements FileGeneratorInte
 
     protected string $extension = 'xlsx';
 
-    private IValueBinder $previousValueBinder;
-
     public function __construct(public string $fileName, protected ?string $dir)
     {
         parent::__construct($fileName, $dir);
-
-        // The value binder is process-global, so save the current one and
-        // restore it on destruct to keep the override scoped to this generator.
-        $this->previousValueBinder = Cell::getValueBinder();
-        Cell::setValueBinder(new NonFormulaValueBinder());
     }
 
     public function __destruct()
     {
-        Cell::setValueBinder($this->previousValueBinder);
-
         // https://phpspreadsheet.readthedocs.io/en/latest/topics/creating-spreadsheet/#clearing-a-workbook-from-memory
         if ($this->spreadsheet) {
             $this->spreadsheet->disconnectWorksheets();
@@ -40,6 +29,17 @@ abstract class ExcelGenerator extends FileGenerator implements FileGeneratorInte
     public function getSpreadsheet(): ?Spreadsheet
     {
         return $this->spreadsheet;
+    }
+
+    // Build a spreadsheet whose value binder keeps "="-leading user text as a
+    // string. The binder lives on the instance so it survives queue
+    // serialization — generate() runs in the worker, not where we were built.
+    protected function newSpreadsheet(): Spreadsheet
+    {
+        $spreadsheet = new Spreadsheet();
+        $spreadsheet->setValueBinder(new NonFormulaValueBinder());
+
+        return $spreadsheet;
     }
 
     public function write()

--- a/api/app/Generators/NominationsExcelGenerator.php
+++ b/api/app/Generators/NominationsExcelGenerator.php
@@ -35,7 +35,6 @@ use App\Traits\Generator\GeneratesFile;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Lang;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 class NominationsExcelGenerator extends ExcelGenerator implements FileGeneratorInterface
 {
@@ -180,7 +179,7 @@ class NominationsExcelGenerator extends ExcelGenerator implements FileGeneratorI
 
     public function generate(): self
     {
-        $this->spreadsheet = new Spreadsheet();
+        $this->spreadsheet = $this->newSpreadsheet();
 
         // Nominations overview sheet
         $overviewSheet = $this->spreadsheet->getActiveSheet();

--- a/api/app/Generators/NonFormulaValueBinder.php
+++ b/api/app/Generators/NonFormulaValueBinder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Generators;
+
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Cell\DefaultValueBinder;
+
+// Stops auto-detection from typing user text that starts with "=" as a formula.
+// Explicit formulas via setCellValueExplicit(..., TYPE_FORMULA) are unaffected.
+class NonFormulaValueBinder extends DefaultValueBinder
+{
+    public static function dataTypeForValue(mixed $value): string
+    {
+        $type = parent::dataTypeForValue($value);
+
+        return $type === DataType::TYPE_FORMULA ? DataType::TYPE_STRING : $type;
+    }
+}

--- a/api/app/Generators/NonFormulaValueBinder.php
+++ b/api/app/Generators/NonFormulaValueBinder.php
@@ -5,8 +5,8 @@ namespace App\Generators;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Cell\DefaultValueBinder;
 
-// Stops auto-detection from typing user text that starts with "=" as a formula.
-// Explicit formulas via setCellValueExplicit(..., TYPE_FORMULA) are unaffected.
+// Treat "="-leading user text as a string, not a formula. PhpSpreadsheet adds a
+// quote-prefix so the literal text shows in Excel without being executed.
 class NonFormulaValueBinder extends DefaultValueBinder
 {
     public static function dataTypeForValue(mixed $value): string

--- a/api/app/Generators/PoolCandidateExcelGenerator.php
+++ b/api/app/Generators/PoolCandidateExcelGenerator.php
@@ -34,7 +34,6 @@ use App\Traits\Generator\GeneratesFile;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Lang;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 class PoolCandidateExcelGenerator extends ExcelGenerator implements FileGeneratorInterface
@@ -134,7 +133,7 @@ class PoolCandidateExcelGenerator extends ExcelGenerator implements FileGenerato
 
     public function generate(): self
     {
-        $this->spreadsheet = new Spreadsheet();
+        $this->spreadsheet = $this->newSpreadsheet();
 
         $sheet = $this->spreadsheet->getActiveSheet();
 

--- a/api/app/Generators/UserExcelGenerator.php
+++ b/api/app/Generators/UserExcelGenerator.php
@@ -52,7 +52,6 @@ use App\Traits\Generator\GeneratesFile;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Lang;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 class UserExcelGenerator extends ExcelGenerator implements FileGeneratorInterface
@@ -226,7 +225,7 @@ class UserExcelGenerator extends ExcelGenerator implements FileGeneratorInterfac
 
     public function generate(): self
     {
-        $this->spreadsheet = new Spreadsheet();
+        $this->spreadsheet = $this->newSpreadsheet();
 
         // Users sheet
         $usersSheet = $this->spreadsheet->getActiveSheet();

--- a/api/tests/Feature/Generators/PoolCandidatesExcelTest.php
+++ b/api/tests/Feature/Generators/PoolCandidatesExcelTest.php
@@ -10,6 +10,8 @@ use Database\Seeders\SkillFamilySeeder;
 use Database\Seeders\SkillSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Storage;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\IOFactory;
 use Tests\TestCase;
 
 class PoolCandidatesExcelTest extends TestCase
@@ -74,5 +76,65 @@ class PoolCandidatesExcelTest extends TestCase
         $this->assertTrue($fileExists, 'File was not generated');
         $fileSize = $disk->size($path);
         $this->assertGreaterThan(0, $fileSize, 'File is empty');
+    }
+
+    // A free-text field starting with "=" must not be treated as a formula.
+    // Previously this threw a TypeError out of PhpSpreadsheet during save.
+    public function testNeutralizesFormulaInjection(): void
+    {
+        // arrange
+        $adminUser = User::factory()
+            ->asApplicant()
+            ->asAdmin()
+            ->create();
+
+        $targetUser = User::factory()
+            ->asApplicant()
+            ->withNonGovProfile()
+            ->create();
+
+        $payload = '=HYPERLINK("http://evil.test","To become more involved")';
+        $application = PoolCandidate::factory()
+            ->availableInSearch()
+            ->withSnapshot()
+            ->create([
+                'user_id' => $targetUser->id,
+                'notes' => $payload,
+            ]);
+
+        // act
+        $fileName = sprintf('%s_%s', __('filename.candidates_rod'), date('Y-m-d_His'));
+        $generator = new PoolCandidateExcelGenerator(
+            fileName: $fileName,
+            dir: 'test',
+            lang: 'en',
+            withROD: true,
+        );
+
+        $generator
+            ->setAuthenticatedUserId($adminUser->id)
+            ->setIds([$application->id])
+            ->setFilters([]);
+
+        // would throw before the NonFormulaValueBinder fix
+        $generator->generate()->write();
+
+        // assert: the payload was written as inert text, not a formula
+        $path = Storage::disk('user_generated')->path('test'.DIRECTORY_SEPARATOR.$fileName.'.xlsx');
+        $sheet = IOFactory::load($path)->getActiveSheet();
+
+        $found = null;
+        foreach ($sheet->getRowIterator() as $row) {
+            foreach ($row->getCellIterator() as $cell) {
+                if ($cell->getValue() === $payload) {
+                    $found = $cell;
+                    break 2;
+                }
+            }
+        }
+
+        $this->assertNotNull($found, 'Payload cell was not found in the generated file');
+        $this->assertNotSame(DataType::TYPE_FORMULA, $found->getDataType(), 'Payload was written as a formula');
+        $this->assertSame($payload, $found->getValue(), 'Payload content was altered');
     }
 }

--- a/api/tests/Feature/Generators/PoolCandidatesExcelTest.php
+++ b/api/tests/Feature/Generators/PoolCandidatesExcelTest.php
@@ -10,8 +10,8 @@ use Database\Seeders\SkillFamilySeeder;
 use Database\Seeders\SkillSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Storage;
-use PhpOffice\PhpSpreadsheet\Cell\DataType;
-use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Cell\Cell;
+use PhpOffice\PhpSpreadsheet\Cell\DefaultValueBinder;
 use Tests\TestCase;
 
 class PoolCandidatesExcelTest extends TestCase
@@ -78,8 +78,11 @@ class PoolCandidatesExcelTest extends TestCase
         $this->assertGreaterThan(0, $fileSize, 'File is empty');
     }
 
-    // A free-text field starting with "=" must not be treated as a formula.
-    // Previously this threw a TypeError out of PhpSpreadsheet during save.
+    // A free-text field starting with "=" must not be typed as a formula. An
+    // invalid formula like "= To become more involved" crashed PhpSpreadsheet
+    // with a TypeError when the writer tried to calculate it. The binder lives
+    // on the Spreadsheet instance because generate() runs in a queue worker,
+    // not where the generator was constructed.
     public function testNeutralizesFormulaInjection(): void
     {
         // arrange
@@ -93,7 +96,9 @@ class PoolCandidatesExcelTest extends TestCase
             ->withNonGovProfile()
             ->create();
 
-        $payload = '=HYPERLINK("http://evil.test","To become more involved")';
+        // Exact shape of the value that crashed in production: an invalid formula.
+        $payload = '= To become more involved';
+
         $application = PoolCandidate::factory()
             ->availableInSearch()
             ->withSnapshot()
@@ -116,25 +121,27 @@ class PoolCandidatesExcelTest extends TestCase
             ->setIds([$application->id])
             ->setFilters([]);
 
-        // would throw before the NonFormulaValueBinder fix
+        // Simulate the queue worker: the process running generate() has the
+        // default global binder, so the fix must not rely on construction-time state.
+        Cell::setValueBinder(new DefaultValueBinder());
+
         $generator->generate()->write();
 
-        // assert: the payload was written as inert text, not a formula
+        // assert: the file was produced (write() above would have thrown the
+        // TypeError before the fix) and the value is text, not a formula element
         $path = Storage::disk('user_generated')->path('test'.DIRECTORY_SEPARATOR.$fileName.'.xlsx');
-        $sheet = IOFactory::load($path)->getActiveSheet();
-
-        $found = null;
-        foreach ($sheet->getRowIterator() as $row) {
-            foreach ($row->getCellIterator() as $cell) {
-                if ($cell->getValue() === $payload) {
-                    $found = $cell;
-                    break 2;
-                }
+        $zip = new \ZipArchive();
+        $zip->open($path);
+        $xml = '';
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $name = $zip->getNameIndex($i);
+            if (str_contains($name, 'worksheets/') || str_contains($name, 'sharedStrings')) {
+                $xml .= $zip->getFromName($name);
             }
         }
+        $zip->close();
 
-        $this->assertNotNull($found, 'Payload cell was not found in the generated file');
-        $this->assertNotSame(DataType::TYPE_FORMULA, $found->getDataType(), 'Payload was written as a formula');
-        $this->assertSame($payload, $found->getValue(), 'Payload content was altered');
+        $this->assertStringContainsString('To become more involved', $xml, 'Payload text was not written to the file');
+        $this->assertStringNotContainsString('<f>', $xml, 'Payload was written as a formula element');
     }
 }


### PR DESCRIPTION
🤖 Resolves #16565 

## 👋 Introduction

Fixes an issue were user input could crash our excel file generation.

## 🕵️ Details

The isuse was some user input that was prefixed with an `=` character. `PhpSpreadsheet` sees this and infers that the cell should be a formula. It then tries to insert the forumla but, this was how the user submitted the data and was not a valid formula which is what resulted in the error.

This disables the ability for `PhpSpreadsheet` to try and auto-detect formulas and results in just the string being inserted rather that it trying to be converted into a formula.

```
Worksheet->writeCellFormula(Object(XMLWriter), '= To become mor...', Object(PhpOffice\PhpSpreadsheet\Cell\Cell))
```

## 🧪 Testing

1. Start the queue `make queue-work`
2. Login as `admin@test.com`
3. Update some user input to start with `=`
4. Go and try and download an excel that contains that field
5. Confirm the download works with no error and the document contains the string version and not a formula