### PR TITLE
[Feature] Removes IAP card on search page when `IT-01` selected

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -11574,10 +11574,6 @@
     "defaultMessage": "Modifier les informations sur le groupe de compétences",
     "description": "Link text to edit a skill family"
   },
-  "ifqj46": {
-    "defaultMessage": "Le Programme d'apprentissage en TI pour les personnes autochtones a pour but d'aider à éliminer les obstacles en matière d'emploi pour les personnes autochtones dans le domaine numérique au sein du gouvernement du Canada. Devenez un partenaire de recrutement dès aujourd'hui et découvrez comment vous pouvez renforcer votre équipe en embauchant des talents autochtones en informatique et aider à bâtir à une fonction publique plus inclusive. Votre participation contribue à l'objectif plus large de promouvoir l'inclusion, l'équité et la réconciliation au Canada.",
-    "description": "Paragraph for IT Apprenticeship Program for Indigenous Peoples search card"
-  },
   "igTwND": {
     "defaultMessage": "Nous contacter - ConnexionCanada",
     "description": "CanadaLogin contact us link"
@@ -12153,10 +12149,6 @@
   "kvxHHl": {
     "defaultMessage": "Français essentiel",
     "description": "French essential language requirement"
-  },
-  "kyM6sV": {
-    "defaultMessage": "Pensez-vous embaucher une apprentie ou un apprenti en TI autochtone?",
-    "description": "Title for IT Apprenticeship Program for Indigenous Peoples search card"
   },
   "kyOGve": {
     "defaultMessage": "Note spéciale relative aux compétences comportementales essentielles",
@@ -15700,10 +15692,6 @@
   "zVGK45": {
     "defaultMessage": "Cet utilisateur n'a pas vérifié son statut d'employé(e)",
     "description": "Label for when an employee was found but not verified"
-  },
-  "zVGzWa": {
-    "defaultMessage": "Visitez la page du gestionnaire du Programme d'apprentissage en TI pour les personnes autochtones",
-    "description": "Link to visit IT Apprenticeship Program for Indigenous Peoples manager page"
   },
   "zWR47V": {
     "defaultMessage": "La collectivité n'a pas été supprimée. Veuillez réessayer.",

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -6,19 +6,13 @@ import { useState, useEffect } from "react";
 
 import {
   Button,
-  Card,
   Container,
   Heading,
-  Link,
   Loading,
   Pending,
   Separator,
 } from "@gc-digital-talent/ui";
-import {
-  unpackMaybes,
-  notEmpty,
-  buildMailToUri,
-} from "@gc-digital-talent/helpers";
+import { unpackMaybes, notEmpty } from "@gc-digital-talent/helpers";
 import type {
   Classification,
   ApplicantFilterInput,
@@ -123,53 +117,6 @@ export const SearchForm = ({
     setValue("count", candidateCount);
   };
 
-  const hireAnApprenticeEmailUri = buildMailToUri(
-    "edsc.patipa.jumelage.emplois-itapip.job.matching.esdc@hrsdc-rhdcc.gc.ca",
-    intl.formatMessage({
-      defaultMessage: "I'm interested in offering an apprenticeship",
-      id: "HqtjhD",
-      description: "Subject line of a manager's email for apprenticeship",
-    }),
-    [
-      intl.formatMessage({
-        defaultMessage:
-          "To best support you in your journey to hire an IT Apprentice, please let us know if you",
-        id: "ZKss5S",
-        description: "Paragraph 1 of a manager's email for apprenticeship",
-      }),
-      intl.formatMessage({
-        defaultMessage:
-          "1. are interested in hiring an Apprentice and would like to learn more about the IT Apprenticeship Program for Indigenous Peoples",
-        id: "ipKAvI",
-        description: "Paragraph 2 of a manager's email for apprenticeship",
-      }),
-      intl.formatMessage({
-        defaultMessage:
-          "2. have reviewed the checklist in the manager’s package and have positions available to hire an IT Apprentice",
-        id: "18pJdz",
-        description: "Paragraph 3 of a manager's email for apprenticeship",
-      }),
-      intl.formatMessage({
-        defaultMessage: "3. Other…",
-        id: "Fz49kD",
-        description: "Paragraph 4 of a manager's email for apprenticeship",
-      }),
-      intl.formatMessage({
-        defaultMessage:
-          "A team member from the Office of Indigenous Initiatives will be in touch shortly.",
-        id: "x45gSl",
-        description: "Paragraph 5 of a manager's email for apprenticeship",
-      }),
-    ].join("\n"),
-  );
-
-  const selectedClassificationIsIT1 = applicantFilter.qualifiedInClassifications
-    ?.filter(notEmpty)
-    .some(
-      (classification) =>
-        classification.group === "IT" && classification.level === 1,
-    );
-
   return (
     <Container className="my-18">
       <FormProvider {...methods}>
@@ -269,55 +216,6 @@ export const SearchForm = ({
                     {intl.formatMessage(commonMessages.dividingColon)}
                   </p>
                   <div className="flex flex-col gap-y-6">
-                    {selectedClassificationIsIT1 && (
-                      <Card className="rounded-l-none border-l-12 border-l-error">
-                        <p className="text-lg font-bold lg:text-xl">
-                          {intl.formatMessage({
-                            defaultMessage:
-                              "Have you considered hiring an Indigenous IT apprentice?",
-                            id: "kyM6sV",
-                            description:
-                              "Title for IT Apprenticeship Program for Indigenous Peoples search card",
-                          })}
-                        </p>
-                        <p className="mt-5 mb-6 flex gap-x-3">
-                          {intl.formatMessage({
-                            defaultMessage:
-                              "The IT Apprenticeship Program for Indigenous Peoples aims to help address and remove barriers Indigenous peoples face when it comes to finding employment in the Government of Canada's digital workforce. Become a hiring partner today and discover how you can strengthen your team with Indigenous IT talent and help build a more inclusive public service. Your participation contributes to the broader goal of inclusion, equity, and reconciliation in Canada.",
-                            id: "ifqj46",
-                            description:
-                              "Paragraph for IT Apprenticeship Program for Indigenous Peoples search card",
-                          })}
-                        </p>
-                        <Separator space="sm" />
-                        <div className="mt-6 flex flex-wrap items-center gap-6">
-                          <Link
-                            mode="solid"
-                            color="error"
-                            href={hireAnApprenticeEmailUri}
-                          >
-                            {intl.formatMessage({
-                              defaultMessage: "Contact the team",
-                              id: "gJ7CQw",
-                              description: "Link to send an email to the team",
-                            })}
-                          </Link>
-                          <Link
-                            mode="inline"
-                            color="error"
-                            href={paths.iapManager()}
-                          >
-                            {intl.formatMessage({
-                              defaultMessage:
-                                "Visit the IT Apprenticeship Program for Indigenous Peoples manager page",
-                              id: "zVGzWa",
-                              description:
-                                "Link to visit IT Apprenticeship Program for Indigenous Peoples manager page",
-                            })}
-                          </Link>
-                        </div>
-                      </Card>
-                    )}
                     {results.map(({ pool, count: resultsCount }) => (
                       <SearchResultCard
                         key={pool.id}


### PR DESCRIPTION
🤖 Resolves #17192.

## 👋 Introduction

This PR removes an IAP card on the search page at the beginning of the results section when the classification `IT-01` is selected.

## 🧪 Testing

1. `pnpm build`
2. Navigate to http://localhost:8000/en/search
3. Verify element with text **Have you considered hiring an Indigenous IT apprentice** does not render after **Or request candidates by pool** text
4. From the Classification filter `select` element, select **IT-01: Technician**
5. Verify element with text **Have you considered hiring an Indigenous IT apprentice** does not render after **Or request candidates by pool** text