### PR TITLE
[Feature] Advancement referral expiry backend

### DIFF
--- a/api/app/GraphQL/Validators/Mutation/UpdateTalentNominationGroupValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/UpdateTalentNominationGroupValidator.php
@@ -37,7 +37,7 @@ final class UpdateTalentNominationGroupValidator extends Validator
             ],
             'talentNominationGroup.advancementClassifications' => [
                 // when updating a decision, updating the classifications is also required
-                'present_with:talentNominationGroup.advancementDecision,talentNominationGroup.lateralMovementDecision,talentNominationGroup.developmentProgramsDecision',
+                'required_with:talentNominationGroup.advancementDecision,talentNominationGroup.lateralMovementDecision,talentNominationGroup.developmentProgramsDecision',
             ],
             'talentNominationGroup.advancementClassifications.sync' => [
                 'list',

--- a/api/app/GraphQL/Validators/Mutation/UpdateTalentNominationGroupValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/UpdateTalentNominationGroupValidator.php
@@ -37,7 +37,7 @@ final class UpdateTalentNominationGroupValidator extends Validator
             ],
             'talentNominationGroup.advancementClassifications' => [
                 // when updating a decision, updating the classifications is also required
-                'required_with:talentNominationGroup.advancementDecision,talentNominationGroup.lateralMovementDecision,talentNominationGroup.developmentProgramsDecision',
+                'present_with:talentNominationGroup.advancementDecision,talentNominationGroup.lateralMovementDecision,talentNominationGroup.developmentProgramsDecision',
             ],
             'talentNominationGroup.advancementClassifications.sync' => [
                 'list',
@@ -47,9 +47,10 @@ final class UpdateTalentNominationGroupValidator extends Validator
                     ['max:0']), // unless approved, can't sync any classifications
             ],
             'talentNominationGroup.referralExpiryDate' => [
-                'sometimes', // 'present',  // we will eventually require this field
+                // when updating a decision, updating the referral expiry date is also required
+                'present_with:talentNominationGroup.advancementDecision,talentNominationGroup.lateralMovementDecision,talentNominationGroup.developmentProgramsDecision',
                 Rule::when(fn ($attributes) => $attributes->get('talentNominationGroup.advancementDecision') === 'APPROVED',
-                    ['todayOrAfter'],  // we will eventually require expiry date when approving
+                    ['present'], // ['todayOrAfter'],  // we will eventually require expiry date when approving
                     ['prohibited']), // must be null if not approved
             ],
         ];

--- a/api/app/GraphQL/Validators/Mutation/UpdateTalentNominationGroupValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/UpdateTalentNominationGroupValidator.php
@@ -46,7 +46,12 @@ final class UpdateTalentNominationGroupValidator extends Validator
                     ['min:0'],  // we will eventually require classifications when approving
                     ['max:0']), // unless approved, can't sync any classifications
             ],
-
+            'talentNominationGroup.referralExpiryDate' => [
+                'sometimes', // 'present',  // we will eventually require this field
+                Rule::when(fn ($attributes) => $attributes->get('talentNominationGroup.advancementDecision') === 'APPROVED',
+                    ['todayOrAfter'],  // we will eventually require expiry date when approving
+                    ['prohibited']), // must be null if not approved
+            ],
         ];
     }
 

--- a/api/app/Models/TalentNominationGroup.php
+++ b/api/app/Models/TalentNominationGroup.php
@@ -37,6 +37,7 @@ use Spatie\Activitylog\Support\LogOptions;
  * @property string $computed_status
  * @property string $comments
  * @property bool $consentToShareProfile
+ * @property ?Carbon $referral_expiry_date
  *
  * @method Builder|static authorizedToView()
  * @method static Builder|static query()

--- a/api/app/Models/TalentNominationGroup.php
+++ b/api/app/Models/TalentNominationGroup.php
@@ -49,6 +49,13 @@ class TalentNominationGroup extends Model
     protected $keyType = 'string';
 
     /**
+     * The attributes that should be cast.
+     */
+    protected $casts = [
+        'referral_expiry_date' => 'date',
+    ];
+
+    /**
      * The attributes that can be filled using mass-assignment.
      */
     protected $fillable = [

--- a/api/database/factories/TalentNominationFactory.php
+++ b/api/database/factories/TalentNominationFactory.php
@@ -296,6 +296,10 @@ class TalentNominationFactory extends Factory
                     $talentNominationGroup->lateral_movement_notes = $this->faker->sentence();
                 }
 
+                if ($talentNominationGroup->advancement_decision == TalentNominationGroupDecision::APPROVED->name) {
+                    $talentNominationGroup->referral_expiry_date = $this->faker->dateTimeBetween('+6 month', '+12 month');
+                }
+
                 $talentNominationGroup->save();
             });
     }

--- a/api/database/migrations/2026_07_14_180530_advancement_referral_expiry.php
+++ b/api/database/migrations/2026_07_14_180530_advancement_referral_expiry.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('talent_nomination_groups', function (Blueprint $table) {
+            $table->date('referral_expiry_date')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('talent_nomination_groups', function (Blueprint $table) {
+            $table->dropColumn('referral_expiry_date');
+        });
+    }
+};

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1005,6 +1005,7 @@ type TalentNominationGroup {
   consentToShareProfile: Boolean @rename(attribute: "consent_to_share_profile")
   comments: String
   advancementClassifications: [Classification!] @belongsToMany
+  referralExpiryDate: Date @rename(attribute: "referral_expiry_date")
 }
 
 type Team implements HasRoleAssignments {
@@ -2817,6 +2818,7 @@ input UpdateTalentNominationGroupInput {
     @rename(attribute: "development_programs_notes")
   comments: String
   advancementClassifications: ClassificationBelongsToMany
+  referralExpiryDate: Date @rename(attribute: "referral_expiry_date")
 }
 
 input CreateApplicantFilterInput {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -3770,11 +3770,6 @@ dealing with really large numbers to be on the safe side.
 """
 scalar Mixed
 
-enum NotificationType {
-  UserFileGenerated
-  UserFileGenerationError
-}
-
 enum RoleName {
   Guest
   BaseUser
@@ -3944,6 +3939,11 @@ enum Permission {
   CreateTeamCommunityDevelopmentProgram
   UpdateTeamCommunityDevelopmentProgram
   DeleteTeamCommunityDevelopmentProgram
+}
+
+enum NotificationType {
+  UserFileGenerated
+  UserFileGenerationError
 }
 
 enum ActivityEvent {

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1542,6 +1542,7 @@ type TalentNominationGroup {
   status: LocalizedTalentNominationGroupStatus
   comments: String
   advancementClassifications: [Classification!]
+  referralExpiryDate: Date
 }
 
 type Team implements HasRoleAssignments {
@@ -2736,6 +2737,7 @@ input UpdateTalentNominationGroupInput {
   developmentProgramsNotes: String
   comments: String
   advancementClassifications: ClassificationBelongsToMany
+  referralExpiryDate: Date
 }
 
 input CreateApplicantFilterInput {

--- a/api/tests/Feature/TalentNominationGroupTest.php
+++ b/api/tests/Feature/TalentNominationGroupTest.php
@@ -422,9 +422,9 @@ class TalentNominationGroupTest extends TestCase
                     'advancementClassifications' => [
                         'sync' => $classifications->pluck('id')->toArray(),
                     ],
+                    'referralExpiryDate' => config('constants.far_future_date'),
                 ],
             ]);
-
         $response->assertGraphQLErrorFree();
         $response->assertJsonFragment([
             'advancementClassifications' => [

--- a/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/form.ts
+++ b/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/form.ts
@@ -112,5 +112,7 @@ export function convertFormValuesToMutationInput(
     advancementClassifications: {
       sync: [],
     },
+    // no UI yet
+    referralExpiryDate: null,
   };
 }


### PR DESCRIPTION
🤖 Resolves #17392 

## 👋 Introduction

Adds an advancement referral expiry date for talent nomination groups to the backend.

## 🕵️ Details

Some validation and placement in the frontend requests for this field was stubbed out but final validation will come with the UI.

## 🧪 Testing

1. Run migration and rebuild
- [ ] Can roll back migration and remigrate

2. Log in as `community@example.com` and find a nomination to evalutate
- [ ] Can still evaluate a nomination as usual
- [ ] Can still add a comment to a nomination as usual

3. Grab your access token and fire up your graphql client
- [ ] Can manually add referral expiry date

Sample graphql query:
```graphql

mutation NominationGroupEvaluationDialog_Mutation($id: UUID!, $talentNominationGroup: UpdateTalentNominationGroupInput!) {
  updateTalentNominationGroup(
    id: $id
    talentNominationGroup: $talentNominationGroup
  ) {
    id
    __typename
  }
}
############
{
  "id": "4dee696a-249a-45ae-9007-82546aa0f40f",
  "talentNominationGroup": {
    "advancementClassifications": { "sync": [] },
    "advancementDecision": "APPROVED",
    "advancementNotes": null,
    "advancementReferenceConfirmed": true,
    "developmentProgramsDecision": null,
    "developmentProgramsNotes": null,
    "lateralMovementDecision": null,
    "lateralMovementNotes": null,
    "referralExpiryDate": "2030-01-01"
  }
}
``` 
