### PR TITLE
[Bug] Fix email take

### DIFF
--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -183,15 +183,17 @@ class AuthController extends Controller
                             ->orWhere('work_email', 'ilike', $incomingEmailAddress))
                         ->withTrashed()
                         ->first();
-                    if (strcasecmp($existingUser->email, $incomingEmailAddress) == 0) {
-                        $existingUser->email_backup = $existingUser->email;
-                        $existingUser->email = null;
+                    if ($existingUser) {
+                        if (strcasecmp($existingUser->email, $incomingEmailAddress) == 0) {
+                            $existingUser->email_backup = $existingUser->email;
+                            $existingUser->email = null;
+                        }
+                        if (strcasecmp($existingUser->work_email, $incomingEmailAddress) == 0) {
+                            $existingUser->work_email_backup = $existingUser->work_email;
+                            $existingUser->work_email = null;
+                        }
+                        $existingUser->save();
                     }
-                    if (strcasecmp($existingUser->work_email, $incomingEmailAddress) == 0) {
-                        $existingUser->work_email_backup = $existingUser->work_email;
-                        $existingUser->work_email = null;
-                    }
-                    $existingUser->save();
                 } catch (Throwable $e) {
                     // log and continue - don't break log in for failure to take address
                     Log::error('Failed to take email address on log in.'.$e->getMessage(), [

--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -184,11 +184,11 @@ class AuthController extends Controller
                         ->withTrashed()
                         ->first();
                     if ($existingUser) {
-                        if (strcasecmp($existingUser->email, $incomingEmailAddress) == 0) {
+                        if (! empty($existingUser->email) && strcasecmp($existingUser->email, $incomingEmailAddress) == 0) {
                             $existingUser->email_backup = $existingUser->email;
                             $existingUser->email = null;
                         }
-                        if (strcasecmp($existingUser->work_email, $incomingEmailAddress) == 0) {
+                        if (! empty($existingUser->work_email) && strcasecmp($existingUser->work_email, $incomingEmailAddress) == 0) {
                             $existingUser->work_email_backup = $existingUser->work_email;
                             $existingUser->work_email = null;
                         }


### PR DESCRIPTION
🤖 Resolves #17106 

## 👋 Introduction

Fixes an exception (that is already being handled) to reduce error logging.

## 🕵️ Details

- checks if there is an existing user with the address before trying to take over the address
- checks if the email is not null before trying to take over the address

> [!TIP]
> I recommend viewing the code diff without whitespace changes.

## 🧪 Testing

1. Configure environment for CanadaLogin

- [ ] Logging in as a new user works without logging errors
- [ ] Logging in as an existing user works without logging errors
- [ ] Logging in as a user which takes over an email address from another user works without logging errors

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

## 🚚 Deployment

<!--
Add any additional details that are required for deploying the application.

Examples of when this is required include:

- re-running database seeders
- environment variable changes

> **Notes**
>
> - Remove deployment section if no steps are needed
> - Add [deployment label](https://github.com/GCTC-NTGC/gc-digital-talent/labels/deployment) to the PR if deployment steps are needed

 -->
