### PR TITLE
[Feature] Red colour the expiry date when a candidate is expired

### DIFF
--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/Sidebar/ApplicationStatusMeta/QualifiedStatusMeta.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/Sidebar/ApplicationStatusMeta/QualifiedStatusMeta.tsx
@@ -8,9 +8,14 @@ import {
 } from "@gc-digital-talent/graphql";
 import { commonMessages } from "@gc-digital-talent/i18n";
 import { Notice, Ul } from "@gc-digital-talent/ui";
-import { formatDate, parseDateTimeUtc } from "@gc-digital-talent/date-helpers";
+import {
+  formatDate,
+  isDateStringExpired,
+  parseDateTimeUtc,
+} from "@gc-digital-talent/date-helpers";
 
 import FieldDisplay from "~/components/FieldDisplay/FieldDisplay";
+import messages from "~/messages/poolCandidateMessages";
 
 import ApplicationExpiryDateDialog from "../Dialog/ApplicationExpiryDateDialog";
 import ApplicationPlacementDialog from "../Dialog/ApplicationPlacementDialog";
@@ -19,6 +24,7 @@ import ApplicationResumeReferralsDialog from "../Dialog/ApplicationResumeReferra
 
 const QualifiedStatusMeta_Fragment = graphql(/** GraphQL */ `
   fragment QualifiedStatusMeta on PoolCandidate {
+    expiryDate
     applicationStatusData {
       placedDepartment {
         name {
@@ -68,6 +74,14 @@ const QualifiedStatusMeta = ({ query }: QualifiedStatusMetaProps) => {
         intl,
       })
     : null;
+
+  let isExpired = false;
+  if (application.expiryDate && isDateStringExpired(application.expiryDate)) {
+    isExpired = true;
+  }
+
+  const expiredMessage = intl.formatMessage(messages.expired);
+  const expiredMessageParentheses = `(${expiredMessage})`;
 
   return (
     <>
@@ -127,7 +141,15 @@ const QualifiedStatusMeta = ({ query }: QualifiedStatusMetaProps) => {
         </FieldDisplay>
       )}
       <FieldDisplay label={intl.formatMessage(commonMessages.expiryDate)}>
-        <ApplicationExpiryDateDialog query={application} />
+        <ApplicationExpiryDateDialog
+          query={application}
+          isExpired={isExpired}
+        />
+        {isExpired && (
+          <p className="text-gray-600 dark:text-gray-200">
+            {expiredMessageParentheses}
+          </p>
+        )}
       </FieldDisplay>
     </>
   );

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/Sidebar/ApplicationStatusMeta/QualifiedStatusMeta.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/Sidebar/ApplicationStatusMeta/QualifiedStatusMeta.tsx
@@ -7,7 +7,7 @@ import {
   PlacementType,
 } from "@gc-digital-talent/graphql";
 import { commonMessages } from "@gc-digital-talent/i18n";
-import { Notice, Ul } from "@gc-digital-talent/ui";
+import { Notice, Ul, wrapParens } from "@gc-digital-talent/ui";
 import {
   formatDate,
   isDateStringExpired,
@@ -81,7 +81,6 @@ const QualifiedStatusMeta = ({ query }: QualifiedStatusMetaProps) => {
   }
 
   const expiredMessage = intl.formatMessage(messages.expired);
-  const expiredMessageParentheses = `(${expiredMessage})`;
 
   return (
     <>
@@ -147,7 +146,7 @@ const QualifiedStatusMeta = ({ query }: QualifiedStatusMetaProps) => {
         />
         {isExpired && (
           <p className="text-gray-600 dark:text-gray-200">
-            {expiredMessageParentheses}
+            {wrapParens(expiredMessage)}
           </p>
         )}
       </FieldDisplay>

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/Sidebar/Dialog/ApplicationExpiryDateDialog.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/Sidebar/Dialog/ApplicationExpiryDateDialog.tsx
@@ -39,10 +39,12 @@ interface FormValues {
 
 interface ApplicationExpiryDateDialogProps {
   query: FragmentType<typeof ApplicationExpiryDateDialog_Fragment>;
+  isExpired: boolean;
 }
 
 const ApplicationExpiryDateDialog = ({
   query,
+  isExpired,
 }: ApplicationExpiryDateDialogProps) => {
   const intl = useIntl();
   const [isOpen, setOpen] = useState<boolean>(false);
@@ -107,12 +109,14 @@ const ApplicationExpiryDateDialog = ({
 
   const todayDate = new Date();
 
+  const computedTriggerColour = isExpired ? "error" : "success";
+
   return (
     <Dialog.Root open={isOpen} onOpenChange={setOpen}>
       <Dialog.Trigger>
         <Button
           mode="text"
-          color="success"
+          color={computedTriggerColour}
           aria-label={intl.formatMessage(
             {
               defaultMessage: "Expiry date: {date}. Edit.",

--- a/packages/date-helpers/src/index.ts
+++ b/packages/date-helpers/src/index.ts
@@ -214,3 +214,23 @@ export function getUtcEndOfDayForLocalDate(
 
 export const getUserTimeZone = () =>
   Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+/**
+ * Given an API date (so implicitly UTC) compute whether it should appear as expired in the client.
+ * Need to account for client timezone changing what day it is
+ */
+export const isDateStringExpired = (expiryDate: string): boolean => {
+  // figure out "now" from client, in UTC
+  // API input is assumed to be in terms of UTC date, database standard
+  const now = new Date();
+  const nowUTC = new Date(now.getTime() + now.getTimezoneOffset() * 60000);
+  const formattedNowUTC = format(nowUTC, DATE_FORMAT_STRING);
+
+  // compare parsed values, the same timezone should be appended (if at all) to both
+  const expiryDateParsed = parseDateTimeUtc(expiryDate);
+  const nowParsed = parseDateTimeUtc(formattedNowUTC);
+
+  // the function and below line are matching the logic in
+  // PoolCandidateBuilder::whereExpiryStatus()
+  return expiryDateParsed < nowParsed ? true : false;
+};


### PR DESCRIPTION
🤖 Resolves #17091

## 👋 Introduction

Colour the button and add the line for when a candidate is expired

A little complicated by good old timezones and how they might have an effect. I thought it was most important to keep it in sync with how expired is determined elsewhere

## 🧪 Testing

1. Navigate to expired and unexpired candidates
2. Observe expiry button

## 📸 Screenshot

<img width="376" height="297" alt="image" src="https://github.com/user-attachments/assets/f70e42a8-53b5-4699-9456-cce96af4113a" />


