### PR TITLE
[Bug] Fix pools being seeded without teams

### DIFF
--- a/api/database/factories/TalentRequestFactory.php
+++ b/api/database/factories/TalentRequestFactory.php
@@ -88,7 +88,7 @@ class TalentRequestFactory extends BaseFactory
 
                 PoolCandidate::factory()
                     ->availableInSearch()
-                    ->create([
+                    ->createQuietly([
                         'pool_id' => $pool->id,
                         'user_id' => $user->id,
                     ]);

--- a/api/database/seeders/TalentRequestRandomSeeder.php
+++ b/api/database/seeders/TalentRequestRandomSeeder.php
@@ -18,7 +18,7 @@ class TalentRequestRandomSeeder extends Seeder
         foreach ($applicantFilters as $applicantFilter) {
             TalentRequest::factory()
                 ->withTrackedUsers()
-                ->createQuietly([
+                ->create([
                     'community_id' => $applicantFilter->community_id,
                     'applicant_filter_id' => $applicantFilter->id,
                 ]);


### PR DESCRIPTION
🤖 Resolves #17125 

## 👋 Introduction

Stop seeding pools without teams which breaks functionality in some places.
The `createQuietly` was the reason, so I bumped it down a layer to within the factory

## 🧪 Testing

1. Seed
2. All pools have teams