### PR TITLE
[Fix] Hide draft pools from filter input

### DIFF
--- a/apps/web/src/components/PoolFilterInput/PoolFilterInput.tsx
+++ b/apps/web/src/components/PoolFilterInput/PoolFilterInput.tsx
@@ -4,7 +4,10 @@ import { useState } from "react";
 import type { RegisterOptions } from "react-hook-form";
 
 import { Combobox } from "@gc-digital-talent/forms";
-import type { PoolFilterInput as TPoolFilterInput } from "@gc-digital-talent/graphql";
+import {
+  PoolStatus,
+  type PoolFilterInput as TPoolFilterInput,
+} from "@gc-digital-talent/graphql";
 
 import adminMessages from "~/messages/adminMessages";
 
@@ -37,6 +40,7 @@ const PoolFilterInput = ({
     fetching: poolsFetching,
   } = usePoolFilterOptions(
     {
+      statuses: [PoolStatus.Published, PoolStatus.Closed, PoolStatus.Archived],
       ...filterInput,
       generalSearch: query || undefined,
     },


### PR DESCRIPTION
🤖 Resolves #17120 

## 👋 Introduction

This hides draft pools from the pool filter input since they will not produce results where the filter is used (candidates, users and talent requests).

## 🧪 Testing

1. Find a draft pool and remeber it
2. Navigate to the all candidates table
3. Open the filter dialog
4. Search for the draft pool in the pool filter combobox
5. Confirm the draft pool does not appear
