### PR TITLE
Upgrade activity log with with bulk sql instead of one row at time

### DIFF
--- a/api/database/migrations/2026_05_21_000000_upgrade_activity_log_v5.php
+++ b/api/database/migrations/2026_05_21_000000_upgrade_activity_log_v5.php
@@ -14,16 +14,35 @@ return new class() extends Migration
             $table->dropColumn('batch_uuid');
         });
 
-        DB::table('activity_log')->whereNotNull('properties')->eachById(function ($row) {
-            $properties = json_decode($row->properties, true);
-            $changes = array_intersect_key($properties, array_flip(['attributes', 'old']));
-            $remaining = array_diff_key($properties, array_flip(['attributes', 'old']));
+        // Extract 'attributes' and 'old' keys from properties into attribute_changes
+        DB::statement("
+            UPDATE activity_log
+            SET attribute_changes = (
+                CASE
+                    WHEN properties::jsonb ?| ARRAY['attributes', 'old']
+                    THEN (
+                        SELECT jsonb_object_agg(key, value)
+                        FROM jsonb_each(properties::jsonb)
+                        WHERE key IN ('attributes', 'old')
+                    )
+                    ELSE NULL
+                END
+            )::text::json
+            WHERE properties IS NOT NULL
+        ");
 
-            DB::table('activity_log')->where('id', $row->id)->update([
-                'attribute_changes' => empty($changes) ? null : json_encode($changes),
-                'properties' => empty($remaining) ? null : json_encode($remaining),
-            ]);
-        });
+        // Remove those keys from properties, nulling out empty objects
+        DB::statement("
+            UPDATE activity_log
+            SET properties = (
+                CASE
+                    WHEN (properties::jsonb - 'attributes' - 'old') = '{}'::jsonb
+                    THEN NULL
+                    ELSE (properties::jsonb - 'attributes' - 'old')::text::json
+                END
+            )
+            WHERE properties IS NOT NULL
+        ");
     }
 
     public function down(): void

--- a/api/database/migrations/2026_05_21_000000_upgrade_activity_log_v5.php
+++ b/api/database/migrations/2026_05_21_000000_upgrade_activity_log_v5.php
@@ -19,7 +19,7 @@ return new class() extends Migration
             UPDATE activity_log
             SET attribute_changes = (
                 CASE
-                    WHEN properties::jsonb ?| ARRAY['attributes', 'old']
+                    WHEN jsonb_exists_any(properties::jsonb, ARRAY['attributes', 'old'])
                     THEN (
                         SELECT jsonb_object_agg(key, value)
                         FROM jsonb_each(properties::jsonb)


### PR DESCRIPTION
-- Generated with Claude Code

🤖 Resolves #16958

## 👋 Introduction

Converts migration to use two SQL operations instead of running through whole table 1 row at a time.

## 🕵️ Details

The previous migration came directly from the upgrade guide. This should be much more efficient.
I updated the existing migration instead of creating a new one. That should be safe, since this _should_ have identical results as the previous version, its just faster. Meaning, if the previous migration has already run, this version should not need to run again.

Previous to this upgrade, the `properties` column is a json blob that includes `attributes` (new values), `old` (old version of values) and possible custom values. It moves `attributes` and `old` to a new column, and preserved custom values in `properties` column.

We never add any custom values to properties column, so the result of this migration SHOULD be to copy everything that was in properties to a new column, and leave properties as null.

## 🧪 Testing

The previous version came directly from the official upgrade guide, so we're pretty confident it gives the correct results, if it runs at all.

To test this, you could run it on a small batch of test data, ensuring it gave the same results as previous version?

1. Checkout a commit from just before the activity log update: https://github.com/GCTC-NTGC/gc-digital-talent/commit/1285a0c666
2. Run `make seed-fresh`. You should now have lots of entries in activity log with `attributes` but not `old` in properties.
3. Log into app and change something on your user profile. Should now have activity log entries with both `attributes` and `old` in properties.
4. checkout this commit, run migrations
5. Comfirm the following in activity log:
   - entries that used to have just `attributes`, or that had `attributes` _and_ `old`, have been copied to new column `attribute_changes`.
   - because we never add custom values to `properties`, that column should always be null.

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

## 🚚 Deployment
 
run the migration