### PR TITLE
Update setup documentation and add lint commands to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,17 @@ watch:
 lint:
 	$(DOCKER_API) "php ./vendor/bin/pint"
 	$(DOCKER_PNPM) lint
+	$(DOCKER_PNPM) run tsc
+	$(DOCKER_PNPM) run prettier -- --write
 
 lint-php:
 	$(DOCKER_API) "vendor/bin/pint"
+
+tsc:
+	$(DOCKER_PNPM) run tsc
+
+prettier:
+	$(DOCKER_PNPM) run prettier -- --write
 
 phpstan:
 	$(DOCKER_API) "vendor/bin/phpstan analyse -c phpstan.neon"

--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -22,7 +22,7 @@ To set up a local development environment, run these commands from anywhere in r
 ## Environment Maintenance
 
 To refresh each subproject after they have been setup run one of the refresh scripts:
-sdf
+
 - `docker compose run --rm maintenance bash refresh_api.sh`
 - `docker compose run --rm maintenance bash refresh_frontend.sh`
 
@@ -39,7 +39,7 @@ In order to compile and render UI for development, you have two options:
 
 ### Logging into the UI
 
-- From progect root run `pnpm run watch`
+- From project root run `pnpm run watch`
 - Allow the first compile to happen
 - Make some changes, watch it recompile, and refresh your page
 

--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -12,17 +12,17 @@ To set up a local development environment, run these commands from anywhere in r
    - For testing admin accounts:
      1. Navigate to http://localhost:8000/login
      2. Enter `admin@test.com` as the "User/subject" (the "Claims" input can be left blank, and there is no password)
-     3. Navigate to http://localhost:8000/admin/dashboard
+     3. Navigate to http://localhost:8000/admin
    - For testing applicant accounts:
      1. Navigate to http://localhost:8000/en/login-info
      2. Click on "Sign in with GCKey"
      3. Enter `applicant@test.com` as the "User/subject" (the "Claims" input can be left blank, and there is no password)
-     4. Navigate to http://localhost:8000/en/talent/profile
+     4. Navigate to http://localhost:8000/en/applicant
 
 ## Environment Maintenance
 
 To refresh each subproject after they have been setup run one of the refresh scripts:
-
+sdf
 - `docker compose run --rm maintenance bash refresh_api.sh`
 - `docker compose run --rm maintenance bash refresh_frontend.sh`
 
@@ -39,17 +39,15 @@ In order to compile and render UI for development, you have two options:
 
 ### Logging into the UI
 
-- Navigate to the app you'd like to work on (e.g. `cd apps/web`)
-- Run `pnpm run watch`
+- From progect root run `pnpm run watch`
 - Allow the first compile to happen
 - Make some changes, watch it recompile, and refresh your page
 
 ### Running Storybook
 
-- Navigate to the app you'd like to work on (e.g. `cd apps/web`)
-- Run `pnpm run storybook`
+- From project root run `pnpm run storybook`
 - Allow the first compile to happen
 - Make some changes, watch it recompile, and your Storybook page should automatically refresh
 
-> [!TIP]  
+> [!TIP]
 > Having trouble with Storybook `.cache` permissions? Try running `sudo chmod 777 -R node_modules/.cache` from the relevant workspace.


### PR DESCRIPTION
## Summary
- Add `tsc` and `prettier` as individual Makefile targets, and include them in the combined `lint` target
- Update `maintenance/README.md` with corrected paths (admin dashboard, applicant profile) and simplified instructions (run commands from project root instead of navigating to sub-apps)

## Test plan
- [ ] Verify `make lint`, `make tsc`, and `make prettier` run correctly
- [ ] Review updated README paths match current routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(PR Description was generated with claude, not the code)