### PR TITLE
[Fix] Follow up date overdue state

### DIFF
--- a/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/TalentRequestFollowUpDate.tsx
+++ b/apps/web/src/pages/SearchRequests/ViewSearchRequestPage/components/TalentRequestFollowUpDate.tsx
@@ -71,7 +71,10 @@ const TalentRequestFollowUpDate = ({
   const followUpDate = talentRequest?.followUpDate
     ? parseDateTimeUtc(talentRequest.followUpDate)
     : null;
-  const { isOverdue, daysOverdue } = followUpDateOverdueInfo(followUpDate, now);
+  const { isOverdue, isDueToday, daysOverdue } = followUpDateOverdueInfo(
+    followUpDate,
+    now,
+  );
   const label = intl.formatMessage(talentRequestMessages.followUpDate);
 
   const methods = useForm<FormValues>({
@@ -165,9 +168,13 @@ const TalentRequestFollowUpDate = ({
             </Dialog.Body>
           </Dialog.Content>
         </Dialog.Root>
-        {isOverdue && (
+        {(isOverdue || isDueToday) && (
           <Chip color="error">
-            {intl.formatMessage(commonMessages.overdueDate, { daysOverdue })}
+            {isOverdue
+              ? intl.formatMessage(commonMessages.overdueDate, {
+                  daysOverdue,
+                })
+              : intl.formatMessage(commonMessages.dueToday)}
           </Chip>
         )}
       </span>

--- a/apps/web/src/pages/TalentRequests/components/TalentRequestFollowUpDate.tsx
+++ b/apps/web/src/pages/TalentRequests/components/TalentRequestFollowUpDate.tsx
@@ -68,7 +68,10 @@ const TalentRequestFollowUpDate = ({
   const followUpDate = talentRequest?.followUpDate
     ? parseDateTimeUtc(talentRequest.followUpDate)
     : null;
-  const { isOverdue, daysOverdue } = followUpDateOverdueInfo(followUpDate, now);
+  const { isOverdue, isDueToday, daysOverdue } = followUpDateOverdueInfo(
+    followUpDate,
+    now,
+  );
   const label = intl.formatMessage(talentRequestMessages.followUpDate);
 
   const methods = useForm<FormValues>({
@@ -162,9 +165,13 @@ const TalentRequestFollowUpDate = ({
             </Dialog.Body>
           </Dialog.Content>
         </Dialog.Root>
-        {isOverdue && (
+        {(isOverdue || isDueToday) && (
           <Chip color="error">
-            {intl.formatMessage(commonMessages.overdueDate, { daysOverdue })}
+            {isOverdue
+              ? intl.formatMessage(commonMessages.overdueDate, {
+                  daysOverdue,
+                })
+              : intl.formatMessage(commonMessages.dueToday)}
           </Chip>
         )}
       </span>

--- a/apps/web/src/pages/TalentRequests/components/TalentRequestFollowUpDate.tsx
+++ b/apps/web/src/pages/TalentRequests/components/TalentRequestFollowUpDate.tsx
@@ -123,7 +123,7 @@ const TalentRequestFollowUpDate = ({
 
   return (
     <FieldDisplay label={label} className="mb-3">
-      <span className="flex gap-2">
+      <span className="flex flex-col items-start gap-2">
         <Dialog.Root open={isOpen} onOpenChange={setOpen}>
           <Dialog.Trigger>
             <Button mode="inline" color={isOverdue ? "error" : "primary"}>

--- a/apps/web/src/pages/TalentRequests/components/TalentRequestTable/utils.tsx
+++ b/apps/web/src/pages/TalentRequests/components/TalentRequestTable/utils.tsx
@@ -211,14 +211,16 @@ export const followUpDateCell = (
 ) => {
   if (!followUpDate) return null;
 
-  const { isOverdue, daysOverdue } = followUpDateOverdueInfo(
+  const { isOverdue, isDueToday, daysOverdue } = followUpDateOverdueInfo(
     parseDateTimeUtc(followUpDate),
     now,
   );
 
-  return isOverdue ? (
+  return isOverdue || isDueToday ? (
     <Chip color="error">
-      {intl.formatMessage(commonMessages.overdueDate, { daysOverdue })}
+      {isOverdue
+        ? intl.formatMessage(commonMessages.overdueDate, { daysOverdue })
+        : intl.formatMessage(commonMessages.dueToday)}
     </Chip>
   ) : (
     cells.date(followUpDate, intl, DATE_FORMAT_LOCALIZED)

--- a/apps/web/src/utils/searchRequestUtils.test.ts
+++ b/apps/web/src/utils/searchRequestUtils.test.ts
@@ -8,14 +8,16 @@ describe("followUpDateOverdueInfo", () => {
     expect(followUpDateOverdueInfo(followUpDate, now)).toEqual({
       daysOverdue: -1,
       isOverdue: false,
+      isDueToday: false,
     });
   });
 
-  test("is not overdue when follow-up date is today", () => {
+  test("is due today, not overdue, when follow-up date is today", () => {
     const followUpDate = new Date("2026-07-10T04:00:00Z");
     expect(followUpDateOverdueInfo(followUpDate, now)).toEqual({
       daysOverdue: 0,
       isOverdue: false,
+      isDueToday: true,
     });
   });
 
@@ -24,6 +26,7 @@ describe("followUpDateOverdueInfo", () => {
     expect(followUpDateOverdueInfo(followUpDate, now)).toEqual({
       daysOverdue: 1,
       isOverdue: true,
+      isDueToday: false,
     });
   });
 
@@ -31,6 +34,7 @@ describe("followUpDateOverdueInfo", () => {
     expect(followUpDateOverdueInfo(null, now)).toEqual({
       daysOverdue: -1,
       isOverdue: false,
+      isDueToday: false,
     });
   });
 });

--- a/apps/web/src/utils/searchRequestUtils.test.ts
+++ b/apps/web/src/utils/searchRequestUtils.test.ts
@@ -1,0 +1,36 @@
+import { followUpDateOverdueInfo } from "./searchRequestUtils";
+
+describe("followUpDateOverdueInfo", () => {
+  const now = new Date("2026-07-10T19:00:00Z");
+
+  test("is not overdue when follow-up date is tomorrow", () => {
+    const followUpDate = new Date("2026-07-11T04:00:00Z");
+    expect(followUpDateOverdueInfo(followUpDate, now)).toEqual({
+      daysOverdue: -1,
+      isOverdue: false,
+    });
+  });
+
+  test("is not overdue when follow-up date is today", () => {
+    const followUpDate = new Date("2026-07-10T04:00:00Z");
+    expect(followUpDateOverdueInfo(followUpDate, now)).toEqual({
+      daysOverdue: 0,
+      isOverdue: false,
+    });
+  });
+
+  test("is overdue when follow-up date was yesterday", () => {
+    const followUpDate = new Date("2026-07-09T04:00:00Z");
+    expect(followUpDateOverdueInfo(followUpDate, now)).toEqual({
+      daysOverdue: 1,
+      isOverdue: true,
+    });
+  });
+
+  test("is not overdue when follow-up date is null", () => {
+    expect(followUpDateOverdueInfo(null, now)).toEqual({
+      daysOverdue: -1,
+      isOverdue: false,
+    });
+  });
+});

--- a/apps/web/src/utils/searchRequestUtils.ts
+++ b/apps/web/src/utils/searchRequestUtils.ts
@@ -1,5 +1,5 @@
 import type { IntlShape } from "react-intl";
-import { differenceInDays } from "date-fns/differenceInDays";
+import { differenceInCalendarDays } from "date-fns/differenceInCalendarDays";
 
 import { EmploymentDuration } from "@gc-digital-talent/i18n";
 import type { EquitySelections } from "@gc-digital-talent/graphql";
@@ -103,8 +103,10 @@ export const followUpDateOverdueInfo = (
   compareTo?: Date,
 ) => {
   const now = compareTo ?? new Date();
-  const daysOverdue = followUpDate ? differenceInDays(now, followUpDate) : -1;
-  const isOverdue = daysOverdue >= 0;
+  const daysOverdue = followUpDate
+    ? differenceInCalendarDays(now, followUpDate)
+    : -1;
+  const isOverdue = daysOverdue > 0;
 
   return { daysOverdue, isOverdue };
 };

--- a/apps/web/src/utils/searchRequestUtils.ts
+++ b/apps/web/src/utils/searchRequestUtils.ts
@@ -107,6 +107,7 @@ export const followUpDateOverdueInfo = (
     ? differenceInCalendarDays(now, followUpDate)
     : -1;
   const isOverdue = daysOverdue > 0;
+  const isDueToday = daysOverdue === 0;
 
-  return { daysOverdue, isOverdue };
+  return { daysOverdue, isOverdue, isDueToday };
 };

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -139,6 +139,10 @@
     "defaultMessage": "L’article {index} a été supprimé.",
     "description": "Message announced to assistive technology when a repeatable field has been removed"
   },
+  "2H5KbR": {
+    "defaultMessage": "Date limite : aujourd’hui",
+    "description": "Message shown when something is due on the current date"
+  },
   "2Tm9BE": {
     "defaultMessage": "J'accepte de faire des heures supplémentaires à l'occasion.",
     "description": "The operational requirement described as occasional overtime."

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -611,6 +611,11 @@ const commonMessages = defineMessages({
     description:
       "Message showing the number of days by which something is overdue",
   },
+  dueToday: {
+    defaultMessage: "Due today",
+    id: "2H5KbR",
+    description: "Message shown when something is due on the current date",
+  },
   startDate: {
     defaultMessage: "Start date",
     id: "9tH7k0",


### PR DESCRIPTION
🤖 Resolves #17365 

## 👋 Introduction

Fixes an issue with the overdue bagde being set too early on a talent requests follow up date.

## 🕵️ Details

The issue was, we were treating 0 as overdue. We swapped the underlying function to calendar days rather than 24 hour period since the date has no time associated with it. We also changed the `<=` to a simple `<` so that a 0 value ddi not trigger "overdue"

## 🧪 Testing

1. Find a talent request in the database and set its overdue date to less than 24 hours in the future
2. Build `pnpm dev:fresh`
3. Login as `admin@test.com`
4. Navigate to the talent request
5. Confirm the followup date does not show "overdue"
6. Set the date to less than 24 hours in the past
7. Refresh the page and confirm irt now says overdue by a single day