### PR TITLE
[Fix] Community talent table classification column values

### DIFF
--- a/apps/web/src/pages/CommunityInterests/CommunityTalentPage/CommunityTalentTable.tsx
+++ b/apps/web/src/pages/CommunityInterests/CommunityTalentPage/CommunityTalentTable.tsx
@@ -432,9 +432,7 @@ const CommunityTalentTable = ({ title }: CommunityTalentTableProps) => {
         communityInterest: {
           user: { currentClassification },
         },
-      }) =>
-        () =>
-          currentClassification?.groupAndLevel ?? "",
+      }) => currentClassification?.groupAndLevel ?? "",
       {
         id: "classification",
         header: intl.formatMessage(processMessages.classification),


### PR DESCRIPTION
🤖 Resolves #17024.

## 👋 Introduction

This PR fix the community talent table classification column values.

## 🧪 Testing

1. `pnpm dev`
2. Login as admin@test.com
3. Navigate to http://localhost:8000/en/admin/community-talent
4. Verify the values in the classification column as correctly formatted group and level

## 📸 Screenshot

<img width="965" height="939" alt="Screenshot 2026-06-09 at 11 37 40" src="https://github.com/user-attachments/assets/5111e572-9d7f-4dd5-989d-b745fd3e9052" />