### PR TITLE
[Fix] Sending emails to null

### DIFF
--- a/api/app/Console/Commands/SendNotificationsAdHocEmail.php
+++ b/api/app/Console/Commands/SendNotificationsAdHocEmail.php
@@ -138,10 +138,13 @@ class SendNotificationsAdHocEmail extends Command implements PromptsForMissingIn
             }
         }
 
-        $builder = User::whereJsonContains('enabled_email_notifications', $notificationFamilies[0]);
-        for ($i = 1; $i < count($notificationFamilies); $i++) {
-            $builder->orWhereJsonContains('enabled_email_notifications', $notificationFamilies[$i]);
-        }
+        $builder = User::whereNotNull('email')
+            ->where(function (Builder $query) use ($notificationFamilies) {
+                $query->whereJsonContains('enabled_email_notifications', $notificationFamilies[0]);
+                for ($i = 1; $i < count($notificationFamilies); $i++) {
+                    $query->orWhereJsonContains('enabled_email_notifications', $notificationFamilies[$i]);
+                }
+            });
 
         return $builder;
     }

--- a/api/app/Console/Commands/SendNotificationsAdHocEmail.php
+++ b/api/app/Console/Commands/SendNotificationsAdHocEmail.php
@@ -105,7 +105,7 @@ class SendNotificationsAdHocEmail extends Command implements PromptsForMissingIn
         }
 
         if ($notifyAllUsers) {
-            return User::query();
+            return User::whereNotNull('email');
         }
 
         throw new \InvalidArgumentException('Unexpected function end point for options: '.json_encode($options));

--- a/api/tests/Feature/Notifications/SendNotificationsAdHocEmailTest.php
+++ b/api/tests/Feature/Notifications/SendNotificationsAdHocEmailTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Notifications;
 
+use App\Enums\NotificationFamily;
 use App\Models\User;
 use App\Notifications\AdHocEmail;
 use Database\Seeders\RolePermissionSeeder;
@@ -32,6 +33,31 @@ class SendNotificationsAdHocEmailTest extends TestCase
             'templateIdEn' => 'template-en',
             'templateIdFr' => 'template-fr',
             '--notifyAllUsers' => true,
+        ])
+            ->expectsConfirmation('Do you wish to send notifications to 1 users?', 'yes')
+            ->assertExitCode(Command::SUCCESS)
+            ->run();
+
+        Notification::assertSentTo([$userWithEmail], AdHocEmail::class);
+        Notification::assertNotSentTo([$userWithoutEmail], AdHocEmail::class);
+    }
+
+    // will not send a notification to a user with no email address when filtering by notification family
+    public function testDoesNotNotifyUserWithNullEmailByNotificationFamily(): void
+    {
+        $userWithEmail = User::factory()->create([
+            'email' => 'has-email@example.org',
+            'enabled_email_notifications' => [NotificationFamily::JOB_ALERT->name],
+        ]);
+        $userWithoutEmail = User::factory()->create([
+            'email' => null,
+            'enabled_email_notifications' => [NotificationFamily::JOB_ALERT->name],
+        ]);
+
+        $this->artisan('send-notifications:ad-hoc-email', [
+            'templateIdEn' => 'template-en',
+            'templateIdFr' => 'template-fr',
+            '--notificationFamily' => [NotificationFamily::JOB_ALERT->name],
         ])
             ->expectsConfirmation('Do you wish to send notifications to 1 users?', 'yes')
             ->assertExitCode(Command::SUCCESS)

--- a/api/tests/Feature/Notifications/SendNotificationsAdHocEmailTest.php
+++ b/api/tests/Feature/Notifications/SendNotificationsAdHocEmailTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature\Notifications;
+
+use App\Models\User;
+use App\Notifications\AdHocEmail;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Console\Command;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class SendNotificationsAdHocEmailTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Notification::fake();
+        $this->seed(RolePermissionSeeder::class);
+    }
+
+    // will not send a notification to a user with no email address when notifying all users
+    public function testDoesNotNotifyUserWithNullEmail(): void
+    {
+        $userWithEmail = User::factory()->create(['email' => 'has-email@example.org']);
+        $userWithoutEmail = User::factory()->create(['email' => null]);
+
+        $this->artisan('send-notifications:ad-hoc-email', [
+            'templateIdEn' => 'template-en',
+            'templateIdFr' => 'template-fr',
+            '--notifyAllUsers' => true,
+        ])
+            ->expectsConfirmation('Do you wish to send notifications to 1 users?', 'yes')
+            ->assertExitCode(Command::SUCCESS)
+            ->run();
+
+        Notification::assertSentTo([$userWithEmail], AdHocEmail::class);
+        Notification::assertNotSentTo([$userWithoutEmail], AdHocEmail::class);
+    }
+}


### PR DESCRIPTION
🤖 Resolves #17032 

## 👋 Introduction

Fixes and issue where the adhoc email was attempting to send to users who had a `null` email.

## 🧪 Testing

> [!NOTE]
> I'm not sure how to get info to tell this happened during manual testing but there is a test for it. I'll do my best guess in the testing instructions

1. Make sure a user has a `null` email
2. Run the adhoc email command
3. Confirm no errors or attempts to send to the user with the null emil
    - Maybe by chekcing the send couint to make sure it only countsd those with an email? 
