### PR TITLE
[Feature] Better Xdebug experience

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,9 @@
 {
   "configurations": [
+    // For using Xdebug with the PHP runtime in the webserver container and your debugger is running in WSL.
+    // For webserver Xdebug configuration, see the infrastructure/conf/xdebug.ini file.
     {
-      "name": "Listen for PHP Xdebug from webserver",
+      "name": "PHP Xdebug webserver (WSL)",
       "type": "php",
       "request": "launch",
       "port": 9003,
@@ -9,12 +11,24 @@
         "/home/site/wwwroot/": "${workspaceFolder}"
       },
       "linux": {
-        "hostname": "localhost" // WSL-specific: This is necessary when connecting to a webserver running in a docker container from inside WSL. If on native linux, you may need to comment out this line.
+        "hostname": "localhost" // WSL-specific: This is necessary when connecting to a webserver running in a docker container from inside WSL.
       }
-      // For configuration, see the infrastructure/conf/xdebug.ini file.
     },
+    // For using Xdebug with the PHP runtime in the webserver container and your debugger is running in your native OS.
+    // For webserver Xdebug configuration, see the infrastructure/conf/xdebug.ini file.
     {
-      "name": "Listen for PHP Xdebug locally",
+      "name": "PHP Xdebug webserver (native)",
+      "type": "php",
+      "request": "launch",
+      "port": 9003,
+      "pathMappings": {
+        "/home/site/wwwroot/": "${workspaceFolder}"
+      }
+    },
+    // For using Xdebug with the PHP CLI runtime on your native OS and your debugger is running in your native OS.
+    // For CLI Xdebug configuration, see your local config file in a location like /etc/php/8.4/cli/conf.d/20-xdebug.ini.
+    {
+      "name": "PHP Xdebug CLI (native)",
       "type": "php",
       "request": "launch",
       "port": 9003

--- a/documentation/debugging.md
+++ b/documentation/debugging.md
@@ -1,0 +1,39 @@
+# Debugging
+
+There are many ways to debug the code in this project. This guide contains a couple of different ways to do that.
+
+## PHP running in the webserver container
+
+Debugging PHP in the webserver container allows stepping though Laravel code in your IDE that was launched by a browser request.
+
+1. Start your Xdebug debugging client. For example, launch the "PHP Xdebug webserver (WSL)" profile if you are using VSCode with WSL or "PHP Xdebug webserver (native)" if you are running VSCode with a native Linux environment.
+
+2. Set a code breakpoint. For example, any line in AppServiceProvider::boot should be hit with every API request.
+
+3. Ensure that a trigger is sent with the browser requests. A good choice is [Xdebug Helper by JetBrains](https://www.jetbrains.com/help/phpstorm/browser-debugging-extensions.html). Ensure that the browser extension is set to "Debug".
+
+4. Navigate to http://localhost:8000/en/ and observe that the loading is interrupted and the debugger has stopped at your breakpoint.
+
+Troubleshooting:
+
+1. Navigate to http://localhost:8000/xdebuginfo.php and confirm that the Diagnostic Log shows no errors and that Step Debugging shows "Active" with a Connected Client.
+
+2. In the browser dev tools network requests pane, ensure that a XDEBUG_SESSION cookie is being populated for every request.
+
+## PHP running in the native CLI
+
+Debugging PHP in the native CLI allows stepping though Laravel code running in PHP tests launched locally.
+
+1. Start your Xdebug debugging client. For example, launch the "PHP Xdebug CLI (native)" if you are running VSCode with a native Linux environment.
+
+2. Set a code breakpoint. For example, the line in AuthControllerTest::setUp.
+
+3. Ensure that a trigger is sent with the command. A good choice is the "Xdebug" terminal profile set up in VSCode which automatically adds the XDEBUG_SESSION environment variable.
+
+4. In your terminal with the variable, run a test, like `./artisan test tests/Unit/AuthControllerTest.php`. Observe that testing is interrupted and the debugger has stopped at your breakpoint.
+
+Troubleshooting:
+
+1. Run `php -r "xdebug_info();"` and confirm that the Diagnostic Log shows no errors and that Step Debugging shows "Active" with a Connected Client.
+
+2. In your terminal, run `env | grep -i XDEBUG_SESSION` to ensure that an XDEBUG_SESSION variable is present.

--- a/infrastructure/conf/mock-oauth2-server.json
+++ b/infrastructure/conf/mock-oauth2-server.json
@@ -5,7 +5,7 @@
   "tokenCallbacks": [
     {
       "issuerId": "oxauth",
-      "tokenExpiry": 600,
+      "tokenExpiry": 3600,
       "requestMappings": [
         {
           "requestParam": "client_id",

--- a/infrastructure/conf/php-fpm-www.conf
+++ b/infrastructure/conf/php-fpm-www.conf
@@ -389,7 +389,7 @@ ping.response = pong
 ; does not stop script execution for some reason. A value of '0' means 'off'.
 ; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
 ; Default Value: 0
-request_terminate_timeout = 60s
+;request_terminate_timeout = 60s
 
 ; The timeout set by 'request_terminate_timeout' ini option is not engaged after
 ; application calls 'fastcgi_finish_request' or when application has finished and


### PR DESCRIPTION
🤖 Resolves #16923 

## 👋 Introduction

Improves the experience for using Xdebug.

Note that this PR is focused on the "native Linux" experience since that's what I use.  If you're using WSL or MacOS, this may not help you too much.  You're welcome to contribute to the PR to improve those experiences, too, though.

## 🕵️ Details

Main changes:
- Bumps the token lifetime to one hour.  This helps when using a GraphQL client like Graphiql or Altair that doesn't automatically refresh the token set.
- Disables the PHP-FPM request timeout.  This helps when using a step debugger in Xdebug.  Note that the Nginx gateway timeout will still occur after 60 seconds (HTTP 504) but the debugging session stays alive.
- Splits the Xdebug webserver debugging profile between WSL and native profiles.  This alleviates the need to manually edit the profile before using it on native Linux.
- Adds documentation to help users who are unfamiliar with Xdebug get started.

## 🧪 Testing

1. Read the Xdebug documentation
2. Try debugging on the webserver
3. Try debugging on the CLI

## 📸 Screenshot

<img width="1254" height="1011" alt="image" src="https://github.com/user-attachments/assets/819ccdf2-34d3-4141-8b88-166ce0f345df" />
