### PR TITLE
[Feature] Rendering English and French in the skills table

### DIFF
--- a/apps/web/src/pages/Skills/components/SkillTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillTable.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import type { ColumnDef, PaginationState } from "@tanstack/react-table";
 import { createColumnHelper } from "@tanstack/react-table";
-import { createIntl, createIntlCache, useIntl } from "react-intl";
+import { useIntl } from "react-intl";
 import type { OperationContext } from "urql";
 import { useQuery } from "urql";
 import { useLocation, useSearchParams } from "react-router";
@@ -11,6 +11,9 @@ import {
   commonMessages,
   getLocalizedName,
   combineMessages,
+  getIntlForLocale,
+  appendShortenedLanguageName,
+  getLocale,
 } from "@gc-digital-talent/i18n";
 import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 import { Link, LoadingErrorMessage } from "@gc-digital-talent/ui";
@@ -138,23 +141,12 @@ const SkillTable = ({
   isPublic,
 }: SkillTableProps) => {
   const intl = useIntl();
-  const cache = createIntlCache();
+  const locale = getLocale(intl);
   const englishMessages = combineMessages("en", messages);
   const frenchMessages = combineMessages("fr", messages);
-  const intlEn = createIntl(
-    {
-      locale: "en",
-      messages: englishMessages,
-    },
-    cache,
-  );
-  const intlFr = createIntl(
-    {
-      locale: "fr",
-      messages: frenchMessages,
-    },
-    cache,
-  );
+  const intlEn = getIntlForLocale("en", englishMessages);
+  const intlFr = getIntlForLocale("fr", frenchMessages);
+
   const [{ data, fetching, error }] = useQuery({
     query: SkillTableSkills_Query,
     context,
@@ -207,36 +199,100 @@ const SkillTable = ({
     setFilterState(transformedData);
   };
 
-  const columns = [
-    columnHelper.accessor("id", {
-      id: "id",
-      enableColumnFilter: false,
-      header: intl.formatMessage(adminMessages.id),
-    }),
-    columnHelper.accessor((skill) => getLocalizedName(skill.name, intl), {
-      id: "name",
-      header: intl.formatMessage(commonMessages.name),
+  const columnNameEnglishAppended = columnHelper.accessor(
+    (skill) => getLocalizedName(skill.name, intlEn),
+    {
+      id: "nameEN",
+      header: appendShortenedLanguageName({
+        label: intl.formatMessage(commonMessages.name),
+        lang: "en",
+        intl: intl,
+      }),
       sortingFn: normalizedText,
       meta: {
-        isRowTitle: true,
+        isRowTitle: locale === "en" ? true : false,
       },
       cell: ({ row: { original: skill } }) => {
-        const skillName = getLocalizedName(skill.name, intl);
+        const skillName = getLocalizedName(skill.name, intlEn);
         return isPublic ? (
           skillName
         ) : (
           <Link href={paths.skillView(skill.id)}>{skillName}</Link>
         );
       },
-    }),
-    columnHelper.accessor(
-      (skill) => getLocalizedName(skill.description, intl, true),
-      {
-        id: "description",
-        sortingFn: normalizedText,
-        header: intl.formatMessage(commonMessages.description),
+    },
+  );
+  const columnNameFrenchAppended = columnHelper.accessor(
+    (skill) => getLocalizedName(skill.name, intlFr),
+    {
+      id: "nameFR",
+      header: appendShortenedLanguageName({
+        label: intl.formatMessage(commonMessages.name),
+        lang: "fr",
+        intl: intl,
+      }),
+      sortingFn: normalizedText,
+      meta: {
+        isRowTitle: locale === "en" ? false : true,
       },
-    ),
+      cell: ({ row: { original: skill } }) => {
+        const skillName = getLocalizedName(skill.name, intlFr);
+        return isPublic ? (
+          skillName
+        ) : (
+          <Link href={paths.skillView(skill.id)}>{skillName}</Link>
+        );
+      },
+    },
+  );
+  const columnDescriptionEnglishAppended = columnHelper.accessor(
+    (skill) => getLocalizedName(skill.description, intlEn, true),
+    {
+      id: "descriptionEN",
+      sortingFn: normalizedText,
+      header: appendShortenedLanguageName({
+        label: intl.formatMessage(commonMessages.description),
+        lang: "en",
+        intl: intl,
+      }),
+    },
+  );
+  const columnDescriptionFrenchAppended = columnHelper.accessor(
+    (skill) => getLocalizedName(skill.description, intlFr, true),
+    {
+      id: "descriptionFR",
+      sortingFn: normalizedText,
+      header: appendShortenedLanguageName({
+        label: intl.formatMessage(commonMessages.description),
+        lang: "fr",
+        intl: intl,
+      }),
+    },
+  );
+
+  // ordering of name and description locale dependent
+  const columnsOrderedByLocale =
+    locale === "en"
+      ? [
+          columnNameEnglishAppended,
+          columnNameFrenchAppended,
+          columnDescriptionEnglishAppended,
+          columnDescriptionFrenchAppended,
+        ]
+      : [
+          columnNameFrenchAppended,
+          columnNameEnglishAppended,
+          columnDescriptionFrenchAppended,
+          columnDescriptionEnglishAppended,
+        ];
+
+  const columns = [
+    columnHelper.accessor("id", {
+      id: "id",
+      enableColumnFilter: false,
+      header: intl.formatMessage(adminMessages.id),
+    }),
+    ...columnsOrderedByLocale,
     columnHelper.accessor((skill) => familiesAccessor(skill, intl), {
       id: "skillFamilies",
       sortingFn: normalizedText,

--- a/apps/web/src/pages/Skills/components/SkillTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillTable.tsx
@@ -10,7 +10,6 @@ import type { SubmitHandler } from "react-hook-form";
 import {
   commonMessages,
   getLocalizedName,
-  combineMessages,
   getIntlForLocale,
   appendShortenedLanguageName,
   getLocale,
@@ -142,10 +141,8 @@ const SkillTable = ({
 }: SkillTableProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
-  const englishMessages = combineMessages("en", messages);
-  const frenchMessages = combineMessages("fr", messages);
-  const intlEn = getIntlForLocale("en", englishMessages);
-  const intlFr = getIntlForLocale("fr", frenchMessages);
+  const intlEn = getIntlForLocale("en", messages);
+  const intlFr = getIntlForLocale("fr", messages);
 
   const [{ data, fetching, error }] = useQuery({
     query: SkillTableSkills_Query,
@@ -206,11 +203,11 @@ const SkillTable = ({
       header: appendShortenedLanguageName({
         label: intl.formatMessage(commonMessages.name),
         lang: "en",
-        intl: intl,
+        intl,
       }),
       sortingFn: normalizedText,
       meta: {
-        isRowTitle: locale === "en" ? true : false,
+        isRowTitle: locale === "en",
       },
       cell: ({ row: { original: skill } }) => {
         const skillName = getLocalizedName(skill.name, intlEn);
@@ -229,11 +226,11 @@ const SkillTable = ({
       header: appendShortenedLanguageName({
         label: intl.formatMessage(commonMessages.name),
         lang: "fr",
-        intl: intl,
+        intl,
       }),
       sortingFn: normalizedText,
       meta: {
-        isRowTitle: locale === "en" ? false : true,
+        isRowTitle: locale !== "en",
       },
       cell: ({ row: { original: skill } }) => {
         const skillName = getLocalizedName(skill.name, intlFr);
@@ -253,7 +250,7 @@ const SkillTable = ({
       header: appendShortenedLanguageName({
         label: intl.formatMessage(commonMessages.description),
         lang: "en",
-        intl: intl,
+        intl,
       }),
     },
   );
@@ -265,7 +262,7 @@ const SkillTable = ({
       header: appendShortenedLanguageName({
         label: intl.formatMessage(commonMessages.description),
         lang: "fr",
-        intl: intl,
+        intl,
       }),
     },
   );
@@ -329,7 +326,9 @@ const SkillTable = ({
       }}
       sort={{
         internal: true,
-        initialState: [{ id: "name", desc: false }],
+        initialState: [
+          { id: locale === "en" ? "nameEN" : "nameFR", desc: false },
+        ],
       }}
       search={{
         internal: true,

--- a/packages/i18n/src/index.tsx
+++ b/packages/i18n/src/index.tsx
@@ -17,6 +17,7 @@ import {
 import {
   combineMessages,
   getDesiredLocale,
+  getIntlForLocale,
   getPathLocale,
   STORED_LOCALE,
 } from "./utils/utils";
@@ -86,7 +87,7 @@ import {
   ENUM_SORT_ORDER,
 } from "./utils/enum";
 import type { Locales, Messages } from "./types";
-import { appendLanguageName } from "./utils/lang";
+import { appendLanguageName, appendShortenedLanguageName } from "./utils/lang";
 
 export {
   isLocale,
@@ -112,6 +113,7 @@ export {
   NestedLanguageProvider,
   combineMessages,
   getIntl,
+  getIntlForLocale,
   useLocale,
   getLocalizedEnumByValue,
   getLocalizedEnumStringByValue,
@@ -136,6 +138,7 @@ export {
   sortSecurityStatus,
   sortLocalizedEnumOptions,
   appendLanguageName,
+  appendShortenedLanguageName,
 };
 
 export {

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -795,6 +795,10 @@
     "defaultMessage": "Organisation",
     "description": "Label displayed for organization input"
   },
+  "Q6GYga": {
+    "defaultMessage": "(EN)",
+    "description": "Name of English language formatted for appending, shortened"
+  },
   "Q6sBsq": {
     "defaultMessage": "Étape complétée, {label}",
     "description": "Prefix when a step has been completed."
@@ -1734,6 +1738,10 @@
   "tHeY7N": {
     "defaultMessage": "Je souhaite bénéficier du coaching des cadres.",
     "description": "The executive coaching interest status described as learning."
+  },
+  "tfgjgQ": {
+    "defaultMessage": "(FR)",
+    "description": "Name of French language formatted for appending, shortened"
   },
   "tpVujp": {
     "defaultMessage": "Renseignements manquants",

--- a/packages/i18n/src/lang/whitelist.yml
+++ b/packages/i18n/src/lang/whitelist.yml
@@ -10,3 +10,5 @@
 - nSENOg # Asterisk
 - x/BiQS # Questions
 - nqYfCF # Label for count and total
+- Q6GYga # Shortened English label
+- tfgjgQ # Shortened French label

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -524,10 +524,20 @@ const commonMessages = defineMessages({
     id: "tyc8W0",
     description: "Name of English language formatted for appending",
   },
+  englishLabelShort: {
+    defaultMessage: "(EN)",
+    id: "Q6GYga",
+    description: "Name of English language formatted for appending, shortened",
+  },
   frenchLabel: {
     defaultMessage: "(French)",
     id: "E+zFTA",
     description: "Name of French language formatted for appending",
+  },
+  frenchLabelShort: {
+    defaultMessage: "(FR)",
+    id: "tfgjgQ",
+    description: "Name of French language formatted for appending, shortened",
   },
   questions: {
     defaultMessage: "Questions",

--- a/packages/i18n/src/utils/lang.tsx
+++ b/packages/i18n/src/utils/lang.tsx
@@ -34,3 +34,21 @@ export const appendLanguageName = ({
   // eslint-disable-next-line @typescript-eslint/no-base-to-string, @typescript-eslint/restrict-template-expressions
   return `${label} ${labels[lang]}`;
 };
+
+export const appendShortenedLanguageName = ({
+  label,
+  lang,
+  intl,
+}: {
+  label: ReactNode;
+  lang: Locales;
+  intl: IntlShape;
+}): ReactNode | string => {
+  const labels = {
+    en: intl.formatMessage(commonMessages.englishLabelShort),
+    fr: intl.formatMessage(commonMessages.frenchLabelShort),
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-base-to-string, @typescript-eslint/restrict-template-expressions
+  return `${label} ${labels[lang]}`;
+};

--- a/packages/i18n/src/utils/lang.tsx
+++ b/packages/i18n/src/utils/lang.tsx
@@ -43,7 +43,7 @@ export const appendShortenedLanguageName = ({
   label: ReactNode;
   lang: Locales;
   intl: IntlShape;
-}): ReactNode | string => {
+}): string => {
   const labels = {
     en: intl.formatMessage(commonMessages.englishLabelShort),
     fr: intl.formatMessage(commonMessages.frenchLabelShort),

--- a/packages/i18n/src/utils/utils.ts
+++ b/packages/i18n/src/utils/utils.ts
@@ -1,3 +1,5 @@
+import { createIntl, createIntlCache, type IntlShape } from "react-intl";
+
 import type { Messages, Locales } from "../types";
 import CommonFrench from "../lang/frCompiled.json" with { type: "json" };
 import { isLocale } from "./localize";
@@ -55,4 +57,31 @@ export function combineMessages(
         ...CommonFrench,
       }
     : undefined;
+}
+
+const localeIntlCache = createIntlCache();
+
+/**
+ * Get an `intl` instance pinned to a specific locale.
+ *
+ * Unlike the shared `getIntl` helper (which derives the locale from the
+ * environment), this always resolves messages against the locale you pass in.
+ * Useful when the page is rendering in one language but you need a string in
+ * the other — e.g. formatting a French label while the UI is in English.
+ *
+ * Pass app-specific compiled `messages` (e.g. the web app's `frCompiled.json`)
+ * when you need translations beyond the common i18n bundle; they are merged in
+ * via `combineMessages`.
+ */
+export function getIntlForLocale(
+  locale: Locales,
+  messages?: Messages,
+): IntlShape {
+  return createIntl(
+    {
+      locale,
+      messages: combineMessages(locale, messages),
+    },
+    localeIntlCache,
+  );
 }


### PR DESCRIPTION
🤖 Resolves #15956

## 👋 Introduction

Add the requested simultaneous English and French display 

## 🧪 Testing

1. I believe the component is used in two places, public skills library page and the admin version of the table
2. Navigate to it, observe English and French views

## 📸 Screenshot

#### English

<img width="1223" height="754" alt="image" src="https://github.com/user-attachments/assets/a7ac18d1-cb8e-425b-9526-ee8b36d725b1" />

#### French

<img width="1265" height="781" alt="image" src="https://github.com/user-attachments/assets/fb540ecb-85d5-4eee-b2c9-5ca64963d361" />



