### PR TITLE
[Feature] Custom introduction text and support email

### DIFF
--- a/api/app/Console/Commands/SetEventIntroduction.php
+++ b/api/app/Console/Commands/SetEventIntroduction.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\TalentNominationEvent;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+
+// This temporary command should be used to set up the OCG events when the code in this PR is deployed and can be removed afterwards.
+
+#[Signature('event:set-ocg-introduction {eventId}')]
+#[Description('Sets the introduction text for a talent nomination to the OCG preferred copy.')]
+class SetEventIntroduction extends Command
+{
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $eventId = $this->argument('eventId');
+        $event = TalentNominationEvent::find($eventId);
+
+        if (is_null($event)) {
+            $this->error('Talent nomination event not found.');
+
+            return Command::FAILURE;
+        }
+
+        if ($this->confirm('Do you wish to update '.$event->name['en'].'?')) {
+            $event->custom_instructions = [
+                'en' => 'Nominations must be sponsored by a C-suite level executive working in the candidate’s domain and will be triaged by the associated functional community team. Once confirmed, the candidate will be entered in that community’s talent management system for the current year.',
+                'fr' => "Les mises en candidature doivent être parrainées par un cadre dirigeant travaillant dans le domaine de la personne candidate et seront triées par l'équipe de la collectivité fonctionnelle associée. Une fois la mise en candidature confirmée, la personne candidate sera inscrit dans le système de gestion des talents de cette collectivité pour l'année en cours.",
+            ];
+            $event->save();
+            $this->info('Event updated.');
+
+        } else {
+            $this->info('No updates made.');
+        }
+
+    }
+}

--- a/api/app/GraphQL/Validators/CreateTalentNominationEventInputValidator.php
+++ b/api/app/GraphQL/Validators/CreateTalentNominationEventInputValidator.php
@@ -35,7 +35,7 @@ final class CreateTalentNominationEventInputValidator extends Validator
             'includeNineBox' => ['sometimes', 'boolean'],
             'requireReferenceForAdvancement' => ['sometimes', 'boolean'],
             'customInstructions' => ['nullable', 'localized_string'],
-            'contactEmail' => ['email'],
+            'contactEmail' => ['required', 'email'],
         ];
     }
 

--- a/api/app/GraphQL/Validators/CreateTalentNominationEventInputValidator.php
+++ b/api/app/GraphQL/Validators/CreateTalentNominationEventInputValidator.php
@@ -35,6 +35,7 @@ final class CreateTalentNominationEventInputValidator extends Validator
             'includeNineBox' => ['sometimes', 'boolean'],
             'requireReferenceForAdvancement' => ['sometimes', 'boolean'],
             'customInstructions' => ['nullable', 'localized_string'],
+            'contactEmail' => ['email'],
         ];
     }
 

--- a/api/app/GraphQL/Validators/Mutation/UpdateTalentNominationEventValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/UpdateTalentNominationEventValidator.php
@@ -98,7 +98,7 @@ final class UpdateTalentNominationEventValidator extends Validator
             'talentNominationEvent.includeNineBox' => ['sometimes', 'boolean'],
             'talentNominationEvent.requireReferenceForAdvancement' => ['sometimes', 'boolean'],
             'talentNominationEvent.customInstructions' => ['nullable', 'localized_string'],
-            'talentNominationEvent.contactEmail' => ['required', 'email'],
+            'talentNominationEvent.contactEmail' => ['sometimes', 'email'],
         ];
     }
 

--- a/api/app/GraphQL/Validators/Mutation/UpdateTalentNominationEventValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/UpdateTalentNominationEventValidator.php
@@ -98,6 +98,7 @@ final class UpdateTalentNominationEventValidator extends Validator
             'talentNominationEvent.includeNineBox' => ['sometimes', 'boolean'],
             'talentNominationEvent.requireReferenceForAdvancement' => ['sometimes', 'boolean'],
             'talentNominationEvent.customInstructions' => ['nullable', 'localized_string'],
+            'talentNominationEvent.contactEmail' => ['required', 'email'],
         ];
     }
 

--- a/api/app/Models/TalentNominationEvent.php
+++ b/api/app/Models/TalentNominationEvent.php
@@ -36,6 +36,7 @@ use Staudenmeir\EloquentHasManyDeep\HasRelationships;
  * @property bool $include_nine_box
  * @property bool $require_reference_for_advancement
  * @property ?array $custom_instructions
+ * @property ?string $contact_email
  */
 class TalentNominationEvent extends Model
 {

--- a/api/database/factories/TalentNominationEventFactory.php
+++ b/api/database/factories/TalentNominationEventFactory.php
@@ -50,6 +50,7 @@ class TalentNominationEventFactory extends Factory
             'include_nine_box' => $this->faker->boolean(),
             'require_reference_for_advancement' => $this->faker->boolean(),
             'custom_instructions' => $this->faker->localizedString($this->faker->sentences(3, true)),
+            'contact_email' => $this->faker->email(),
         ];
     }
 

--- a/api/database/migrations/2026_07_10_135801_add_event_email.php
+++ b/api/database/migrations/2026_07_10_135801_add_event_email.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('talent_nomination_events', function (Blueprint $table) {
+            $table->string('contact_email')->nullable(true);
+        });
+
+        // one-time backfill of existing rows
+        DB::table('talent_nomination_events')->update(['contact_email' => 'support-soutien@talent.canada.ca']);
+
+        Schema::table('talent_nomination_events', function (Blueprint $table) {
+            $table->string('contact_email')->nullable(false)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('talent_nomination_events', function (Blueprint $table) {
+            $table->dropColumn('contact_email');
+        });
+    }
+};

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -2671,7 +2671,7 @@ input UpdateTalentNominationEventInput {
     @rename(attribute: "require_reference_for_advancement")
   customInstructions: LocalizedStringInput
     @rename(attribute: "custom_instructions")
-  contactEmail: String! @rename(attribute: "contact_email")
+  contactEmail: String @rename(attribute: "contact_email")
 }
 
 input TalentNominationEventBelongsTo {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -2671,6 +2671,7 @@ input UpdateTalentNominationEventInput {
     @rename(attribute: "require_reference_for_advancement")
   customInstructions: LocalizedStringInput
     @rename(attribute: "custom_instructions")
+  contactEmail: String! @rename(attribute: "contact_email")
 }
 
 input TalentNominationEventBelongsTo {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -893,6 +893,7 @@ type TalentNominationEvent {
   requireReferenceForAdvancement: Boolean!
     @rename(attribute: "require_reference_for_advancement")
   customInstructions: LocalizedString @rename(attribute: "custom_instructions")
+  contactEmail: String @rename(attribute: "contact_email")
 }
 
 type TalentNomination {
@@ -2652,6 +2653,7 @@ input CreateTalentNominationEventInput @validator {
     @rename(attribute: "require_reference_for_advancement")
   customInstructions: LocalizedStringInput
     @rename(attribute: "custom_instructions")
+  contactEmail: String! @rename(attribute: "contact_email")
 }
 
 input UpdateTalentNominationEventInput {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -2637,7 +2637,7 @@ input UpdateTalentNominationEventInput {
   includeNineBox: Boolean
   requireReferenceForAdvancement: Boolean
   customInstructions: LocalizedStringInput
-  contactEmail: String!
+  contactEmail: String
 }
 
 input TalentNominationEventBelongsTo {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1477,6 +1477,7 @@ type TalentNominationEvent {
   includeNineBox: Boolean!
   requireReferenceForAdvancement: Boolean!
   customInstructions: LocalizedString
+  contactEmail: String
 }
 
 type TalentNomination {
@@ -2621,6 +2622,7 @@ input CreateTalentNominationEventInput {
   includeNineBox: Boolean
   requireReferenceForAdvancement: Boolean
   customInstructions: LocalizedStringInput
+  contactEmail: String!
 }
 
 input UpdateTalentNominationEventInput {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -2637,6 +2637,7 @@ input UpdateTalentNominationEventInput {
   includeNineBox: Boolean
   requireReferenceForAdvancement: Boolean
   customInstructions: LocalizedStringInput
+  contactEmail: String!
 }
 
 input TalentNominationEventBelongsTo {

--- a/api/tests/Feature/TalentNominationEventTest.php
+++ b/api/tests/Feature/TalentNominationEventTest.php
@@ -45,6 +45,7 @@ class TalentNominationEventTest extends TestCase
         'description' => ['en' => 'Test EN', 'fr' => 'Test FR'],
         'learnMoreUrl' => ['en' => 'http://en.domain.com', 'fr' => 'http://fr.domain.com'],
         'includeLeadershipCompetencies' => true,
+        'contactEmail' => 'example@example.org',
     ];
 
     protected $createMutation = <<<'GRAPHQL'
@@ -67,6 +68,7 @@ class TalentNominationEventTest extends TestCase
                         }
                     }
                 }
+                contactEmail
             }
         }
     GRAPHQL;

--- a/apps/playwright/utils/talentNominationEvent.ts
+++ b/apps/playwright/utils/talentNominationEvent.ts
@@ -17,6 +17,7 @@ export const defaultTalentNominationEvent: Partial<CreateTalentNominationEventIn
     },
     openDate: oldDate.toISOString().slice(0, 19).replace("T", " "),
     closeDate: newDate.toISOString().slice(0, 19).replace("T", " "),
+    contactEmail: "example@example.org",
   };
 
 const Test_CreateTalentNominationEventMutation = /* GraphQL */ `

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1447,10 +1447,6 @@
     "defaultMessage": "Vous n'avez pas de demande active pour le moment.",
     "description": "Title for notice when there are no pool candidate search requests"
   },
-  "3RUGGK": {
-    "defaultMessage": "Vous avez des questions? <link>Communiquez avec notre équipe de soutien</link>.",
-    "description": "Paragraph two, instructions on how to submit a nomination"
-  },
   "3Rad8l": {
     "defaultMessage": "Souhaitez-vous poursuivre? Ceci vous éloignera de cette page-ci.",
     "description": "Text explaining what will happen after duplicating a pool and confirming the action"
@@ -2042,6 +2038,10 @@
   "5jFkhf": {
     "defaultMessage": "Erreur : Échec de la création de la classification",
     "description": "Message displayed to user after classification fails to get created."
+  },
+  "5jkq2u": {
+    "defaultMessage": "Le formulaire de mise en candidature présente des instructions de base au début de chaque mise en candidature afin d'aider la personne qui soumet la mise en candidature à suivre le processus. Utilisez le champ facultatif ci-dessous pour ajouter des renseignements propres à votre événement.",
+    "description": "description for custom event instructions"
   },
   "5lHi37": {
     "defaultMessage": "Communiquez avec nous<hidden> au sujet de l’expérience d’embauche</hidden>",
@@ -4406,6 +4406,10 @@
   "Fl1K8W": {
     "defaultMessage": "Bassin(s) demandé(s)",
     "description": "Label for the pools being sourced for a talent request"
+  },
+  "FlTPg2": {
+    "defaultMessage": "Si vous avez des questions ou souhaitez modifier votre mise en candidature, veuillez <link>communiquer avec l'équipe responsable de l'événement</link>. Elle vous indiquera les prochaines étapes.",
+    "description": "Instructions to contact support after nomination submission"
   },
   "Fmi0y9": {
     "defaultMessage": "Ajouts récents",
@@ -7187,10 +7191,6 @@
     "defaultMessage": "Activé",
     "description": "A switch to enable or disable a setting"
   },
-  "QqwcpX": {
-    "defaultMessage": "Les mises en candidature doivent être parrainées par un cadre dirigeant travaillant dans le domaine de la personne candidate et seront triées par l'équipe de la collectivité fonctionnelle associée. Une fois la mise en candidature confirmée, la personne candidate sera inscrit dans le système de gestion des talents de cette collectivité pour l'année en cours.",
-    "description": "Paragraph two, instructions on how to submit a nomination"
-  },
   "Qt9Q8k": {
     "defaultMessage": "Le programme dure combien de temps?",
     "description": "Learn more dialog question two heading"
@@ -9458,6 +9458,10 @@
     "defaultMessage": "Vue candidat(e)",
     "description": "Applicant role name for nav menu"
   },
+  "aXY8in": {
+    "defaultMessage": "Date de début des mises en candidature",
+    "description": "start date of a nomination event"
+  },
   "aYgVQT": {
     "defaultMessage": "Types d'organisations envisagées pour une mutation latérale",
     "description": "Label for an employee profile career development preference field"
@@ -9741,6 +9745,10 @@
   "bnhqpY": {
     "defaultMessage": "Est équivalent en termes de durée de l’intensité/de l’apprentissage par rapport aux exigences du diplôme",
     "description": "Text for education accepted information context in screening decision dialog"
+  },
+  "bnjpsH": {
+    "defaultMessage": "Date de clôture des mises en candidature",
+    "description": "end date of a nomination event"
   },
   "boPmF+": {
     "defaultMessage": "Langue de l'examen écrit",
@@ -10286,10 +10294,6 @@
     "defaultMessage": "Je suis dirigeant(e) principal(e) des finances (DPF).",
     "description": "Message when user is a finance chief"
   },
-  "duXf4a": {
-    "defaultMessage": "Si vous avez des questions ou des préoccupations, n'hésitez pas à <link>communiquer avec notre équipe de soutien</link>.",
-    "description": "Instructions to contact support after nomination submission"
-  },
   "dwYJOo": {
     "defaultMessage": "Expérience professionnelle appliquée",
     "description": "Title for the applied work experience requirements"
@@ -10630,6 +10634,10 @@
     "defaultMessage": "Volet de travail",
     "description": "The work stream of a job poster template"
   },
+  "ezbo2U": {
+    "defaultMessage": "Adresse courriel de l'équipe responsable de l'événement",
+    "description": "Label displayed on the talent nomination event contact email field"
+  },
   "f/XJsH": {
     "defaultMessage": "La formation ou le perfectionnement m'intéresse",
     "description": "Message when user expresses interest in training or development opportunities"
@@ -10641,6 +10649,10 @@
   "f0dhMc": {
     "defaultMessage": "Je connais l'année à laquelle je suis admissible à la retraite.",
     "description": "The eligible retirement year described as known."
+  },
+  "f1Kpkp": {
+    "defaultMessage": "Texte d'instructions personnalisé",
+    "description": "label for nomination event instructions"
   },
   "f1vqns": {
     "defaultMessage": "Les renseignements suivants seront utilisés pour identifier la collectivité et fournir un aperçu des domaines qu'elle soutient.",
@@ -11841,6 +11853,10 @@
   "jTN0bg": {
     "defaultMessage": "Embauchez des talents pour votre équipe",
     "description": "Title for to go to the search page on Browse IT jobs page"
+  },
+  "jUI9DU": {
+    "defaultMessage": "Vous avez des questions? <link>Communiquez avec l'équipe responsable de l'événement.</link>",
+    "description": "Paragraph two, instructions on how to submit a nomination"
   },
   "jULOHh": {
     "defaultMessage": "Erreur : la mise à jour de l’événement de mise en candidature a échoué",

--- a/apps/web/src/pages/TalentEvents/CreateTalentEventPage.tsx
+++ b/apps/web/src/pages/TalentEvents/CreateTalentEventPage.tsx
@@ -95,6 +95,10 @@ const CreateTalentEventPage = () => {
       );
     }
 
+    if (!formValues.contactEmail) {
+      throw new Error("contact email is mandatory"); // form enforces this - just to make TS happy
+    }
+
     return executeMutation({
       talentNominationEvent: {
         ...formValues,
@@ -113,6 +117,7 @@ const CreateTalentEventPage = () => {
             })),
           ],
         },
+        contactEmail: formValues.contactEmail,
       },
     })
       .then(async (result) => {

--- a/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
@@ -25,6 +25,7 @@ import {
   parseDateTimeUtc,
 } from "@gc-digital-talent/date-helpers";
 import { sortAlphaBy, unpackMaybes } from "@gc-digital-talent/helpers";
+import { htmlToRichTextJSON, RichTextRenderer } from "@gc-digital-talent/forms";
 
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import useRequiredParams from "~/hooks/useRequiredParams";
@@ -87,6 +88,11 @@ const TalentEventDetails_Fragment = graphql(/* GraphQL */ `
         localized
       }
     }
+    customInstructions {
+      en
+      fr
+    }
+    contactEmail
   }
 `);
 
@@ -120,6 +126,7 @@ const TalentEventDetails = ({ query }: TalentEventDetailsProps) => {
     .sort(sortAlphaBy((i) => i.developmentProgram.name.localized));
 
   const notFound = intl.formatMessage(commonMessages.notFound);
+  const notProvided = intl.formatMessage(commonMessages.notProvided);
 
   return (
     <>
@@ -238,6 +245,17 @@ const TalentEventDetails = ({ query }: TalentEventDetailsProps) => {
           {talentEvent.description?.fr ??
             intl.formatMessage(commonMessages.notProvided)}
         </p>
+        <FieldDisplay
+          label={intl.formatMessage({
+            defaultMessage: "Event contact email",
+            id: "ezbo2U",
+            description:
+              "Label displayed on the talent nomination event contact email field",
+          })}
+          className="col-span-2"
+        >
+          {talentEvent.contactEmail ?? notFound}
+        </FieldDisplay>
         <div className="sm:col-span-2">
           <CardSeparator space="none" decorative />
         </div>
@@ -309,6 +327,39 @@ const TalentEventDetails = ({ query }: TalentEventDetailsProps) => {
             description: "Label for the include leadership competencies",
           })}
         </BoolCheckIcon>
+
+        <FieldDisplay
+          label={intl.formatMessage({
+            defaultMessage: "Customized instruction text",
+            id: "f1Kpkp",
+            description: "label for nomination event instructions",
+          })}
+          appendLanguageToLabel="en"
+        >
+          {talentEvent.customInstructions?.en ? (
+            <RichTextRenderer
+              node={htmlToRichTextJSON(talentEvent.customInstructions.en)}
+            />
+          ) : (
+            notProvided
+          )}
+        </FieldDisplay>
+        <FieldDisplay
+          label={intl.formatMessage({
+            defaultMessage: "Customized instruction text",
+            id: "f1Kpkp",
+            description: "label for nomination event instructions",
+          })}
+          appendLanguageToLabel="fr"
+        >
+          {talentEvent.customInstructions?.fr ? (
+            <RichTextRenderer
+              node={htmlToRichTextJSON(talentEvent.customInstructions.fr)}
+            />
+          ) : (
+            notProvided
+          )}
+        </FieldDisplay>
         <div className="col-span-2">
           <CardSeparator space="none" decorative />
         </div>

--- a/apps/web/src/pages/TalentEvents/UpdateTalentEventPage.tsx
+++ b/apps/web/src/pages/TalentEvents/UpdateTalentEventPage.tsx
@@ -110,6 +110,11 @@ const UpdateTalentEventForm = ({
             fr: cdp.pivot?.descriptionForNominations?.fr,
           },
         })),
+      customInstructions: {
+        en: talentNominationEvent.customInstructions?.en,
+        fr: talentNominationEvent.customInstructions?.fr,
+      },
+      contactEmail: talentNominationEvent.contactEmail,
     },
   });
 

--- a/apps/web/src/pages/TalentEvents/UpdateTalentEventPage.tsx
+++ b/apps/web/src/pages/TalentEvents/UpdateTalentEventPage.tsx
@@ -145,6 +145,10 @@ const UpdateTalentEventForm = ({
       );
     }
 
+    if (!formValues.contactEmail) {
+      throw new Error("contact email is mandatory"); // form enforces this - just to make TS happy
+    }
+
     return executeMutation({
       id: talentNominationEvent.id,
       talentNominationEvent: {
@@ -164,7 +168,7 @@ const UpdateTalentEventForm = ({
             })),
           ],
         },
-        contactEmail: formValues.contactEmail ?? "",
+        contactEmail: formValues.contactEmail,
       },
     })
       .then(async (result) => {

--- a/apps/web/src/pages/TalentEvents/UpdateTalentEventPage.tsx
+++ b/apps/web/src/pages/TalentEvents/UpdateTalentEventPage.tsx
@@ -164,6 +164,7 @@ const UpdateTalentEventForm = ({
             })),
           ],
         },
+        contactEmail: formValues.contactEmail ?? "",
       },
     })
       .then(async (result) => {

--- a/apps/web/src/pages/TalentEvents/components/ActiveTalentEventForm.tsx
+++ b/apps/web/src/pages/TalentEvents/components/ActiveTalentEventForm.tsx
@@ -151,6 +151,7 @@ const ActiveTalentEventForm = ({
             })),
           ],
         },
+        contactEmail: formValues.contactEmail ?? "",
       },
     })
       .then(async (result) => {

--- a/apps/web/src/pages/TalentEvents/components/ActiveTalentEventForm.tsx
+++ b/apps/web/src/pages/TalentEvents/components/ActiveTalentEventForm.tsx
@@ -133,6 +133,10 @@ const ActiveTalentEventForm = ({
   const onSubmit: SubmitHandler<FormValues> = async (
     formValues: FormValues,
   ) => {
+    if (!formValues.contactEmail) {
+      throw new Error("contact email is mandatory"); // form enforces this - just to make TS happy
+    }
+
     return executeMutation({
       id: talentNominationEvent.id,
       talentNominationEvent: {
@@ -151,7 +155,7 @@ const ActiveTalentEventForm = ({
             })),
           ],
         },
-        contactEmail: formValues.contactEmail ?? "",
+        contactEmail: formValues.contactEmail,
       },
     })
       .then(async (result) => {

--- a/apps/web/src/pages/TalentEvents/components/ActiveTalentEventForm.tsx
+++ b/apps/web/src/pages/TalentEvents/components/ActiveTalentEventForm.tsx
@@ -15,7 +15,14 @@ import {
   formMessages,
   getLocale,
 } from "@gc-digital-talent/i18n";
-import { DateInput, Input, Submit, TextArea } from "@gc-digital-talent/forms";
+import {
+  DateInput,
+  htmlToRichTextJSON,
+  Input,
+  RichTextRenderer,
+  Submit,
+  TextArea,
+} from "@gc-digital-talent/forms";
 import {
   convertDateTimeToDate,
   convertDateTimeZone,
@@ -73,8 +80,11 @@ const ActiveTalentEventForm = ({
     learnMoreUrl,
     closeDate,
     communityDevelopmentPrograms,
+    contactEmail,
+    customInstructions,
   } = talentNominationEvent;
   const notFound = intl.formatMessage(commonMessages.notFound);
+  const notProvided = intl.formatMessage(commonMessages.notProvided);
 
   const methods = useForm<FormValues>({
     defaultValues: {
@@ -98,6 +108,7 @@ const ActiveTalentEventForm = ({
           },
         }),
       ),
+      contactEmail: contactEmail,
     },
   });
 
@@ -297,6 +308,22 @@ const ActiveTalentEventForm = ({
               appendLanguageToLabel={"fr"}
               type="url"
             />
+            <div className="xs:col-span-2">
+              <Input
+                id="contactEmail"
+                name="contactEmail"
+                label={intl.formatMessage({
+                  defaultMessage: "Event contact email",
+                  id: "ezbo2U",
+                  description:
+                    "Label displayed on the talent nomination event contact email field",
+                })}
+                type="email"
+                rules={{
+                  required: intl.formatMessage(errorMessages.required),
+                }}
+              />
+            </div>
           </div>
           <CardSeparator />
           <div className="grid grid-cols-1 gap-6 xs:grid-cols-2">
@@ -318,26 +345,6 @@ const ActiveTalentEventForm = ({
                     "Description for subsection create talent management event",
                 })}
               </p>
-            </div>
-            <div className="col-span-2">
-              <FieldDisplay
-                label={intl.formatMessage({
-                  defaultMessage: "Leadership competency requirement",
-                  id: "eBH+tH",
-                  description:
-                    "Bounding box label for the include leadership competencies",
-                })}
-              >
-                <BoolCheckIcon value={includeLeadershipCompetencies}>
-                  {intl.formatMessage({
-                    defaultMessage:
-                      "The nomination must include the nominee's top 3 leadership competencies",
-                    id: "4rkX89",
-                    description:
-                      "Label for the include leadership competencies",
-                  })}
-                </BoolCheckIcon>
-              </FieldDisplay>
             </div>
             <FieldDisplay
               label={intl.formatMessage({
@@ -384,6 +391,58 @@ const ActiveTalentEventForm = ({
                 }}
               />
             </div>
+            <div className="col-span-2">
+              <FieldDisplay
+                label={intl.formatMessage({
+                  defaultMessage: "Leadership competency requirement",
+                  id: "eBH+tH",
+                  description:
+                    "Bounding box label for the include leadership competencies",
+                })}
+              >
+                <BoolCheckIcon value={includeLeadershipCompetencies}>
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "The nomination must include the nominee's top 3 leadership competencies",
+                    id: "4rkX89",
+                    description:
+                      "Label for the include leadership competencies",
+                  })}
+                </BoolCheckIcon>
+              </FieldDisplay>
+            </div>
+            <FieldDisplay
+              label={intl.formatMessage({
+                defaultMessage: "Customized instruction text",
+                id: "f1Kpkp",
+                description: "label for nomination event instructions",
+              })}
+              appendLanguageToLabel="en"
+            >
+              {customInstructions?.en ? (
+                <RichTextRenderer
+                  node={htmlToRichTextJSON(customInstructions.en)}
+                />
+              ) : (
+                notProvided
+              )}
+            </FieldDisplay>
+            <FieldDisplay
+              label={intl.formatMessage({
+                defaultMessage: "Customized instruction text",
+                id: "f1Kpkp",
+                description: "label for nomination event instructions",
+              })}
+              appendLanguageToLabel="fr"
+            >
+              {customInstructions?.fr ? (
+                <RichTextRenderer
+                  node={htmlToRichTextJSON(customInstructions.fr)}
+                />
+              ) : (
+                notProvided
+              )}
+            </FieldDisplay>
           </div>
           {community !== null && (
             <>

--- a/apps/web/src/pages/TalentEvents/components/UpcomingTalentEventForm.tsx
+++ b/apps/web/src/pages/TalentEvents/components/UpcomingTalentEventForm.tsx
@@ -1,6 +1,6 @@
 import { defineMessage, useIntl } from "react-intl";
 import { useFieldArray, useFormContext } from "react-hook-form";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 
 import { CardSeparator, Heading, Notice } from "@gc-digital-talent/ui";
 import { getFragment, type FragmentType } from "@gc-digital-talent/graphql";
@@ -9,11 +9,13 @@ import {
   errorMessages,
   getLocale,
   uiMessages,
+  type Locales,
 } from "@gc-digital-talent/i18n";
 import {
   Checkbox,
   DateInput,
   Input,
+  RichTextInput,
   Select,
   TextArea,
 } from "@gc-digital-talent/forms";
@@ -23,6 +25,7 @@ import { ROLE_NAME } from "@gc-digital-talent/auth";
 import processMessages from "~/messages/processMessages";
 import DevelopmentProgramCard from "~/components/DevelopmentProgramCard/DevelopmentProgramCard";
 import adminMessages from "~/messages/adminMessages";
+import { FRENCH_WORDS_PER_ENGLISH_WORD } from "~/constants/talentSearchConstants";
 
 import { isCommunity } from "../TalentEvent/util";
 import type { FormValues } from "./formValues";
@@ -37,6 +40,8 @@ const atLeastOne = defineMessage({
   id: "bShedV",
   description: "Message to add at least one development opportunity",
 });
+
+const TEXT_AREA_MAX_WORDS_EN = 75;
 
 interface UpcomingTalentEventFormProps {
   query?: FragmentType<typeof TalentNominationEvent_Fragment>;
@@ -117,6 +122,13 @@ const UpcomingTalentEventForm = ({ query }: UpcomingTalentEventFormProps) => {
 
   const [editOpen, setEditOpen] = useState<string | null>(null);
   const [removeOpen, setRemoveOpen] = useState<string | null>(null);
+
+  const wordCountLimits: Record<Locales, number> = {
+    en: TEXT_AREA_MAX_WORDS_EN,
+    fr: Math.round(TEXT_AREA_MAX_WORDS_EN * FRENCH_WORDS_PER_ENGLISH_WORD),
+  } as const;
+
+  const instructionsDescriptionId = useId();
 
   return (
     <>
@@ -201,6 +213,22 @@ const UpcomingTalentEventForm = ({ query }: UpcomingTalentEventFormProps) => {
           appendLanguageToLabel={"fr"}
           type="url"
         />
+        <div className="xs:col-span-2">
+          <Input
+            id="contactEmail"
+            name="contactEmail"
+            label={intl.formatMessage({
+              defaultMessage: "Event contact email",
+              id: "ezbo2U",
+              description:
+                "Label displayed on the talent nomination event contact email field",
+            })}
+            type="email"
+            rules={{
+              required: intl.formatMessage(errorMessages.required),
+            }}
+          />
+        </div>
       </div>
       <CardSeparator />
       <div className="grid gap-6 xs:grid-cols-2">
@@ -223,6 +251,37 @@ const UpcomingTalentEventForm = ({ query }: UpcomingTalentEventFormProps) => {
             })}
           </p>
         </div>
+        <DateInput
+          id="openDate"
+          name="openDate"
+          legend={intl.formatMessage({
+            defaultMessage: "Nomination start date",
+            id: "aXY8in",
+            description: "start date of a nomination event",
+          })}
+          rules={{
+            required: intl.formatMessage(errorMessages.required),
+          }}
+        />
+        <DateInput
+          id="closeDate"
+          name="closeDate"
+          legend={intl.formatMessage({
+            defaultMessage: "Nomination close date",
+            id: "bnjpsH",
+            description: "end date of a nomination event",
+          })}
+          rules={{
+            min: {
+              value: watchOpenDate ? String(watchOpenDate) : "",
+              message: intl.formatMessage(errorMessages.minDateSelfLabel, {
+                labelSelf: intl.formatMessage(processMessages.closingDate),
+                labelAssociated: intl.formatMessage(adminMessages.openingDate),
+              }),
+            },
+            required: intl.formatMessage(errorMessages.required),
+          }}
+        />
         <div className="xs:col-span-2">
           <Checkbox
             id="includeLeadershipCompetencies"
@@ -242,28 +301,39 @@ const UpcomingTalentEventForm = ({ query }: UpcomingTalentEventFormProps) => {
             name="includeLeadershipCompetencies"
           />
         </div>
-        <DateInput
-          id="openDate"
-          name="openDate"
-          legend={intl.formatMessage(adminMessages.openingDate)}
-          rules={{
-            required: intl.formatMessage(errorMessages.required),
-          }}
+        <div className="xs:col-span-2" id={instructionsDescriptionId}>
+          {intl.formatMessage({
+            defaultMessage:
+              "The nomination form offers basic instructions at the beginning of each nomination to help guide the nominator through the process. You use the following optional field to include extra context that might be unique to your event.",
+            id: "5jkq2u",
+            description: "description for custom event instructions",
+          })}
+        </div>
+        <RichTextInput
+          id={"customInstructions.en"}
+          name={"customInstructions.en"}
+          wordLimit={wordCountLimits.en}
+          label={intl.formatMessage({
+            defaultMessage: "Customized instruction text",
+            id: "f1Kpkp",
+            description: "label for nomination event instructions",
+          })}
+          appendLanguageToLabel={"en"}
+          rules={{ required: intl.formatMessage(errorMessages.required) }}
+          aria-describedby={instructionsDescriptionId}
         />
-        <DateInput
-          id="closeDate"
-          name="closeDate"
-          legend={intl.formatMessage(processMessages.closingDate)}
-          rules={{
-            min: {
-              value: watchOpenDate ? String(watchOpenDate) : "",
-              message: intl.formatMessage(errorMessages.minDateSelfLabel, {
-                labelSelf: intl.formatMessage(processMessages.closingDate),
-                labelAssociated: intl.formatMessage(adminMessages.openingDate),
-              }),
-            },
-            required: intl.formatMessage(errorMessages.required),
-          }}
+        <RichTextInput
+          id={"customInstructions.fr"}
+          name={"customInstructions.fr"}
+          wordLimit={wordCountLimits.fr}
+          label={intl.formatMessage({
+            defaultMessage: "Customized instruction text",
+            id: "f1Kpkp",
+            description: "label for nomination event instructions",
+          })}
+          appendLanguageToLabel={"fr"}
+          rules={{ required: intl.formatMessage(errorMessages.required) }}
+          aria-describedby={instructionsDescriptionId}
         />
       </div>
       {watchCommunity && (

--- a/apps/web/src/pages/TalentEvents/components/formValues.ts
+++ b/apps/web/src/pages/TalentEvents/components/formValues.ts
@@ -26,5 +26,5 @@ export interface FormValues {
     en: string | null;
     fr: string | null;
   };
-  contactEmail: string;
+  contactEmail: string | null;
 }

--- a/apps/web/src/pages/TalentEvents/components/formValues.ts
+++ b/apps/web/src/pages/TalentEvents/components/formValues.ts
@@ -22,4 +22,9 @@ export interface FormValues {
       fr: string | null;
     };
   }[];
+  customInstructions: {
+    en: string | null;
+    fr: string | null;
+  };
+  contactEmail: string;
 }

--- a/apps/web/src/pages/TalentEvents/components/fragments.ts
+++ b/apps/web/src/pages/TalentEvents/components/fragments.ts
@@ -78,6 +78,11 @@ export const UpdateTalentNominationEvent_Fragment = graphql(/* GraphQL */ `
         }
       }
     }
+    customInstructions {
+      en
+      fr
+    }
+    contactEmail
   }
 `);
 

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Instructions.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Instructions.tsx
@@ -157,17 +157,17 @@ const Instructions = ({ instructionsQuery }: InstructionsProps) => {
         })}
       </p>
       {data.talentNominationEvent.customInstructions?.localized ? (
-        <p className="my-6">
+        <div className="my-6">
           <RichTextRenderer
             node={htmlToRichTextJSON(
               data.talentNominationEvent.customInstructions.localized,
             )}
           />
-        </p>
+        </div>
       ) : null}
 
       {data.talentNominationEvent.contactEmail ? (
-        <p className="my-6">
+        <div className="my-6">
           {intl.formatMessage(
             {
               defaultMessage:
@@ -187,7 +187,7 @@ const Instructions = ({ instructionsQuery }: InstructionsProps) => {
               ),
             },
           )}
-        </p>
+        </div>
       ) : null}
     </UpdateForm>
   );

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Instructions.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Instructions.tsx
@@ -13,6 +13,7 @@ import {
 } from "@gc-digital-talent/graphql";
 import { Link, Dialog, Button } from "@gc-digital-talent/ui";
 import { useHasPermissions } from "@gc-digital-talent/auth";
+import { htmlToRichTextJSON, RichTextRenderer } from "@gc-digital-talent/forms";
 
 import useRoutes from "~/hooks/useRoutes";
 
@@ -26,6 +27,10 @@ export const NominateTalentInstructions_Fragment = graphql(/* GraphQL */ `
     talentNominationEvent {
       id
       closeDate
+      customInstructions {
+        localized
+      }
+      contactEmail
     }
   }
 `);
@@ -151,33 +156,39 @@ const Instructions = ({ instructionsQuery }: InstructionsProps) => {
             "Paragraph one, instructions on how to submit a nomination",
         })}
       </p>
-      <p className="my-6">
-        {intl.formatMessage({
-          defaultMessage:
-            "Nominations must be sponsored by a C-suite level executive working in the candidate’s domain and will be triaged by the associated functional community team. Once confirmed, the candidate will be entered in that community’s talent management system for the current year.",
-          id: "QqwcpX",
-          description:
-            "Paragraph two, instructions on how to submit a nomination",
-        })}
-      </p>
-      <p className="my-6">
-        {intl.formatMessage(
-          {
-            defaultMessage:
-              "Have questions? <link>Reach out to our support team</link>.",
-            id: "3RUGGK",
-            description:
-              "Paragraph two, instructions on how to submit a nomination",
-          },
-          {
-            link: (chunks: ReactNode) => (
-              <Link href={paths.support()} color="black">
-                {chunks}
-              </Link>
-            ),
-          },
-        )}
-      </p>
+      {data.talentNominationEvent.customInstructions?.localized ? (
+        <p className="my-6">
+          <RichTextRenderer
+            node={htmlToRichTextJSON(
+              data.talentNominationEvent.customInstructions.localized,
+            )}
+          />
+        </p>
+      ) : null}
+
+      {data.talentNominationEvent.contactEmail ? (
+        <p className="my-6">
+          {intl.formatMessage(
+            {
+              defaultMessage:
+                "Have questions? <link>Reach out to the community event team.</link>",
+              id: "jUI9DU",
+              description:
+                "Paragraph two, instructions on how to submit a nomination",
+            },
+            {
+              link: (chunks: ReactNode) => (
+                <Link
+                  href={`mailto:${data.talentNominationEvent.contactEmail}`}
+                  color="black"
+                >
+                  {chunks}
+                </Link>
+              ),
+            },
+          )}
+        </p>
+      ) : null}
     </UpdateForm>
   );
 };

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Success.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Success.tsx
@@ -24,6 +24,7 @@ const NominateTalentSuccess_Fragment = graphql(/* GraphQL */ `
           localized
         }
       }
+      contactEmail
     }
   }
 `);
@@ -74,24 +75,29 @@ const Success = ({ successQuery }: SuccessProps) => {
           },
         )}
       </p>
-      <p className="my-6">
-        {intl.formatMessage(
-          {
-            defaultMessage:
-              "If you have any questions or concerns, feel free to <link>reach out to our support team</link>.",
-            id: "duXf4a",
-            description:
-              "Instructions to contact support after nomination submission",
-          },
-          {
-            link: (chunks: ReactNode) => (
-              <Link href={paths.support()} color="black">
-                {chunks}
-              </Link>
-            ),
-          },
-        )}
-      </p>
+      {talentNomination.talentNominationEvent.contactEmail ? (
+        <p className="my-6">
+          {intl.formatMessage(
+            {
+              defaultMessage:
+                "If you have any questions or need to amend your nomination, please <link>reach out to the community event team</link> and they will provide next steps.",
+              id: "FlTPg2",
+              description:
+                "Instructions to contact support after nomination submission",
+            },
+            {
+              link: (chunks: ReactNode) => (
+                <Link
+                  href={`mailto:${talentNomination.talentNominationEvent.contactEmail}`}
+                  color="black"
+                >
+                  {chunks}
+                </Link>
+              ),
+            },
+          )}
+        </p>
+      ) : null}
       <p className="mt-6">
         <Link href={paths.applicantDashboard()} mode="solid" color="primary">
           {intl.formatMessage(navigationMessages.returnToDashboard)}

--- a/packages/forms/src/components/RichTextInput/ControlledInput.tsx
+++ b/packages/forms/src/components/RichTextInput/ControlledInput.tsx
@@ -6,6 +6,7 @@ import type {
   UseFormStateReturn,
 } from "react-hook-form";
 import { tv } from "tailwind-variants";
+import get from "lodash/get";
 
 import MenuBar from "./MenuBar";
 import Footer from "./Footer";
@@ -46,9 +47,13 @@ const ControlledInput = ({
   editable,
   wordLimit,
 }: ControlledInputProps) => {
-  const content = defaultValues?.[name]
-    ? String(defaultValues[name])
-    : undefined;
+  // lodash/get handles nested values with dotted notation, too
+  const rawDefaultValue: unknown = get(defaultValues, name);
+  const content =
+    rawDefaultValue !== null && rawDefaultValue !== undefined
+      ? // eslint-disable-next-line @typescript-eslint/no-base-to-string
+        String(rawDefaultValue)
+      : undefined;
 
   const editorProps = useMemo(
     () => ({


### PR DESCRIPTION
🤖 Resolves #17253 

## 👋 Introduction

Adds custom introduction text and support emails for talent nomination events.

## 🕵️ Details

High level:
- Migration to add email field
- Artisan command to backfill instructions for OCG events
- Moves date fields in admin event pages
- Admin create event fields for instructions and email
- Admin view event fields for instructions and email
- Admin edit upcoming event fields for instructions and email
- Admin edit active event fields for just email
- Nomination flow instructions page shows instructions and email
- Nomination flow success page shows email
- Fix RichTextInput not accepting nested fields

## 🧪 Testing

1.  Run migration and rebuild app
- [ ] can perform deployment instructions to backfill a talent event

1. Log in as community@test.com
2. Navigate to the talent events table
- [ ] Can create a talent event with a custom email address and instructions
- [ ] Can view a talent event with a custom email address and instructions
- [ ] Can edit an upcoming talent event for email address and instructions
- [ ] Can edit an active talent event for just the email address

1. Navigate to create a nomination flow
- [ ] Can see custom instructions and support email address on "instructions" step
- [ ] Can see support email address on "success" step


## 📸 Screenshot

<img width="1141" height="469" alt="image" src="https://github.com/user-attachments/assets/6fca5091-8ebc-4ec5-9540-318a7ed26ee2" />


## 🚚 Deployment

https://github.com/GCTC-NTGC/gc-digital-talent/issues/17375