### PR TITLE
[Fix] Adds role conditional for edit department link

### DIFF
--- a/apps/web/src/pages/Departments/ViewDepartmentPage.tsx
+++ b/apps/web/src/pages/Departments/ViewDepartmentPage.tsx
@@ -63,6 +63,7 @@ export const ViewDepartmentForm = ({ query }: ViewDepartmentProps) => {
   const paths = useRoutes();
   const department = getFragment(DepartmentView_Fragment, query);
   const notProvided = intl.formatMessage(commonMessages.notProvided);
+  const { canEditAdmin } = useOutletContext<ContextType>();
 
   return (
     <>
@@ -126,19 +127,23 @@ export const ViewDepartmentForm = ({ query }: ViewDepartmentProps) => {
             {department.size?.label.localized ?? notProvided}
           </FieldDisplay>
         </div>
-        <CardSeparator />
-        <div className="flex justify-center xs:justify-start">
-          <Link
-            href={paths.departmentUpdate(department.id)}
-            className="font-bold"
-          >
-            {intl.formatMessage({
-              defaultMessage: "Edit department information",
-              id: "os2TYf",
-              description: "Link to edit the currently viewed department",
-            })}
-          </Link>
-        </div>
+        {canEditAdmin && (
+          <>
+            <CardSeparator />
+            <div className="flex justify-center xs:justify-start">
+              <Link
+                href={paths.departmentUpdate(department.id)}
+                className="font-bold"
+              >
+                {intl.formatMessage({
+                  defaultMessage: "Edit department information",
+                  id: "os2TYf",
+                  description: "Link to edit the currently viewed department",
+                })}
+              </Link>
+            </div>
+          </>
+        )}
       </Card>
     </>
   );


### PR DESCRIPTION
🤖 Resolves #17127.

## 👋 Introduction

This PR adds conditional for edit department link so that only platform admin users have the link rendered.

## 🧪 Testing

1. `pnpm dev`
2. Log in as admin@test.com
3. Navigate to http://localhost:8000/en/admin/settings/departments
4. Navigate to a department
5. Verify Edit department information link is rendered
6. Log in as department-admin@test.com
7. Navigate to http://localhost:8000/en/admin/department
8. Navigate to view and manage department
9. Verify Edit department information link is not rendered
10. Log in as department-advisor@test.com
11. Navigate to http://localhost:8000/en/admin/department
12. Navigate to view and manage department
13. Verify Edit department information link is not rendered

## 📸 Screenshot

<img width="1372" height="836" alt="Screenshot 2026-06-19 at 11 21 59" src="https://github.com/user-attachments/assets/7c1822b2-6677-42d8-a87a-472dcf681bec" />
