### PR TITLE
[Refactor] Reduce spacing around `<Card />`

### DIFF
--- a/packages/ui/src/components/Card/Card.tsx
+++ b/packages/ui/src/components/Card/Card.tsx
@@ -7,7 +7,7 @@ import type { SeparatorProps } from "../Separator/Separator";
 import { Grid, GridItem } from "./CardGrid";
 
 const card = tv({
-  base: "rounded-md bg-white text-black dark:bg-gray-600 dark:text-white",
+  base: "-mx-3 rounded-md bg-white text-black xs:mx-0 dark:bg-gray-600 dark:text-white",
   variants: {
     space: {
       xs: "p-3",


### PR DESCRIPTION
🤖 Resolves #16051

## 👋 Introduction

Reduce the spacing around the component. In the smallest viewport only

Tricky bit as the padding came from the parent `<Container />` . As the issue dealt with the cards in specific, I decided to solve by negative margins on the cards themselves rather than ripple out a much larger change

## 🧪 Testing

1. Navigate to pages with `<Card />`
2. Shrink window
3. Also, look at Chromatic


## 📸 Screenshot

#### Other (Unchanged)

<img width="891" height="592" alt="image" src="https://github.com/user-attachments/assets/8f236ee9-282d-4a1c-8fc6-eaefb4289d43" />


#### Smallest viewport 

<img width="656" height="548" alt="image" src="https://github.com/user-attachments/assets/d522dbd1-f883-4d13-bdd3-c22ed9b3565e" />



