### PR TITLE
[Fix] Remove notification dialog description

### DIFF
--- a/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
+++ b/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
@@ -137,14 +137,6 @@ const DialogPortalWithPresence = ({
                 </Dialog.Close>
               </div>
             </div>
-            <DialogPrimitive.Description>
-              {intl.formatMessage({
-                defaultMessage:
-                  "Welcome to your notification panel. Click or activate a notification to be taken to the relevant page. Each notification can be marked as read or deleted.",
-                id: "qek0N+",
-                description: "Instructions on how to manage notifications",
-              })}
-            </DialogPrimitive.Description>
           </div>
           <NotificationActions
             onRead={onRead}

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -13626,10 +13626,6 @@
     "defaultMessage": "Classification de la personne de référence",
     "description": "Label for the advancement reference classification"
   },
-  "qek0N+": {
-    "defaultMessage": "Bienvenue dans votre panneau de notification. Cliquez ou activez une notification pour accéder à la page concernée. Chaque notification peut être marquée comme lue ou supprimée.",
-    "description": "Instructions on how to manage notifications"
-  },
   "qhws/V": {
     "defaultMessage": "Erreur : l'archivage du processus a échoué",
     "description": "Message displayed to user after pool fails to get archived."


### PR DESCRIPTION
🤖 Resolves #15926 

## 👋 Introduction

Removes the notification dialog description.

## 🕵️ Details

The description was very chatty and was making things diffiuclt for assitive technoligies. Since it was not necessary, we opted to remove it as the most simple fix.

## 🧪 Testing

> [!TIP]
> Best tested with a screen reader on 

1. Build `pnpm dev:fresh`
2. Login as any user so that we have the noficiation dialog
3. Open it
4. Confirm no description exists or is read by a screen reader