### PR TITLE
[Feature] Advancement classification

### DIFF
--- a/api/app/GraphQL/Validators/Mutation/UpdateTalentNominationGroupValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/UpdateTalentNominationGroupValidator.php
@@ -36,13 +36,14 @@ final class UpdateTalentNominationGroupValidator extends Validator
                 Rule::when(fn () => $talentNominationGroup->development_programs_nomination_count == 0, ['prohibited']),
             ],
             'talentNominationGroup.advancementClassifications' => [
-                'required',
+                // when updating a decision, updating the classifications is also required
+                'required_with:talentNominationGroup.advancementDecision,talentNominationGroup.lateralMovementDecision,talentNominationGroup.developmentProgramsDecision',
             ],
             'talentNominationGroup.advancementClassifications.sync' => [
                 'list',
                 'distinct',
-                // if we want to eventually add rules for when it is approved, switch to !== 'APPROVED' and default back to the max:0 instead
-                Rule::when(fn ($attributes) => $attributes['talentNominationGroup.advancementDecision'] !== 'APPROVED', ['max:0']), // unless approved, can't sync any classifications
+                // if we want to eventually add rules for when it is approved, switch to == 'APPROVED' and default back to the max:0 instead
+                Rule::when(fn ($attributes) => $attributes->get('talentNominationGroup.advancementDecision') !== 'APPROVED', ['max:0']), // unless approved, can't sync any classifications
             ],
 
         ];

--- a/api/app/GraphQL/Validators/Mutation/UpdateTalentNominationGroupValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/UpdateTalentNominationGroupValidator.php
@@ -42,8 +42,9 @@ final class UpdateTalentNominationGroupValidator extends Validator
             'talentNominationGroup.advancementClassifications.sync' => [
                 'list',
                 'distinct',
-                // if we want to eventually add rules for when it is approved, switch to == 'APPROVED' and default back to the max:0 instead
-                Rule::when(fn ($attributes) => $attributes->get('talentNominationGroup.advancementDecision') !== 'APPROVED', ['max:0']), // unless approved, can't sync any classifications
+                Rule::when(fn ($attributes) => $attributes->get('talentNominationGroup.advancementDecision') === 'APPROVED',
+                    ['min:0'],  // we will eventually require classifications when approving
+                    ['max:0']), // unless approved, can't sync any classifications
             ],
 
         ];

--- a/api/app/GraphQL/Validators/Mutation/UpdateTalentNominationGroupValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/UpdateTalentNominationGroupValidator.php
@@ -35,6 +35,15 @@ final class UpdateTalentNominationGroupValidator extends Validator
                 Rule::in(array_column(TalentNominationGroupDecision::cases(), 'name')),
                 Rule::when(fn () => $talentNominationGroup->development_programs_nomination_count == 0, ['prohibited']),
             ],
+            'talentNominationGroup.advancementClassifications' => [
+                'required',
+            ],
+            'talentNominationGroup.advancementClassifications.sync' => [
+                'list',
+                'distinct',
+                // if we want to eventually add rules for when it is approved, switch to !== 'APPROVED' and default back to the max:0 instead
+                Rule::when(fn ($attributes) => $attributes['talentNominationGroup.advancementDecision'] !== 'APPROVED', ['max:0']), // unless approved, can't sync any classifications
+            ],
 
         ];
     }

--- a/api/app/Models/TalentNominationGroup.php
+++ b/api/app/Models/TalentNominationGroup.php
@@ -100,7 +100,9 @@ class TalentNominationGroup extends Model
     /** @return BelongsToMany<Classification, $this> */
     public function advancementClassifications(): BelongsToMany
     {
-        return $this->belongsToMany(Classification::class, 'classification_talent_nomination_group_advancement');
+        return $this
+            ->belongsToMany(Classification::class, 'classification_talent_nomination_group_advancement')
+            ->withTimestamps();
     }
 
     /**

--- a/api/app/Models/TalentNominationGroup.php
+++ b/api/app/Models/TalentNominationGroup.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
@@ -94,6 +95,12 @@ class TalentNominationGroup extends Model
     public function nominations(): HasMany
     {
         return $this->hasMany(TalentNomination::class, 'talent_nomination_group_id');
+    }
+
+    /** @return BelongsToMany<Classification, $this> */
+    public function advancementClassifications(): BelongsToMany
+    {
+        return $this->belongsToMany(Classification::class, 'classification_talent_nomination_group_advancement');
     }
 
     /**

--- a/api/database/migrations/2026_07_08_185106_add_advancement_classifications.php
+++ b/api/database/migrations/2026_07_08_185106_add_advancement_classifications.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('classification_talent_nomination_group_advancement', function (Blueprint $table) {
+            $table->uuid('id')
+                ->primary()
+                ->default(new Expression('public.gen_random_uuid()'));
+            $table->timestamps();
+            $table->foreignUuid('classification_id')
+                ->constrained();
+            $table->foreignUuid('talent_nomination_group_id')
+                ->constrained()
+                ->onDelete('cascade');
+            $table->unique(['classification_id', 'talent_nomination_group_id'], 'classification_nomination_group_advancement_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('classification_talent_nomination_group_advancement');
+    }
+};

--- a/api/database/migrations/2026_07_08_185106_add_advancement_classifications.php
+++ b/api/database/migrations/2026_07_08_185106_add_advancement_classifications.php
@@ -20,8 +20,7 @@ return new class() extends Migration
             $table->foreignUuid('classification_id')
                 ->constrained();
             $table->foreignUuid('talent_nomination_group_id')
-                ->constrained()
-                ->onDelete('cascade');
+                ->constrained();
             $table->unique(['classification_id', 'talent_nomination_group_id'], 'classification_nomination_group_advancement_unique');
         });
     }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1004,6 +1004,7 @@ type TalentNominationGroup {
   status: LocalizedTalentNominationGroupStatus
   consentToShareProfile: Boolean @rename(attribute: "consent_to_share_profile")
   comments: String
+  advancementClassifications: [Classification!] @belongsToMany
 }
 
 type Team implements HasRoleAssignments {
@@ -2798,6 +2799,7 @@ input UpdateTalentNominationGroupInput {
   developmentProgramsNotes: String
     @rename(attribute: "development_programs_notes")
   comments: String
+  advancementClassifications: ClassificationBelongsToMany
 }
 
 input CreateApplicantFilterInput {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1541,6 +1541,7 @@ type TalentNominationGroup {
   consentToShareProfile: Boolean
   status: LocalizedTalentNominationGroupStatus
   comments: String
+  advancementClassifications: [Classification!]
 }
 
 type Team implements HasRoleAssignments {
@@ -2717,6 +2718,7 @@ input UpdateTalentNominationGroupInput {
   developmentProgramsDecision: TalentNominationGroupDecision
   developmentProgramsNotes: String
   comments: String
+  advancementClassifications: ClassificationBelongsToMany
 }
 
 input CreateApplicantFilterInput {

--- a/api/tests/Feature/TalentNominationGroupTest.php
+++ b/api/tests/Feature/TalentNominationGroupTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\Classification;
 use App\Models\Community;
 use App\Models\CommunityInterest;
 use App\Models\TalentNomination;
@@ -75,6 +76,9 @@ class TalentNominationGroupTest extends TestCase
         mutation UpdateTalentNominationGroup($id: UUID!, $talentNominationGroup: UpdateTalentNominationGroupInput!) {
             updateTalentNominationGroup(id: $id, talentNominationGroup: $talentNominationGroup) {
                 id
+                advancementClassifications {
+                    id
+                }
             }
         }
     GRAPHQL;
@@ -385,5 +389,92 @@ class TalentNominationGroupTest extends TestCase
 
         // Assert nominee did consent to share profile info to admins on nomination profile
         assertEquals($group->consentToShareProfile, true);
+    }
+
+    public function testCoordinatorCanAddAdvancementClassificationsWhenApproved()
+    {
+        $community = Community::factory()->create();
+        $talentNominationEvent = TalentNominationEvent::factory()
+            ->for($community)
+            ->create(['close_date' => config('constants.far_future_datetime')]);
+
+        $nominator = $this->makeEmployee('nominator');
+        $nominee = $this->makeEmployee('nominee');
+        $coordinator = $this->makeCommunityTalentCoordinator('coordinator', $community->id);
+
+        $nomination = TalentNomination::factory()
+            ->submittedReviewAndSubmit()
+            ->create([
+                'talent_nomination_event_id' => $talentNominationEvent->id,
+                'submitter_id' => $nominator->id,
+                'nominator_id' => $nominator->id,
+                'nominee_id' => $nominee->id,
+                'nominate_for_advancement' => true,
+            ]);
+
+        $classifications = Classification::factory()->count(2)->create();
+
+        $response = $this->actingAs($coordinator, 'api')
+            ->graphQL($this->updateTalentNominationGroup, [
+                'id' => $nomination->talentNominationGroup->id,
+                'talentNominationGroup' => [
+                    'advancementDecision' => 'APPROVED',
+                    'advancementClassifications' => [
+                        'sync' => $classifications->pluck('id')->toArray(),
+                    ],
+                ],
+            ]);
+
+        $response->assertGraphQLErrorFree();
+        $response->assertJsonFragment([
+            'advancementClassifications' => [
+                ['id' => $classifications[0]->id],
+                ['id' => $classifications[1]->id],
+            ],
+        ]);
+
+        $this->assertEqualsCanonicalizing(
+            $classifications->pluck('id')->toArray(),
+            $nomination->talentNominationGroup->fresh()->advancementClassifications->pluck('id')->toArray(),
+        );
+    }
+
+    public function testCannotAddAdvancementClassificationsUnlessAdvancementApproved()
+    {
+        $community = Community::factory()->create();
+        $talentNominationEvent = TalentNominationEvent::factory()
+            ->for($community)
+            ->create(['close_date' => config('constants.far_future_datetime')]);
+
+        $nominator = $this->makeEmployee('nominator');
+        $nominee = $this->makeEmployee('nominee');
+        $coordinator = $this->makeCommunityTalentCoordinator('coordinator', $community->id);
+
+        $nomination = TalentNomination::factory()
+            ->submittedReviewAndSubmit()
+            ->create([
+                'talent_nomination_event_id' => $talentNominationEvent->id,
+                'submitter_id' => $nominator->id,
+                'nominator_id' => $nominator->id,
+                'nominee_id' => $nominee->id,
+                'nominate_for_advancement' => true,
+            ]);
+
+        $classification = Classification::factory()->create();
+
+        // decision left as not approved (null) while attempting to sync a classification
+        $response = $this->actingAs($coordinator, 'api')
+            ->graphQL($this->updateTalentNominationGroup, [
+                'id' => $nomination->talentNominationGroup->id,
+                'talentNominationGroup' => [
+                    'advancementClassifications' => [
+                        'sync' => [$classification->id],
+                    ],
+                ],
+            ]);
+
+        $response->assertGraphQLValidationKeys(['talentNominationGroup.advancementClassifications.sync']);
+
+        $this->assertDatabaseEmpty('classification_talent_nomination_group_advancement');
     }
 }

--- a/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/form.ts
+++ b/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/form.ts
@@ -108,5 +108,9 @@ export function convertFormValuesToMutationInput(
       formValues.developmentProgramsApprovedNotes,
       formValues.developmentProgramsRejectedNotes,
     ),
+    // no UI yet
+    advancementClassifications: {
+      sync: [],
+    },
   };
 }


### PR DESCRIPTION
🤖 Resolves #16996 

## 👋 Introduction

Adds a pivot table so that classifications can be associated with a nomination group when advancement is approved.

## 🕵️ Details

- For validation, the classification array is now required when updating decisions so the frontend was updated to always send an empty array with decisions.
- Validation for when advancement is approved is a placeholder "min 0" that can be replaced later.
- Validation for when advancement is not approved is "max 0" to prevent classifications without advancement.
- There is no UI for this yet - you'll need to do some testing with GraphQL and database clients.

## 🧪 Testing

### Regression Testing

1. Rebuild, including the new migration
2. Log in as `community@test.com`

- [ ] Can still approve or reject nomination groups
- [ ] Can still update notes on nomination groups

### API Testing

Sample query:
```graphql
mutation NominationGroupEvaluationDialog_Mutation(
  $id: UUID!
  $talentNominationGroup: UpdateTalentNominationGroupInput!
) {
  updateTalentNominationGroup(
    id: $id
    talentNominationGroup: $talentNominationGroup
  ) {
    id
    __typename
  }
}
#######
{
  "id": "b4aae511-488d-47bb-b405-5b617153c6ca",
  "talentNominationGroup": {
    "advancementClassifications": { "sync": ["a9053d52-9674-4876-91e4-e68809c363ac"] },
    "advancementDecision": "APPROVED",    
    "advancementReferenceConfirmed": true,
    "developmentProgramsDecision": null,    
    "lateralMovementDecision": "APPROVED"
  }
}
```

1. Grab the token for the `community@test.com` login and use a Graphql client

- [ ] add/remove classifications to a nomination group that has advancement
- [ ] can't add classifications to a nomination group that doesn't have advancement

