### PR TITLE
[Fix] Always display nominee's name in excel download

### DIFF
--- a/api/app/Generators/NominationsExcelGenerator.php
+++ b/api/app/Generators/NominationsExcelGenerator.php
@@ -251,8 +251,8 @@ class NominationsExcelGenerator extends ExcelGenerator implements FileGeneratorI
 
                 $values = [
                     $user->id,
-                    $this->canShare($consentToShare, $user->first_name),
-                    $this->canShare($consentToShare, $user->last_name),
+                    $user->first_name,
+                    $user->last_name,
                     $this->localizeEnum($talentNominationGroup->status, TalentNominationGroupStatus::class),
                     $nominators->join(', '),
                     $optionsStr,
@@ -342,8 +342,8 @@ class NominationsExcelGenerator extends ExcelGenerator implements FileGeneratorI
 
                 $values = [
                     $user->id,
-                    $this->canShare($consentToShare, $user->first_name),
-                    $this->canShare($consentToShare, $user->last_name),
+                    $user->first_name,
+                    $user->last_name,
                     $this->canShare($consentToShare, $user->email ?? ''),
                     $this->canShare($consentToShare, $user->telephone ?? ''),
                     $this->canShare($consentToShare, $this->localizeEnum($user->armed_forces_status, ArmedForcesStatus::class)),
@@ -456,8 +456,8 @@ class NominationsExcelGenerator extends ExcelGenerator implements FileGeneratorI
 
                     $values = [
                         $user->id,
-                        $this->canShare($consentToShare, $user->first_name), // nominee's first name
-                        $this->canShare($consentToShare, $user->last_name), // nominee's last name
+                        $user->first_name, // nominee's first name
+                        $user->last_name, // nominee's last name
                         $nomination->submitted_at ? $nomination->submitted_at->format('Y-m-d') : '', // Date received
                         $optionsStr, // nomination options
                         $nominator?->getFullName() ?? $nomination->nominator_fallback_name, // nominator


### PR DESCRIPTION
🤖 Resolves #16056 

## 👋 Introduction

Updates the nominaitons excel download to no longer guard first and last name behind a consent to share profile check.

## 🧪 Testing

1. Start the queue `make queue-work`
2. Make sure a talent managemenr event has some nominations
3. Remove the consent to share profile from one of the users who were nominated
4. Download the excel
5. Confirm you can view first and last name
6. Confirm all other profile information remains redacted

## 📸 Screenshot

<img width="395" height="95" alt="swappy-20260721_114258" src="https://github.com/user-attachments/assets/9857219d-5c7c-42a9-82d3-4af98ce5e463" />
