### PR TITLE
[Fix] Talent nomination event update validator development programs

### DIFF
--- a/api/app/GraphQL/Validators/Mutation/UpdateTalentNominationEventValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/UpdateTalentNominationEventValidator.php
@@ -34,6 +34,11 @@ final class UpdateTalentNominationEventValidator extends Validator
             ? $thisEvent->community_id
             : $this->arg('talentNominationEvent.community.connect');
 
+        $attachedCommunityDevelopmentProgramIds = $thisEvent->communityDevelopmentPrograms()
+            ->withTrashed()
+            ->pluck('community_development_program.id')
+            ->all();
+
         return [
             'talentNominationEvent.community.connect' => [
                 'uuid',
@@ -48,8 +53,9 @@ final class UpdateTalentNominationEventValidator extends Validator
             'talentNominationEvent.communityDevelopmentPrograms.sync.*.id' => [
                 'uuid',
                 Rule::exists('community_development_program', 'id')
-                    ->where(function ($query) use ($communityId) {
-                        $query->where('community_id', $communityId);
+                    ->where(function ($query) use ($communityId, $attachedCommunityDevelopmentProgramIds) {
+                        $query->where('community_id', $communityId)
+                            ->orWhereIn('id', $attachedCommunityDevelopmentProgramIds);
                     }),
             ],
             'talentNominationEvent.name' => ['localized_string'],
@@ -100,7 +106,7 @@ final class UpdateTalentNominationEventValidator extends Validator
         return [
             'talentNominationEvent.community.connect.App\\Rules\\ValueIsIdentical' => ErrorCode::TALENT_EVENT_CANNOT_CHANGE_COMMUNITY->name,
             'talentNominationEvent.community.connect.exists' => ErrorCode::COMMUNITY_NOT_FOUND->name,
-            'communityDevelopmentPrograms.sync.*.id.exists' => ErrorCode::COMMUNITY_DEVELOPMENT_PROGRAM_NOT_FOUND_OR_INVALID->name,
+            'talentNominationEvent.communityDevelopmentPrograms.sync.*.id.exists' => ErrorCode::COMMUNITY_DEVELOPMENT_PROGRAM_NOT_FOUND_OR_INVALID->name,
             'talentNominationEvent.name.en.App\\Rules\\ValueIsIdentical' => ErrorCode::TALENT_EVENT_CANNOT_CHANGE_NAME->name,
             'talentNominationEvent.name.fr.App\\Rules\\ValueIsIdentical' => ErrorCode::TALENT_EVENT_CANNOT_CHANGE_NAME->name,
         ];

--- a/api/tests/Feature/TalentNominationEventTest.php
+++ b/api/tests/Feature/TalentNominationEventTest.php
@@ -10,6 +10,7 @@ use App\Models\TalentNominationEvent;
 use App\Models\User;
 use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
@@ -28,6 +29,8 @@ class TalentNominationEventTest extends TestCase
     protected $platformAdmin;
 
     protected $talentCoordinator;
+
+    protected $community;
 
     protected $communityId;
 
@@ -75,6 +78,7 @@ class TalentNominationEventTest extends TestCase
         $this->seed(RolePermissionSeeder::class);
 
         $community = Community::factory()->create();
+        $this->community = $community;
         $this->communityId = $community->id;
 
         $otherCommunity = Community::factory()->create();
@@ -322,6 +326,96 @@ class TalentNominationEventTest extends TestCase
                             [
                                 'id' => $newCommunityDevelopmentProgram->id,
                             ],
+                        ],
+                    ],
+                ],
+            ])
+            ->assertGraphQLValidationError('talentNominationEvent.communityDevelopmentPrograms.sync.0.id', ErrorCode::COMMUNITY_DEVELOPMENT_PROGRAM_NOT_FOUND_OR_INVALID->name);
+    }
+
+    // #17164 - a development program id already attached to the event should not
+    // block an unrelated update, even if it no longer belongs to the event's community
+    public function testStaleCommunityDevelopmentProgramIdDoesNotBlockUpdate()
+    {
+        $openDate = config('constants.far_future_datetime');
+        $closeDate = Carbon::parse($openDate)->addYear();
+        $laterCloseDate = Carbon::parse($openDate)->addYears(2);
+
+        $talentNominationEvent = TalentNominationEvent::factory()
+            ->for($this->community)
+            ->create([
+                'open_date' => $openDate,
+                'close_date' => $closeDate,
+            ]);
+
+        $developmentProgram = DevelopmentProgram::factory()->create();
+        $communityDevelopmentProgram = CommunityDevelopmentProgram::create([
+            'community_id' => $this->communityId,
+            'development_program_id' => $developmentProgram->id,
+        ]);
+        $talentNominationEvent->communityDevelopmentPrograms()->sync([$communityDevelopmentProgram->id]);
+
+        // the program no longer belongs to this event's community
+        $communityDevelopmentProgram->update(['community_id' => $this->otherCommunityId]);
+
+        $this->actingAs($this->admin, 'api')
+            ->graphQL(<<<'GRAPHQL'
+                mutation UpdateTalentNominationEvent($id: UUID!, $talentNominationEvent: UpdateTalentNominationEventInput!) {
+                    updateTalentNominationEvent(id: $id, talentNominationEvent: $talentNominationEvent) {
+                        id
+                        closeDate
+                    }
+                }
+                GRAPHQL, [
+                'id' => $talentNominationEvent->id,
+                'talentNominationEvent' => [
+                    'community' => ['connect' => $this->communityId],
+                    'closeDate' => $laterCloseDate->toDateTimeString(),
+                    'communityDevelopmentPrograms' => [
+                        'sync' => [
+                            ['id' => $communityDevelopmentProgram->id],
+                        ],
+                    ],
+                ],
+            ])
+            ->assertJson([
+                'data' => [
+                    'updateTalentNominationEvent' => [
+                        'id' => $talentNominationEvent->id,
+                        'closeDate' => $laterCloseDate->toDateTimeString(),
+                    ],
+                ],
+            ]);
+    }
+
+    // a genuinely new, wrongly-scoped development program id is still rejected on update
+    public function testNewDevelopmentProgramMustBelongToCommunityOnUpdate()
+    {
+        $talentNominationEvent = TalentNominationEvent::factory()
+            ->for($this->community)
+            ->create();
+
+        $newCommunity = Community::factory()->create();
+        $developmentProgram = DevelopmentProgram::factory()->create();
+        $newCommunityDevelopmentProgram = CommunityDevelopmentProgram::create([
+            'community_id' => $newCommunity->id,
+            'development_program_id' => $developmentProgram->id,
+        ]);
+
+        $this->actingAs($this->admin, 'api')
+            ->graphQL(<<<'GRAPHQL'
+                mutation UpdateTalentNominationEvent($id: UUID!, $talentNominationEvent: UpdateTalentNominationEventInput!) {
+                    updateTalentNominationEvent(id: $id, talentNominationEvent: $talentNominationEvent) {
+                        id
+                    }
+                }
+                GRAPHQL, [
+                'id' => $talentNominationEvent->id,
+                'talentNominationEvent' => [
+                    'community' => ['connect' => $this->communityId],
+                    'communityDevelopmentPrograms' => [
+                        'sync' => [
+                            ['id' => $newCommunityDevelopmentProgram->id],
                         ],
                     ],
                 ],


### PR DESCRIPTION
🤖 Resolves #17164 

## 👋 Introduction

Fixes an issue with the talent notmination event update validator blocking updates due to development program changes.

## 🕵️ Details

We recentyl restricted talent nomination evens to only allow development programs that are paet of the community. Existing eventsd may have development programs that are not part of the community which was preventing updating. This changes it to ignore those existing items when updating.

## 🧪 Testing

1. Seed an event with development programs outside its community
2. Login as `admin@test.com`
3. Go to update the event without touching development programs
4. Confirm the update is successful