### PR TITLE
[Bug] Fix unauthorized error on talent request table query

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1953,7 +1953,7 @@ type Query {
       scopes: ["withPolicyEagerLoads", "whereAuthorizedToView"]
     )
     @guard
-    @canModel(ability: "viewAny")
+    @canResolved(ability: "view", scopes: ["withPolicyEagerLoads"])
   talentRequestTrackedUsers(
     talentRequestId: UUID!
       @eq(key: "talent_request_id")

--- a/api/tests/Feature/TalentRequestTest.php
+++ b/api/tests/Feature/TalentRequestTest.php
@@ -6,6 +6,7 @@ use App\Enums\TalentRequestPositionType;
 use App\Enums\TalentRequestReason;
 use App\Models\Community;
 use App\Models\Department;
+use App\Models\TalentRequest;
 use App\Models\User;
 use Database\Seeders\CommunitySeeder;
 use Database\Seeders\DepartmentSeeder;
@@ -38,6 +39,25 @@ class TalentRequestTest extends TestCase
 
     protected User $adminUser;
 
+    protected User $teamRecruiter;
+
+    protected Community $authorizedCommunity;
+
+    protected Community $otherCommunity;
+
+    protected string $talentRequestsQuery = <<<'GRAPHQL'
+        query TalentRequests {
+            talentRequests {
+                data {
+                    id
+                }
+                paginatorInfo {
+                    total
+                }
+            }
+        }
+        GRAPHQL;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -54,6 +74,16 @@ class TalentRequestTest extends TestCase
             ->create([
                 'email' => 'admin-user@test.com',
                 'sub' => 'admin-user@test.com',
+            ]);
+
+        $this->authorizedCommunity = Community::factory()->create();
+        $this->otherCommunity = Community::factory()->create();
+
+        $this->teamRecruiter = User::factory()
+            ->asCommunityRecruiter([$this->authorizedCommunity->id])
+            ->create([
+                'email' => 'team-recruiter@test.com',
+                'sub' => 'team-recruiter@test.com',
             ]);
     }
 
@@ -121,5 +151,21 @@ class TalentRequestTest extends TestCase
             ])
             ->assertGraphQLErrorFree()
             ->assertJsonFragment(['user' => ['id' => $this->adminUser->id]]);
+    }
+
+    public function testTeamRecruiterCanQueryTalentRequestsForOwnCommunity(): void
+    {
+        $visibleRequest = TalentRequest::factory()->create([
+            'community_id' => $this->authorizedCommunity->id,
+        ]);
+        $hiddenRequest = TalentRequest::factory()->create([
+            'community_id' => $this->otherCommunity->id,
+        ]);
+
+        $this->actingAs($this->teamRecruiter, 'api')
+            ->graphQL($this->talentRequestsQuery)
+            ->assertGraphQLErrorFree()
+            ->assertJsonFragment(['id' => $visibleRequest->id])
+            ->assertJsonMissing(['id' => $hiddenRequest->id]);
     }
 }


### PR DESCRIPTION
🤖 Resolves #17233 

## 👋 Introduction

- Changed query authorization from global-model check to per-record check
- Adds a new test to prevent regression in the future

## 🧪 Testing

1. Build api `make refresh-api`
2. Login as community admin and recruiter: `community@test.com` or `recuiter@test.com`
3. Go to talent requests page
4. Ensure no authorisation error occurs
