### PR TITLE
[Feature] Add nine box question to event form

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3051,10 +3051,6 @@
     "defaultMessage": "Passer au contenu principal",
     "description": "Default Skip to main content message."
   },
-  "A3m7l/": {
-    "defaultMessage": "Les compétences de leadership sont obligatoires pour être admissible à une candidature dans le cadre de cet événement.",
-    "description": "Label for the include leadership competencies"
-  },
   "A4dp/3": {
     "defaultMessage": "Masquer tout<hidden>es les sections de perfectionnement de carrière</hidden>",
     "description": "Button text to hide all career development sections"
@@ -3806,6 +3802,10 @@
   "D5Hqhf": {
     "defaultMessage": "Cercle de soutien",
     "description": "Title of the 'Circle of Support' subsection"
+  },
+  "D5KDrf": {
+    "defaultMessage": "Questions sur le rendement en leadership",
+    "description": "Bounding box label for the include leadership performance and potential"
   },
   "D6f8hs": {
     "defaultMessage": "1. <strong>Préparez votre appareil</strong> en téléchargeant votre application d’authentification à deux facteurs préférée.",
@@ -14813,6 +14813,10 @@
   "vRNv4w": {
     "defaultMessage": "Revoir la demande",
     "description": "Title for the review application dialog"
+  },
+  "vRkQB+": {
+    "defaultMessage": "La mise en candidature doit comprendre le rendement et le potentiel en leadership de la personne mise en candidature",
+    "description": "Label for the include leadership performance and potential"
   },
   "vUZf8Y": {
     "defaultMessage": "Texte de rechange en langage clair",

--- a/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
+++ b/apps/web/src/pages/TalentEvents/TalentEvent/DetailsPage.tsx
@@ -57,6 +57,7 @@ const TalentEventDetails_Fragment = graphql(/* GraphQL */ `
     }
     openDate
     closeDate
+    includeNineBox
     includeLeadershipCompetencies
     community {
       id
@@ -316,18 +317,43 @@ const TalentEventDetails = ({ query }: TalentEventDetailsProps) => {
             )}
           </span>
         </FieldDisplay>
-        <BoolCheckIcon
-          value={talentEvent.includeLeadershipCompetencies}
+        <FieldDisplay
+          label={intl.formatMessage({
+            defaultMessage: "Leadership performance questions",
+            id: "D5KDrf",
+            description:
+              "Bounding box label for the include leadership performance and potential",
+          })}
           className="col-span-2"
         >
-          {intl.formatMessage({
-            defaultMessage:
-              "Leadership competencies are required to be nominated for this event",
-            id: "A3m7l/",
-            description: "Label for the include leadership competencies",
+          <BoolCheckIcon value={talentEvent.includeNineBox}>
+            {intl.formatMessage({
+              defaultMessage:
+                "The nomination must include the nominee’s performance and leadership potential",
+              id: "vRkQB+",
+              description:
+                "Label for the include leadership performance and potential",
+            })}
+          </BoolCheckIcon>
+        </FieldDisplay>
+        <FieldDisplay
+          label={intl.formatMessage({
+            defaultMessage: "Leadership competency requirement",
+            id: "eBH+tH",
+            description:
+              "Bounding box label for the include leadership competencies",
           })}
-        </BoolCheckIcon>
-
+          className="col-span-2"
+        >
+          <BoolCheckIcon value={talentEvent.includeLeadershipCompetencies}>
+            {intl.formatMessage({
+              defaultMessage:
+                "The nomination must include the nominee's top 3 leadership competencies",
+              id: "4rkX89",
+              description: "Label for the include leadership competencies",
+            })}
+          </BoolCheckIcon>
+        </FieldDisplay>
         <FieldDisplay
           label={intl.formatMessage({
             defaultMessage: "Customized instruction text",

--- a/apps/web/src/pages/TalentEvents/UpdateTalentEventPage.tsx
+++ b/apps/web/src/pages/TalentEvents/UpdateTalentEventPage.tsx
@@ -99,6 +99,7 @@ const UpdateTalentEventForm = ({
           "Canada/Pacific",
         ),
       ),
+      includeNineBox: talentNominationEvent.includeNineBox,
       includeLeadershipCompetencies:
         talentNominationEvent.includeLeadershipCompetencies,
       community: talentNominationEvent.community.id,

--- a/apps/web/src/pages/TalentEvents/components/ActiveTalentEventForm.tsx
+++ b/apps/web/src/pages/TalentEvents/components/ActiveTalentEventForm.tsx
@@ -74,6 +74,7 @@ const ActiveTalentEventForm = ({
   const {
     community,
     name,
+    includeNineBox,
     includeLeadershipCompetencies,
     openDate,
     description,
@@ -395,6 +396,26 @@ const ActiveTalentEventForm = ({
                   required: intl.formatMessage(errorMessages.required),
                 }}
               />
+            </div>
+            <div className="col-span-2">
+              <FieldDisplay
+                label={intl.formatMessage({
+                  defaultMessage: "Leadership performance questions",
+                  id: "D5KDrf",
+                  description:
+                    "Bounding box label for the include leadership performance and potential",
+                })}
+              >
+                <BoolCheckIcon value={includeNineBox}>
+                  {intl.formatMessage({
+                    defaultMessage:
+                      "The nomination must include the nominee’s performance and leadership potential",
+                    id: "vRkQB+",
+                    description:
+                      "Label for the include leadership performance and potential",
+                  })}
+                </BoolCheckIcon>
+              </FieldDisplay>
             </div>
             <div className="col-span-2">
               <FieldDisplay

--- a/apps/web/src/pages/TalentEvents/components/UpcomingTalentEventForm.tsx
+++ b/apps/web/src/pages/TalentEvents/components/UpcomingTalentEventForm.tsx
@@ -284,6 +284,25 @@ const UpcomingTalentEventForm = ({ query }: UpcomingTalentEventFormProps) => {
         />
         <div className="xs:col-span-2">
           <Checkbox
+            id="includeNineBox"
+            boundingBox
+            boundingBoxLabel={intl.formatMessage({
+              defaultMessage: "Leadership performance questions",
+              id: "bCqtne",
+              description:
+                "Bounding box label for the include leadership performance",
+            })}
+            label={intl.formatMessage({
+              defaultMessage:
+                "The nomination must include the nominee’s performance and leadership potential",
+              id: "x7c8ZO",
+              description: "Label for the include leadership performance",
+            })}
+            name="includeNineBox"
+          />
+        </div>
+        <div className="xs:col-span-2">
+          <Checkbox
             id="includeLeadershipCompetencies"
             boundingBox
             boundingBoxLabel={intl.formatMessage({

--- a/apps/web/src/pages/TalentEvents/components/UpcomingTalentEventForm.tsx
+++ b/apps/web/src/pages/TalentEvents/components/UpcomingTalentEventForm.tsx
@@ -288,15 +288,16 @@ const UpcomingTalentEventForm = ({ query }: UpcomingTalentEventFormProps) => {
             boundingBox
             boundingBoxLabel={intl.formatMessage({
               defaultMessage: "Leadership performance questions",
-              id: "bCqtne",
+              id: "D5KDrf",
               description:
-                "Bounding box label for the include leadership performance",
+                "Bounding box label for the include leadership performance and potential",
             })}
             label={intl.formatMessage({
               defaultMessage:
                 "The nomination must include the nominee’s performance and leadership potential",
-              id: "x7c8ZO",
-              description: "Label for the include leadership performance",
+              id: "vRkQB+",
+              description:
+                "Label for the include leadership performance and potential",
             })}
             name="includeNineBox"
           />

--- a/apps/web/src/pages/TalentEvents/components/formValues.ts
+++ b/apps/web/src/pages/TalentEvents/components/formValues.ts
@@ -13,6 +13,7 @@ export interface FormValues {
     en: string | null;
     fr: string | null;
   };
+  includeNineBox: boolean;
   includeLeadershipCompetencies: boolean;
   community: string;
   communityDevelopmentPrograms: {

--- a/apps/web/src/pages/TalentEvents/components/fragments.ts
+++ b/apps/web/src/pages/TalentEvents/components/fragments.ts
@@ -52,6 +52,7 @@ export const UpdateTalentNominationEvent_Fragment = graphql(/* GraphQL */ `
       en
       fr
     }
+    includeNineBox
     includeLeadershipCompetencies
     community {
       id


### PR DESCRIPTION
🤖 Resolves #17254 

## 👋 Introduction

Adds the nine box question to the event create, view, and edit forms.

## 🧪 Testing

1. Rebuild and log in as community@test.com
2. Navigate to the talent management -> events table

- [x] Can create an event with or without nine box
- [x] Can view the event nine box setting on the view event page
- [x] Can edit the event nine box setting on the edit upcoming event page
- [x] Can only view the event nine box setting on the edit current or past event page

## 📸 Screenshot

<img width="1150" height="656" alt="image" src="https://github.com/user-attachments/assets/cb4b6d95-400d-41fc-9884-36f6be76d185" />

