### PR TITLE
[Feat] Add tracked user model

### DIFF
--- a/api/app/Enums/TalentRequestTrackedUserNotReferredReason.php
+++ b/api/app/Enums/TalentRequestTrackedUserNotReferredReason.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Enums;
+
+use App\Traits\HasLocalization;
+
+enum TalentRequestTrackedUserNotReferredReason
+{
+    use HasLocalization;
+
+    case OTHER;
+
+    public static function getLangFilename(): string
+    {
+        return 'talent_request_tracked_user_not_referred_reason';
+    }
+}

--- a/api/app/Enums/TalentRequestTrackedUserNotSelectedReason.php
+++ b/api/app/Enums/TalentRequestTrackedUserNotSelectedReason.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Enums;
+
+use App\Traits\HasLocalization;
+
+enum TalentRequestTrackedUserNotSelectedReason
+{
+    use HasLocalization;
+
+    case OTHER;
+
+    public static function getLangFilename(): string
+    {
+        return 'talent_request_tracked_user_not_selected_reason';
+    }
+}

--- a/api/app/Enums/TalentRequestTrackedUserReferralDecision.php
+++ b/api/app/Enums/TalentRequestTrackedUserReferralDecision.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Enums;
+
+use App\Traits\HasLocalization;
+
+enum TalentRequestTrackedUserReferralDecision
+{
+    use HasLocalization;
+
+    case REFERRED;
+    case NOT_REFERRED;
+
+    public static function getLangFilename(): string
+    {
+        return 'talent_request_tracked_user_referral_decision';
+    }
+}

--- a/api/app/Enums/TalentRequestTrackedUserSelectionDecision.php
+++ b/api/app/Enums/TalentRequestTrackedUserSelectionDecision.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Enums;
+
+use App\Traits\HasLocalization;
+
+enum TalentRequestTrackedUserSelectionDecision
+{
+    use HasLocalization;
+
+    case SELECTED;
+    case NOT_SELECTED;
+
+    public static function getLangFilename(): string
+    {
+        return 'talent_request_tracked_user_selection_decision';
+    }
+}

--- a/api/app/Models/TalentRequest.php
+++ b/api/app/Models/TalentRequest.php
@@ -112,6 +112,12 @@ class TalentRequest extends Model
         return $this->belongsTo(User::class);
     }
 
+    /** @return HasMany<TalentRequestTrackedUser, $this> */
+    public function trackedUsers(): BelongsTo
+    {
+        return $this->belongsTo(TalentRequestTrackedUser::class);
+    }
+
     /**
      * Aggregate accessor: returns the localized label for whichever detail field is populated.
      */

--- a/api/app/Models/TalentRequest.php
+++ b/api/app/Models/TalentRequest.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 use Spatie\Activitylog\Models\Concerns\LogsActivity;
@@ -113,9 +114,9 @@ class TalentRequest extends Model
     }
 
     /** @return HasMany<TalentRequestTrackedUser, $this> */
-    public function trackedUsers(): BelongsTo
+    public function trackedUsers(): HasMany
     {
-        return $this->belongsTo(TalentRequestTrackedUser::class);
+        return $this->hasMany(TalentRequestTrackedUser::class);
     }
 
     /**

--- a/api/app/Models/TalentRequestTrackedUser.php
+++ b/api/app/Models/TalentRequestTrackedUser.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Database\Factories\TalentRequestTrackedUserFactory;
 use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
@@ -24,12 +25,13 @@ use Spatie\Activitylog\Support\LogOptions;
  * @property ?Carbon $updated_at
  * @property ?Carbon $deleted_at
  */
-#[Table(keyType: 'string', incrementing: false)]
+#[Table(name: 'talent_request_tracked_users', keyType: 'string', incrementing: false)]
 class TalentRequestTrackedUser extends Pivot
 {
     /** @use HasFactory<TalentRequestTrackedUserFactory> */
     use HasFactory;
 
+    use HasUuids;
     use LogsActivity;
 
     public function getActivitylogOptions(): LogOptions

--- a/api/app/Models/TalentRequestTrackedUser.php
+++ b/api/app/Models/TalentRequestTrackedUser.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\TalentRequestTrackedUserFactory;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use Spatie\Activitylog\Models\Concerns\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
+
+/**
+ * Class TalentRequestTrackedUser
+ *
+ * @property string $id
+ * @property string $user_id
+ * @property string $talent_request_id
+ * @property string $referral_decision
+ * @property string $selection_decision
+ * @property string $not_referred_reason
+ * @property string $not_selected_reason
+ * @property Carbon $created_at
+ * @property ?Carbon $updated_at
+ * @property ?Carbon $deleted_at
+ */
+#[Table(keyType: 'string', incrementing: false)]
+class TalentRequestTrackedUser extends Pivot
+{
+    /** @use HasFactory<TalentRequestTrackedUserFactory> */
+    use HasFactory;
+
+    use LogsActivity;
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['*'])
+            ->logOnlyDirty()
+            ->dontLogEmptyChanges();
+    }
+
+    /** @return BelongsTo<TalentRequest, $this> */
+    public function talentRequest(): BelongsTo
+    {
+        return $this->belongsTo(TalentRequest::class);
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/api/app/Models/TalentRequestTrackedUser.php
+++ b/api/app/Models/TalentRequestTrackedUser.php
@@ -83,4 +83,26 @@ class TalentRequestTrackedUser extends Pivot
             }),
         ]);
     }
+
+    /**
+     * @param  ?array<string>  $decisions
+     */
+    public function scopeWhereReferralDecisionIn(Builder $query, ?array $decisions): Builder
+    {
+        return $query->when(
+            $decisions,
+            fn (Builder $query) => $query->whereIn('referral_decision', $decisions)
+        );
+    }
+
+    /**
+     * @param  ?array<string>  $decisions
+     */
+    public function scopeWhereSelectionDecisionIn(Builder $query, ?array $decisions): Builder
+    {
+        return $query->when(
+            $decisions,
+            fn (Builder $query) => $query->whereIn('selection_decision', $decisions)
+        );
+    }
 }

--- a/api/app/Models/TalentRequestTrackedUser.php
+++ b/api/app/Models/TalentRequestTrackedUser.php
@@ -2,8 +2,10 @@
 
 namespace App\Models;
 
+use App\Builders\UserBuilder;
 use Database\Factories\TalentRequestTrackedUserFactory;
 use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -52,5 +54,33 @@ class TalentRequestTrackedUser extends Pivot
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Only keep tracked users whose underlying user the viewer is allowed to see.
+     */
+    public function scopeWhereAuthorizedToView(Builder $query): Builder
+    {
+        return $query->whereHas('user', function (Builder $userQuery) {
+            /** @var UserBuilder $userQuery */
+            $userQuery->whereAuthorizedToView();
+        });
+    }
+
+    /**
+     * Add a live count of the user's skills that match this request's applicant filter skills.
+     */
+    public function scopeWithSkillCount(Builder $query): Builder
+    {
+        return $query->addSelect(['skill_count' => UserSkill::query()
+            ->selectRaw('count(*)')
+            ->whereColumn('user_skills.user_id', 'talent_request_tracked_users.user_id')
+            ->whereIn('user_skills.skill_id', function ($subQuery) {
+                $subQuery->select('applicant_filter_skill.skill_id')
+                    ->from('applicant_filter_skill')
+                    ->join('talent_requests', 'talent_requests.applicant_filter_id', '=', 'applicant_filter_skill.applicant_filter_id')
+                    ->whereColumn('talent_requests.id', 'talent_request_tracked_users.talent_request_id');
+            }),
+        ]);
     }
 }

--- a/api/app/Models/TalentRequestTrackedUser.php
+++ b/api/app/Models/TalentRequestTrackedUser.php
@@ -20,10 +20,10 @@ use Spatie\Activitylog\Support\LogOptions;
  * @property string $id
  * @property string $user_id
  * @property string $talent_request_id
- * @property string $referral_decision
- * @property string $selection_decision
- * @property string $not_referred_reason
- * @property string $not_selected_reason
+ * @property ?string $referral_decision
+ * @property ?string $selection_decision
+ * @property ?string $not_referred_reason
+ * @property ?string $not_selected_reason
  * @property Carbon $created_at
  * @property ?Carbon $updated_at
  */

--- a/api/app/Models/TalentRequestTrackedUser.php
+++ b/api/app/Models/TalentRequestTrackedUser.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Support\Carbon;
 use Spatie\Activitylog\Models\Concerns\LogsActivity;
 use Spatie\Activitylog\Support\LogOptions;
 
@@ -25,7 +26,6 @@ use Spatie\Activitylog\Support\LogOptions;
  * @property string $not_selected_reason
  * @property Carbon $created_at
  * @property ?Carbon $updated_at
- * @property ?Carbon $deleted_at
  */
 #[Table(name: 'talent_request_tracked_users', keyType: 'string', incrementing: false)]
 class TalentRequestTrackedUser extends Pivot

--- a/api/app/Models/TalentRequestTrackedUser.php
+++ b/api/app/Models/TalentRequestTrackedUser.php
@@ -84,9 +84,6 @@ class TalentRequestTrackedUser extends Pivot
         ]);
     }
 
-    /**
-     * @param  ?array<string>  $decisions
-     */
     public function scopeWhereReferralDecisionIn(Builder $query, ?array $decisions): Builder
     {
         return $query->when(
@@ -95,9 +92,6 @@ class TalentRequestTrackedUser extends Pivot
         );
     }
 
-    /**
-     * @param  ?array<string>  $decisions
-     */
     public function scopeWhereSelectionDecisionIn(Builder $query, ?array $decisions): Builder
     {
         return $query->when(

--- a/api/database/factories/TalentRequestFactory.php
+++ b/api/database/factories/TalentRequestFactory.php
@@ -2,16 +2,25 @@
 
 namespace Database\Factories;
 
+use App\Enums\IndigenousCommunity;
+use App\Enums\LanguageAbility;
+use App\Enums\PositionDuration;
+use App\Enums\SkillLevel;
 use App\Enums\TalentRequestCompletionDetail;
 use App\Enums\TalentRequestInProgressDetail;
 use App\Enums\TalentRequestPositionType;
 use App\Enums\TalentRequestReason;
 use App\Enums\TalentRequestStatus;
+use App\Enums\WhenSkillUsed;
 use App\Models\ApplicantFilter;
 use App\Models\Community;
 use App\Models\Department;
+use App\Models\Pool;
+use App\Models\PoolCandidate;
 use App\Models\TalentRequest;
+use App\Models\TalentRequestTrackedUser;
 use App\Models\User;
+use App\Models\UserSkill;
 
 class TalentRequestFactory extends BaseFactory
 {
@@ -57,5 +66,100 @@ class TalentRequestFactory extends BaseFactory
             'in_progress_details' => null,
             'follow_up_date' => null,
         ]);
+    }
+
+    /**
+     * Attach tracked users, each backed by a qualified & available PoolCandidate
+     * that satisfies the request's ApplicantFilter (i.e. would surface in a search).
+     */
+    public function withTrackedUsers(int $count = 3): self
+    {
+        return $this->afterCreating(function (TalentRequest $talentRequest) use ($count) {
+            $filter = $talentRequest->applicantFilter;
+
+            for ($i = 0; $i < $count; $i++) {
+                $user = User::factory()->create($this->matchingUserAttributes($filter));
+
+                $pool = Pool::factory()->candidatesAvailableInSearch()->create(array_filter([
+                    'community_id' => $filter->community_id,
+                    'classification_id' => $filter->qualifiedInClassifications->shuffle()->first()?->id,
+                    'work_stream_id' => $filter->qualifiedInWorkStreams->shuffle()->first()?->id,
+                ]));
+
+                PoolCandidate::factory()
+                    ->availableInSearch()
+                    ->create([
+                        'pool_id' => $pool->id,
+                        'user_id' => $user->id,
+                    ]);
+
+                // whereSkillsAdditive is an OR match - only one filter skill is required.
+                // Take a random non-empty subset per user for a spread of skill coverage.
+                $skills = $filter->skills;
+                if ($skills->isNotEmpty()) {
+                    $skills->shuffle()
+                        ->take($this->faker->numberBetween(1, $skills->count()))
+                        ->each(fn ($skill) => UserSkill::firstOrCreate(
+                            ['user_id' => $user->id, 'skill_id' => $skill->id],
+                            [
+                                'skill_level' => $this->randomEnum(SkillLevel::class),
+                                'when_skill_used' => $this->randomEnum(WhenSkillUsed::class),
+                            ]
+                        ));
+                }
+
+                TalentRequestTrackedUser::factory()->create([
+                    'talent_request_id' => $talentRequest->id,
+                    'user_id' => $user->id,
+                ]);
+            }
+        });
+    }
+
+    /**
+     * Build User attributes that satisfy the scalar/equity/language scopes of an ApplicantFilter.
+     *
+     * @return array<string, mixed>
+     */
+    private function matchingUserAttributes(ApplicantFilter $filter): array
+    {
+        // whereEquityIn is an OR match - the user only needs one of the requested attributes.
+        // Pick a random non-empty subset per user for a spread of equity coverage.
+        $requestedEquity = array_keys(array_filter([
+            'is_woman' => $filter->is_woman,
+            'has_disability' => $filter->has_disability,
+            'is_visible_minority' => $filter->is_visible_minority,
+            'is_indigenous' => $filter->is_indigenous,
+        ]));
+        $chosenEquity = empty($requestedEquity)
+            ? []
+            : (array) $this->faker->randomElements($requestedEquity, $this->faker->numberBetween(1, count($requestedEquity)));
+
+        return [
+            'has_diploma' => $filter->has_diploma ?: $this->faker->boolean(),
+
+            // equity (OR match)
+            'is_woman' => in_array('is_woman', $chosenEquity),
+            'has_disability' => in_array('has_disability', $chosenEquity),
+            'is_visible_minority' => in_array('is_visible_minority', $chosenEquity),
+            'indigenous_communities' => in_array('is_indigenous', $chosenEquity)
+                ? [$this->faker->randomElement(IndigenousCommunity::cases())->name]
+                : [],
+
+            // language ability
+            'looking_for_english' => $filter->language_ability === LanguageAbility::ENGLISH->name,
+            'looking_for_french' => $filter->language_ability === LanguageAbility::FRENCH->name,
+            'looking_for_bilingual' => $filter->language_ability === LanguageAbility::BILINGUAL->name,
+
+            // operational requirements (AND match) - must contain all requested
+            'accepted_operational_requirements' => $filter->operational_requirements ?? [],
+
+            // position duration (OR match)
+            'position_duration' => $filter->position_duration ?: [PositionDuration::PERMANENT->name],
+
+            // location (special matching) - mirror the filter so the sets overlap
+            'location_preferences' => $filter->location_preferences ?? [],
+            'flexible_work_locations' => $filter->flexible_work_locations ?? [],
+        ];
     }
 }

--- a/api/database/factories/TalentRequestTrackedUserFactory.php
+++ b/api/database/factories/TalentRequestTrackedUserFactory.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\TalentRequestTrackedUserNotReferredReason;
+use App\Enums\TalentRequestTrackedUserNotSelectedReason;
+use App\Enums\TalentRequestTrackedUserReferralDecision;
+use App\Enums\TalentRequestTrackedUserSelectionDecision;
+use App\Models\TalentRequest;
+use App\Models\TalentRequestTrackedUser;
+use App\Models\User;
+
+/**
+ * @extends BaseFactory<TalentRequestTrackedUser>
+ */
+class TalentRequestTrackedUserFactory extends BaseFactory
+{
+    protected $model = TalentRequestTrackedUser::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => fn () => User::factory(),
+            'talent_request_id' => fn () => TalentRequest::factory(),
+            'referral_decision' => null,
+            'selection_decision' => null,
+            'not_referred_reason' => null,
+            'not_selected_reason' => null,
+        ];
+    }
+
+    public function referred(): self
+    {
+        return $this->state(fn () => [
+            'referral_decision' => TalentRequestTrackedUserReferralDecision::REFERRED->name,
+            'not_referred_reason' => null,
+        ]);
+    }
+
+    public function notReferred(?TalentRequestTrackedUserNotReferredReason $reason = null): self
+    {
+        $reason = $reason?->name ?? $this->randomEnum(TalentRequestTrackedUserNotReferredReason::class);
+
+        return $this->state(fn () => [
+            'referral_decision' => TalentRequestTrackedUserReferralDecision::NOT_REFERRED->name,
+            'not_referred_reason' => $reason,
+            'selection_decision' => null,
+            'not_selected_reason' => null,
+        ]);
+    }
+
+    public function selected(): self
+    {
+        return $this->referred()->state(fn () => [
+            'selection_decision' => TalentRequestTrackedUserSelectionDecision::SELECTED->name,
+            'not_selected_reason' => null,
+        ]);
+    }
+
+    public function notSelected(?TalentRequestTrackedUserNotSelectedReason $reason = null): self
+    {
+        $reason = $reason?->name ?? $this->randomEnum(TalentRequestTrackedUserNotSelectedReason::class);
+
+        return $this->referred()->state(fn () => [
+            'selection_decision' => TalentRequestTrackedUserSelectionDecision::NOT_SELECTED->name,
+            'not_selected_reason' => $reason,
+        ]);
+    }
+}

--- a/api/database/migrations/2026_06_03_114126_create_talent_request_tracked_users_table.php
+++ b/api/database/migrations/2026_06_03_114126_create_talent_request_tracked_users_table.php
@@ -22,6 +22,8 @@ return new class() extends Migration
                 ->constrained()
                 ->onDelete('cascade');
 
+            $table->unique(['talent_request_id', 'user_id']);
+
             $table->string('referral_decision')->nullable();
             $table->string('selection_decision')->nullable();
             $table->string('not_referred_reason')->nullable();

--- a/api/database/migrations/2026_06_03_114126_create_talent_request_tracked_users_table.php
+++ b/api/database/migrations/2026_06_03_114126_create_talent_request_tracked_users_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('talent_request_tracked_users', function (Blueprint $table) {
+            $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
+
+            $table->foreignUuid('user_id')
+                ->constrained()
+                ->onDelete('cascade');
+            $table->foreignUuid('talent_request_id')
+                ->constrained()
+                ->onDelete('cascade');
+
+            $table->string('referral_decision')->nullable();
+            $table->string('selection_decision')->nullable();
+            $table->string('not_referred_reason')->nullable();
+            $table->string('not_selected_reason')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('talent_request_tracked_users');
+    }
+};

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1156,6 +1156,22 @@ type TalentRequest {
   statusChangedAt: DateTime @rename(attribute: "status_changed_at")
   createdAt: DateTime @rename(attribute: "created_at")
   updatedAt: DateTime @rename(attribute: "updated_at")
+  trackedUsers: [TalentRequestTrackedUser!]
+    @hasMany(scopes: ["whereAuthorizedToView", "withSkillCount"])
+}
+
+type TalentRequestTrackedUser {
+  id: UUID!
+  user: User! @belongsTo
+  skillCount: Int @rename(attribute: "skill_count") # live subquery column from the withSkillCount scope - count of the user's skills matching this request's applicant filter
+  referralDecision: LocalizedTalentRequestTrackedUserReferralDecision
+    @rename(attribute: "referral_decision")
+  selectionDecision: LocalizedTalentRequestTrackedUserSelectionDecision
+    @rename(attribute: "selection_decision")
+  notReferredReason: LocalizedTalentRequestTrackedUserNotReferredReason
+    @rename(attribute: "not_referred_reason")
+  notSelectedReason: LocalizedTalentRequestTrackedUserNotSelectedReason
+    @rename(attribute: "not_selected_reason")
 }
 
 type SkillFamily {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1156,8 +1156,15 @@ type TalentRequest {
   statusChangedAt: DateTime @rename(attribute: "status_changed_at")
   createdAt: DateTime @rename(attribute: "created_at")
   updatedAt: DateTime @rename(attribute: "updated_at")
-  trackedUsers: [TalentRequestTrackedUser!]
+  trackedUsers(where: TalentRequestTrackedUserFilterInput): [TalentRequestTrackedUser!]
     @hasMany(scopes: ["whereAuthorizedToView", "withSkillCount"])
+}
+
+input TalentRequestTrackedUserFilterInput {
+  referralDecisions: [TalentRequestTrackedUserReferralDecision!]
+    @scope(name: "whereReferralDecisionIn")
+  selectionDecisions: [TalentRequestTrackedUserSelectionDecision!]
+    @scope(name: "whereSelectionDecisionIn")
 }
 
 type TalentRequestTrackedUser {

--- a/api/lang/en/talent_request_tracked_user_not_referred_reason.php
+++ b/api/lang/en/talent_request_tracked_user_not_referred_reason.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Support\Facades\Lang;
+
+return [
+    'other' => Lang::get('common.other', [], 'en'),
+];

--- a/api/lang/en/talent_request_tracked_user_not_selected_reason.php
+++ b/api/lang/en/talent_request_tracked_user_not_selected_reason.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Support\Facades\Lang;
+
+return [
+    'other' => Lang::get('common.other', [], 'en'),
+];

--- a/api/lang/en/talent_request_tracked_user_referral_decision.php
+++ b/api/lang/en/talent_request_tracked_user_referral_decision.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'referred' => 'Referred',
+    'not_referred' => 'Not referred',
+];

--- a/api/lang/en/talent_request_tracked_user_selection_decision.php
+++ b/api/lang/en/talent_request_tracked_user_selection_decision.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'selected' => 'Selected',
+    'not_selected' => 'Not selected',
+];

--- a/api/lang/fr/talent_request_tracked_user_not_referred_reason.php
+++ b/api/lang/fr/talent_request_tracked_user_not_referred_reason.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Support\Facades\Lang;
+
+return [
+    'other' => Lang::get('common.other', [], 'fr'),
+];

--- a/api/lang/fr/talent_request_tracked_user_not_selected_reason.php
+++ b/api/lang/fr/talent_request_tracked_user_not_selected_reason.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Support\Facades\Lang;
+
+return [
+    'other' => Lang::get('common.other', [], 'fr'),
+];

--- a/api/lang/fr/talent_request_tracked_user_referral_decision.php
+++ b/api/lang/fr/talent_request_tracked_user_referral_decision.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'referred' => 'Recommandation effectuée',
+    'not_referred' => 'Pas de recommandation',
+];

--- a/api/lang/fr/talent_request_tracked_user_selection_decision.php
+++ b/api/lang/fr/talent_request_tracked_user_selection_decision.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'selected' => 'Candidature retenue',
+    'not_selected' => 'Candidature non retenue',
+];

--- a/api/programmatic-types.graphql
+++ b/api/programmatic-types.graphql
@@ -429,6 +429,26 @@ type LocalizedTalentRequestStatus implements LocalizedEnumOption {
   label: LocalizedString!
 }
 
+type LocalizedTalentRequestTrackedUserNotReferredReason implements LocalizedEnumOption {
+  value: TalentRequestTrackedUserNotReferredReason!
+  label: LocalizedString!
+}
+
+type LocalizedTalentRequestTrackedUserNotSelectedReason implements LocalizedEnumOption {
+  value: TalentRequestTrackedUserNotSelectedReason!
+  label: LocalizedString!
+}
+
+type LocalizedTalentRequestTrackedUserReferralDecision implements LocalizedEnumOption {
+  value: TalentRequestTrackedUserReferralDecision!
+  label: LocalizedString!
+}
+
+type LocalizedTalentRequestTrackedUserSelectionDecision implements LocalizedEnumOption {
+  value: TalentRequestTrackedUserSelectionDecision!
+  label: LocalizedString!
+}
+
 type LocalizedTargetRole implements LocalizedEnumOption {
   value: TargetRole!
   label: LocalizedString!
@@ -1978,6 +1998,24 @@ enum TalentRequestStatus {
   NEW
   IN_PROGRESS
   COMPLETED
+}
+
+enum TalentRequestTrackedUserNotReferredReason {
+  OTHER
+}
+
+enum TalentRequestTrackedUserNotSelectedReason {
+  OTHER
+}
+
+enum TalentRequestTrackedUserReferralDecision {
+  REFERRED
+  NOT_REFERRED
+}
+
+enum TalentRequestTrackedUserSelectionDecision {
+  SELECTED
+  NOT_SELECTED
 }
 
 enum TargetRole {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1615,7 +1615,12 @@ type TalentRequest {
   statusChangedAt: DateTime
   createdAt: DateTime
   updatedAt: DateTime
-  trackedUsers: [TalentRequestTrackedUser!]
+  trackedUsers(where: TalentRequestTrackedUserFilterInput): [TalentRequestTrackedUser!]
+}
+
+input TalentRequestTrackedUserFilterInput {
+  referralDecisions: [TalentRequestTrackedUserReferralDecision!]
+  selectionDecisions: [TalentRequestTrackedUserSelectionDecision!]
 }
 
 type TalentRequestTrackedUser {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -418,6 +418,26 @@ type LocalizedTalentRequestStatus implements LocalizedEnumOption {
   label: LocalizedString!
 }
 
+type LocalizedTalentRequestTrackedUserNotReferredReason implements LocalizedEnumOption {
+  value: TalentRequestTrackedUserNotReferredReason!
+  label: LocalizedString!
+}
+
+type LocalizedTalentRequestTrackedUserNotSelectedReason implements LocalizedEnumOption {
+  value: TalentRequestTrackedUserNotSelectedReason!
+  label: LocalizedString!
+}
+
+type LocalizedTalentRequestTrackedUserReferralDecision implements LocalizedEnumOption {
+  value: TalentRequestTrackedUserReferralDecision!
+  label: LocalizedString!
+}
+
+type LocalizedTalentRequestTrackedUserSelectionDecision implements LocalizedEnumOption {
+  value: TalentRequestTrackedUserSelectionDecision!
+  label: LocalizedString!
+}
+
 type LocalizedTargetRole implements LocalizedEnumOption {
   value: TargetRole!
   label: LocalizedString!
@@ -1595,6 +1615,17 @@ type TalentRequest {
   statusChangedAt: DateTime
   createdAt: DateTime
   updatedAt: DateTime
+  trackedUsers: [TalentRequestTrackedUser!]
+}
+
+type TalentRequestTrackedUser {
+  id: UUID!
+  user: User!
+  skillCount: Int
+  referralDecision: LocalizedTalentRequestTrackedUserReferralDecision
+  selectionDecision: LocalizedTalentRequestTrackedUserSelectionDecision
+  notReferredReason: LocalizedTalentRequestTrackedUserNotReferredReason
+  notSelectedReason: LocalizedTalentRequestTrackedUserNotSelectedReason
 }
 
 type SkillFamily {
@@ -4641,6 +4672,24 @@ enum TalentRequestStatus {
   NEW
   IN_PROGRESS
   COMPLETED
+}
+
+enum TalentRequestTrackedUserNotReferredReason {
+  OTHER
+}
+
+enum TalentRequestTrackedUserNotSelectedReason {
+  OTHER
+}
+
+enum TalentRequestTrackedUserReferralDecision {
+  REFERRED
+  NOT_REFERRED
+}
+
+enum TalentRequestTrackedUserSelectionDecision {
+  SELECTED
+  NOT_SELECTED
 }
 
 enum TargetRole {

--- a/api/tests/Feature/TalentRequestTrackedUserTest.php
+++ b/api/tests/Feature/TalentRequestTrackedUserTest.php
@@ -1,0 +1,305 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\TalentRequestTrackedUserNotReferredReason;
+use App\Enums\TalentRequestTrackedUserNotSelectedReason;
+use App\Enums\TalentRequestTrackedUserReferralDecision;
+use App\Enums\TalentRequestTrackedUserSelectionDecision;
+use App\Models\ApplicantFilter;
+use App\Models\Community;
+use App\Models\Pool;
+use App\Models\PoolCandidate;
+use App\Models\Skill;
+use App\Models\TalentRequest;
+use App\Models\TalentRequestTrackedUser;
+use App\Models\User;
+use App\Models\UserSkill;
+use Carbon\CarbonImmutable;
+use Database\Seeders\DepartmentSeeder;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+use Tests\UsesProtectedGraphqlEndpoint;
+
+class TalentRequestTrackedUserTest extends TestCase
+{
+    use MakesGraphQLRequests;
+    use RefreshDatabase;
+    use RefreshesSchemaCache;
+    use UsesProtectedGraphqlEndpoint;
+
+    protected Community $community;
+
+    protected User $admin;
+
+    protected User $recruiter;
+
+    protected string $query = <<<'GRAPHQL'
+        query TrackedUsers($id: ID!) {
+            talentRequest(id: $id) {
+                trackedUsers {
+                    skillCount
+                    user { id }
+                    referralDecision { value }
+                    selectionDecision { value }
+                    notReferredReason { value }
+                    notSelectedReason { value }
+                }
+            }
+        }
+        GRAPHQL;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([
+            RolePermissionSeeder::class,
+            DepartmentSeeder::class,
+        ]);
+
+        $this->community = Community::factory()->create();
+
+        $this->admin = User::factory()
+            ->asAdmin()
+            ->create([
+                'email' => 'admin@test.com',
+                'sub' => 'admin@test.com',
+            ]);
+
+        $this->recruiter = User::factory()
+            ->asCommunityRecruiter([$this->community->id])
+            ->create([
+                'email' => 'recruiter@test.com',
+                'sub' => 'recruiter@test.com',
+            ]);
+    }
+
+    private function createRequest(): TalentRequest
+    {
+        return TalentRequest::factory()->create(['community_id' => $this->community->id]);
+    }
+
+    public function testReturnsEmptyArrayWhenNoTrackedUsers(): void
+    {
+        $request = $this->createRequest();
+
+        $this->actingAs($this->admin, 'api')
+            ->graphQL($this->query, ['id' => $request->id])
+            ->assertJson(['data' => ['talentRequest' => ['trackedUsers' => []]]]);
+    }
+
+    /**
+     * @return array<string, array{0: array<string, string>, 1: array<string, mixed>}>
+     */
+    public static function decisionFieldsProvider(): array
+    {
+        return [
+            'no decisions' => [
+                [],
+                [
+                    'referralDecision' => null,
+                    'selectionDecision' => null,
+                    'notReferredReason' => null,
+                    'notSelectedReason' => null,
+                ],
+            ],
+            'referred' => [
+                ['referral_decision' => TalentRequestTrackedUserReferralDecision::REFERRED->name],
+                [
+                    'referralDecision' => ['value' => TalentRequestTrackedUserReferralDecision::REFERRED->name],
+                    'selectionDecision' => null,
+                    'notReferredReason' => null,
+                    'notSelectedReason' => null,
+                ],
+            ],
+            'not referred with reason' => [
+                [
+                    'referral_decision' => TalentRequestTrackedUserReferralDecision::NOT_REFERRED->name,
+                    'not_referred_reason' => TalentRequestTrackedUserNotReferredReason::OTHER->name,
+                ],
+                [
+                    'referralDecision' => ['value' => TalentRequestTrackedUserReferralDecision::NOT_REFERRED->name],
+                    'notReferredReason' => ['value' => TalentRequestTrackedUserNotReferredReason::OTHER->name],
+                    'selectionDecision' => null,
+                    'notSelectedReason' => null,
+                ],
+            ],
+            'selected' => [
+                [
+                    'referral_decision' => TalentRequestTrackedUserReferralDecision::REFERRED->name,
+                    'selection_decision' => TalentRequestTrackedUserSelectionDecision::SELECTED->name,
+                ],
+                [
+                    'referralDecision' => ['value' => TalentRequestTrackedUserReferralDecision::REFERRED->name],
+                    'selectionDecision' => ['value' => TalentRequestTrackedUserSelectionDecision::SELECTED->name],
+                    'notReferredReason' => null,
+                    'notSelectedReason' => null,
+                ],
+            ],
+            'not selected with reason' => [
+                [
+                    'referral_decision' => TalentRequestTrackedUserReferralDecision::REFERRED->name,
+                    'selection_decision' => TalentRequestTrackedUserSelectionDecision::NOT_SELECTED->name,
+                    'not_selected_reason' => TalentRequestTrackedUserNotSelectedReason::OTHER->name,
+                ],
+                [
+                    'referralDecision' => ['value' => TalentRequestTrackedUserReferralDecision::REFERRED->name],
+                    'selectionDecision' => ['value' => TalentRequestTrackedUserSelectionDecision::NOT_SELECTED->name],
+                    'notSelectedReason' => ['value' => TalentRequestTrackedUserNotSelectedReason::OTHER->name],
+                    'notReferredReason' => null,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, string>  $attributes
+     * @param  array<string, mixed>  $expected
+     */
+    #[DataProvider('decisionFieldsProvider')]
+    public function testDecisionFieldsResolve(array $attributes, array $expected): void
+    {
+        $request = $this->createRequest();
+        $user = User::factory()->create();
+
+        TalentRequestTrackedUser::factory()->create([
+            'talent_request_id' => $request->id,
+            'user_id' => $user->id,
+            ...$attributes,
+        ]);
+
+        $this->actingAs($this->admin, 'api')
+            ->graphQL($this->query, ['id' => $request->id])
+            ->assertJsonFragment([
+                'user' => ['id' => $user->id],
+                ...$expected,
+            ]);
+    }
+
+    /**
+     * @return array<string, array{0: int, 1: int}>
+     */
+    public static function skillCountProvider(): array
+    {
+        return [
+            'no matching skills' => [0, 0],
+            'one matching skill' => [1, 1],
+            'all matching skills' => [3, 3],
+        ];
+    }
+
+    #[DataProvider('skillCountProvider')]
+    public function testSkillCountCountsOnlyApplicantFilterSkills(int $matching, int $expected): void
+    {
+        $filterSkills = Skill::factory()->count(3)->create();
+        $filter = ApplicantFilter::factory()->create(['community_id' => $this->community->id]);
+        $filter->skills()->sync($filterSkills->pluck('id')->all());
+
+        $request = TalentRequest::factory()->create([
+            'community_id' => $this->community->id,
+            'applicant_filter_id' => $filter->id,
+        ]);
+
+        $user = User::factory()->create();
+        // an unrelated skill that must never be counted
+        UserSkill::factory()->create(['user_id' => $user->id, 'skill_id' => Skill::factory()->create()->id]);
+        foreach ($filterSkills->take($matching) as $skill) {
+            UserSkill::factory()->create(['user_id' => $user->id, 'skill_id' => $skill->id]);
+        }
+
+        TalentRequestTrackedUser::factory()->create([
+            'talent_request_id' => $request->id,
+            'user_id' => $user->id,
+        ]);
+
+        $this->actingAs($this->admin, 'api')
+            ->graphQL($this->query, ['id' => $request->id])
+            ->assertJsonFragment([
+                'user' => ['id' => $user->id],
+                'skillCount' => $expected,
+            ]);
+    }
+
+    public function testPlatformAdminSeesAllTrackedUsers(): void
+    {
+        $request = $this->createRequest();
+        $users = User::factory()->count(3)->create();
+        foreach ($users as $user) {
+            TalentRequestTrackedUser::factory()->create([
+                'talent_request_id' => $request->id,
+                'user_id' => $user->id,
+            ]);
+        }
+
+        $this->actingAs($this->admin, 'api')
+            ->graphQL($this->query, ['id' => $request->id])
+            ->assertJsonCount(3, 'data.talentRequest.trackedUsers');
+    }
+
+    public function testTrackedUsersFilteredToThoseTheViewerCanSee(): void
+    {
+        $request = $this->createRequest();
+
+        // viewable: applicant with a submitted candidate in a published pool of the community
+        $pool = Pool::factory()->for($this->admin)->published()
+            ->create(['community_id' => $this->community->id]);
+        $viewableUser = User::factory()->asApplicant()->create();
+        PoolCandidate::factory()->for($viewableUser)->for($pool)
+            ->create(['submitted_at' => CarbonImmutable::now()]);
+
+        // hidden: plain applicant with no candidacy in the community
+        $hiddenUser = User::factory()->asApplicant()->create();
+
+        foreach ([$viewableUser, $hiddenUser] as $user) {
+            TalentRequestTrackedUser::factory()->create([
+                'talent_request_id' => $request->id,
+                'user_id' => $user->id,
+            ]);
+        }
+
+        $this->actingAs($this->recruiter, 'api')
+            ->graphQL($this->query, ['id' => $request->id])
+            ->assertJsonCount(1, 'data.talentRequest.trackedUsers')
+            ->assertJsonFragment(['user' => ['id' => $viewableUser->id]])
+            ->assertJsonMissing(['user' => ['id' => $hiddenUser->id]]);
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function cannotViewRequestProvider(): array
+    {
+        return [
+            'applicant' => ['applicant'],
+            'recruiter of other community' => ['other_recruiter'],
+        ];
+    }
+
+    #[DataProvider('cannotViewRequestProvider')]
+    public function testRolesWithoutAccessCannotViewRequest(string $role): void
+    {
+        $request = $this->createRequest();
+
+        $actor = match ($role) {
+            'applicant' => User::factory()->asApplicant()->create(),
+            'other_recruiter' => User::factory()->asCommunityRecruiter([Community::factory()->create()->id])->create(),
+        };
+
+        $this->actingAs($actor, 'api')
+            ->graphQL($this->query, ['id' => $request->id])
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
+    }
+
+    public function testUnauthenticatedCannotViewRequest(): void
+    {
+        $request = $this->createRequest();
+
+        $this->graphQL($this->query, ['id' => $request->id])
+            ->assertGraphQLErrorMessage('Unauthenticated.');
+    }
+}

--- a/api/tests/Feature/TalentRequestTrackedUserTest.php
+++ b/api/tests/Feature/TalentRequestTrackedUserTest.php
@@ -53,6 +53,18 @@ class TalentRequestTrackedUserTest extends TestCase
         }
         GRAPHQL;
 
+    protected string $filterQuery = <<<'GRAPHQL'
+        query FilteredTrackedUsers($id: ID!, $where: TalentRequestTrackedUserFilterInput) {
+            talentRequest(id: $id) {
+                trackedUsers(where: $where) {
+                    user { id }
+                    referralDecision { value }
+                    selectionDecision { value }
+                }
+            }
+        }
+        GRAPHQL;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -94,13 +106,13 @@ class TalentRequestTrackedUserTest extends TestCase
     }
 
     /**
-     * @return array<string, array{0: array<string, string>, 1: array<string, mixed>}>
+     * @return array<string, array{0: string, 1: array<string, mixed>}>
      */
     public static function decisionFieldsProvider(): array
     {
         return [
             'no decisions' => [
-                [],
+                'default',
                 [
                     'referralDecision' => null,
                     'selectionDecision' => null,
@@ -109,7 +121,7 @@ class TalentRequestTrackedUserTest extends TestCase
                 ],
             ],
             'referred' => [
-                ['referral_decision' => TalentRequestTrackedUserReferralDecision::REFERRED->name],
+                'referred',
                 [
                     'referralDecision' => ['value' => TalentRequestTrackedUserReferralDecision::REFERRED->name],
                     'selectionDecision' => null,
@@ -118,10 +130,7 @@ class TalentRequestTrackedUserTest extends TestCase
                 ],
             ],
             'not referred with reason' => [
-                [
-                    'referral_decision' => TalentRequestTrackedUserReferralDecision::NOT_REFERRED->name,
-                    'not_referred_reason' => TalentRequestTrackedUserNotReferredReason::OTHER->name,
-                ],
+                'notReferred',
                 [
                     'referralDecision' => ['value' => TalentRequestTrackedUserReferralDecision::NOT_REFERRED->name],
                     'notReferredReason' => ['value' => TalentRequestTrackedUserNotReferredReason::OTHER->name],
@@ -130,10 +139,7 @@ class TalentRequestTrackedUserTest extends TestCase
                 ],
             ],
             'selected' => [
-                [
-                    'referral_decision' => TalentRequestTrackedUserReferralDecision::REFERRED->name,
-                    'selection_decision' => TalentRequestTrackedUserSelectionDecision::SELECTED->name,
-                ],
+                'selected',
                 [
                     'referralDecision' => ['value' => TalentRequestTrackedUserReferralDecision::REFERRED->name],
                     'selectionDecision' => ['value' => TalentRequestTrackedUserSelectionDecision::SELECTED->name],
@@ -142,11 +148,7 @@ class TalentRequestTrackedUserTest extends TestCase
                 ],
             ],
             'not selected with reason' => [
-                [
-                    'referral_decision' => TalentRequestTrackedUserReferralDecision::REFERRED->name,
-                    'selection_decision' => TalentRequestTrackedUserSelectionDecision::NOT_SELECTED->name,
-                    'not_selected_reason' => TalentRequestTrackedUserNotSelectedReason::OTHER->name,
-                ],
+                'notSelected',
                 [
                     'referralDecision' => ['value' => TalentRequestTrackedUserReferralDecision::REFERRED->name],
                     'selectionDecision' => ['value' => TalentRequestTrackedUserSelectionDecision::NOT_SELECTED->name],
@@ -158,19 +160,24 @@ class TalentRequestTrackedUserTest extends TestCase
     }
 
     /**
-     * @param  array<string, string>  $attributes
      * @param  array<string, mixed>  $expected
      */
     #[DataProvider('decisionFieldsProvider')]
-    public function testDecisionFieldsResolve(array $attributes, array $expected): void
+    public function testDecisionFieldsResolve(string $state, array $expected): void
     {
         $request = $this->createRequest();
         $user = User::factory()->create();
 
-        TalentRequestTrackedUser::factory()->create([
+        $factory = match ($state) {
+            'default' => TalentRequestTrackedUser::factory(),
+            'referred' => TalentRequestTrackedUser::factory()->referred(),
+            'notReferred' => TalentRequestTrackedUser::factory()->notReferred(TalentRequestTrackedUserNotReferredReason::OTHER),
+            'selected' => TalentRequestTrackedUser::factory()->selected(),
+            'notSelected' => TalentRequestTrackedUser::factory()->notSelected(TalentRequestTrackedUserNotSelectedReason::OTHER),
+        };
+        $factory->create([
             'talent_request_id' => $request->id,
             'user_id' => $user->id,
-            ...$attributes,
         ]);
 
         $this->actingAs($this->admin, 'api')
@@ -301,5 +308,121 @@ class TalentRequestTrackedUserTest extends TestCase
 
         $this->graphQL($this->query, ['id' => $request->id])
             ->assertGraphQLErrorMessage('Unauthenticated.');
+    }
+
+    /**
+     * @return array<string, array{0: array<int, string>, 1: array<int, string>}>
+     */
+    public static function referralFilterProvider(): array
+    {
+        return [
+            'referred only' => [
+                [TalentRequestTrackedUserReferralDecision::REFERRED->name],
+                ['referred'],
+            ],
+            'not referred only' => [
+                [TalentRequestTrackedUserReferralDecision::NOT_REFERRED->name],
+                ['notReferred'],
+            ],
+            'both decisions' => [
+                [
+                    TalentRequestTrackedUserReferralDecision::REFERRED->name,
+                    TalentRequestTrackedUserReferralDecision::NOT_REFERRED->name,
+                ],
+                ['referred', 'notReferred'],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<int, string>  $filter
+     * @param  array<int, string>  $expectedKeys
+     */
+    #[DataProvider('referralFilterProvider')]
+    public function testFilterByReferralDecisions(array $filter, array $expectedKeys): void
+    {
+        $request = $this->createRequest();
+        $users = [
+            'referred' => User::factory()->create(),
+            'notReferred' => User::factory()->create(),
+        ];
+
+        TalentRequestTrackedUser::factory()->referred()->create([
+            'talent_request_id' => $request->id,
+            'user_id' => $users['referred']->id,
+        ]);
+        TalentRequestTrackedUser::factory()->notReferred()->create([
+            'talent_request_id' => $request->id,
+            'user_id' => $users['notReferred']->id,
+        ]);
+
+        $response = $this->actingAs($this->admin, 'api')
+            ->graphQL($this->filterQuery, [
+                'id' => $request->id,
+                'where' => ['referralDecisions' => $filter],
+            ])
+            ->assertJsonCount(count($expectedKeys), 'data.talentRequest.trackedUsers');
+
+        foreach ($expectedKeys as $key) {
+            $response->assertJsonFragment(['user' => ['id' => $users[$key]->id]]);
+        }
+    }
+
+    /**
+     * @return array<string, array{0: array<int, string>, 1: array<int, string>}>
+     */
+    public static function selectionFilterProvider(): array
+    {
+        return [
+            'selected only' => [
+                [TalentRequestTrackedUserSelectionDecision::SELECTED->name],
+                ['selected'],
+            ],
+            'not selected only' => [
+                [TalentRequestTrackedUserSelectionDecision::NOT_SELECTED->name],
+                ['notSelected'],
+            ],
+            'both decisions' => [
+                [
+                    TalentRequestTrackedUserSelectionDecision::SELECTED->name,
+                    TalentRequestTrackedUserSelectionDecision::NOT_SELECTED->name,
+                ],
+                ['selected', 'notSelected'],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<int, string>  $filter
+     * @param  array<int, string>  $expectedKeys
+     */
+    #[DataProvider('selectionFilterProvider')]
+    public function testFilterBySelectionDecisions(array $filter, array $expectedKeys): void
+    {
+        $request = $this->createRequest();
+        $users = [
+            'selected' => User::factory()->create(),
+            'notSelected' => User::factory()->create(),
+        ];
+
+        TalentRequestTrackedUser::factory()->selected()->create([
+            'talent_request_id' => $request->id,
+            'user_id' => $users['selected']->id,
+        ]);
+        TalentRequestTrackedUser::factory()->notSelected()->create([
+            'talent_request_id' => $request->id,
+            'user_id' => $users['notSelected']->id,
+        ]);
+
+        $response = $this->actingAs($this->admin, 'api')
+            ->graphQL($this->filterQuery, [
+                'id' => $request->id,
+                'where' => ['selectionDecisions' => $filter],
+            ])
+            ->assertJsonCount(count($expectedKeys), 'data.talentRequest.trackedUsers');
+
+        foreach ($expectedKeys as $key) {
+            $response->assertJsonFragment(['user' => ['id' => $users[$key]->id]]);
+        }
     }
 }


### PR DESCRIPTION
🤖 Resolves #16861 

## 👋 Introduction

Adds a new model `TalentRequestTrackedUser`.

## 🕵️ Details

This is the new pivot model between a `TalentRequest` and `User` with pivot information aobut the state of that tracked user. The contains:

 - Model
 - Factory
 - Migration
 - Schema changes
 - Scopes
 - Skill count matching
 - Tests

> [!NOTE]
> Notably, what this does not add is the actual queries and mutations for managing this. Those are to come in a different PR. 

## 🧪 Testing

1. Confirm the new model matches what is expected
2. Confirm tests cover the cases required (specficallty auth is important to have)