### PR TITLE
[Bug] Don't disregard the filtering operation

### DIFF
--- a/apps/web/src/components/RecruitmentProcesses/RecruitmentProcesses.tsx
+++ b/apps/web/src/components/RecruitmentProcesses/RecruitmentProcesses.tsx
@@ -50,7 +50,7 @@ const RecruitmentProcesses = ({
   const recruitmentProcesses = unpackMaybes(
     recruitmentProcessesFragment.poolCandidates,
   );
-  const recruitmentProcessesFiltered = recruitmentProcesses
+  let recruitmentProcessesFiltered = recruitmentProcesses
     ? recruitmentProcesses.filter(
         ({ applicationStatusData }) =>
           applicationStatusData?.candidateStatus?.value ===
@@ -60,7 +60,7 @@ const RecruitmentProcesses = ({
 
   // Add additional filtering for community if communityId exists
   if (communityId) {
-    recruitmentProcessesFiltered.filter(
+    recruitmentProcessesFiltered = recruitmentProcessesFiltered.filter(
       (recruitment) => recruitment.pool.community?.id === communityId,
     );
   }

--- a/apps/web/src/components/RecruitmentProcesses/RecruitmentProcessesPreviewList.tsx
+++ b/apps/web/src/components/RecruitmentProcesses/RecruitmentProcessesPreviewList.tsx
@@ -77,7 +77,7 @@ const RecruitmentProcessPreviewList = ({
   const recruitmentProcesses = unpackMaybes(
     recruitmentProcessesFragment.poolCandidates,
   );
-  const recruitmentProcessesFiltered = recruitmentProcesses
+  let recruitmentProcessesFiltered = recruitmentProcesses
     ? recruitmentProcesses.filter(
         ({ applicationStatusData }) =>
           applicationStatusData?.candidateStatus?.value ===
@@ -87,7 +87,7 @@ const RecruitmentProcessPreviewList = ({
 
   // Add additional filtering for community if communityId exists
   if (communityId) {
-    recruitmentProcessesFiltered.filter(
+    recruitmentProcessesFiltered = recruitmentProcessesFiltered.filter(
       (recruitment) => recruitment.pool.community?.id === communityId,
     );
   }


### PR DESCRIPTION
🤖 Resolves #17162

## 👋 Introduction

Don't discard the returned filtered array

As far as I could tell, the only place that the optional community id value was set was `TalentNominationGroupProfilePage` which I think matches to 
`/en/admin/talent-events/:eventId/nominations/:groupId/profile`
Which might explain why this wasn't a quickly noticed bug

## 🧪 Testing

1. Not sure what to recommend, assess the above mentioned page?


