### PR TITLE
[Feat] Log forwarded ip

### DIFF
--- a/api/app/Http/Kernel.php
+++ b/api/app/Http/Kernel.php
@@ -6,6 +6,7 @@ use App\Http\Middleware\Authenticate;
 use App\Http\Middleware\EncryptCookies;
 use App\Http\Middleware\PreventRequestsDuringMaintenance;
 use App\Http\Middleware\ProtectedRequest;
+use App\Http\Middleware\RequestOriginLoggerMiddleware;
 use App\Http\Middleware\TrimStrings;
 use App\Http\Middleware\TrustProxies;
 use BeyondCode\ServerTiming\Middleware\ServerTimingMiddleware;
@@ -45,6 +46,7 @@ class Kernel extends HttpKernel
         TrimStrings::class,
         ConvertEmptyStringsToNull::class,
         ProtectedRequest::class,
+        RequestOriginLoggerMiddleware::class,
     ];
 
     /**

--- a/api/app/Http/Middleware/RequestOriginLoggerMiddleware.php
+++ b/api/app/Http/Middleware/RequestOriginLoggerMiddleware.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Psr\Log\LoggerInterface;
 
 class RequestOriginLoggerMiddleware
@@ -18,6 +19,10 @@ class RequestOriginLoggerMiddleware
     public function handle(Request $request, Closure $next)
     {
         $result = $next($request);
+
+        Log::info('TEMP DEBUG azure test', [
+            'XForwardedIP' => $request->header('X-Forwarded-For'),
+        ]);
 
         if ($request->hasSession()) {
             $xForwardedFor = $request->header('X-Forwarded-For');

--- a/api/app/Http/Middleware/RequestOriginLoggerMiddleware.php
+++ b/api/app/Http/Middleware/RequestOriginLoggerMiddleware.php
@@ -33,6 +33,7 @@ class RequestOriginLoggerMiddleware
             if (! is_null($xForwardedFor) && $xForwardedFor !== $previous) {
                 $this->logger->info('Session IP changed', [
                     'XForwardedIP' => $xForwardedFor,
+                    'UserId' => $user->id,
                 ]);
                 $this->cache->put($cacheKey, $xForwardedFor, now()->addMinutes((int) config('session.lifetime')));
             }

--- a/api/app/Http/Middleware/RequestOriginLoggerMiddleware.php
+++ b/api/app/Http/Middleware/RequestOriginLoggerMiddleware.php
@@ -4,7 +4,6 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
 use Psr\Log\LoggerInterface;
 
 class RequestOriginLoggerMiddleware
@@ -19,10 +18,6 @@ class RequestOriginLoggerMiddleware
     public function handle(Request $request, Closure $next)
     {
         $result = $next($request);
-
-        Log::info('TEMP DEBUG azure test', [
-            'XForwardedIP' => $request->header('X-Forwarded-For'),
-        ]);
 
         if ($request->hasSession()) {
             $xForwardedFor = $request->header('X-Forwarded-For');

--- a/api/app/Http/Middleware/RequestOriginLoggerMiddleware.php
+++ b/api/app/Http/Middleware/RequestOriginLoggerMiddleware.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Http\Request;
 use Psr\Log\LoggerInterface;
 
@@ -10,24 +11,30 @@ class RequestOriginLoggerMiddleware
 {
     protected $logger;
 
-    public function __construct(LoggerInterface $logger)
+    protected $cache;
+
+    public function __construct(LoggerInterface $logger, Cache $cache)
     {
         $this->logger = $logger;
+        $this->cache = $cache;
     }
 
     public function handle(Request $request, Closure $next)
     {
         $result = $next($request);
 
-        if ($request->hasSession()) {
+        $user = $request->user();
+
+        if ($user) {
+            $cacheKey = 'last_x_forwarded_ip:'.$user->getAuthIdentifier();
             $xForwardedFor = $request->header('X-Forwarded-For');
-            $previous = $request->session()->get('last_x_forwarded_ip');
+            $previous = $this->cache->get($cacheKey);
 
             if (! is_null($xForwardedFor) && $xForwardedFor !== $previous) {
                 $this->logger->info('Session IP changed', [
                     'XForwardedIP' => $xForwardedFor,
                 ]);
-                $request->session()->put('last_x_forwarded_ip', $xForwardedFor);
+                $this->cache->put($cacheKey, $xForwardedFor, now()->addMinutes((int) config('session.lifetime')));
             }
         }
 

--- a/api/app/Http/Middleware/RequestOriginLoggerMiddleware.php
+++ b/api/app/Http/Middleware/RequestOriginLoggerMiddleware.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Psr\Log\LoggerInterface;
+
+class RequestOriginLoggerMiddleware
+{
+    protected $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    public function handle(Request $request, Closure $next)
+    {
+        $result = $next($request);
+
+        $this->logger->info('Request logged', [
+            'XForwardedIP' => $request->header('X-Forwarded-For'),
+        ]);
+
+        return $result;
+    }
+}

--- a/api/app/Http/Middleware/RequestOriginLoggerMiddleware.php
+++ b/api/app/Http/Middleware/RequestOriginLoggerMiddleware.php
@@ -19,9 +19,17 @@ class RequestOriginLoggerMiddleware
     {
         $result = $next($request);
 
-        $this->logger->info('Request logged', [
-            'XForwardedIP' => $request->header('X-Forwarded-For'),
-        ]);
+        if ($request->hasSession()) {
+            $xForwardedFor = $request->header('X-Forwarded-For');
+            $previous = $request->session()->get('last_x_forwarded_ip');
+
+            if (! is_null($xForwardedFor) && $xForwardedFor !== $previous) {
+                $this->logger->info('Session IP changed', [
+                    'XForwardedIP' => $xForwardedFor,
+                ]);
+                $request->session()->put('last_x_forwarded_ip', $xForwardedFor);
+            }
+        }
 
         return $result;
     }

--- a/api/tests/Unit/RequestOriginLoggerMiddlewareTest.php
+++ b/api/tests/Unit/RequestOriginLoggerMiddlewareTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Middleware\RequestOriginLoggerMiddleware;
+use Illuminate\Http\Request;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Tests\TestCase;
+
+class RequestOriginLoggerMiddlewareTest extends TestCase
+{
+    public function testLogsXForwardedIp(): void
+    {
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('info')->once()->with('Request logged', [
+            'XForwardedIP' => '1.2.3.4',
+        ]);
+
+        $request = Request::create('/graphql');
+        $request->headers->set('X-Forwarded-For', '1.2.3.4');
+
+        $middleware = new RequestOriginLoggerMiddleware($logger);
+        $middleware->handle($request, fn ($req) => response('ok'));
+    }
+}

--- a/api/tests/Unit/RequestOriginLoggerMiddlewareTest.php
+++ b/api/tests/Unit/RequestOriginLoggerMiddlewareTest.php
@@ -18,6 +18,7 @@ class RequestOriginLoggerMiddlewareTest extends TestCase
 
         $user = Mockery::mock(Authenticatable::class);
         $user->shouldReceive('getAuthIdentifier')->andReturn($userId);
+        $user->id = $userId;
         $request->setUserResolver(fn () => $user);
 
         return $request;
@@ -28,6 +29,7 @@ class RequestOriginLoggerMiddlewareTest extends TestCase
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldReceive('info')->once()->with('Session IP changed', [
             'XForwardedIP' => '1.2.3.4',
+            'UserId' => 'user-1',
         ]);
 
         $cache = Mockery::mock(Cache::class);

--- a/api/tests/Unit/RequestOriginLoggerMiddlewareTest.php
+++ b/api/tests/Unit/RequestOriginLoggerMiddlewareTest.php
@@ -4,18 +4,64 @@ namespace Tests\Unit;
 
 use App\Http\Middleware\RequestOriginLoggerMiddleware;
 use Illuminate\Http\Request;
+use Illuminate\Session\ArraySessionHandler;
+use Illuminate\Session\Store;
 use Mockery;
 use Psr\Log\LoggerInterface;
 use Tests\TestCase;
 
 class RequestOriginLoggerMiddlewareTest extends TestCase
 {
-    public function testLogsXForwardedIp(): void
+    protected function requestWithSession(): Request
+    {
+        $request = Request::create('/graphql');
+        $request->setLaravelSession(new Store('test-session', new ArraySessionHandler(120)));
+
+        return $request;
+    }
+
+    public function testLogsOnFirstSighting(): void
     {
         $logger = Mockery::mock(LoggerInterface::class);
-        $logger->shouldReceive('info')->once()->with('Request logged', [
+        $logger->shouldReceive('info')->once()->with('Session IP changed', [
             'XForwardedIP' => '1.2.3.4',
         ]);
+
+        $request = $this->requestWithSession();
+        $request->headers->set('X-Forwarded-For', '1.2.3.4');
+
+        $middleware = new RequestOriginLoggerMiddleware($logger);
+        $middleware->handle($request, fn ($req) => response('ok'));
+    }
+
+    public function testSkipsLoggingWhenIpUnchanged(): void
+    {
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('info');
+
+        $request = $this->requestWithSession();
+        $request->headers->set('X-Forwarded-For', '1.2.3.4');
+        $request->session()->put('last_x_forwarded_ip', '1.2.3.4');
+
+        $middleware = new RequestOriginLoggerMiddleware($logger);
+        $middleware->handle($request, fn ($req) => response('ok'));
+    }
+
+    public function testSkipsLoggingWhenHeaderAbsent(): void
+    {
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('info');
+
+        $request = $this->requestWithSession();
+
+        $middleware = new RequestOriginLoggerMiddleware($logger);
+        $middleware->handle($request, fn ($req) => response('ok'));
+    }
+
+    public function testSkipsLoggingWhenNoSession(): void
+    {
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('info');
 
         $request = Request::create('/graphql');
         $request->headers->set('X-Forwarded-For', '1.2.3.4');

--- a/api/tests/Unit/RequestOriginLoggerMiddlewareTest.php
+++ b/api/tests/Unit/RequestOriginLoggerMiddlewareTest.php
@@ -3,19 +3,22 @@
 namespace Tests\Unit;
 
 use App\Http\Middleware\RequestOriginLoggerMiddleware;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Http\Request;
-use Illuminate\Session\ArraySessionHandler;
-use Illuminate\Session\Store;
 use Mockery;
 use Psr\Log\LoggerInterface;
 use Tests\TestCase;
 
 class RequestOriginLoggerMiddlewareTest extends TestCase
 {
-    protected function requestWithSession(): Request
+    protected function requestWithUser(string $userId): Request
     {
         $request = Request::create('/graphql');
-        $request->setLaravelSession(new Store('test-session', new ArraySessionHandler(120)));
+
+        $user = Mockery::mock(Authenticatable::class);
+        $user->shouldReceive('getAuthIdentifier')->andReturn($userId);
+        $request->setUserResolver(fn () => $user);
 
         return $request;
     }
@@ -27,10 +30,14 @@ class RequestOriginLoggerMiddlewareTest extends TestCase
             'XForwardedIP' => '1.2.3.4',
         ]);
 
-        $request = $this->requestWithSession();
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldReceive('get')->once()->with('last_x_forwarded_ip:user-1')->andReturn(null);
+        $cache->shouldReceive('put')->once()->with('last_x_forwarded_ip:user-1', '1.2.3.4', Mockery::any());
+
+        $request = $this->requestWithUser('user-1');
         $request->headers->set('X-Forwarded-For', '1.2.3.4');
 
-        $middleware = new RequestOriginLoggerMiddleware($logger);
+        $middleware = new RequestOriginLoggerMiddleware($logger, $cache);
         $middleware->handle($request, fn ($req) => response('ok'));
     }
 
@@ -39,11 +46,14 @@ class RequestOriginLoggerMiddlewareTest extends TestCase
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldNotReceive('info');
 
-        $request = $this->requestWithSession();
-        $request->headers->set('X-Forwarded-For', '1.2.3.4');
-        $request->session()->put('last_x_forwarded_ip', '1.2.3.4');
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldReceive('get')->once()->with('last_x_forwarded_ip:user-1')->andReturn('1.2.3.4');
+        $cache->shouldNotReceive('put');
 
-        $middleware = new RequestOriginLoggerMiddleware($logger);
+        $request = $this->requestWithUser('user-1');
+        $request->headers->set('X-Forwarded-For', '1.2.3.4');
+
+        $middleware = new RequestOriginLoggerMiddleware($logger, $cache);
         $middleware->handle($request, fn ($req) => response('ok'));
     }
 
@@ -52,21 +62,29 @@ class RequestOriginLoggerMiddlewareTest extends TestCase
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldNotReceive('info');
 
-        $request = $this->requestWithSession();
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldReceive('get')->once()->with('last_x_forwarded_ip:user-1')->andReturn(null);
+        $cache->shouldNotReceive('put');
 
-        $middleware = new RequestOriginLoggerMiddleware($logger);
+        $request = $this->requestWithUser('user-1');
+
+        $middleware = new RequestOriginLoggerMiddleware($logger, $cache);
         $middleware->handle($request, fn ($req) => response('ok'));
     }
 
-    public function testSkipsLoggingWhenNoSession(): void
+    public function testSkipsLoggingWhenNoUser(): void
     {
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldNotReceive('info');
 
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldNotReceive('get');
+        $cache->shouldNotReceive('put');
+
         $request = Request::create('/graphql');
         $request->headers->set('X-Forwarded-For', '1.2.3.4');
 
-        $middleware = new RequestOriginLoggerMiddleware($logger);
+        $middleware = new RequestOriginLoggerMiddleware($logger, $cache);
         $middleware->handle($request, fn ($req) => response('ok'));
     }
 }


### PR DESCRIPTION
🤖 Resolves #16993 

## 👋 Introduction

Adds a middleware to log `X-Forwaded-For` header for every session.

## 🧪 Testing

> [!IMPORTANT]
> Local testing may not work since you likely are not being forwarded. This will likely need to be deployed to dev to be tested properly.

1. Login as any user
2. Check logs to make sure you see the IP log line 