### PR TITLE
Ignore CLAUDE.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ storybook-static
 coverage
 
 .claude/settings.local.json
+CLAUDE.local.md


### PR DESCRIPTION
## 👋 Introduction

Adds a .gitignore for CLAUDE.local.md.

I've started experimenting with a local Claude file to customize my workflow.  I'm trying out GNU Stow to drop it in new workspaces, too.

Ref: https://code.claude.com/docs/en/memory#choose-where-to-put-claude-md-files

## 🕵️ Details

FWIW, this is what I'm trying right now:

```md
# Local environment (personal)

I have all tooling installed locally (PHP, Node, PostgreSQL, etc.) — do not suggest entering or using the maintenance container.

- Ignore `Makefile` (Docker/maintenance-container targets). Use `Makefile.nix` for common commands instead, e.g. `make -f Makefile.nix setup_web`.
- Manage TypeScript/JS parts of the app with `pnpm` (not npm/yarn).
- Manage PHP parts of the app with `composer` and `php artisan` directly (not via Docker exec).
```

This is what I've got in my custom settings file.  I'm not 100% sure these are working as intended or are actually safe 100% of the time.  :sweat_smile: 

```json
{
  "permissions": {
    "allow": [
      "Bash(git status *)",
      "Bash(php artisan test *)",
      "Bash(gh issue view  *)",
      "Bash(gh --version)",
      "Bash(gh repo view *)",
      "Bash(grep *)",
      "Bash(find *)"
    ]
  }
}
```

## 🧪 Testing

1. Make a CLAUDE.local.md file in the root of the repo.

- [ ] git ignores it

## 📸 Screenshot

<img width="206" height="633" alt="image" src="https://github.com/user-attachments/assets/047ce037-f832-44a0-a64b-6a456b73a066" />
