### PR TITLE
[Fix] Copy status data from PoolCandidateSearchRequests to TalentRequests if updated since migration

### DIFF
--- a/api/app/Console/Commands/SyncTalentRequests.php
+++ b/api/app/Console/Commands/SyncTalentRequests.php
@@ -35,7 +35,14 @@ class SyncTalentRequests extends Command
                 request_status_changed_at, created_at, updated_at, deleted_at
             FROM pool_candidate_search_requests
             WHERE applicant_filter_id IS NOT NULL
-            ON CONFLICT (id) DO NOTHING;
+            ON CONFLICT (id) DO UPDATE SET
+                status = EXCLUDED.status,
+                in_progress_details = EXCLUDED.in_progress_details,
+                completion_details = EXCLUDED.completion_details,
+                status_changed_at = EXCLUDED.status_changed_at,
+                follow_up_date = EXCLUDED.follow_up_date,
+                admin_notes = EXCLUDED.admin_notes
+            WHERE EXCLUDED.updated_at > talent_requests.updated_at;
             SQL
             );
 

--- a/api/app/Console/Commands/SyncTalentRequests.php
+++ b/api/app/Console/Commands/SyncTalentRequests.php
@@ -41,7 +41,8 @@ class SyncTalentRequests extends Command
                 completion_details = EXCLUDED.completion_details,
                 status_changed_at = EXCLUDED.status_changed_at,
                 follow_up_date = EXCLUDED.follow_up_date,
-                admin_notes = EXCLUDED.admin_notes
+                admin_notes = EXCLUDED.admin_notes,
+                updated_at = EXCLUDED.updated_at
             WHERE EXCLUDED.updated_at > talent_requests.updated_at;
             SQL
             );


### PR DESCRIPTION
🤖 Resolves #17329 

## 👋 Introduction

Improves SyncTalentRequests script to ensure status data is not lost when turning on TalentRequests feature flag.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

Prerequisites:
1. migration https://github.com/GCTC-NTGC/gc-digital-talent/blob/main/api/database/migrations/2026_05_26_140000_create_talent_requests_table.php has been run
2. there exists at least one PoolCandidateSearchRequest which existed before the migration (to be thorough)
3. Talent Requests feature flag is FALSE
4. You have **the main branch** checked out, not this one.

Testing:
1. Submit a new talent request
2. Log in as a community admin
3. Change the status of the new request, and a request from before the migration (set them to in progress)
5. Turn the feature flag on and rebuild the app
6. Log in as community admin
7. Observe that the new talent request doesn't appear, and the old request doesn't have the correct status
8. Run `php artisan app:sync-talent-requests`
9. Observe that the new talent request appears correctly now, but the old request still has incorrect status.
10. Change the status on the new talent request again (set to completed)
12. Checkout this branch, with an updated sync script
13. Run `php artisan app:sync-talent-requests`
14. You should now see both requests correctly: the old one as in-progress and the new one as complete.

Note: the sync script is equivalent to the create_talent_requests_table migration. If you need to try the test multiple times even after running the sync script, you can turn the feature flag off and create new requests and change old requests, and observe the same behaviour after turning the flag on and running the sync script again.

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

## 🚚 Deployment

Ensure TALENT_REQUESTS feature flag is true
Run  `php artisan app:sync-talent-requests`