### PR TITLE
[Feature] Exclude tracked users

### DIFF
--- a/api/app/Builders/UserBuilder.php
+++ b/api/app/Builders/UserBuilder.php
@@ -388,6 +388,12 @@ class UserBuilder extends Builder
             ->whereAuthorizedToView()
             ->with('pool')]);
 
+        $excludeTrackedByRequestId = $args['excludeTrackedByRequestId'] ?? null;
+        if ($excludeTrackedByRequestId) {
+            $this->whereDoesntHave('talentRequestTrackedUsers', fn ($trackedUsers) => $trackedUsers
+                ->where('talent_request_id', $excludeTrackedByRequestId));
+        }
+
         return $this;
     }
 

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -307,6 +307,12 @@ class User extends Model implements Authenticatable, HasLocalePreference, Laratr
         return $this->hasMany(PoolCandidate::class)->withTrashed();
     }
 
+    /** @return HasMany<TalentRequestTrackedUser, $this> */
+    public function talentRequestTrackedUsers(): HasMany
+    {
+        return $this->hasMany(TalentRequestTrackedUser::class);
+    }
+
     /** @return BelongsTo<Department, $this> */
     public function department(): BelongsTo
     {

--- a/api/tests/Feature/TalentRequestMatchesTest.php
+++ b/api/tests/Feature/TalentRequestMatchesTest.php
@@ -12,11 +12,12 @@ use App\Models\Community;
 use App\Models\Pool;
 use App\Models\PoolCandidate;
 use App\Models\Skill;
+use App\Models\TalentRequest;
+use App\Models\TalentRequestTrackedUser;
 use App\Models\User;
 use App\Models\UserSkill;
 use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Str;
 use Illuminate\Testing\TestResponse;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
@@ -281,17 +282,27 @@ class TalentRequestMatchesTest extends TestCase
             ->assertJsonPath('data.talentRequestMatches.data.0.skillCount', null);
     }
 
-    public function testExcludeTrackedByRequestIdIsAcceptedButDoesNotAffectResults(): void
+    public function testExcludeTrackedByRequestIdFiltersOutUsersTrackedByThatRequest(): void
     {
         $pool = Pool::factory()->candidatesAvailableInSearch()->create();
-        $match = $this->matchingUser($pool);
+        $included = $this->matchingUser($pool);
+        $tracked = $this->matchingUser($pool);
+
+        $talentRequest = TalentRequest::factory()->create();
+        TalentRequestTrackedUser::factory()->create([
+            'talent_request_id' => $talentRequest->id,
+            'user_id' => $tracked->id,
+        ]);
 
         $this->runMatches([
-            'excludeTrackedByRequestId' => Str::uuid()->toString(),
+            'excludeTrackedByRequestId' => $talentRequest->id,
             'applicantFilter' => [],
         ])
             ->assertJsonPath('data.talentRequestMatches.paginatorInfo.total', 1)
-            ->assertJsonPath('data.talentRequestMatches.data.0.user.id', $match->id);
+            ->assertJsonPath('data.talentRequestMatches.data.0.user.id', $included->id)
+            ->assertJsonMissing([
+                'user' => ['id' => $tracked->id],
+            ]);
     }
 
     public function testMatchesAreFilteredByViewAuthorization(): void


### PR DESCRIPTION
🤖 Resolves #17040 

## 👋 Introduction

- Add filtering to exclude tracked users from the `talentRequestMatches` query

## 🧪 Testing

1. Refresh api and run seeder: `make referesh-api` and `make seed-fresh`
2. Test `talentRequestMatches` on `admin/graphiql` using the `excludeTrackedByRequestId` 
3. Ensure that all tracked users are excluded from the response
4. Ensure tests look good