### PR TITLE
[Feature] Show "Copy nomination link" on all nomination events

### DIFF
--- a/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
@@ -8,11 +8,7 @@ import type {
   FragmentType,
   LocalizedTalentNominationEventStatus,
 } from "@gc-digital-talent/graphql";
-import {
-  getFragment,
-  graphql,
-  TalentNominationEventStatus,
-} from "@gc-digital-talent/graphql";
+import { getFragment, graphql } from "@gc-digital-talent/graphql";
 import {
   Button,
   Card,
@@ -137,64 +133,60 @@ const TalentEventDetails = ({ query }: TalentEventDetailsProps) => {
           >
             {intl.formatMessage(adminMessages.eventDetails)}
           </Heading>
-          {talentEvent.status?.value === TalentNominationEventStatus.Active ? (
-            <div className="flex flex-col items-center justify-center gap-6 text-right sm:col-span-2 sm:flex-row">
-              <Button
-                mode="inline"
-                color="primary"
-                icon={linkCopied ? CheckIcon : undefined}
-                onClick={async () => {
-                  await navigator.clipboard.writeText(
-                    window.location.protocol +
-                      "//" +
-                      window.location.host +
-                      paths.createTalentNomination(talentEvent.id),
-                  );
-                  setLinkCopied(true);
-                  setTimeout(() => {
-                    setLinkCopied(false);
-                  }, 2000);
-                }}
-                aria-label={
-                  linkCopied
-                    ? intl.formatMessage({
-                        defaultMessage: "Nomination link copied",
-                        id: "ms0CBt",
-                        description:
-                          "Button text to indicate that a talent event nomination URL has been copied",
-                      })
-                    : intl.formatMessage(
-                        {
-                          defaultMessage:
-                            "Copy {title} nomination URL to clipboard",
-                          id: "zxHKZ2",
-                          description:
-                            "Button text to copy a create talent event URL",
-                        },
-                        {
-                          title: talentEvent.name.localized,
-                        },
-                      )
-                }
-              >
-                {linkCopied
+          <div className="flex flex-col items-center justify-center gap-6 text-right sm:col-span-2 sm:flex-row">
+            <Button
+              mode="inline"
+              color="primary"
+              icon={linkCopied ? CheckIcon : undefined}
+              onClick={async () => {
+                await navigator.clipboard.writeText(
+                  window.location.protocol +
+                    "//" +
+                    window.location.host +
+                    paths.createTalentNomination(talentEvent.id),
+                );
+                setLinkCopied(true);
+                setTimeout(() => {
+                  setLinkCopied(false);
+                }, 2000);
+              }}
+              aria-label={
+                linkCopied
                   ? intl.formatMessage({
                       defaultMessage: "Nomination link copied",
                       id: "ms0CBt",
                       description:
                         "Button text to indicate that a talent event nomination URL has been copied",
                     })
-                  : intl.formatMessage({
-                      defaultMessage: "Copy nomination link",
-                      id: "vV5a2X",
-                      description: "Button text to copy a nomination URL",
-                    })}
-              </Button>
-              <StatusChip status={talentEvent.status} />
-            </div>
-          ) : (
+                  : intl.formatMessage(
+                      {
+                        defaultMessage:
+                          "Copy {title} nomination URL to clipboard",
+                        id: "zxHKZ2",
+                        description:
+                          "Button text to copy a create talent event URL",
+                      },
+                      {
+                        title: talentEvent.name.localized,
+                      },
+                    )
+              }
+            >
+              {linkCopied
+                ? intl.formatMessage({
+                    defaultMessage: "Nomination link copied",
+                    id: "ms0CBt",
+                    description:
+                      "Button text to indicate that a talent event nomination URL has been copied",
+                  })
+                : intl.formatMessage({
+                    defaultMessage: "Copy nomination link",
+                    id: "vV5a2X",
+                    description: "Button text to copy a nomination URL",
+                  })}
+            </Button>
             <StatusChip status={talentEvent.status} />
-          )}
+          </div>
         </div>
         <p className="col-span-2 my-6">
           {intl.formatMessage({


### PR DESCRIPTION
🤖 Resolves #17001 
🤖 Resolves #16995

## 👋 Introduction

This PR removes the code that was hiding the "Copy nomination link" button when a nomination event is "closed"/"past"

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `talent-coordinator@test.com`
3. Navigate to `admin/talent-events` and select a event that has a status "Past"
4. Verify the "Copy nomination link" is visible 

## 📸 Screenshot

<img width="689" height="377" alt="image" src="https://github.com/user-attachments/assets/524b4ef8-cc7d-4c00-a20c-95e473946054" />
