### PR TITLE
Fix codespace setup

### DIFF
--- a/maintenance/scripts/setup-codespace.sh
+++ b/maintenance/scripts/setup-codespace.sh
@@ -85,7 +85,7 @@ echo "✓ apps/web/.env updated"
 # external browser.
 # ---------------------------------------------------------------------------
 
-NGINX_CONF="infrastructure/conf/nginx-conf-local/default"
+NGINX_CONF="infrastructure/conf/nginx-local.conf"
 
 sed -i "s|proxy_set_header X-Forwarded-Proto http;|proxy_set_header X-Forwarded-Proto https;|" "${NGINX_CONF}"
 sed -i "s|proxy_set_header Host localhost:8000;|proxy_set_header Host ${APP_HOST};|" "${NGINX_CONF}"


### PR DESCRIPTION
## What was broken

Running `make codespace-setup` (which invokes `maintenance/scripts/setup-codespace.sh`) failed partway through with:

```
sed: can't read infrastructure/conf/nginx-conf-local/default: No such file or directory
make: *** [Makefile:27: codespace-setup] Error 2
```

This left codespaces unusable for external sharing, since the nginx mock-auth proxy headers never got patched and the rest of the setup (API refresh, seeding, frontend rebuild) never ran.

## Why it happened

The script patches the local nginx config to make the mock OAuth server advertise the Codespace's forwarded-port URL instead of `localhost:8000`. It referenced that config at `infrastructure/conf/nginx-conf-local/default`.

That file was renamed to `infrastructure/conf/nginx-local.conf` in #17157 (a pure rename — the contents didn't change). The setup script was never updated to follow the rename, so as soon as `sed` tried to read the old path, it errored out and `make` aborted.

## The fix

Point the script at the current path:

```diff
-NGINX_CONF="infrastructure/conf/nginx-conf-local/default"
+NGINX_CONF="infrastructure/conf/nginx-local.conf"
```

No other changes are needed:
- `nginx-local.conf` is the file `docker-compose.yml` actually mounts as the local nginx config.
- The two lines the script's `sed` commands rewrite (`proxy_set_header X-Forwarded-Proto http;` and `proxy_set_header Host localhost:8000;`) still exist verbatim in the renamed file, so both substitutions match cleanly.

Fixes #17415

🤖 Generated with [Claude Code](https://claude.com/claude-code)