### PR TITLE
[Chore] Remove too many candidates reason

### DIFF
--- a/api/app/Enums/TalentRequestTrackedUserNotReferredReason.php
+++ b/api/app/Enums/TalentRequestTrackedUserNotReferredReason.php
@@ -10,7 +10,6 @@ enum TalentRequestTrackedUserNotReferredReason
 
     case MISMATCH_IN_QUALIFICATIONS;
     case JOB_MISMATCHES_EXPECTATIONS;
-    case TOO_MANY_CANDIDATES;
     case OTHER;
 
     public static function getLangFilename(): string

--- a/api/lang/en/talent_request_tracked_user_not_referred_reason.php
+++ b/api/lang/en/talent_request_tracked_user_not_referred_reason.php
@@ -5,6 +5,5 @@ use Illuminate\Support\Facades\Lang;
 return [
     'mismatch_in_qualifications' => 'Mismatch in candidate qualifications',
     'job_mismatches_expectations' => 'Job doesn\'t match candidate expectations',
-    'too_many_candidates' => 'Too many candidates',
     'other' => Lang::get('common.other', [], 'en'),
 ];

--- a/api/lang/fr/talent_request_tracked_user_not_referred_reason.php
+++ b/api/lang/fr/talent_request_tracked_user_not_referred_reason.php
@@ -5,6 +5,5 @@ use Illuminate\Support\Facades\Lang;
 return [
     'mismatch_in_qualifications' => 'Qualifications de la personne candidate incompatibles',
     'job_mismatches_expectations' => 'Le poste ne correspond pas aux attentes de la personne candidate',
-    'too_many_candidates' => 'Trop de candidatures',
     'other' => Lang::get('common.other', [], 'fr'),
 ];

--- a/api/programmatic-types.graphql
+++ b/api/programmatic-types.graphql
@@ -2071,7 +2071,6 @@ enum TalentRequestStatus {
 enum TalentRequestTrackedUserNotReferredReason {
   MISMATCH_IN_QUALIFICATIONS
   JOB_MISMATCHES_EXPECTATIONS
-  TOO_MANY_CANDIDATES
   OTHER
 }
 

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -4873,7 +4873,6 @@ enum TalentRequestStatus {
 enum TalentRequestTrackedUserNotReferredReason {
   MISMATCH_IN_QUALIFICATIONS
   JOB_MISMATCHES_EXPECTATIONS
-  TOO_MANY_CANDIDATES
   OTHER
 }
 


### PR DESCRIPTION
🤖 Resolves #17205 

## 👋 Introduction

This removes the "Too many candidates" reason for a user not being referred.

## 🧪 Testing

1. Confirm it is no longer present
2. Confirm submitting other reasons still works.