### PR TITLE
[Fix] Draft pool lazy loading error

### DIFF
--- a/api/app/Models/Team.php
+++ b/api/app/Models/Team.php
@@ -40,7 +40,17 @@ class Team extends LaratrustTeam
 
     public function teamable(): MorphTo
     {
-        return $this->morphTo();
+        // Eager load what PoolPolicy::view reads (via getPoolTeams). without('teamable') breaks the
+        // teamable -> team -> teamable cycle caused by $with = ['teamable'].
+        $withoutTeamable = fn ($query) => $query->without('teamable');
+
+        return $this->morphTo()->morphWith([
+            Pool::class => [
+                'team' => $withoutTeamable,
+                'community.team' => $withoutTeamable,
+                'department.team' => $withoutTeamable,
+            ],
+        ]);
     }
 
     /** @return HasMany<RoleAssignment, $this> */

--- a/api/tests/Feature/UserRoleTest.php
+++ b/api/tests/Feature/UserRoleTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\Community;
+use App\Models\Pool;
 use App\Models\Role;
 use App\Models\Team;
 use App\Models\User;
@@ -458,5 +459,34 @@ class UserRoleTest extends TestCase
                 ],
             ]
         )->assertGraphQLErrorMessage('This action is unauthorized.');
+    }
+
+    // Authorizing a draft Pool teamable runs PoolPolicy::view, which reads the pool's teams.
+    // Needs >1 pool so the morphTo batch hydrates multiple models (when Eloquent enforces
+    // lazy-load prevention), else it throws "lazy load [team] on model Pool".
+    public function testTeamableDraftPoolEagerLoadsItsTeams()
+    {
+        $role = Role::where('name', 'process_operator')->sole();
+        $pools = Pool::factory()->count(3)->create(); // draft by default
+        $user = User::factory()->create();
+        $pools->each(fn (Pool $pool) => $user->addRole($role, $pool->team));
+
+        $this->actingAs($user, 'api')->graphQL(
+            /** @lang GraphQL */
+            '
+            query myAuthTeamable {
+                myAuth {
+                    roleAssignments {
+                        teamable {
+                            id
+                            ... on Pool { id }
+                        }
+                        team { id }
+                    }
+                }
+            }
+        '
+        )->assertGraphQLErrorFree()
+            ->assertJsonFragment(['teamable' => ['id' => $pools->first()->id]]);
     }
 }


### PR DESCRIPTION
🤖 Resolves #16882 

## 👋 Introduction

Fixes a lazy load error when attempting to view a process that is draft with only the process operator role for that process.

## 🕵️ Details

This adds `morphWith` that allows you to define eager loads for polymorphic relationships. Notably, we already have an eager load for `teamable` so we disable that so we do not create a circular eager load.

## 🧪 Testing

1. Login as `process@test.com`
2. Go to view any draft process at `/admin/pools/{id}`
3. Confirm the page loads with no lazy loading error