### PR TITLE
[Fix] Removes unused `notes` field from `PoolStatusTable` fragment

### DIFF
--- a/apps/web/src/components/PoolStatusTable/PoolStatusTable.tsx
+++ b/apps/web/src/components/PoolStatusTable/PoolStatusTable.tsx
@@ -50,7 +50,6 @@ const PoolStatusTable_Fragment = graphql(/* GraphQL */ `
         }
       }
       expiryDate
-      notes
       suspendedAt
       pool {
         id


### PR DESCRIPTION
🤖 Resolves #16317.

## 👋 Introduction

This PR removes unused `notes` field from `PoolStatusTable` fragment.

## 🧪 Testing

1. `pnpm dev:fresh`
2. Sign in as community@test.com
3. Navigate to http://localhost:8000/en/admin/pool-candidates
5. Navigate to a candidate
6. Verify no errors rendered on page