### PR TITLE
[fix] down migration error

### DIFF
--- a/api/database/migrations/2026_07_03_173110_add_classification_at_approval.php
+++ b/api/database/migrations/2026_07_03_173110_add_classification_at_approval.php
@@ -22,6 +22,7 @@ return new class() extends Migration
     public function down(): void
     {
         Schema::table('talent_nomination_groups', function (Blueprint $table) {
+            $table->dropForeign(['classification_at_time_of_advancement_approval_id']);
             $table->dropColumn('classification_at_time_of_advancement_approval_id');
         });
     }


### PR DESCRIPTION
The `down()` method at api/database/migrations/2026_07_03_173110_add_classification_at_approval.php 
drops the column without first dropping the foreign key constraint. 

You should call `$table->dropForeign(['classification_at_time_of_advancement_approval_id'])` before `dropColumn`.

_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/GCTC-NTGC/gc-digital-talent/security/quality/ai-findings)._