### PR TITLE
Reverse default sort order for Talent Requests follow-up-date column

### DIFF
--- a/apps/web/src/pages/TalentRequests/components/TalentRequestTable/TalentRequestTable.tsx
+++ b/apps/web/src/pages/TalentRequests/components/TalentRequestTable/TalentRequestTable.tsx
@@ -299,6 +299,7 @@ const TalentRequestTable = ({ title }: TalentRequestTableProps) => {
     }),
     columnHelper.accessor(({ followUpDate }) => accessors.date(followUpDate), {
       id: "followUpDate",
+      sortDescFirst: false,
       enableColumnFilter: false,
       header: intl.formatMessage(talentRequestMessages.followUpDate),
       cell: ({


### PR DESCRIPTION
🤖 Resolves #17373 

## 👋 Introduction

Reverses default sort order for Talent Requests follow-up-date column

## 🕵️ Details

Makes a change on the frontend which changes which sort order it requests first from the backend.

## 🧪 Testing

1, Log in as community@test.com
2. Ensure some talent requests have follow up dates
3. Go to talent requests table
4. Click "follow up date" column header to sort by that column
5. most overdue rows should appear at top
6. click header again - rows with no follow up date should appear at top now, with most overdue at end of list
