### PR TITLE
[Fix] Default value reset for select inputs

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -560,7 +560,7 @@ export function transformFormValuesToFilterState(
 ): PoolCandidateSearchInput {
   return {
     applicantFilter: {
-      languageAbility: data.languageAbility,
+      languageAbility: data.languageAbility || undefined,
       operationalRequirements: data.operationalRequirement,
       locationPreferences: data.workRegion,
       flexibleWorkLocations: data.flexibleWorkLocations,

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -560,6 +560,8 @@ export function transformFormValuesToFilterState(
 ): PoolCandidateSearchInput {
   return {
     applicantFilter: {
+      // NOTE: we do want to treat an empty string as unset
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       languageAbility: data.languageAbility || undefined,
       operationalRequirements: data.operationalRequirement,
       locationPreferences: data.workRegion,

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -506,10 +506,11 @@ export function transformPoolCandidateSearchInputToFormValues(
         ?.filter(notEmpty)
         .map((c) => `${c.group}-${c.level}`) ?? [],
     stream: input?.workStreams?.filter(notEmpty).map(({ id }) => id) ?? [],
-    languageAbility: input?.applicantFilter?.languageAbility ?? undefined,
-    employmentDuration: positionDurationToEmploymentDuration(
-      input?.applicantFilter?.positionDuration,
-    ),
+    languageAbility: input?.applicantFilter?.languageAbility ?? "",
+    employmentDuration:
+      positionDurationToEmploymentDuration(
+        input?.applicantFilter?.positionDuration,
+      ) ?? "",
     workRegion: unpackMaybes(input?.applicantFilter?.locationPreferences),
     operationalRequirement: unpackMaybes(
       input?.applicantFilter?.operationalRequirements,

--- a/apps/web/src/components/PoolCandidatesTable/types.ts
+++ b/apps/web/src/components/PoolCandidatesTable/types.ts
@@ -21,14 +21,14 @@ export interface FormValues {
   classifications: string[];
   community?: string;
   departments: string[];
-  employmentDuration?: TEmploymentDuration;
+  employmentDuration?: TEmploymentDuration | "";
   equity: string[];
   expiryStatus?: CandidateExpiryFilter;
   referralStatuses?: CandidateReferralFilter[];
   statuses: ApplicationStatus[];
   flexibleWorkLocations: FlexibleWorkLocation[];
   govEmployee?: EmployeeVerification[];
-  languageAbility?: LanguageAbility;
+  languageAbility?: LanguageAbility | "";
   operationalRequirement: OperationalRequirement[];
   placementTypes: PlacementType[];
   pools: string[];

--- a/apps/web/src/pages/CommunityInterests/CommunityTalentPage/components/CommunityTalentFilterDialog.tsx
+++ b/apps/web/src/pages/CommunityInterests/CommunityTalentPage/components/CommunityTalentFilterDialog.tsx
@@ -37,8 +37,8 @@ export interface FormValues {
   classifications: string[];
   mobilityInterest: string[];
   mobilityType: string[];
-  languageAbility?: LanguageAbility;
-  employmentDuration?: TEmploymentDuration;
+  languageAbility?: LanguageAbility | "";
+  employmentDuration?: TEmploymentDuration | "";
   locationPreferences: WorkRegion[];
   operationalRequirements: OperationalRequirement[];
   flexibleWorkLocations: FlexibleWorkLocation[];

--- a/apps/web/src/pages/CommunityInterests/CommunityTalentPage/utils.tsx
+++ b/apps/web/src/pages/CommunityInterests/CommunityTalentPage/utils.tsx
@@ -193,9 +193,9 @@ export function transformCommunityInterestFilterInputToFormValues(
     workStreams: unpackMaybes(input?.workStreams),
     mobilityInterest,
     mobilityType,
-    languageAbility: input?.languageAbility ?? undefined,
+    languageAbility: input?.languageAbility ?? "",
     employmentDuration: !positionDuration?.length
-      ? undefined
+      ? ""
       : positionDuration.includes(PositionDuration.Temporary)
         ? EmploymentDuration.Term
         : EmploymentDuration.Indeterminate,

--- a/apps/web/src/pages/CommunityInterests/CommunityTalentPage/utils.tsx
+++ b/apps/web/src/pages/CommunityInterests/CommunityTalentPage/utils.tsx
@@ -170,6 +170,8 @@ export function transformFormValuesToCommunityInterestFilterInput(
     trainingInterest: data.mobilityInterest.includes("trainingInterest"),
     lateralMoveInterest: data.mobilityType.includes("lateralMoveInterest"),
     promotionMoveInterest: data.mobilityType.includes("promotionMoveInterest"),
+    // NOTE: we do want to treat an empty string as unset
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     languageAbility: data.languageAbility || undefined,
     positionDuration: data.employmentDuration
       ? unpackMaybes([durationToEnumPositionDuration(data.employmentDuration)])

--- a/apps/web/src/pages/CommunityInterests/CommunityTalentPage/utils.tsx
+++ b/apps/web/src/pages/CommunityInterests/CommunityTalentPage/utils.tsx
@@ -170,6 +170,7 @@ export function transformFormValuesToCommunityInterestFilterInput(
     trainingInterest: data.mobilityInterest.includes("trainingInterest"),
     lateralMoveInterest: data.mobilityType.includes("lateralMoveInterest"),
     promotionMoveInterest: data.mobilityType.includes("promotionMoveInterest"),
+    languageAbility: data.languageAbility || undefined,
     positionDuration: data.employmentDuration
       ? unpackMaybes([durationToEnumPositionDuration(data.employmentDuration)])
       : undefined,

--- a/apps/web/src/pages/TalentRequests/components/TalentRequestMatchesTable/TalentRequestMatchesFilterDialog.tsx
+++ b/apps/web/src/pages/TalentRequests/components/TalentRequestMatchesTable/TalentRequestMatchesFilterDialog.tsx
@@ -129,8 +129,8 @@ export interface FormValues {
   classifications?: string[];
   streams?: string[];
   pools?: string[];
-  languageAbility?: LanguageAbility;
-  employmentDuration?: TEmploymentDuration;
+  languageAbility?: LanguageAbility | "";
+  employmentDuration?: TEmploymentDuration | "";
   equity?: string[];
   priorityWeight?: PriorityWeight[];
   operationalRequirements?: OperationalRequirement[];

--- a/apps/web/src/pages/TalentRequests/components/TalentRequestMatchesTable/utils.tsx
+++ b/apps/web/src/pages/TalentRequests/components/TalentRequestMatchesTable/utils.tsx
@@ -172,7 +172,7 @@ export function transformFormValuesToWhere(
 ): TalentRequestMatchFilterInput {
   return {
     applicantFilter: {
-      languageAbility: data.languageAbility,
+      languageAbility: data.languageAbility || undefined,
       operationalRequirements: data.operationalRequirements,
       locationPreferences: data.workRegions,
       flexibleWorkLocations: data.flexibleWorkLocations,

--- a/apps/web/src/pages/TalentRequests/components/TalentRequestMatchesTable/utils.tsx
+++ b/apps/web/src/pages/TalentRequests/components/TalentRequestMatchesTable/utils.tsx
@@ -172,6 +172,8 @@ export function transformFormValuesToWhere(
 ): TalentRequestMatchFilterInput {
   return {
     applicantFilter: {
+      // NOTE: we do want to treat an empty string as unset
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       languageAbility: data.languageAbility || undefined,
       operationalRequirements: data.operationalRequirements,
       locationPreferences: data.workRegions,

--- a/apps/web/src/pages/TalentRequests/components/TalentRequestMatchesTable/utils.tsx
+++ b/apps/web/src/pages/TalentRequests/components/TalentRequestMatchesTable/utils.tsx
@@ -96,7 +96,7 @@ export function transformApplicantFilterToFormValues(
       ({ id }) => id,
     ),
     pools: unpackMaybes(applicantFilter?.pools).map(({ id }) => id),
-    languageAbility: applicantFilter?.languageAbility?.value ?? undefined,
+    languageAbility: applicantFilter?.languageAbility?.value ?? "",
     equity: applicantFilter?.equity
       ? [
           ...(applicantFilter.equity.isWoman ? ["isWoman"] : []),
@@ -120,9 +120,9 @@ export function transformApplicantFilterToFormValues(
     priorityWeight: [],
     govEmployee: [],
     departments: [],
-    employmentDuration: positionDurationToEmploymentDuration(
-      applicantFilter?.positionDuration,
-    ),
+    employmentDuration:
+      positionDurationToEmploymentDuration(applicantFilter?.positionDuration) ??
+      "",
   };
 }
 
@@ -141,7 +141,7 @@ export function transformWhereToFormValues(
         ?.filter(notEmpty)
         .map(({ id }) => id) ?? [],
     pools: applicantFilter?.pools?.filter(notEmpty).map(({ id }) => id) ?? [],
-    languageAbility: applicantFilter?.languageAbility ?? undefined,
+    languageAbility: applicantFilter?.languageAbility ?? "",
     equity: applicantFilter?.equity
       ? [
           ...(applicantFilter.equity.isWoman ? ["isWoman"] : []),
@@ -161,9 +161,9 @@ export function transformWhereToFormValues(
     priorityWeight: unpackMaybes(input?.priorityWeight),
     govEmployee: unpackMaybes(input?.employeeVerification),
     departments: unpackMaybes(input?.departments),
-    employmentDuration: positionDurationToEmploymentDuration(
-      applicantFilter?.positionDuration,
-    ),
+    employmentDuration:
+      positionDurationToEmploymentDuration(applicantFilter?.positionDuration) ??
+      "",
   };
 }
 

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserFilterDialog.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserFilterDialog.tsx
@@ -45,11 +45,11 @@ export type OtherFilter = ObjectValues<typeof OTHER_FILTER>;
 
 export interface FormValues {
   pools: string[];
-  languageAbility?: LanguageAbility;
+  languageAbility?: LanguageAbility | "";
   operationalRequirement: OperationalRequirement[];
   workRegion: WorkRegion[];
   flexibleWorkLocations: FlexibleWorkLocation[];
-  employmentDuration?: TEmploymentDuration;
+  employmentDuration?: TEmploymentDuration | "";
   skills: string[];
   govEmployee: EmployeeVerification[];
   roles: string[];

--- a/apps/web/src/pages/Users/IndexUserPage/components/utils.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/utils.tsx
@@ -143,7 +143,7 @@ export function transformUserFilterInputToFormValues(
   }
 
   return {
-    languageAbility: input?.applicantFilter?.languageAbility ?? undefined,
+    languageAbility: input?.applicantFilter?.languageAbility ?? "",
     workRegion: unpackMaybes(input?.applicantFilter?.locationPreferences),
     operationalRequirement: unpackMaybes(
       input?.applicantFilter?.operationalRequirements,
@@ -155,7 +155,7 @@ export function transformUserFilterInputToFormValues(
       input?.applicantFilter?.skills?.flatMap((skill) => skill?.id),
     ),
     employmentDuration: !positionDuration?.length
-      ? undefined
+      ? ""
       : positionDuration.includes(PositionDuration.Temporary)
         ? EmploymentDuration.Term
         : EmploymentDuration.Indeterminate,

--- a/apps/web/src/pages/Users/IndexUserPage/components/utils.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/utils.tsx
@@ -107,6 +107,8 @@ export function transformFormValuesToUserFilterInput(
 ): UserFilterInput {
   return {
     applicantFilter: {
+      // NOTE: we do want to treat an empty string as unset
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       languageAbility: data.languageAbility || undefined,
       locationPreferences: data.workRegion,
       operationalRequirements: data.operationalRequirement,

--- a/apps/web/src/pages/Users/IndexUserPage/components/utils.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/utils.tsx
@@ -107,7 +107,7 @@ export function transformFormValuesToUserFilterInput(
 ): UserFilterInput {
   return {
     applicantFilter: {
-      languageAbility: data.languageAbility,
+      languageAbility: data.languageAbility || undefined,
       locationPreferences: data.workRegion,
       operationalRequirements: data.operationalRequirement,
       flexibleWorkLocations: data.flexibleWorkLocations,


### PR DESCRIPTION
🤖 Resolves #17363 

## 👋 Introduction

Fixes an issue where some select inputs were not resetting correctly.

## 🕵️ Details

This was due to the selects having `undefined` as their default value. It seems `react-hook-form` silently ignores those when resetting. This updates them to be an empty string instead which is honoured at the time of reset reliably.

## 🧪 Testing

> [!NOTE]
> This seemed to only be an issue when the default vlaue was empty so make sure those are included in the test. 

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to some tables with filter dilaogs
4. Edit some of the inputs (all if possible but foxcus on empty selects)
5. Apply the filters
6. Re-open the dialog and reset the values
7. Confirm all inputs return to their original value before any changes were made