### PR TITLE
[Bug] Fix notification test

### DIFF
--- a/api/tests/Feature/Notifications/SendNotificationsApplicationDeadlineApproachingTest.php
+++ b/api/tests/Feature/Notifications/SendNotificationsApplicationDeadlineApproachingTest.php
@@ -47,7 +47,7 @@ class SendNotificationsApplicationDeadlineApproachingTest extends TestCase
         $closingDateTimeInVancouver = '2029-12-31 23:59:59'; // pools close end of day in Vancouver
         $closingTimeInUtc = '2030-01-01 06:59:59'; // Vancouver stays on permanent DST after March 8, 2026
         $nowInToronto = '2029-12-28 22:00:00'; // three days before closing, at the scheduled time (api/app/Console/Kernel.php)
-        $nowInUtc = '2029-12-29 02:00:00';
+        $nowInUtc = '2029-12-29 03:00:00';
 
         $pool = Pool::factory()
             ->published()
@@ -84,7 +84,7 @@ class SendNotificationsApplicationDeadlineApproachingTest extends TestCase
         $closingDateTimeInVancouver = '2029-12-31 23:59:59'; // pools close end of day in Vancouver
         $closingTimeInUtc = '2030-01-01 06:59:59'; // Vancouver stays on permanent DST after March 8, 2026
         $nowInToronto = '2029-12-28 22:00:00'; // three days before closing, at the scheduled time (api/app/Console/Kernel.php)
-        $nowInUtc = '2029-12-29 02:00:00';
+        $nowInUtc = '2029-12-29 03:00:00';
 
         $pool = Pool::factory()
             ->published()
@@ -119,7 +119,7 @@ class SendNotificationsApplicationDeadlineApproachingTest extends TestCase
         $closingDateTimeInVancouver = '2029-12-31 23:59:59'; // pools close end of day in Vancouver
         $closingTimeInUtc = '2030-01-01 06:59:59'; // Vancouver stays on permanent DST after March 8, 2026
         $nowInToronto = '2029-12-30 22:00:00'; // one day before closing
-        $nowInUtc = '2029-12-31 02:00:00';
+        $nowInUtc = '2029-12-31 03:00:00';
 
         $pool = Pool::factory()
             ->published()

--- a/api/tests/Feature/Notifications/SendNotificationsApplicationDeadlineApproachingTest.php
+++ b/api/tests/Feature/Notifications/SendNotificationsApplicationDeadlineApproachingTest.php
@@ -44,10 +44,10 @@ class SendNotificationsApplicationDeadlineApproachingTest extends TestCase
     // will send a notification to a user if they have a draft application a pool closing in three days
     public function testSendsNotificationThreeDaysBefore(): void
     {
-        $closingDateTimeInPacific = '2999-12-31 23:59:59'; // pools close end of day in Pacific, by convention
-        $closingTimeInUtc = '3000-01-01 07:59:59';
-        $nowInPacific = '2999-12-28 12:00:00'; // three days before closing
-        $nowInUtc = '2999-12-28 20:00:00';
+        $closingDateTimeInVancouver = '2029-12-31 23:59:59'; // pools close end of day in Vancouver
+        $closingTimeInUtc = '2030-01-01 06:59:59'; // Vancouver stays on permanent DST after March 8, 2026
+        $nowInToronto = '2029-12-28 22:00:00'; // three days before closing, at the scheduled time (api/app/Console/Kernel.php)
+        $nowInUtc = '2029-12-29 02:00:00';
 
         $pool = Pool::factory()
             ->published()
@@ -81,10 +81,10 @@ class SendNotificationsApplicationDeadlineApproachingTest extends TestCase
     // will not send a notification to a user if they have submitted their application
     public function testDoesNotSendNotificationIfApplicationSubmitted(): void
     {
-        $closingDateTimeInPacific = '2999-12-31 23:59:59'; // pools close end of day in Pacific, by convention
-        $closingTimeInUtc = '3000-01-01 07:59:59';
-        $nowInPacific = '2999-12-28 12:00:00'; // three days before closing
-        $nowInUtc = '2999-12-28 20:00:00';
+        $closingDateTimeInVancouver = '2029-12-31 23:59:59'; // pools close end of day in Vancouver
+        $closingTimeInUtc = '2030-01-01 06:59:59'; // Vancouver stays on permanent DST after March 8, 2026
+        $nowInToronto = '2029-12-28 22:00:00'; // three days before closing, at the scheduled time (api/app/Console/Kernel.php)
+        $nowInUtc = '2029-12-29 02:00:00';
 
         $pool = Pool::factory()
             ->published()
@@ -116,10 +116,10 @@ class SendNotificationsApplicationDeadlineApproachingTest extends TestCase
     // will not send a notification to a user if they have a draft application a pool not closing in three days
     public function testDoesNotSendNotificationIfNotThreeDaysBefore(): void
     {
-        $closingDateTimeInPacific = '2999-12-31 23:59:59'; // pools close end of day in Pacific, by convention
-        $closingTimeInUtc = '3000-01-01 07:59:59';
-        $nowInPacific = '2999-12-30 12:00:00'; // one day before closing
-        $nowInUtc = '2999-12-30 20:00:00';
+        $closingDateTimeInVancouver = '2029-12-31 23:59:59'; // pools close end of day in Vancouver
+        $closingTimeInUtc = '2030-01-01 06:59:59'; // Vancouver stays on permanent DST after March 8, 2026
+        $nowInToronto = '2029-12-30 22:00:00'; // one day before closing
+        $nowInUtc = '2029-12-31 02:00:00';
 
         $pool = Pool::factory()
             ->published()


### PR DESCRIPTION
🤖 Resolves #17441 

## 👋 Introduction

Fixes the deadline approaching test.

## 🕵️ Details

Our test started failing when time zone data got updated to account for the upcoming change in BC's schedule.
https://www2.gov.bc.ca/gov/content/governments/celebrating-british-columbia/daylight-saving-time

The AI suggested using closer dates for the tests since TZ calculations might be unreliable hundreds of years in the future.

## 🧪 Testing

1. Verify that the manually calculated times are accurate (see screenshot)
2. Observe that the test succeeds in CI
    1. (It may not pass locally if your OS doesn't have up-to-date TZ tables yet)

## 📸 Screenshot

Quick reference:
<img width="1011" height="291" alt="image" src="https://github.com/user-attachments/assets/f2d87b5e-f186-4e29-8aee-28f854f66c28" />


