### PR TITLE
[Feature] Add crumb for candidate tracking page

### DIFF
--- a/apps/web/src/pages/TalentRequests/Layout.tsx
+++ b/apps/web/src/pages/TalentRequests/Layout.tsx
@@ -1,5 +1,5 @@
 import { useIntl } from "react-intl";
-import { Outlet } from "react-router";
+import { Outlet, useLocation } from "react-router";
 import { useQuery } from "urql";
 
 import {
@@ -57,7 +57,10 @@ interface LayoutProps {
 const Layout = ({ query, optionsQuery }: LayoutProps) => {
   const intl = useIntl();
   const paths = useRoutes();
+  const location = useLocation();
   const talentRequest = getFragment(TalentRequestLayout_Fragment, query);
+  const isTrackingRoute =
+    location.pathname === paths.talentRequestTracking(talentRequest.id);
 
   const pageTitle =
     talentRequest.jobTitle ?? intl.formatMessage(commonMessages.notFound);
@@ -75,18 +78,25 @@ const Layout = ({ query, optionsQuery }: LayoutProps) => {
     },
   );
 
-  const crumbs = useBreadcrumbs({
-    crumbs: [
-      {
-        label: intl.formatMessage(pageTitles.talentRequests),
-        url: paths.talentRequests(),
-      },
-      {
-        label: pageTitle,
-        url: paths.talentRequestView(talentRequest.id),
-      },
-    ],
-  });
+  const crumbsConfig = [
+    {
+      label: intl.formatMessage(pageTitles.talentRequests),
+      url: paths.talentRequests(),
+    },
+    {
+      label: pageTitle,
+      url: paths.talentRequestView(talentRequest.id),
+    },
+  ];
+
+  if (isTrackingRoute) {
+    crumbsConfig.push({
+      label: intl.formatMessage(talentRequestMessages.candidateTracking),
+      url: paths.talentRequestTracking(talentRequest.id),
+    });
+  }
+
+  const crumbs = useBreadcrumbs({ crumbs: crumbsConfig });
 
   return (
     <>


### PR DESCRIPTION
🤖 Resolves #17242 

## 👋 Introduction

- Adds crumb for candidate tracking tab in talent request layout

## 🧪 Testing

1. Build front-end `pnpm dev:fresh`
2. Login as admin
3. Go to talent request and click on "Candidate tracking" tab
4. Ensure crumb is showing

## 📸 Screenshot

<img width="1912" height="917" alt="image" src="https://github.com/user-attachments/assets/10e68bde-563c-4c44-b1b9-c10a7710565f" />