### PR TITLE
[Feat] Add talent sources to tracked users in talent request

### DIFF
--- a/api/app/Models/TalentRequestTrackedUser.php
+++ b/api/app/Models/TalentRequestTrackedUser.php
@@ -86,10 +86,19 @@ class TalentRequestTrackedUser extends Pivot
     /** @return Attribute<array<string>, never> */
     protected function sources(): Attribute
     {
-        return Attribute::get(fn (): array => $this->has_prequalified_source
+        return Attribute::get(fn (): array => $this->hasQualifiedInPoolSource()
             ? [TalentRequestSource::QUALIFIED_IN_POOL->name]
             : []
         );
+    }
+
+    private function hasQualifiedInPoolSource(): bool
+    {
+        if (isset($this->has_prequalified_source)) {
+            return (bool) $this->has_prequalified_source;
+        }
+
+        return $this->matchingQualifiedInPoolSources()->exists();
     }
 
     /** @return Attribute<array<never>, never> */

--- a/api/app/Models/TalentRequestTrackedUser.php
+++ b/api/app/Models/TalentRequestTrackedUser.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Builders\UserBuilder;
+use App\Enums\TalentRequestSource;
 use App\Enums\TalentRequestTrackedUserReferralDecision;
 use App\Enums\TalentRequestTrackedUserSelectionDecision;
 use App\Enums\TalentRequestTrackedUserStatus;
@@ -13,6 +14,7 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Carbon;
 use SortDirection;
@@ -62,6 +64,46 @@ class TalentRequestTrackedUser extends Pivot
         return $this->belongsTo(User::class);
     }
 
+    /** @return HasManyThrough<PoolCandidate, User, $this> */
+    public function matchingQualifiedInPoolSources(): HasManyThrough
+    {
+        // talentRequest.applicantFilter.* is pre-loaded via @with on the schema field
+        $filter = $this->talentRequest->applicantFilter;
+
+        return $this->hasManyThrough(PoolCandidate::class, User::class, 'id', 'user_id', 'user_id', 'id')
+            ->whereMatchesTalentRequest([
+                'qualifiedInClassifications' => $filter->qualifiedInClassifications
+                    ->map(fn ($c) => ['group' => $c->group, 'level' => $c->level])
+                    ->toArray(),
+                'qualifiedInWorkStreams' => $filter->qualifiedInWorkStreams
+                    ->map(fn ($ws) => ['id' => $ws->id])
+                    ->toArray(),
+                'community' => $filter->community_id,
+            ])
+            ->whereAuthorizedToView();
+    }
+
+    /** @return Attribute<array<string>, never> */
+    protected function sources(): Attribute
+    {
+        return Attribute::get(fn (): array => $this->has_prequalified_source
+            ? [TalentRequestSource::QUALIFIED_IN_POOL->name]
+            : []
+        );
+    }
+
+    /** @return Attribute<array<never>, never> */
+    protected function matchingAtLevelSources(): Attribute
+    {
+        return Attribute::get(fn (): array => []);
+    }
+
+    /** @return Attribute<array<never>, never> */
+    protected function matchingAdvancementSources(): Attribute
+    {
+        return Attribute::get(fn (): array => []);
+    }
+
     /**
      * The tracked user's current position in the referral → selection flow,
      * as a TalentRequestTrackedUserStatus name. A selection decision supersedes
@@ -107,6 +149,33 @@ class TalentRequestTrackedUser extends Pivot
                     ->join('talent_requests', 'talent_requests.applicant_filter_id', '=', 'applicant_filter_skill.applicant_filter_id')
                     ->whereColumn('talent_requests.id', 'talent_request_tracked_users.talent_request_id');
             }),
+        ]);
+    }
+
+    public function scopeWithSources(Builder $query, string $talentRequestId): Builder
+    {
+        $filter = TalentRequest::with([
+            'applicantFilter.qualifiedInClassifications',
+            'applicantFilter.qualifiedInWorkStreams',
+        ])->find($talentRequestId)?->applicantFilter;
+
+        if (! $filter) {
+            return $query;
+        }
+
+        return $query->addSelect(['has_prequalified_source' => PoolCandidate::query()
+            ->selectRaw('1')
+            ->whereColumn('pool_candidates.user_id', 'talent_request_tracked_users.user_id')
+            ->whereMatchesTalentRequest([
+                'qualifiedInClassifications' => $filter->qualifiedInClassifications
+                    ->map(fn ($c) => ['group' => $c->group, 'level' => $c->level])
+                    ->toArray(),
+                'qualifiedInWorkStreams' => $filter->qualifiedInWorkStreams
+                    ->map(fn ($ws) => ['id' => $ws->id])
+                    ->toArray(),
+                'community' => $filter->community_id,
+            ])
+            ->limit(1),
         ]);
     }
 

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1187,6 +1187,8 @@ type TalentRequestTrackedUser {
   notSelectedReason: LocalizedTalentRequestTrackedUserNotSelectedReason
     @rename(attribute: "not_selected_reason")
   sources: [TalentRequestSource!]!
+    @with(relation: "talentRequest.applicantFilter.qualifiedInClassifications")
+    @with(relation: "talentRequest.applicantFilter.qualifiedInWorkStreams")
   # matchingAtLevelSources and matchingAdvancementSources are not populated yet.
   matchingQualifiedInPoolSources: [PoolCandidate!]
     @with(relation: "talentRequest.applicantFilter.qualifiedInClassifications")

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1186,6 +1186,13 @@ type TalentRequestTrackedUser {
     @rename(attribute: "not_referred_reason")
   notSelectedReason: LocalizedTalentRequestTrackedUserNotSelectedReason
     @rename(attribute: "not_selected_reason")
+  sources: [TalentRequestSource!]!
+  # matchingAtLevelSources and matchingAdvancementSources are not populated yet.
+  matchingQualifiedInPoolSources: [PoolCandidate!]
+    @with(relation: "talentRequest.applicantFilter.qualifiedInClassifications")
+    @with(relation: "talentRequest.applicantFilter.qualifiedInWorkStreams")
+  matchingAtLevelSources: [CommunityInterest!]
+  matchingAdvancementSources: [TalentNominationGroup!]
 }
 
 type SkillFamily {
@@ -1907,7 +1914,7 @@ type Query {
     @guard
     @canModel(ability: "viewAny")
   talentRequestTrackedUsers(
-    talentRequestId: UUID! @eq(key: "talent_request_id")
+    talentRequestId: UUID! @eq(key: "talent_request_id") @scope(name: "withSources")
     where: TalentRequestTrackedUserFilterInput
   ): [TalentRequestTrackedUser!]
     @advancedOrderBy

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1674,6 +1674,10 @@ type TalentRequestTrackedUser {
   selectionDecision: LocalizedTalentRequestTrackedUserSelectionDecision
   notReferredReason: LocalizedTalentRequestTrackedUserNotReferredReason
   notSelectedReason: LocalizedTalentRequestTrackedUserNotSelectedReason
+  sources: [TalentRequestSource!]!
+  matchingQualifiedInPoolSources: [PoolCandidate!]
+  matchingAtLevelSources: [CommunityInterest!]
+  matchingAdvancementSources: [TalentNominationGroup!]
 }
 
 type SkillFamily {

--- a/api/tests/Feature/TalentRequestTrackedUserTest.php
+++ b/api/tests/Feature/TalentRequestTrackedUserTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Enums\TalentRequestSource;
 use App\Enums\TalentRequestTrackedUserNotReferredReason;
 use App\Enums\TalentRequestTrackedUserNotSelectedReason;
 use App\Enums\TalentRequestTrackedUserReferralDecision;
@@ -9,6 +10,7 @@ use App\Enums\TalentRequestTrackedUserSelectionDecision;
 use App\Enums\TalentRequestTrackedUserStatus;
 use App\Jobs\GenerateUserFile;
 use App\Models\ApplicantFilter;
+use App\Models\Classification;
 use App\Models\Community;
 use App\Models\Pool;
 use App\Models\PoolCandidate;
@@ -79,6 +81,20 @@ class TalentRequestTrackedUserTest extends TestCase
                     selectionDecision { value }
                 }
                 paginatorInfo { total }
+            }
+        }
+        GRAPHQL;
+
+    protected string $sourcesQuery = <<<'GRAPHQL'
+        query SourcesTrackedUsers($talentRequestId: UUID!) {
+            talentRequestTrackedUsers(talentRequestId: $talentRequestId) {
+                data {
+                    user { id }
+                    sources
+                    matchingQualifiedInPoolSources { pool { id } }
+                    matchingAtLevelSources { id }
+                    matchingAdvancementSources { id }
+                }
             }
         }
         GRAPHQL;
@@ -1247,5 +1263,135 @@ class TalentRequestTrackedUserTest extends TestCase
             ])
             ->assertJsonCount(0, 'data.talentRequest.trackedUsers')
             ->assertJsonMissing(['user' => ['id' => $inconsistent->id]]);
+    }
+
+    public function testSourcesQualifiedInPoolWhenUserHasMatchingCandidacy(): void
+    {
+        $classification = Classification::factory()->create();
+        $filter = ApplicantFilter::factory()->create(['community_id' => $this->community->id]);
+        $filter->qualifiedInClassifications()->sync([$classification->id]);
+
+        $request = TalentRequest::factory()->create([
+            'community_id' => $this->community->id,
+            'applicant_filter_id' => $filter->id,
+        ]);
+
+        $pool = Pool::factory()->candidatesAvailableInSearch()->create([
+            'community_id' => $this->community->id,
+            'classification_id' => $classification->id,
+        ]);
+
+        $user = User::factory()->create();
+        PoolCandidate::factory()->availableInSearch()->create([
+            'user_id' => $user->id,
+            'pool_id' => $pool->id,
+        ]);
+
+        TalentRequestTrackedUser::factory()->create([
+            'talent_request_id' => $request->id,
+            'user_id' => $user->id,
+        ]);
+
+        $this->actingAs($this->admin, 'api')
+            ->graphQL($this->sourcesQuery, ['talentRequestId' => $request->id])
+            ->assertJsonPath('data.talentRequestTrackedUsers.data.0.sources', [TalentRequestSource::QUALIFIED_IN_POOL->name])
+            ->assertJsonCount(1, 'data.talentRequestTrackedUsers.data.0.matchingQualifiedInPoolSources');
+    }
+
+    public function testSourcesEmptyWhenUserHasNoMatchingCandidacy(): void
+    {
+        $request = $this->createRequest();
+        $user = User::factory()->create();
+
+        TalentRequestTrackedUser::factory()->create([
+            'talent_request_id' => $request->id,
+            'user_id' => $user->id,
+        ]);
+
+        $this->actingAs($this->admin, 'api')
+            ->graphQL($this->sourcesQuery, ['talentRequestId' => $request->id])
+            ->assertJsonPath('data.talentRequestTrackedUsers.data.0.sources', [])
+            ->assertJsonCount(0, 'data.talentRequestTrackedUsers.data.0.matchingQualifiedInPoolSources');
+    }
+
+    public function testMatchingQualifiedInPoolSourcesOnlyIncludesFilterMatchingPools(): void
+    {
+        $matchingClass = Classification::factory()->create();
+        $otherClass = Classification::factory()->create();
+
+        $filter = ApplicantFilter::factory()->create(['community_id' => $this->community->id]);
+        $filter->qualifiedInClassifications()->sync([$matchingClass->id]);
+
+        $request = TalentRequest::factory()->create([
+            'community_id' => $this->community->id,
+            'applicant_filter_id' => $filter->id,
+        ]);
+
+        $matchingPool = Pool::factory()->candidatesAvailableInSearch()->create([
+            'community_id' => $this->community->id,
+            'classification_id' => $matchingClass->id,
+        ]);
+        $otherPool = Pool::factory()->candidatesAvailableInSearch()->create([
+            'community_id' => $this->community->id,
+            'classification_id' => $otherClass->id,
+        ]);
+
+        $user = User::factory()->create();
+        PoolCandidate::factory()->availableInSearch()->create([
+            'user_id' => $user->id,
+            'pool_id' => $matchingPool->id,
+        ]);
+        PoolCandidate::factory()->availableInSearch()->create([
+            'user_id' => $user->id,
+            'pool_id' => $otherPool->id,
+        ]);
+
+        TalentRequestTrackedUser::factory()->create([
+            'talent_request_id' => $request->id,
+            'user_id' => $user->id,
+        ]);
+
+        $this->actingAs($this->admin, 'api')
+            ->graphQL($this->sourcesQuery, ['talentRequestId' => $request->id])
+            ->assertJsonPath('data.talentRequestTrackedUsers.data.0.sources', [TalentRequestSource::QUALIFIED_IN_POOL->name])
+            ->assertJsonCount(1, 'data.talentRequestTrackedUsers.data.0.matchingQualifiedInPoolSources')
+            ->assertJsonPath('data.talentRequestTrackedUsers.data.0.matchingQualifiedInPoolSources.0.pool.id', $matchingPool->id);
+    }
+
+    public function testUserQualifiedInTwoMatchingPoolsGetsBothInMatchingQualifiedInPoolSources(): void
+    {
+        $request = $this->createRequest();
+
+        $poolA = Pool::factory()->candidatesAvailableInSearch()->create([
+            'community_id' => $this->community->id,
+        ]);
+        $poolB = Pool::factory()->candidatesAvailableInSearch()->create([
+            'community_id' => $this->community->id,
+        ]);
+
+        $user = User::factory()->create();
+        PoolCandidate::factory()->availableInSearch()->create([
+            'user_id' => $user->id,
+            'pool_id' => $poolA->id,
+        ]);
+        PoolCandidate::factory()->availableInSearch()->create([
+            'user_id' => $user->id,
+            'pool_id' => $poolB->id,
+        ]);
+
+        TalentRequestTrackedUser::factory()->create([
+            'talent_request_id' => $request->id,
+            'user_id' => $user->id,
+        ]);
+
+        $response = $this->actingAs($this->admin, 'api')
+            ->graphQL($this->sourcesQuery, ['talentRequestId' => $request->id])
+            ->assertJsonCount(2, 'data.talentRequestTrackedUsers.data.0.matchingQualifiedInPoolSources');
+
+        $poolIds = collect($response->json('data.talentRequestTrackedUsers.data.0.matchingQualifiedInPoolSources'))
+            ->pluck('pool.id')
+            ->all();
+
+        $this->assertEqualsCanonicalizing([$poolA->id, $poolB->id], $poolIds);
     }
 }

--- a/api/tests/Feature/TalentRequestTrackedUserTest.php
+++ b/api/tests/Feature/TalentRequestTrackedUserTest.php
@@ -1394,4 +1394,54 @@ class TalentRequestTrackedUserTest extends TestCase
 
         $this->assertEqualsCanonicalizing([$poolA->id, $poolB->id], $poolIds);
     }
+
+    public function testSourcesCorrectOnNestedPathWithoutPaginatedScope(): void
+    {
+        $classification = Classification::factory()->create();
+        $filter = ApplicantFilter::factory()->create(['community_id' => $this->community->id]);
+        $filter->qualifiedInClassifications()->sync([$classification->id]);
+
+        $request = TalentRequest::factory()->create([
+            'community_id' => $this->community->id,
+            'applicant_filter_id' => $filter->id,
+        ]);
+
+        $pool = Pool::factory()->candidatesAvailableInSearch()->create([
+            'community_id' => $this->community->id,
+            'classification_id' => $classification->id,
+        ]);
+
+        $withCandidacy = User::factory()->create();
+        PoolCandidate::factory()->availableInSearch()->create([
+            'user_id' => $withCandidacy->id,
+            'pool_id' => $pool->id,
+        ]);
+
+        $withoutCandidacy = User::factory()->create();
+
+        foreach ([$withCandidacy, $withoutCandidacy] as $user) {
+            TalentRequestTrackedUser::factory()->create([
+                'talent_request_id' => $request->id,
+                'user_id' => $user->id,
+            ]);
+        }
+
+        $response = $this->actingAs($this->admin, 'api')
+            ->graphQL(/** @lang GraphQL */ '
+                query NestedSources($id: UUID!) {
+                    talentRequest(id: $id) {
+                        trackedUsers {
+                            user { id }
+                            sources
+                        }
+                    }
+                }
+            ', ['id' => $request->id]);
+
+        $byUser = collect($response->json('data.talentRequest.trackedUsers'))
+            ->keyBy(fn ($row) => $row['user']['id']);
+
+        $this->assertEquals([TalentRequestSource::QUALIFIED_IN_POOL->name], $byUser[$withCandidacy->id]['sources']);
+        $this->assertEquals([], $byUser[$withoutCandidacy->id]['sources']);
+    }
 }


### PR DESCRIPTION
🤖 Resolves #17110 

## 👋 Introduction

Adds the computed talent sources for a tracked user on a talent request.

## 🕵️ Details

These filters are intended to always match the current filters so we added a scope that adds the selects in. Unfortunatley, this means baking in a very light n+1. We may want to consider making these stored computed values when the following change:

 - One of the potential sources for a user are created or updated
 - The talent request applicant filter changes

## 🧪 Testing

1. Confirm the talent sources exist
2. Confirm the test coverage is accurate and tests pass
