### PR TITLE
[Bug] Fix talent sources in edit dialog

### DIFF
--- a/apps/web/src/pages/TalentRequests/Tracking.tsx
+++ b/apps/web/src/pages/TalentRequests/Tracking.tsx
@@ -29,7 +29,6 @@ const TalentRequestTracking_Query = graphql(/** GraphQL */ `
     }
 
     ...TalentRequestReferralDialogOptions
-    ...TalentRequestEditReferralDialogSourceOptions
   }
 `);
 

--- a/apps/web/src/pages/TalentRequests/components/TalentRequestReferralDialogs/TalentRequestEditReferralDialog.stories.tsx
+++ b/apps/web/src/pages/TalentRequests/components/TalentRequestReferralDialogs/TalentRequestEditReferralDialog.stories.tsx
@@ -20,7 +20,6 @@ import {
 
 import TalentRequestEditReferralDialog, {
   TalentRequestEditReferralDialog_Fragment,
-  TalentRequestEditReferralDialogSourceOptions_Fragment,
 } from "./TalentRequestEditReferralDialog";
 import { TalentRequestReferralDialogOptions_Fragment } from "./ReferralFormFields";
 import { ReferralHistory_Fragment } from "./ReferralHistory";
@@ -56,16 +55,6 @@ const optionsQuery = makeFragmentData(
     })),
   },
   TalentRequestReferralDialogOptions_Fragment,
-);
-
-const sourceOptionsQuery = makeFragmentData(
-  {
-    talentRequestSources: fakeLocalizedEnum(TalentRequestSource).map((opt) => ({
-      __typename: "LocalizedTalentRequestSource" as const,
-      ...toLocalizedEnum(opt.value),
-    })),
-  },
-  TalentRequestEditReferralDialogSourceOptions_Fragment,
 );
 
 const mockTrackedUser = {
@@ -124,7 +113,6 @@ const meta = {
   },
   args: {
     optionsQuery,
-    sourceOptionsQuery,
     defaultOpen: true,
   },
 } satisfies Meta<typeof TalentRequestEditReferralDialog>;

--- a/apps/web/src/pages/TalentRequests/components/TalentRequestReferralDialogs/TalentRequestEditReferralDialog.tsx
+++ b/apps/web/src/pages/TalentRequests/components/TalentRequestReferralDialogs/TalentRequestEditReferralDialog.tsx
@@ -10,8 +10,7 @@ import {
 } from "@gc-digital-talent/graphql";
 import { Button, Dialog } from "@gc-digital-talent/ui";
 import { toast } from "@gc-digital-talent/toast";
-import { unpackMaybes } from "@gc-digital-talent/helpers";
-import { commonMessages, narrowEnumType } from "@gc-digital-talent/i18n";
+import { commonMessages } from "@gc-digital-talent/i18n";
 
 import { getFullNameLabel } from "~/utils/nameUtils";
 
@@ -46,27 +45,6 @@ const UpdateTalentRequestTrackedUser_Mutation = graphql(/* GraphQL */ `
     }
   }
 `);
-
-export const TalentRequestEditReferralDialogSourceOptions_Fragment = graphql(
-  /* GraphQL */ `
-    fragment TalentRequestEditReferralDialogSourceOptions on Query {
-      talentRequestSources: localizedEnumOptions(
-        enumName: "TalentRequestSource"
-      ) {
-        ... on LocalizedTalentRequestSource {
-          value
-          label {
-            localized
-          }
-        }
-      }
-    }
-  `,
-);
-
-export type TalentRequestEditReferralDialogSourceOptions = FragmentType<
-  typeof TalentRequestEditReferralDialogSourceOptions_Fragment
->;
 
 export const TalentRequestEditReferralDialog_Fragment = graphql(/* GraphQL */ `
   fragment TalentRequestEditReferralDialog on TalentRequestTrackedUser {
@@ -106,7 +84,6 @@ export const TalentRequestEditReferralDialog_Fragment = graphql(/* GraphQL */ `
 interface TalentRequestEditReferralDialogProps {
   query: FragmentType<typeof TalentRequestEditReferralDialog_Fragment>;
   optionsQuery?: TalentRequestReferralDialogOptions;
-  sourceOptionsQuery?: TalentRequestEditReferralDialogSourceOptions;
   trigger?: ReactNode;
   defaultOpen?: boolean;
 }
@@ -114,7 +91,6 @@ interface TalentRequestEditReferralDialogProps {
 const TalentRequestEditReferralDialog = ({
   query,
   optionsQuery,
-  sourceOptionsQuery,
   trigger,
   defaultOpen = false,
 }: TalentRequestEditReferralDialogProps) => {
@@ -134,20 +110,9 @@ const TalentRequestEditReferralDialog = ({
     intl,
   );
 
-  const sourceOptions = narrowEnumType(
-    unpackMaybes(
-      getFragment(
-        TalentRequestEditReferralDialogSourceOptions_Fragment,
-        sourceOptionsQuery,
-      )?.talentRequestSources,
-    ),
-    "TalentRequestSource",
-  );
   const notAvailable = intl.formatMessage(commonMessages.notAvailable);
   const sourceLabels = trackedUser.sources.map(
-    (source) =>
-      sourceOptions.find((o) => o.value === source.value)?.label.localized ??
-      notAvailable,
+    (source) => source.label.localized ?? notAvailable,
   );
 
   const methods = useForm<FormValues>({


### PR DESCRIPTION
🤖 Resolves #17355 

## 👋 Introduction

- Adds fix for "Source of talent" section in talent request referral edit dialog.

## 🧪 Testing

1. Build front-end
2. Login as admin
3. Go to talent request with tracked users
4. Open dialog by clicking on user in the inbox/table
5. Ensure talent sources are showing

## 📸 Screenshot

<img width="1029" height="743" alt="image" src="https://github.com/user-attachments/assets/67900b23-9f9f-485a-8cfa-bd394786d7ba" />