### PR TITLE
[Copy] Adds messages for talent request error codes

### DIFF
--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -307,6 +307,10 @@
     "defaultMessage": "Je ne participe à aucun programme de coaching des cadres.",
     "description": "The executive coaching status described as not participating."
   },
+  "8FkvT5": {
+    "defaultMessage": "La valeur du champ de statut de la demande de talents n’est pas valide.",
+    "description": "Error message for talent request invalid status"
+  },
   "8RX9iJ": {
     "defaultMessage": "Être disponible, disposé(e) et apte à travailler des heures supplémentaires (occasionnellement)",
     "description": "The operational requirement described as occasional overtime."
@@ -687,6 +691,10 @@
     "defaultMessage": "Modifier la séquence de {from} à {to}",
     "description": "Button text for moving an item from one position to another"
   },
+  "NXyprm": {
+    "defaultMessage": "Le champ des détails de la demande de talents est obligatoire lorsque le statut est défini comme terminé.",
+    "description": "Error message for talent request completion details required"
+  },
   "Nf2jAz": {
     "defaultMessage": "J'ai un poste doté pour une période déterminée.",
     "description": "Term selection for government employee type."
@@ -758,6 +766,10 @@
   "PKkPSW": {
     "defaultMessage": "J'accepte de faire des <strong>heures supplémentaires à l'occasion</strong>.",
     "description": "The operational requirement described as occasional overtime."
+  },
+  "PLVEUB": {
+    "defaultMessage": "La valeur du champ du type de poste de la demande de talents n’est pas valide.",
+    "description": "Error message for talent request invalid position type"
   },
   "PMwqcS": {
     "defaultMessage": "La date doit être avant ou égale au {date}",
@@ -1094,6 +1106,10 @@
   "a+twlj": {
     "defaultMessage": "Les possibilités de réseautage entre pairs m'intéressent.",
     "description": "Interest label for peer networking."
+  },
+  "a02YvL": {
+    "defaultMessage": "La valeur du champ du motif de la demande de talents n’est pas valide.",
+    "description": "Error message for talent request invalid reason"
   },
   "a5edSg": {
     "defaultMessage": "Jour",
@@ -1622,6 +1638,10 @@
   "rH9RNh": {
     "defaultMessage": "Intérêt",
     "description": "Expressed interest"
+  },
+  "rNmajm": {
+    "defaultMessage": "Le champ des détails de la demande de talents est obligatoire lorsque le statut est défini comme en cours.",
+    "description": "Error message for talent request in progress details required"
   },
   "rYodJu": {
     "defaultMessage": "Durée indéterminée (permanente)",

--- a/packages/i18n/src/messages/apiMessages.ts
+++ b/packages/i18n/src/messages/apiMessages.ts
@@ -570,6 +570,35 @@ export const apiMessages: Record<string, MessageDescriptor> = defineMessages({
     id: "MJzimR",
     description: "Error message for talent event cannot change name",
   },
+  [ErrorCode.TalentRequestInvalidPositionType]: {
+    defaultMessage:
+      "The talent request position type field value is not valid.",
+    id: "PLVEUB",
+    description: "Error message for talent request invalid position type",
+  },
+  [ErrorCode.TalentRequestInvalidReason]: {
+    defaultMessage: "The talent request reason field value is not valid.",
+    id: "a02YvL",
+    description: "Error message for talent request invalid reason",
+  },
+  [ErrorCode.TalentRequestInvalidStatus]: {
+    defaultMessage: "The talent request status field value is not valid.",
+    id: "8FkvT5",
+    description: "Error message for talent request invalid status",
+  },
+  [ErrorCode.TalentRequestInProgressDetailsRequired]: {
+    defaultMessage:
+      "The talent request details field is required when the status field is set to in progress.",
+    id: "rNmajm",
+    description:
+      "Error message for talent request in progress details required",
+  },
+  [ErrorCode.TalentRequestCompletionDetailsRequired]: {
+    defaultMessage:
+      "The talent request details field is required when the status field is set to complete.",
+    id: "NXyprm",
+    description: "Error message for talent request completion details required",
+  },
 });
 
 export const tryFindMessageDescriptor = (


### PR DESCRIPTION
🤖 Resolves #16952.

## 👋 Introduction

This PR adds messages for talent request error codes to provide more context for a user.

## 🧪 Testing

Verify messages make sense in context.