### PR TITLE
[Feat] Arbitrary table actions

### DIFF
--- a/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
@@ -435,6 +435,9 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
                   rowSelect: !!rowSelect,
                   download,
                   actions,
+                  selectedRowIds: Object.keys(rowSelection).filter(
+                    (rowId) => rowSelection[rowId],
+                  ),
                   isLoading,
                   count: Object.values(rowSelection).length,
                   onClear: () => table.resetRowSelection(),

--- a/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/ResponsiveTable.tsx
@@ -39,6 +39,7 @@ import type {
   SearchDef,
   SearchState,
   SortDef,
+  TableAction,
 } from "./types";
 import { getColumnHeader } from "./utils";
 
@@ -67,6 +68,8 @@ interface TableProps<TData, TFilters> {
   pagination?: PaginationDef;
   /** Download buttons */
   download?: DownloadDef;
+  /** Arbitrary bulk actions for selected rows, shown in a dropdown menu */
+  actions?: TableAction[];
   /** Enable the "add item" button */
   add?: AddDef;
   filter?: FilterDef<TFilters>;
@@ -87,6 +90,7 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
   search,
   sort,
   download,
+  actions,
   add,
   pagination,
   filter,
@@ -425,11 +429,12 @@ const ResponsiveTable = <TData extends object, TFilters = object>({
                 ))}
               </Table.Body>
             </Table.Table>
-            {(!!rowSelect || !!download?.all) && (
+            {(!!rowSelect || !!download?.all || !!actions?.length) && (
               <RowSelection.Actions
                 {...{
                   rowSelect: !!rowSelect,
                   download,
+                  actions,
                   isLoading,
                   count: Object.values(rowSelection).length,
                   onClear: () => table.resetRowSelection(),

--- a/apps/web/src/components/Table/ResponsiveTable/RowSelection.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/RowSelection.tsx
@@ -345,12 +345,7 @@ const Actions = ({
                   <Bullet />
                   <DropdownMenu.Root>
                     <DropdownMenu.Trigger btnProps={actionButtonStyles}>
-                      {intl.formatMessage({
-                        defaultMessage: "Actions",
-                        id: "PtnJL7",
-                        description:
-                          "Trigger label for the bulk actions menu on selected table rows",
-                      })}
+                      {intl.formatMessage(tableMessages.actions)}
                     </DropdownMenu.Trigger>
                     <DropdownMenu.Popup
                       positionerProps={{ align: "end", collisionPadding: 2 }}

--- a/apps/web/src/components/Table/ResponsiveTable/RowSelection.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/RowSelection.tsx
@@ -353,7 +353,6 @@ const Actions = ({
                       {actions.map((action, index) => (
                         <DropdownMenu.Item
                           key={index}
-                          disabled={action.disabled}
                           onClick={() => handleActionClick(action)}
                         >
                           {action.label}

--- a/apps/web/src/components/Table/ResponsiveTable/RowSelection.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/RowSelection.tsx
@@ -340,7 +340,7 @@ const Actions = ({
                   )}
                 </span>
               )}
-              {actions?.length ? (
+              {actions?.length && selectedRowIds?.length ? (
                 <>
                   <Bullet />
                   <DropdownMenu.Root>

--- a/apps/web/src/components/Table/ResponsiveTable/RowSelection.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/RowSelection.tsx
@@ -27,13 +27,14 @@ import type { ButtonProps } from "@gc-digital-talent/ui";
 import {
   Button,
   DownloadCsv,
+  DropdownMenu,
   Loading,
   UNICODE_CHAR,
 } from "@gc-digital-talent/ui";
 import { notEmpty } from "@gc-digital-talent/helpers";
 import { toast } from "@gc-digital-talent/toast";
 
-import type { DownloadDef, RowSelectDef } from "./types";
+import type { DownloadDef, RowSelectDef, TableAction } from "./types";
 import SpinnerIcon from "../../SpinnerIcon/SpinnerIcon";
 import tableMessages from "../tableMessages";
 
@@ -206,6 +207,8 @@ interface ActionsProps {
   onClear: MouseEventHandler;
   /** Button to trigger an async download */
   download?: DownloadDef;
+  /** Arbitrary bulk actions for the selected rows, shown in a dropdown menu */
+  actions?: TableAction[];
 }
 
 /**
@@ -220,6 +223,7 @@ const Actions = ({
   count,
   onClear,
   download,
+  actions,
 }: ActionsProps) => {
   const intl = useIntl();
 
@@ -325,6 +329,36 @@ const Actions = ({
                   )}
                 </span>
               )}
+              {actions?.length ? (
+                <>
+                  <Bullet />
+                  <DropdownMenu.Root>
+                    <DropdownMenu.Trigger btnProps={actionButtonStyles}>
+                      {intl.formatMessage({
+                        defaultMessage: "Actions",
+                        id: "PtnJL7",
+                        description:
+                          "Trigger label for the bulk actions menu on selected table rows",
+                      })}
+                    </DropdownMenu.Trigger>
+                    <DropdownMenu.Popup
+                      positionerProps={{ align: "end", collisionPadding: 2 }}
+                    >
+                      {actions.map((action, index) => (
+                        <DropdownMenu.Item
+                          key={index}
+                          disabled={action.disabled}
+                          onClick={
+                            count > 0 ? action.onClick : handleNoRowsSelected
+                          }
+                        >
+                          {action.label}
+                        </DropdownMenu.Item>
+                      ))}
+                    </DropdownMenu.Popup>
+                  </DropdownMenu.Root>
+                </>
+              ) : null}
             </Section>
           )}
         </Column>

--- a/apps/web/src/components/Table/ResponsiveTable/RowSelection.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/RowSelection.tsx
@@ -209,6 +209,8 @@ interface ActionsProps {
   download?: DownloadDef;
   /** Arbitrary bulk actions for the selected rows, shown in a dropdown menu */
   actions?: TableAction[];
+  /** IDs of the currently selected rows, passed to action handlers */
+  selectedRowIds: string[];
 }
 
 /**
@@ -224,11 +226,20 @@ const Actions = ({
   onClear,
   download,
   actions,
+  selectedRowIds,
 }: ActionsProps) => {
   const intl = useIntl();
 
   const handleNoRowsSelected = () => {
     toast.warning(intl.formatMessage(tableMessages.noRowsSelected));
+  };
+
+  const handleActionClick = (action: TableAction) => {
+    if (count <= 0) {
+      handleNoRowsSelected();
+      return;
+    }
+    action.onClick?.(selectedRowIds);
   };
 
   return (
@@ -348,9 +359,7 @@ const Actions = ({
                         <DropdownMenu.Item
                           key={index}
                           disabled={action.disabled}
-                          onClick={
-                            count > 0 ? action.onClick : handleNoRowsSelected
-                          }
+                          onClick={() => handleActionClick(action)}
                         >
                           {action.label}
                         </DropdownMenu.Item>

--- a/apps/web/src/components/Table/ResponsiveTable/RowSelection.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/RowSelection.tsx
@@ -234,14 +234,6 @@ const Actions = ({
     toast.warning(intl.formatMessage(tableMessages.noRowsSelected));
   };
 
-  const handleActionClick = (action: TableAction) => {
-    if (count <= 0) {
-      handleNoRowsSelected();
-      return;
-    }
-    action.onClick?.(selectedRowIds);
-  };
-
   return (
     <div className="sticky left-0 flex flex-col items-center justify-between gap-y-3 bg-gray-700 px-6 py-3 text-white sm:flex-row sm:items-start sm:gap-x-3 sm:gap-y-0">
       {rowSelect && (
@@ -353,7 +345,13 @@ const Actions = ({
                       {actions.map((action, index) => (
                         <DropdownMenu.Item
                           key={index}
-                          onClick={() => handleActionClick(action)}
+                          onClick={() => {
+                            if (count <= 0) {
+                              handleNoRowsSelected();
+                              return;
+                            }
+                            action.onClick?.(selectedRowIds);
+                          }}
                         >
                           {action.label}
                         </DropdownMenu.Item>

--- a/apps/web/src/components/Table/ResponsiveTable/Table.stories.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/Table.stories.tsx
@@ -14,6 +14,9 @@ import { fakeUsers } from "@gc-digital-talent/fake-data";
 import type { User } from "@gc-digital-talent/graphql";
 import { Language } from "@gc-digital-talent/graphql";
 import { allModes } from "@gc-digital-talent/storybook-helpers";
+import { Button, Dialog } from "@gc-digital-talent/ui";
+
+import useSelectedRows from "~/hooks/useSelectedRows";
 
 import Table from "./ResponsiveTable";
 import Selection from "./RowSelection";
@@ -137,38 +140,99 @@ RowSelection.args = {
   },
 };
 
-export const RowSelectionWithActions = Template.bind({});
-RowSelectionWithActions.args = {
-  caption: "Table with bulk actions",
-  rowSelect: {
-    getRowId: (row) => row.id,
-    onRowSelection: (rows) => {
-      action("onRowSelection")(rows);
-    },
-    cell: rowSelectCell,
-  },
-  actions: [
-    {
-      label: "Assign to pool",
-      onClick: () => {
-        action("assignToPool")();
-      },
-    },
-    {
-      label: "Send notification",
-      onClick: () => {
-        action("sendNotification")();
-      },
-    },
-    {
-      label: "Archive",
-      onClick: () => {
-        action("archive")();
-      },
-      disabled: true,
-    },
-  ],
+/**
+ * Bulk actions hand the selected row IDs to `onClick`. To open a dialog, the
+ * caller tracks selection with `useSelectedRows` and renders a controlled
+ * dialog *outside* the table — so it isn't unmounted when the menu closes.
+ */
+const ActionsTemplate: StoryFn<typeof Table<User>> = (args) => {
+  const { selectedRows, setSelectedRows } = useSelectedRows<string>([]);
+  const [isAssignOpen, setAssignOpen] = useState(false);
+  const [poolId, setPoolId] = useState("");
+
+  const closeDialog = () => {
+    setAssignOpen(false);
+    setPoolId("");
+  };
+
+  return (
+    <>
+      <Table
+        {...args}
+        caption="Table with bulk actions"
+        rowSelect={{
+          getRowId: (row) => row.id,
+          onRowSelection: setSelectedRows,
+          cell: rowSelectCell,
+        }}
+        actions={[
+          {
+            label: "Assign to pool",
+            onClick: () => setAssignOpen(true),
+          },
+          {
+            label: "Send notification",
+            onClick: (ids) => {
+              action("sendNotification")(ids);
+            },
+          },
+          {
+            label: "Archive",
+            onClick: (ids) => {
+              action("archive")(ids);
+            },
+            disabled: true,
+          },
+        ]}
+      />
+      <Dialog.Root
+        open={isAssignOpen}
+        onOpenChange={(open) => {
+          if (!open) closeDialog();
+        }}
+      >
+        <Dialog.Content>
+          <Dialog.Header>Assign to pool</Dialog.Header>
+          <Dialog.Body>
+            <p className="mb-6">
+              Assigning {selectedRows.length} selected candidate(s).
+            </p>
+            <form
+              onSubmit={(event) => {
+                event.preventDefault();
+                action("assignToPool")({ poolId, candidateIds: selectedRows });
+                closeDialog();
+              }}
+            >
+              <label className="mb-1.5 block font-bold" htmlFor="poolId">
+                Pool ID
+              </label>
+              <input
+                id="poolId"
+                name="poolId"
+                value={poolId}
+                onChange={(event) => setPoolId(event.target.value)}
+                className="w-full rounded-md border border-gray-300 p-3"
+              />
+              <Dialog.Footer>
+                <Button type="submit" color="primary">
+                  Assign
+                </Button>
+                <Dialog.Close>
+                  <Button type="button" mode="inline" color="warning">
+                    Cancel
+                  </Button>
+                </Dialog.Close>
+              </Dialog.Footer>
+            </form>
+          </Dialog.Body>
+        </Dialog.Content>
+      </Dialog.Root>
+    </>
+  );
 };
+
+export const RowSelectionWithActions = ActionsTemplate.bind({});
 
 export const InitialState = Template.bind({});
 InitialState.args = {

--- a/apps/web/src/components/Table/ResponsiveTable/Table.stories.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/Table.stories.tsx
@@ -137,6 +137,39 @@ RowSelection.args = {
   },
 };
 
+export const RowSelectionWithActions = Template.bind({});
+RowSelectionWithActions.args = {
+  caption: "Table with bulk actions",
+  rowSelect: {
+    getRowId: (row) => row.id,
+    onRowSelection: (rows) => {
+      action("onRowSelection")(rows);
+    },
+    cell: rowSelectCell,
+  },
+  actions: [
+    {
+      label: "Assign to pool",
+      onClick: () => {
+        action("assignToPool")();
+      },
+    },
+    {
+      label: "Send notification",
+      onClick: () => {
+        action("sendNotification")();
+      },
+    },
+    {
+      label: "Archive",
+      onClick: () => {
+        action("archive")();
+      },
+      disabled: true,
+    },
+  ],
+};
+
 export const InitialState = Template.bind({});
 InitialState.args = {
   caption: "Default table",

--- a/apps/web/src/components/Table/ResponsiveTable/Table.stories.tsx
+++ b/apps/web/src/components/Table/ResponsiveTable/Table.stories.tsx
@@ -181,7 +181,6 @@ const ActionsTemplate: StoryFn<typeof Table<User>> = (args) => {
             onClick: (ids) => {
               action("archive")(ids);
             },
-            disabled: true,
           },
         ]}
       />

--- a/apps/web/src/components/Table/ResponsiveTable/types.ts
+++ b/apps/web/src/components/Table/ResponsiveTable/types.ts
@@ -117,8 +117,6 @@ export interface DownloadDef {
 export interface TableAction {
   /** Item label */
   label: ReactNode;
-  /** Disable the item */
-  disabled?: boolean;
   /** Fires when clicked with at least one row selected; receives the selected row IDs */
   onClick?: (selectedRowIds: string[]) => void;
 }

--- a/apps/web/src/components/Table/ResponsiveTable/types.ts
+++ b/apps/web/src/components/Table/ResponsiveTable/types.ts
@@ -117,10 +117,10 @@ export interface DownloadDef {
 export interface TableAction {
   /** Item label */
   label: ReactNode;
-  /** Fires when clicked and at least one row is selected */
-  onClick?: () => void;
   /** Disable the item */
   disabled?: boolean;
+  /** Fires when clicked with at least one row selected; receives the selected row IDs */
+  onClick?: (selectedRowIds: string[]) => void;
 }
 
 export interface PaginationDef {

--- a/apps/web/src/components/Table/ResponsiveTable/types.ts
+++ b/apps/web/src/components/Table/ResponsiveTable/types.ts
@@ -114,6 +114,15 @@ export interface DownloadDef {
       };
 }
 
+export interface TableAction {
+  /** Item label */
+  label: ReactNode;
+  /** Fires when clicked and at least one row is selected */
+  onClick?: () => void;
+  /** Disable the item */
+  disabled?: boolean;
+}
+
 export interface PaginationDef {
   /** Allows the table to manage search */
   internal: boolean;


### PR DESCRIPTION
🤖 Resolves #17036 

## 👋 Introduction

Adds the option to add arbitrary actions to our table component.

## 🕵️ Details

This is rerquired to support actions for setting status for multiple talent request users.

## 🧪 Testing

1. Run storybook `pnpm storybook`
2. Navigate to the table with actions story
3. Confirm it does what you expect

## 📸 Screenshot

<img width="434" height="266" alt="swappy-20260610_091903" src="https://github.com/user-attachments/assets/29fdf3dd-e28e-4960-9611-3fd9c622a02a" />
