### PR TITLE
[Bug] Remove clear and save from the follow-up dialog

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -14846,10 +14846,6 @@
     "defaultMessage": "La personne candidate n'a pas fourni d'informations sur son objectif de carrière final.",
     "description": "Message displayed if nominee hasn't filled out career objective info"
   },
-  "wLR3Ux": {
-    "defaultMessage": "Effacer la date et enregistrer",
-    "description": "Button text to clear out a date"
-  },
   "wMni5o": {
     "defaultMessage": "Processus de recrutement ({numOfProcesses})",
     "description": "Recruitment processes expandable"

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/TalentRequestFollowUpDate.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/TalentRequestFollowUpDate.tsx
@@ -171,20 +171,6 @@ const TalentRequestFollowUpDate = ({
                     >
                       {intl.formatMessage(formMessages.saveChanges)}
                     </Button>
-                    <Button
-                      type="submit"
-                      mode="inline"
-                      color="secondary"
-                      value={INTENT.REMOVE}
-                      onClick={() => methods.setValue("intent", INTENT.REMOVE)}
-                      {...intentProps}
-                    >
-                      {intl.formatMessage({
-                        defaultMessage: "Clear date and save",
-                        id: "wLR3Ux",
-                        description: "Button text to clear out a date",
-                      })}
-                    </Button>
                     <Dialog.Close>
                       <Button type="button" color="warning" mode="inline">
                         {intl.formatMessage(commonMessages.cancel)}

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/TalentRequestFollowUpDate.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/TalentRequestFollowUpDate.tsx
@@ -50,17 +50,8 @@ const TalentRequestFollowUpDate_Fragment = graphql(/** GraphQL */ `
   }
 `);
 
-const INTENT = {
-  UPDATE: "update",
-  REMOVE: "remove",
-} as const;
-
-type ObjectValues<T> = T[keyof T];
-export type Intent = ObjectValues<typeof INTENT>;
-
 interface FormValues {
   followUpDate?: string | null;
-  intent: Intent;
 }
 
 interface TalentRequestFollowUpDateProps {
@@ -90,7 +81,6 @@ const TalentRequestFollowUpDate = ({
         : null,
     },
   });
-  const intentProps = methods.register("intent");
 
   const handleSubmit = async (values: FormValues) => {
     const newDate = values.followUpDate ?? null;
@@ -161,12 +151,7 @@ const TalentRequestFollowUpDate = ({
                     }}
                   />
                   <Dialog.Footer>
-                    <Button
-                      type="submit"
-                      value={INTENT.UPDATE}
-                      onClick={() => methods.setValue("intent", INTENT.UPDATE)}
-                      {...intentProps}
-                    >
+                    <Button type="submit">
                       {intl.formatMessage(formMessages.saveChanges)}
                     </Button>
                     <Dialog.Close>

--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/TalentRequestFollowUpDate.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/TalentRequestFollowUpDate.tsx
@@ -93,10 +93,8 @@ const TalentRequestFollowUpDate = ({
   const intentProps = methods.register("intent");
 
   const handleSubmit = async (values: FormValues) => {
-    let newDate = values.followUpDate ?? null;
-    if (values.intent === INTENT.REMOVE) {
-      newDate = null;
-    }
+    const newDate = values.followUpDate ?? null;
+
     await executeMutation({
       id: talentRequest.id,
       input: { followUpDate: newDate },


### PR DESCRIPTION
🤖 Resolves #16887 

## 👋 Introduction

Remove the clear and save button. Per issue refinement, the issue's goal was revised and shrunk to just removing it
https://github.com/GCTC-NTGC/gc-digital-talent/issues/16887#issuecomment-4595016227

## 🧪 Testing

<!-- Assist reviewers with steps they can take to test that the PR does what it says it does. -->

1. Update the follow-up date of a request


## 📸 Screenshot

<img width="829" height="227" alt="image" src="https://github.com/user-attachments/assets/6857f2e1-1dcf-415c-b273-27ad81985b49" />




