### PR TITLE
[Bug] Speed up slow query

### DIFF
--- a/api/database/migrations/2026_06_03_162804_add_index_for_experience_skill.php
+++ b/api/database/migrations/2026_06_03_162804_add_index_for_experience_skill.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('experience_skill', function (Blueprint $table) {
+            $table->index('experience_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('experience_skill', function (Blueprint $table) {
+            $table->dropIndex('geo_state_index');
+        });
+    }
+};

--- a/api/database/migrations/2026_06_03_162804_add_index_for_experience_skill.php
+++ b/api/database/migrations/2026_06_03_162804_add_index_for_experience_skill.php
@@ -22,7 +22,7 @@ return new class() extends Migration
     public function down(): void
     {
         Schema::table('experience_skill', function (Blueprint $table) {
-            $table->dropIndex('geo_state_index');
+            $table->dropIndex('experience_skill_experience_id_index');
         });
     }
 };


### PR DESCRIPTION
🤖 Resolves #16616 

## 👋 Introduction

Speeds up the career experiences query by adding an index.

## 🕵️ Details

At a point in the past we probably had a foreign key reference from `experience_skill.experience_id` to `experiences.id`.  After splitting up the experiences table we no longer had a index to quickly look up rows in `experience_skill` by experience_id.  This adds an index for that.

## 🧪 Testing


> [!WARNING]
> Database execution plans can vary a lot depending on the number of rows in a table and how recent the statistics are.  You may not be able to exactly replicate my results.  

> [!TIP]
> I'm using https://explain.dalibo.com/ to analyze my explain plans.  It's a cool tool and I recommend you use it, too.

Here's the query to use.  Substitute in one or more experience IDs from your `work_experiences` table.

```sql
EXPLAIN (ANALYZE, COSTS, VERBOSE, BUFFERS, FORMAT JSON)
select
    "skills".*,
    "experience_skill"."experience_id" as "laravel_through_key",
    "experience_skill"."created_at" as "__experience_skill__created_at",
    "experience_skill"."updated_at" as "__experience_skill__updated_at",
    "experience_skill"."details" as "__experience_skill__details"
from
    "skills"
    inner join "user_skills" on "user_skills"."skill_id" = "skills"."id"
    inner join "experience_skill" on "experience_skill"."user_skill_id" = "user_skills"."id"
where
    "experience_skill"."deleted_at" is null
    and "experience_skill"."experience_id" in ('019e8db2-aa33-70c6-8050-cd6a2631e237')
    and "experience_skill"."experience_type" = 'App\Models\WorkExperience'
    and "user_skills"."deleted_at" is null
```


1. Rollback the new migration (or don't run it before testing)
2. Seed a whole pile of new users: `User::factory()->count(1000)->withNonGovProfile()->create()`
3. Run the query above and analyze it.  Observe the high cost to access the `experience_skill` table
4. Run the new migration
5. Run the query analyze it again.  Observe the cost to access the `experience_skill` table is greatly reduced

## 📸 Screenshot

Before (L) and After (R)

<img width="1907" height="425" alt="image" src="https://github.com/user-attachments/assets/ecd5a8c8-6e29-443d-93b3-8b4dc0491fb3" />


## :truck: Deployment

When logged into the DB server to backup:

1. Dump the current pg_stat_statement table:

`psql -d gctalent -c "\copy (select * from public.pg_stat_statements) to '/backups/pg_stat_statements_2026_06_03.csv' csv header"`

2. Reset the table:

`psql -d gctalent -c "select pg_stat_statements_reset();"`