### PR TITLE
[Fix] Only verified gov employees match at level talent source

### DIFF
--- a/api/app/Builders/CommunityInterestBuilder.php
+++ b/api/app/Builders/CommunityInterestBuilder.php
@@ -22,7 +22,8 @@ class CommunityInterestBuilder extends Builder implements TalentRequestMatchable
         $qualifiedInClassifications = $filters['qualifiedInClassifications'] ?? null;
 
         if (! empty($qualifiedInClassifications)) {
-            $this->whereHas('user', function (UserBuilder $userQuery) use ($qualifiedInClassifications) {
+            $this->whereHas('user', function (Builder $userQuery) use ($qualifiedInClassifications) {
+                /** @var UserBuilder $userQuery */
                 $userQuery->whereHas('currentClassification', function (Builder $classQuery) use ($qualifiedInClassifications) {
                     $classQuery->where(function (Builder $q) use ($qualifiedInClassifications) {
                         foreach ($qualifiedInClassifications as $classification) {

--- a/api/app/Builders/CommunityInterestBuilder.php
+++ b/api/app/Builders/CommunityInterestBuilder.php
@@ -22,7 +22,7 @@ class CommunityInterestBuilder extends Builder implements TalentRequestMatchable
         $qualifiedInClassifications = $filters['qualifiedInClassifications'] ?? null;
 
         if (! empty($qualifiedInClassifications)) {
-            $this->whereHas('user', function (Builder $userQuery) use ($qualifiedInClassifications) {
+            $this->whereHas('user', function (UserBuilder $userQuery) use ($qualifiedInClassifications) {
                 $userQuery->whereHas('currentClassification', function (Builder $classQuery) use ($qualifiedInClassifications) {
                     $classQuery->where(function (Builder $q) use ($qualifiedInClassifications) {
                         foreach ($qualifiedInClassifications as $classification) {
@@ -32,7 +32,7 @@ class CommunityInterestBuilder extends Builder implements TalentRequestMatchable
                             });
                         }
                     });
-                });
+                })->whereIsVerifiedGovEmployee();
             });
         }
 

--- a/api/tests/Feature/TalentRequestMatchesTest.php
+++ b/api/tests/Feature/TalentRequestMatchesTest.php
@@ -138,7 +138,10 @@ class TalentRequestMatchesTest extends TestCase
     // A user with a current substantive classification (for AT_LEVEL matching), no pool candidacy.
     private function atLevelUser(Classification $classification, Community $community): User
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create([
+            'work_email' => 'at.level.user@gc.ca',
+            'work_email_verified_at' => now(),
+        ]);
         WorkExperience::factory()->for($user)->create([
             'employment_category' => EmploymentCategory::GOVERNMENT_OF_CANADA->name,
             'gov_employment_type' => GovEmployeeType::INDETERMINATE->name,
@@ -632,7 +635,10 @@ class TalentRequestMatchesTest extends TestCase
         $this->atLevelUser($classification, $community);
 
         // user matching both sources for this community — should count once in the total
-        $bothUser = $this->matchingUser($pool);
+        $bothUser = $this->matchingUser($pool, [
+            'work_email' => 'both.sources.user@gc.ca',
+            'work_email_verified_at' => now(),
+        ]);
         WorkExperience::factory()->for($bothUser)->create([
             'employment_category' => EmploymentCategory::GOVERNMENT_OF_CANADA->name,
             'gov_employment_type' => GovEmployeeType::INDETERMINATE->name,

--- a/api/tests/Feature/TalentRequestMatchesTest.php
+++ b/api/tests/Feature/TalentRequestMatchesTest.php
@@ -891,12 +891,15 @@ class TalentRequestMatchesTest extends TestCase
     {
         $classification = Classification::factory()->create();
 
-        $user = User::factory()->create();
-        WorkExperience::factory()->for($user)->create([
+        // a verified gov employee qualified in the classification — should match
+        $user = User::factory()->create([
+            'work_email' => 'verified.employee@gc.ca',
+            'work_email_verified_at' => now(),
+        ]);
+        WorkExperience::factory()->for($user)->for($classification)->create([
             'employment_category' => EmploymentCategory::GOVERNMENT_OF_CANADA->name,
             'gov_employment_type' => GovEmployeeType::INDETERMINATE->name,
             'gov_position_type' => GovPositionType::SUBSTANTIVE->name,
-            'classification_id' => $classification->id,
             'end_date' => null,
         ]);
         CommunityInterest::factory()->consented()->for($user)->create();
@@ -911,6 +914,37 @@ class TalentRequestMatchesTest extends TestCase
                 ],
             ])
             ->assertJsonFragment(['user' => ['id' => $user->id]]);
+    }
+
+    // Regression test for #17465 — the classification filter must require a
+    // verified work email, not just computed_is_gov_employee, so an employee
+    // who never verified their work email does not match at that level.
+    public function testAtLevelClassificationFilterExcludesUnverifiedGovEmployee(): void
+    {
+        $classification = Classification::factory()->create();
+
+        $unverified = User::factory()->create([
+            'work_email' => 'unverified.employee@gc.ca',
+            'work_email_verified_at' => null,
+        ]);
+        WorkExperience::factory()->for($unverified)->for($classification)->create([
+            'employment_category' => EmploymentCategory::GOVERNMENT_OF_CANADA->name,
+            'gov_employment_type' => GovEmployeeType::INDETERMINATE->name,
+            'gov_position_type' => GovPositionType::SUBSTANTIVE->name,
+            'end_date' => null,
+        ]);
+        CommunityInterest::factory()->consented()->for($unverified)->create();
+
+        $this->actingAs($this->admin, 'api')
+            ->graphQL($this->atLevelQuery, [
+                'where' => [
+                    'applicantFilter' => [
+                        'talentSources' => [TalentRequestSource::AT_LEVEL->name],
+                        'qualifiedInClassifications' => [['group' => $classification->group, 'level' => $classification->level]],
+                    ],
+                ],
+            ])
+            ->assertJsonPath('data.talentRequestMatches.paginatorInfo.total', 0);
     }
 
     public function testTalentSourcesAllSourcesReturnsBothPoolAndAtLevelUsers(): void


### PR DESCRIPTION
🤖 Resolves #17465 

## 👋 Introduction

Updates the at level talent source match scope to only include verified government employees.

## 🧪 Testing

> [!NOTE]
> Hard to manually test since you should not be able to create a community interest (requried to match) unless you are verified. This PR is about redundancy.

1. I guess confirm test coverage is good around this or,
2. Remove a matches `work_email_verified_at` by setting it to null to make then unverified
3. Confuirm they no longer appear in the results as an "At-level" match