### PR TITLE
[Bug] Manage access role updating improvement for admins

### DIFF
--- a/apps/web/src/pages/Communities/CommunityMembersPage/components/EditCommunityMemberDialog.tsx
+++ b/apps/web/src/pages/Communities/CommunityMembersPage/components/EditCommunityMemberDialog.tsx
@@ -10,7 +10,6 @@ import { Combobox } from "@gc-digital-talent/forms";
 import { toast } from "@gc-digital-talent/toast";
 import {
   commonMessages,
-  errorMessages,
   formMessages,
   getLocalizedName,
 } from "@gc-digital-talent/i18n";
@@ -177,9 +176,6 @@ const EditCommunityMemberDialog = forwardRef<
                     description:
                       "Label for the input to add roles to a user's community membership",
                   })}
-                  rules={{
-                    required: intl.formatMessage(errorMessages.required),
-                  }}
                   placeholder={intl.formatMessage({
                     defaultMessage: "Select roles",
                     id: "Cn73yN",

--- a/apps/web/src/pages/Departments/ManageAccessPage/components/EditDepartmentMembership.tsx
+++ b/apps/web/src/pages/Departments/ManageAccessPage/components/EditDepartmentMembership.tsx
@@ -8,11 +8,7 @@ import { useOutletContext } from "react-router";
 import { Dialog, Button, DropdownMenu } from "@gc-digital-talent/ui";
 import { Combobox } from "@gc-digital-talent/forms";
 import { toast } from "@gc-digital-talent/toast";
-import {
-  commonMessages,
-  errorMessages,
-  formMessages,
-} from "@gc-digital-talent/i18n";
+import { commonMessages, formMessages } from "@gc-digital-talent/i18n";
 import type {
   RoleInput,
   DepartmentManageAccessPage_DepartmentFragment as DepartmentManageAccessPageDepartmentFragmentType,
@@ -185,9 +181,6 @@ const EditDepartmentMembershipDialog = forwardRef<
                     description:
                       "Label for the input to add roles to a user's community membership",
                   })}
-                  rules={{
-                    required: intl.formatMessage(errorMessages.required),
-                  }}
                   placeholder={intl.formatMessage({
                     defaultMessage: "Select roles",
                     id: "Cn73yN",


### PR DESCRIPTION
🤖 Resolves #15895 

## 👋 Introduction

Make it less of a pain for admins to update roles in certain cases. Now community or department admin can conveniently remove the roles they are allowed to remove, which they accidentally couldn't in some circumstances

## 🕵️ Details

Less work than expected as a handy bit was already setup. Preventing users from removing their own admin role

<img width="761" height="112" alt="image" src="https://github.com/user-attachments/assets/88f7c9b2-2cbb-4cd8-aabd-c515b4bc1957" />


## 🧪 Testing

1. Login as community or department admin
2. Navigate to respective manage access page
3. Assign additional roles to yourself
4. Then remove them

## 📸 Screenshot

### Step one

<img width="1191" height="78" alt="image" src="https://github.com/user-attachments/assets/c891ebfe-94a4-4295-9216-52215f76825d" />

### Step two

<img width="1139" height="104" alt="image" src="https://github.com/user-attachments/assets/e3a73df5-3a52-4345-8267-eca7ed063db3" />

### Step three

<img width="1003" height="80" alt="image" src="https://github.com/user-attachments/assets/3d8bb3ea-b0d0-404e-be8c-be22d51c4ca5" />



