### PR TITLE
[Bug] Use client credentials for ping

### DIFF
--- a/api/app/Console/Commands/AuthPing.php
+++ b/api/app/Console/Commands/AuthPing.php
@@ -31,13 +31,11 @@ class AuthPing extends Command
     public function handle()
     {
         $url = config('oauth.token_uri');
-        // typical payload for requesting a login in the auth callback
+        // client credentials payload for OIDC token endpoint
         $data = [
-            'grant_type' => 'authorization_code',
+            'grant_type' => 'client_credentials',
             'client_id' => config('oauth.client_id'),
             'client_secret' => config('oauth.client_secret'),
-            'redirect_uri' => config('oauth.redirect_uri'),
-            'code' => '1', // not a real code, of course
         ];
 
         $results = $this->pingTokenUri($url, $data);
@@ -66,11 +64,10 @@ class AuthPing extends Command
             try {
                 $response = Http::asForm()->post($url, $data);
                 $transferStats = $response->transferStats;
-
                 $results->push([
                     'transferTime' => $transferStats->getTransferTime() * 1000, // s -> ms
-                    // since we don't have a real code we're expecting the invalid_grant error
-                    'success' => $response->status() == 400 && $response->json('error') == 'invalid_grant',
+                    // success: 200 response with an access_token present
+                    'success' => $response->successful() && ! is_null($response->json('access_token')),
                 ]);
             } catch (\Throwable $_) {
                 $results->push([


### PR DESCRIPTION
🤖 Resolves #17159 

## 👋 Introduction

Updates the auth ping command with the client credentials flow provided by the CanadaLogin team.

## 🕵️ Details

It only sort-of works with Sign In Canada.  We still get timing but the response is unsuccessful.  We should be live with CL by the time this deploys so I'm not too worried.

## 🧪 Testing



1. Configure your environment for CanadaLogin.
2. `./artisan auth:ping`

## 📸 Screenshot

<img width="783" height="73" alt="image" src="https://github.com/user-attachments/assets/983f8ed1-8a96-4cdd-9d18-88871b73013e" />
