### PR TITLE
17403 advancement classifications frontend

### DIFF
--- a/apps/playwright/fixtures/TalentManagement.ts
+++ b/apps/playwright/fixtures/TalentManagement.ts
@@ -135,6 +135,27 @@ class TalentManagement extends AppPage {
       .click();
 
     await this.page
+      .getByRole("combobox", {
+        name: /classifications this nominee is eligible to advance to/i,
+      })
+      .click();
+    await this.page.getByRole("option").first().click();
+    await this.page.keyboard.press("Tab");
+
+    const referralExpiryDate = this.page.getByRole("group", {
+      name: /referral expiry date/i,
+    });
+    await referralExpiryDate
+      .getByRole("spinbutton", { name: /year/i })
+      .fill("2099");
+    await referralExpiryDate
+      .getByRole("combobox", { name: /month/i })
+      .selectOption("12");
+    await referralExpiryDate
+      .getByRole("spinbutton", { name: /day/i })
+      .fill("31");
+
+    await this.page
       .getByRole("group", { name: /Lateral movement approval/i })
       .getByRole("radio", {
         name: /this nomination for lateral movement is approved./i,

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -5527,6 +5527,10 @@
     "defaultMessage": "Masquer tout<hidden>es les sections de candidatures et processus</hidden>",
     "description": "Button text to hide all applications and processes sections"
   },
+  "K5x0Ph": {
+    "defaultMessage": "Classifications pour lesquelles cette personne peut être recommandée en vue d'un avancement",
+    "description": "Label for advancement eligible classifications field"
+  },
   "K6Tzh1": {
     "defaultMessage": "Reliez votre parcours professionnel",
     "description": "Heading for checklist section in application education page."
@@ -8321,6 +8325,10 @@
   "Vd9VIn": {
     "defaultMessage": "Confirmer une adresse courriel professionnelle du GC",
     "description": "Link to update the work email"
+  },
+  "VeYTqO": {
+    "defaultMessage": "Date de fin de la recommandation",
+    "description": "Label for referral expiry date field"
   },
   "Vfa3Ek": {
     "defaultMessage": "Compétence mise à jour avec succès!",
@@ -13937,6 +13945,10 @@
   "rmsF/w": {
     "defaultMessage": "impossible de marquer les notifications comme lues.",
     "description": "Message announced to assistive technology when error occurred making notifications as read"
+  },
+  "rnFFzE": {
+    "defaultMessage": "La personne pourra être recommandée pour les classifications sélectionnées ci-dessus jusqu'à cette date (inclusivement).",
+    "description": "Help text for referral expiry date field"
   },
   "rpM/Sw": {
     "defaultMessage": "Gérer les modèles d’emploi",

--- a/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/components/AdvancementSection.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/components/AdvancementSection.tsx
@@ -2,7 +2,13 @@ import { useIntl } from "react-intl";
 import { useFormContext } from "react-hook-form";
 import { useEffect } from "react";
 
-import { Checkbox, RadioGroup, RichTextInput } from "@gc-digital-talent/forms";
+import {
+  Checkbox,
+  Combobox,
+  DateInput,
+  RadioGroup,
+  RichTextInput,
+} from "@gc-digital-talent/forms";
 import { Heading, Notice } from "@gc-digital-talent/ui";
 import { commonMessages, errorMessages } from "@gc-digital-talent/i18n";
 import type { FragmentType } from "@gc-digital-talent/graphql";
@@ -11,7 +17,7 @@ import {
   graphql,
   TalentNominationGroupDecision,
 } from "@gc-digital-talent/graphql";
-import { notEmpty } from "@gc-digital-talent/helpers";
+import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 
 import FieldDisplay from "~/components/FieldDisplay/FieldDisplay";
 
@@ -29,6 +35,22 @@ const NominationGroupEvaluationDialogAdvancement_Fragment = graphql(
         }
         advancementReferenceFallbackWorkEmail
       }
+      advancementClassifications {
+        id
+        groupAndLevel
+      }
+      referralExpiryDate
+    }
+  `,
+);
+
+const NominationGroupEvaluationDialogAdvancementOptions_Fragment = graphql(
+  /* GraphQL */ `
+    fragment NominationGroupEvaluationDialogAdvancementOptions on Query {
+      classifications {
+        id
+        groupAndLevel
+      }
     }
   `,
 );
@@ -37,10 +59,14 @@ interface AdvancementSectionProps {
   talentNominationGroupQuery: FragmentType<
     typeof NominationGroupEvaluationDialogAdvancement_Fragment
   >;
+  talentNominationGroupOptionsQuery: FragmentType<
+    typeof NominationGroupEvaluationDialogAdvancementOptions_Fragment
+  >;
 }
 
 const AdvancementSection = ({
   talentNominationGroupQuery,
+  talentNominationGroupOptionsQuery,
 }: AdvancementSectionProps) => {
   const intl = useIntl();
 
@@ -50,7 +76,7 @@ const AdvancementSection = ({
   useEffect(() => {
     const resetDirtyField = (
       name: keyof FormValues,
-      defaultValue: null | string | boolean,
+      defaultValue: null | string | boolean | string[],
     ) => {
       resetField(name, { keepDirty: false, defaultValue });
     };
@@ -60,6 +86,8 @@ const AdvancementSection = ({
     ) {
       resetDirtyField("advancementReferenceConfirmed", null);
       resetDirtyField("advancementApprovedNotes", null);
+      resetDirtyField("advancementClassifications", []);
+      resetDirtyField("referralExpiryDate", "");
     }
 
     if (
@@ -72,6 +100,10 @@ const AdvancementSection = ({
   const talentNominationGroup = getFragment(
     NominationGroupEvaluationDialogAdvancement_Fragment,
     talentNominationGroupQuery,
+  );
+  const talentNominationGroupOptions = getFragment(
+    NominationGroupEvaluationDialogAdvancementOptions_Fragment,
+    talentNominationGroupOptionsQuery,
   );
 
   const nominations = talentNominationGroup.nominations ?? [];
@@ -136,6 +168,31 @@ const AdvancementSection = ({
             boundingBoxLabel={intl.formatMessage(
               formMessages.referenceConfirmationLabel,
             )}
+            rules={{
+              required: intl.formatMessage(errorMessages.required),
+            }}
+          />
+          <Combobox
+            id="advancementClassifications"
+            name="advancementClassifications"
+            isMulti
+            label={intl.formatMessage(formMessages.advancementClassifications)}
+            options={unpackMaybes(
+              talentNominationGroupOptions?.classifications,
+            ).map(({ id, groupAndLevel }) => ({
+              value: id,
+              label:
+                groupAndLevel ?? intl.formatMessage(commonMessages.notProvided),
+            }))}
+            rules={{
+              required: intl.formatMessage(errorMessages.required),
+            }}
+          />
+          <DateInput
+            id="referralExpiryDate"
+            name="referralExpiryDate"
+            legend={intl.formatMessage(formMessages.referralExpiryDate)}
+            context={intl.formatMessage(formMessages.referralExpiryDateContext)}
             rules={{
               required: intl.formatMessage(errorMessages.required),
             }}

--- a/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/components/AdvancementSection.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/components/AdvancementSection.tsx
@@ -176,7 +176,13 @@ const AdvancementSection = ({
             id="advancementClassifications"
             name="advancementClassifications"
             isMulti
-            label={intl.formatMessage(formMessages.advancementClassifications)}
+            label={intl.formatMessage({
+              defaultMessage:
+                "Classifications this nominee is eligible to advance to",
+              id: "K5x0Ph",
+              description:
+                "Label for advancement eligible classifications field",
+            })}
             options={unpackMaybes(
               talentNominationGroupOptions?.classifications,
             ).map(({ id, groupAndLevel }) => ({
@@ -191,8 +197,17 @@ const AdvancementSection = ({
           <DateInput
             id="referralExpiryDate"
             name="referralExpiryDate"
-            legend={intl.formatMessage(formMessages.referralExpiryDate)}
-            context={intl.formatMessage(formMessages.referralExpiryDateContext)}
+            legend={intl.formatMessage({
+              defaultMessage: "Referral expiry date",
+              id: "VeYTqO",
+              description: "Label for referral expiry date field",
+            })}
+            context={intl.formatMessage({
+              defaultMessage:
+                "The nominee will be referred for the classifications chosen above until this date (inclusive).",
+              id: "rnFFzE",
+              description: "Help text for referral expiry date field",
+            })}
             rules={{
               required: intl.formatMessage(errorMessages.required),
             }}

--- a/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/components/NominationGroupEvaluationForm.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/components/NominationGroupEvaluationForm.tsx
@@ -37,6 +37,10 @@ const NominationGroupEvaluationForm_Fragment = graphql(/* GraphQL */ `
     }
     advancementReferenceConfirmed
     advancementNotes
+    advancementClassifications {
+      id
+    }
+    referralExpiryDate
     lateralMovementDecision {
       value
     }
@@ -51,6 +55,7 @@ const NominationGroupEvaluationForm_Fragment = graphql(/* GraphQL */ `
 const NominationGroupEvaluationFormOptions_Fragment = graphql(/* GraphQL */ `
   fragment NominationGroupEvaluationFormOptions on Query {
     ...NominationGroupEvaluationDialogLateralMovementOptions
+    ...NominationGroupEvaluationDialogAdvancementOptions
   }
 `);
 
@@ -146,6 +151,7 @@ const NominationGroupEvaluationForm = ({
               <Separator space="none" decorative />
               <AdvancementSection
                 talentNominationGroupQuery={talentNominationGroup}
+                talentNominationGroupOptionsQuery={talentNominationGroupOptions}
               />
             </>
           ) : null}

--- a/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/form.ts
+++ b/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/form.ts
@@ -4,12 +4,15 @@ import type {
   UpdateTalentNominationGroupInput,
 } from "@gc-digital-talent/graphql";
 import { TalentNominationGroupDecision } from "@gc-digital-talent/graphql";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
 
 export interface FormValues {
   advancementDecision: TalentNominationGroupDecision | null;
   advancementReferenceConfirmed: boolean | null;
   advancementApprovedNotes: string | null;
   advancementRejectedNotes: string | null;
+  advancementClassifications: string[];
+  referralExpiryDate: string;
   lateralMovementDecision: TalentNominationGroupDecision | null;
   lateralMovementApprovedNotes: string | null;
   lateralMovementRejectedNotes: string | null;
@@ -63,6 +66,10 @@ export function convertQueryDataToFormData(
       queryData?.advancementDecision,
       queryData?.advancementNotes,
     ),
+    advancementClassifications: unpackMaybes(
+      queryData?.advancementClassifications,
+    ).map(({ id }) => id),
+    referralExpiryDate: queryData?.referralExpiryDate ?? "",
     lateralMovementDecision: queryData?.lateralMovementDecision?.value ?? null,
     lateralMovementApprovedNotes: ifApproved(
       queryData?.lateralMovementDecision,
@@ -108,11 +115,9 @@ export function convertFormValuesToMutationInput(
       formValues.developmentProgramsApprovedNotes,
       formValues.developmentProgramsRejectedNotes,
     ),
-    // no UI yet
     advancementClassifications: {
-      sync: [],
+      sync: formValues.advancementClassifications,
     },
-    // no UI yet
-    referralExpiryDate: null,
+    referralExpiryDate: formValues.referralExpiryDate || null,
   };
 }

--- a/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/messages.ts
+++ b/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/messages.ts
@@ -53,6 +53,22 @@ export const formMessages = defineMessages({
     id: "FcHUIQ",
     description: "Statement of confirmation for reference check",
   },
+  advancementClassifications: {
+    defaultMessage: "Classifications this nominee is eligible to advance to",
+    id: "K5x0Ph",
+    description: "Label for advancement eligible classifications field",
+  },
+  referralExpiryDate: {
+    defaultMessage: "Referral expiry date",
+    id: "VeYTqO",
+    description: "Label for referral expiry date field",
+  },
+  referralExpiryDateContext: {
+    defaultMessage:
+      "The nominee will be referred for the classifications chosen above until this date (inclusive).",
+    id: "rnFFzE",
+    description: "Help text for referral expiry date field",
+  },
   approvalNotes: {
     defaultMessage: "Additional notes",
     id: "h9XSU5",

--- a/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/messages.ts
+++ b/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/messages.ts
@@ -53,22 +53,6 @@ export const formMessages = defineMessages({
     id: "FcHUIQ",
     description: "Statement of confirmation for reference check",
   },
-  advancementClassifications: {
-    defaultMessage: "Classifications this nominee is eligible to advance to",
-    id: "K5x0Ph",
-    description: "Label for advancement eligible classifications field",
-  },
-  referralExpiryDate: {
-    defaultMessage: "Referral expiry date",
-    id: "VeYTqO",
-    description: "Label for referral expiry date field",
-  },
-  referralExpiryDateContext: {
-    defaultMessage:
-      "The nominee will be referred for the classifications chosen above until this date (inclusive).",
-    id: "rnFFzE",
-    description: "Help text for referral expiry date field",
-  },
   approvalNotes: {
     defaultMessage: "Additional notes",
     id: "h9XSU5",


### PR DESCRIPTION
🤖 Resolves #17403

## 👋 Introduction

Adds the ability to add classifications and a referral expiry date when evaluating an advancement nomination group.

## 🕵️ Details

The new data doesn't do anything and isn't displayed anywhere yet.

## 🧪 Testing

1. Rebuild the app
2. Log in as "community@test.com"
3. Find a nomination group with advancement 
- [ ] Can support the advancement and attach classifications and a referral date
- [ ] Can reject the advancement which clears classifications and the referral date
4. Find a nomination group without advancement 
- [ ] Can still support and reject

## 📸 Screenshot

<img width="804" height="598" alt="image" src="https://github.com/user-attachments/assets/1366dcda-a966-4872-b6bc-579c32115cb4" />
