### PR TITLE
[Fix] Apply link job card styles

### DIFF
--- a/apps/web/src/components/JobCard/JobCard.stories.tsx
+++ b/apps/web/src/components/JobCard/JobCard.stories.tsx
@@ -187,6 +187,21 @@ const nullCard = {
   poolQuery: makeFragmentData(nullPool, JobCard_Fragment),
 };
 
+const longTitleStr = faker.lorem.sentence(30);
+const longTitle = {
+  poolQuery: makeFragmentData(
+    {
+      ...fakedPool,
+      name: {
+        en: `${longTitleStr} EN`,
+        fr: `${longTitleStr} FR`,
+        localized: `${longTitleStr} LOCALIZED`,
+      },
+    },
+    JobCard_Fragment,
+  ),
+};
+
 const Template: StoryFn<typeof JobCard> = () => (
   <div className="flex flex-col gap-6">
     <JobCard {...open} />
@@ -197,6 +212,7 @@ const Template: StoryFn<typeof JobCard> = () => (
     <JobCard {...all} />
     <JobCard {...deadlineApproaching} />
     <JobCard {...closed} />
+    <JobCard {...longTitle} />
     <JobCard {...nullCard} />
   </div>
 );

--- a/apps/web/src/components/JobCard/JobCard.tsx
+++ b/apps/web/src/components/JobCard/JobCard.tsx
@@ -326,7 +326,7 @@ const JobCard = ({ poolQuery, headingLevel = "h3" }: JobCardProps) => {
           </p>
         </div>
         <Link
-          className="justify-self-end after:absolute after:inset-0 after:content-[''] xs:self-end"
+          className="shrink-0 justify-self-end after:absolute after:inset-0 after:content-[''] xs:self-end"
           color="primary"
           mode="solid"
           href={paths.jobPoster(pool.id)}


### PR DESCRIPTION
🤖 Resolves #17015 

## 👋 Introduction

Fixes an issue where the apply link on a job card was wrapping when a card had a long title that wrapped to multiple lines.

## 🧪 Testing

1. Run storybook `pnpm storybook`
2. Navigate to the "Job card" story
3. Confirm that even when the process has long a title, the apply button does not wrap

## 📸 Screenshot

<img width="1043" height="406" alt="swappy-20260609_143326" src="https://github.com/user-attachments/assets/6ceff6fc-e32f-4246-aecf-05a21fee3a85" />
<img width="1042" height="403" alt="swappy-20260609_143407" src="https://github.com/user-attachments/assets/696dff5c-2487-4918-bd3a-785d7b1cc6ce" />
