### PR TITLE
[Refactor] Remove SIC - Update PW tests

### DIFF
--- a/apps/playwright/fixtures/AccountSettings.ts
+++ b/apps/playwright/fixtures/AccountSettings.ts
@@ -91,13 +91,6 @@ class AccountSettings extends AppPage {
     await this.waitForGraphqlResponse("UpdateUserAsUser");
   }
 
-  async updateContactEmailAddress() {
-    await this.locators[FIELD.UPDATE_CONTACT_EMAIL].click();
-    await this.locators[FIELD.CONTACT_EMAIL_INPUT].fill(
-      this.uniqueEmailAddress,
-    );
-  }
-
   async updateNotificationsSettings() {
     await expect(
       this.locators[FIELD.NOTIFICATION_SETTINGS_HEADING],

--- a/apps/playwright/fixtures/AccountSettings.ts
+++ b/apps/playwright/fixtures/AccountSettings.ts
@@ -98,24 +98,6 @@ class AccountSettings extends AppPage {
     );
   }
 
-  async removeWorkEmail() {
-    await expect(
-      this.page
-        .locator("#personal-info div")
-        .filter({ hasText: "Government of Canada work" })
-        .nth(1)
-        .getByLabel("verified"),
-    ).toBeVisible();
-    await expect(
-      this.page.getByRole("button", { name: "Update work email" }),
-    ).toBeVisible();
-
-    // carry removal out
-    await this.page.getByRole("button", { name: "Remove work email" }).click();
-    await this.page.getByRole("button", { name: "Remove work email" }).click();
-    await this.waitForGraphqlResponse("RemoveUserWorkEmail");
-  }
-
   async updateNotificationsSettings() {
     await expect(
       this.locators[FIELD.NOTIFICATION_SETTINGS_HEADING],

--- a/apps/playwright/fixtures/EmployeeProfile.ts
+++ b/apps/playwright/fixtures/EmployeeProfile.ts
@@ -132,6 +132,22 @@ class EmployeeProfile extends AppPage {
       .getByRole("button", { name: /save career development preferences/i })
       .click();
   }
+
+  workEmailVerificationLabel() {
+    const card = this.page.getByRole("group", {
+      name: /Work email verification/i,
+    });
+    return card.getByRole("img").first().getAttribute("aria-label");
+  }
+
+  async removeWorkEmail() {
+    // carry removal out
+    await this.page.getByRole("button", { name: "Update work email" }).click();
+    await this.page.getByRole("button", { name: "Remove work email" }).click();
+    await this.page.getByRole("button", { name: "Remove work email" }).click();
+    await this.waitForGraphqlResponse("RemoveUserWorkEmail");
+    await this.page.getByRole("button", { name: "Cancel" }).click();
+  }
 }
 
 export default EmployeeProfile;

--- a/apps/playwright/fixtures/Registration.ts
+++ b/apps/playwright/fixtures/Registration.ts
@@ -1,15 +1,9 @@
-import { execSync } from "child_process";
-
 import type { Locator, Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 
 import { loginBySub } from "~/utils/auth";
-import { deleteUser, me } from "~/utils/user";
-import {
-  fetchIdentificationNumber,
-  generateUniqueTestId,
-  uuidRegEx,
-} from "~/utils/id";
+import { deleteUser } from "~/utils/user";
+import { fetchIdentificationNumber, generateUniqueTestId } from "~/utils/id";
 import graphql from "~/utils/graphql";
 import testConfig from "~/constants/config";
 
@@ -18,14 +12,6 @@ import UserPage from "./UserPage";
 
 const FIELD = {
   GETTING_STARTED_HEADING: "gettingStartedHeading",
-  EMAIL_ADDRESS: "emailAddress",
-  SEND_VERIFICATION_EMAIL_BUTTON: "sendVerificationEmailButton",
-  VERIFICATION_EMAIL_SENT_HEADING: "verificationEmailSentHeading",
-  COUNTER_MESSAGE: "counterMessage",
-  VERIFICATION_CODE: "verificationCode",
-  FIRST_NAME: "firstName",
-  LAST_NAME: "lastName",
-  PREFERRED_CONTACT_LANGUAGE: "preferredContactLanguage",
   SAVE_AND_CONTINUE_BUTTON: "saveAndContinueButton",
   SAVE_AND_CONTINUE_LINK: "saveAndContinueLink",
   ADD_MOST_RECENT_WORK_EXPERIENCE: "addMostRecentWorkExperience",
@@ -44,9 +30,7 @@ export type Field = ObjectValues<typeof FIELD>;
 
 class Registration extends AppPage {
   readonly locators: Record<Field, Locator>;
-  readonly baseUrl: string = "/en/applicant";
   uniqueTestId = generateUniqueTestId();
-  context = graphql.newContext(this.uniqueTestId);
   uniqueEmailAddress = `${this.uniqueTestId}@gc.ca`;
   readonly firstName = "Playwright";
   readonly lastName = "Test";
@@ -57,30 +41,6 @@ class Registration extends AppPage {
       [FIELD.GETTING_STARTED_HEADING]: this.page.getByRole("heading", {
         name: /getting started/i,
         level: 2,
-      }),
-      [FIELD.EMAIL_ADDRESS]: this.page.getByRole("textbox", {
-        name: /email address/i,
-      }),
-      [FIELD.SEND_VERIFICATION_EMAIL_BUTTON]: this.page.getByRole("button", {
-        name: /send verification email/i,
-      }),
-      [FIELD.VERIFICATION_EMAIL_SENT_HEADING]: this.page.getByText(
-        /Verification email sent!/i,
-      ),
-      [FIELD.COUNTER_MESSAGE]: this.page.getByText(
-        /Please\s+wait\s+\d+\s+seconds\s+before\s+requesting\s+another\s+verification\s+email./i,
-      ),
-      [FIELD.VERIFICATION_CODE]: this.page.getByRole("textbox", {
-        name: /verification code/i,
-      }),
-      [FIELD.FIRST_NAME]: this.page.getByRole("textbox", {
-        name: /first name/i,
-      }),
-      [FIELD.LAST_NAME]: this.page.getByRole("textbox", {
-        name: /last name/i,
-      }),
-      [FIELD.PREFERRED_CONTACT_LANGUAGE]: this.page.getByRole("group", {
-        name: /preferred contact language/i,
       }),
       [FIELD.SAVE_AND_CONTINUE_BUTTON]: this.page.getByRole("button", {
         name: /save and continue/i,
@@ -176,28 +136,6 @@ class Registration extends AppPage {
     await this.locators[FIELD.ADDITIONAL_DETAILS].fill("additional details");
     await this.locators[FIELD.SAVE_AND_CONTINUE_BUTTON].click();
     // Need tp figure out the way to delete this UI created user
-  }
-
-  async getVerificationCode() {
-    const { id: meUserId } = await me(await this.context, {});
-    expect(meUserId).toMatch(uuidRegEx);
-
-    // pull the verification code from cache since we can't receive an email here
-    const cacheGetCommand = `echo Cache::get('email-verification-${meUserId}')['code']`;
-    const verificationCode = execSync(
-      `docker compose exec -w "/home/site/wwwroot/api" webserver sh -c "php artisan tinker --execute=\\"${cacheGetCommand}\\""`,
-      {
-        stdio: "pipe",
-        encoding: "utf8",
-      },
-    );
-    expect(verificationCode).toMatch(/[A-Z0-9]{6}/);
-    return verificationCode;
-  }
-
-  async verifyThrottlingMessageForVerificationCode() {
-    await this.locators[FIELD.SEND_VERIFICATION_EMAIL_BUTTON].click();
-    await expect(this.locators[FIELD.COUNTER_MESSAGE]).toBeVisible();
   }
 
   async skipAddRecentWorkExperience() {

--- a/apps/playwright/fixtures/Registration.ts
+++ b/apps/playwright/fixtures/Registration.ts
@@ -27,6 +27,7 @@ const FIELD = {
   LAST_NAME: "lastName",
   PREFERRED_CONTACT_LANGUAGE: "preferredContactLanguage",
   SAVE_AND_CONTINUE_BUTTON: "saveAndContinueButton",
+  SAVE_AND_CONTINUE_LINK: "saveAndContinueLink",
   ADD_MOST_RECENT_WORK_EXPERIENCE: "addMostRecentWorkExperience",
   MY_ROLE: "selectMyRole",
   EMPLOYMENT_CATEGORY: "selectEmploymentCategory",
@@ -36,6 +37,7 @@ const FIELD = {
   SENIORITY: "seniority",
   ADDITIONAL_DETAILS: "additionalDetails",
   SKIP_ADD_WORK_EXPERIENCE: "skipAddWorkExperience",
+  GOVERNMENT_EMPLOYEE_STATUS: "governmentEmployeeStatus",
 } as const;
 type ObjectValues<T> = T[keyof T];
 export type Field = ObjectValues<typeof FIELD>;
@@ -83,6 +85,9 @@ class Registration extends AppPage {
       [FIELD.SAVE_AND_CONTINUE_BUTTON]: this.page.getByRole("button", {
         name: /save and continue/i,
       }),
+      [FIELD.SAVE_AND_CONTINUE_LINK]: this.page.getByRole("link", {
+        name: /save and continue/i,
+      }),
       [FIELD.ADD_MOST_RECENT_WORK_EXPERIENCE]: this.page.getByRole("heading", {
         name: /add your most recent work experience/i,
         level: 2,
@@ -108,30 +113,34 @@ class Registration extends AppPage {
         name: /Skip this step/i,
         exact: true,
       }),
+      [FIELD.GOVERNMENT_EMPLOYEE_STATUS]: this.page.getByRole("group", {
+        name: /government employee status/i,
+      }),
     };
   }
 
   async gettingStarted() {
-    await loginBySub(this.page, this.uniqueTestId, false);
-    await this.page.goto(this.baseUrl);
+    // CanadaLogin provides this data for us
+    const claims = {
+      locale: "en",
+      // eslint-disable-next-line camelcase
+      given_name: this.firstName,
+      // eslint-disable-next-line camelcase
+      family_name: this.lastName,
+      email: this.uniqueEmailAddress,
+    };
+
+    await loginBySub(this.page, this.uniqueTestId, false, claims);
     await expect(this.locators[FIELD.GETTING_STARTED_HEADING]).toBeVisible();
   }
 
   async fillRegistrationForm() {
-    await this.locators[FIELD.EMAIL_ADDRESS].fill(this.uniqueEmailAddress);
-    await this.locators[FIELD.SEND_VERIFICATION_EMAIL_BUTTON].click();
-    await expect(
-      this.locators[FIELD.VERIFICATION_EMAIL_SENT_HEADING],
-    ).toBeVisible();
-    await this.verifyThrottlingMessageForVerificationCode();
-    const verificationCode = this.getVerificationCode();
-    await this.locators[FIELD.VERIFICATION_CODE].fill(await verificationCode);
-    await this.locators[FIELD.FIRST_NAME].fill(this.firstName);
-    await this.locators[FIELD.LAST_NAME].fill(this.lastName);
-    await this.locators[FIELD.PREFERRED_CONTACT_LANGUAGE]
-      .getByRole("radio", { name: /english/i })
+    await this.locators[FIELD.GOVERNMENT_EMPLOYEE_STATUS]
+      .getByRole("radio", {
+        name: /I currently work for the Government of Canada/i,
+      })
       .click();
-    await this.locators[FIELD.SAVE_AND_CONTINUE_BUTTON].click();
+    await this.locators[FIELD.SAVE_AND_CONTINUE_LINK].click();
     await expect(
       this.locators[FIELD.ADD_MOST_RECENT_WORK_EXPERIENCE],
     ).toBeVisible();

--- a/apps/playwright/tests/applicant/applicant-settings.spec.ts
+++ b/apps/playwright/tests/applicant/applicant-settings.spec.ts
@@ -39,21 +39,6 @@ test.describe("Applicant settings page", () => {
     }
   });
 
-  test("Work email removal", async ({ appPage }) => {
-    const settingsPage = new AccountSettings(appPage.page);
-    await loginBySub(appPage.page, sub);
-    await settingsPage.goToSettings();
-    await appPage.waitForGraphqlResponse("AccountSettingsDeprecated");
-    await settingsPage.removeWorkEmail();
-    // check changes
-    await expect(
-      appPage.page.getByText("No work email provided"),
-    ).toBeVisible();
-    await expect(
-      appPage.page.getByRole("button", { name: "Verify a GC work email" }),
-    ).toBeVisible();
-  });
-
   test("Account Settings update for New User", async ({ appPage }) => {
     // Register with new user and verify the email address
     const page = appPage.page;

--- a/apps/playwright/tests/applicant/applicant-settings.spec.ts
+++ b/apps/playwright/tests/applicant/applicant-settings.spec.ts
@@ -38,7 +38,7 @@ test.describe("Applicant settings page", () => {
     }
   });
 
-  test("Account Settings update for New User", async ({ appPage }) => {
+  test("Registration and work email for New User", async ({ appPage }) => {
     // Register with new user and verify the email address
     const page = appPage.page;
     const registration = new Registration(page);
@@ -55,7 +55,6 @@ test.describe("Applicant settings page", () => {
     const profilePage = new EmployeeProfile(page);
     await profilePage.goToEmployeeProfile();
     expect(await profilePage.workEmailVerificationLabel()).toBe("Verified");
-    // Update the contact email address and verify throttling message
     await registration.deleteNewUser();
   });
 });

--- a/apps/playwright/tests/applicant/applicant-settings.spec.ts
+++ b/apps/playwright/tests/applicant/applicant-settings.spec.ts
@@ -3,6 +3,7 @@ import type { User } from "@gc-digital-talent/graphql";
 
 import { test, expect } from "~/fixtures";
 import AccountSettings from "~/fixtures/AccountSettings";
+import EmployeeProfile from "~/fixtures/EmployeeProfile";
 import Registration from "~/fixtures/Registration";
 import { loginBySub } from "~/utils/auth";
 import graphql from "~/utils/graphql";
@@ -53,15 +54,10 @@ test.describe("Applicant settings page", () => {
       appPage.page.getByRole("link", { name: /Applicant dashboard/i }),
     ).toBeVisible();
     // Verify the 'Green Check mark' is displayed for personal and work email contact card
-    const settingsPage = new AccountSettings(page);
-    await settingsPage.goToSettings();
-    await expect(
-      settingsPage.page.getByRole("img", { name: /verified/i }).last(),
-    ).toBeVisible();
+    const profilePage = new EmployeeProfile(page);
+    await profilePage.goToEmployeeProfile();
+    expect(await profilePage.workEmailVerificationLabel()).toBe("Verified");
     // Update the contact email address and verify throttling message
-    await settingsPage.updateContactEmailAddress();
-    await registration.verifyThrottlingMessageForVerificationCode();
-    await appPage.page.getByRole("button", { name: /Cancel/i }).click();
     await registration.deleteNewUser();
   });
 

--- a/apps/playwright/tests/applicant/applicant-settings.spec.ts
+++ b/apps/playwright/tests/applicant/applicant-settings.spec.ts
@@ -2,10 +2,8 @@ import { nowUTCDateTime } from "@gc-digital-talent/date-helpers";
 import type { User } from "@gc-digital-talent/graphql";
 
 import { test, expect } from "~/fixtures";
-import AccountSettings from "~/fixtures/AccountSettings";
 import EmployeeProfile from "~/fixtures/EmployeeProfile";
 import Registration from "~/fixtures/Registration";
-import { loginBySub } from "~/utils/auth";
 import graphql from "~/utils/graphql";
 import { generateUniqueTestId } from "~/utils/id";
 import { createUserWithRoles, deleteUser } from "~/utils/user";

--- a/apps/playwright/tests/applicant/applicant-settings.spec.ts
+++ b/apps/playwright/tests/applicant/applicant-settings.spec.ts
@@ -60,14 +60,4 @@ test.describe("Applicant settings page", () => {
     // Update the contact email address and verify throttling message
     await registration.deleteNewUser();
   });
-
-  test("Existing User with Verified Emails", async ({ appPage }) => {
-    const settingsPage = new AccountSettings(appPage.page);
-    await loginBySub(appPage.page, sub);
-    await settingsPage.goToSettings();
-    await appPage.waitForGraphqlResponse("AccountSettingsDeprecated");
-    await expect(
-      settingsPage.page.getByRole("img", { name: /verified/i }).last(),
-    ).toBeVisible({ timeout: 30000 });
-  });
 });

--- a/apps/playwright/tests/applicant/employee-profile.spec.ts
+++ b/apps/playwright/tests/applicant/employee-profile.spec.ts
@@ -29,6 +29,22 @@ test.describe("Employee Profile", () => {
     });
   });
 
+  test("Work email removal", async ({ appPage }) => {
+    const profilePage = new EmployeeProfile(appPage.page);
+    await loginBySub(appPage.page, sub);
+    await appPage.page.goto("/en/applicant/employee-profile");
+    await appPage.waitForGraphqlResponse("EmployeeProfilePage");
+
+    expect(await profilePage.workEmailVerificationLabel()).toBe("Verified");
+
+    await profilePage.removeWorkEmail();
+    // check changes
+    await expect(
+      appPage.page.getByRole("button", { name: "Verify work email" }),
+    ).toBeVisible();
+    expect(await profilePage.workEmailVerificationLabel()).toBe("Not provided");
+  });
+
   test("Career development", async ({ appPage }) => {
     await loginBySub(appPage.page, sub);
     await appPage.page.goto("/en/applicant");

--- a/apps/playwright/tests/applicant/employee-profile.spec.ts
+++ b/apps/playwright/tests/applicant/employee-profile.spec.ts
@@ -3,6 +3,7 @@ import { nowUTCDateTime } from "@gc-digital-talent/date-helpers";
 import { test, expect } from "~/fixtures";
 import EmployeeProfile from "~/fixtures/EmployeeProfile";
 import { loginBySub } from "~/utils/auth";
+import type { GraphQLContext } from "~/utils/graphql";
 import graphql from "~/utils/graphql";
 import { generateUniqueTestId } from "~/utils/id";
 import { createUserWithRoles } from "~/utils/user";
@@ -11,11 +12,12 @@ test.describe("Employee Profile", () => {
   let uniqueTestId: string;
   let sub: string;
   let employeeProfile: EmployeeProfile;
+  let adminCtx: GraphQLContext;
 
   test.beforeAll(async () => {
     uniqueTestId = generateUniqueTestId();
     sub = `playwright.sub.${uniqueTestId}`;
-    const adminCtx = await graphql.newContext();
+    adminCtx = await graphql.newContext();
 
     await createUserWithRoles(adminCtx, {
       user: {
@@ -30,8 +32,23 @@ test.describe("Employee Profile", () => {
   });
 
   test("Work email removal", async ({ appPage }) => {
+    // create a new user to not mess up the shared user for other tests
+    const uniqueTestId2 = `${generateUniqueTestId()}2`;
+    const sub2 = `playwright.sub.${uniqueTestId2}`;
+
+    await createUserWithRoles(adminCtx, {
+      user: {
+        email: `${sub2}@example.org`,
+        sub: sub2,
+        isGovEmployee: true,
+        workEmail: `${sub2}@gc.ca`,
+        workEmailVerifiedAt: nowUTCDateTime(),
+      },
+      roles: ["guest", "base_user", "applicant"],
+    });
+
     const profilePage = new EmployeeProfile(appPage.page);
-    await loginBySub(appPage.page, sub);
+    await loginBySub(appPage.page, sub2);
     await appPage.page.goto("/en/applicant/employee-profile");
     await appPage.waitForGraphqlResponse("EmployeeProfilePage");
 

--- a/apps/playwright/tests/applicant/employee-profile.spec.ts
+++ b/apps/playwright/tests/applicant/employee-profile.spec.ts
@@ -45,6 +45,14 @@ test.describe("Employee Profile", () => {
     expect(await profilePage.workEmailVerificationLabel()).toBe("Not provided");
   });
 
+  test("Existing User with Verified Emails", async ({ appPage }) => {
+    const profilePage = new EmployeeProfile(appPage.page);
+    await loginBySub(appPage.page, sub);
+    await appPage.page.goto("/en/applicant/employee-profile");
+    await appPage.waitForGraphqlResponse("EmployeeProfilePage");
+    expect(await profilePage.workEmailVerificationLabel()).toBe("Verified");
+  });
+
   test("Career development", async ({ appPage }) => {
     await loginBySub(appPage.page, sub);
     await appPage.page.goto("/en/applicant");

--- a/apps/playwright/tests/verified-work-email.spec.ts
+++ b/apps/playwright/tests/verified-work-email.spec.ts
@@ -1,7 +1,6 @@
 import { FAR_PAST_DATE } from "@gc-digital-talent/date-helpers";
 
 import { test, expect } from "~/fixtures";
-import AccountSettings from "~/fixtures/AccountSettings";
 import AdminUser from "~/fixtures/AdminUser";
 import EmployeeProfile from "~/fixtures/EmployeeProfile";
 import { loginBySub } from "~/utils/auth";

--- a/apps/playwright/tests/verified-work-email.spec.ts
+++ b/apps/playwright/tests/verified-work-email.spec.ts
@@ -3,6 +3,7 @@ import { FAR_PAST_DATE } from "@gc-digital-talent/date-helpers";
 import { test, expect } from "~/fixtures";
 import AccountSettings from "~/fixtures/AccountSettings";
 import AdminUser from "~/fixtures/AdminUser";
+import EmployeeProfile from "~/fixtures/EmployeeProfile";
 import { loginBySub } from "~/utils/auth";
 import graphql from "~/utils/graphql";
 import { generateUniqueTestId } from "~/utils/id";
@@ -68,19 +69,18 @@ test.describe("Verified work email", () => {
     ).toBeVisible();
   });
 
-  test("Unverified user does not show icon in account settings", async ({
+  test("Unverified user does not show icon in employee profile", async ({
     appPage,
   }) => {
-    const accountSettings = new AccountSettings(appPage.appPage);
-    await loginBySub(accountSettings.page, unverified.sub);
-    await accountSettings.goToSettings();
+    const profilePage = new EmployeeProfile(appPage.page);
+    await loginBySub(profilePage.page, unverified.sub);
+    await appPage.page.goto("/en/applicant/employee-profile");
+    await appPage.waitForGraphqlResponse("EmployeeProfilePage");
+
+    expect(await profilePage.workEmailVerificationLabel()).toBe("Not verified");
 
     await expect(
-      accountSettings.page.getByRole("img", { name: /verified/i }),
-    ).toBeHidden();
-
-    await expect(
-      accountSettings.page.getByRole("button", {
+      profilePage.page.getByRole("button", {
         name: /re-verify work email/i,
       }),
     ).toBeVisible();

--- a/apps/playwright/utils/auth.ts
+++ b/apps/playwright/utils/auth.ts
@@ -112,7 +112,7 @@ export async function getTokenForSub(sub: string) {
  * Login by sub
  *
  * On UAT (TESTING_ENDPOINT_SECRET set): injects tokens directly into localStorage.
- * On local/CI: navigates through the mock GCKey UI.
+ * On local/CI: navigates through the mock auth UI.
  *
  * @param {Page} page
  * @param {String} sub
@@ -122,6 +122,7 @@ export async function loginBySub(
   page: Page,
   sub: string,
   notAuthorized?: boolean,
+  claims?: Record<string, string>,
 ) {
   if (process.env.TESTING_ENDPOINT_SECRET) {
     const tokens = await getTokenForSub(sub);
@@ -139,16 +140,21 @@ export async function loginBySub(
     return;
   }
 
-  // Local: navigate through mock GCKey UI
+  // Local: navigate through mock auth UI
   await page.goto("/en/login-info");
   await expect(
-    page.getByRole("heading", { name: /sign in using gckey/i }),
+    page.getByRole("heading", { name: /sign in using canadalogin/i }),
   ).toBeVisible();
   await page
-    .getByRole("link", { name: /sign in with gckey/i })
+    .getByRole("link", { name: /get started/i })
     .first()
     .click();
   await page.getByPlaceholder("Enter any user/subject").fill(sub);
+  if (claims) {
+    await page
+      .getByRole("textbox", { name: "Claims" })
+      .fill(JSON.stringify(claims));
+  }
   await page.getByRole("button", { name: /sign in/i }).click();
   if (notAuthorized) {
     await expect(

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -23,7 +23,7 @@ OAUTH_LOGOUT_URI="http://localhost:8000/oxauth/endsession"
 OAUTH_MANAGE_ACCOUNT_URI="https://app.test.login-connexion.alpha.canada.ca?rp_client_id=XYZ"
 
 # Feature flags
-FEATURE_CANADALOGIN=false
+FEATURE_CANADALOGIN=true
 FEATURE_GRAPHQL_SUBSCRIPTIONS=false
 FEATURE_ACTIVITY_TIMER=false
 FEATURE_AUTH_IN_APP_MIGRATION=false

--- a/apps/web/src/components/EmployeeVerificationSection/EmployeeVerificationSection.tsx
+++ b/apps/web/src/components/EmployeeVerificationSection/EmployeeVerificationSection.tsx
@@ -5,6 +5,7 @@ import XCircleIcon from "@heroicons/react/24/solid/XCircleIcon";
 import ExclamationCircleIcon from "@heroicons/react/24/solid/ExclamationCircleIcon";
 import LockClosedIcon from "@heroicons/react/24/solid/LockClosedIcon";
 import { tv, type VariantProps } from "tailwind-variants";
+import { useId } from "react";
 
 import { Button, Card, Heading, Link, Ul } from "@gc-digital-talent/ui";
 import { commonMessages } from "@gc-digital-talent/i18n";
@@ -78,6 +79,9 @@ const EmployeeVerificationSection = ({
 }: EmployeeVerificationSectionProps) => {
   const intl = useIntl();
   const paths = useRoutes();
+  const workEmailCardHeadingId = useId();
+  const workExperienceCardHeadingId = useId();
+  const communityCardHeadingId = useId();
 
   const user = getFragment(UserEmployeeVerification_Fragment, userQuery);
   const communityInterests = user.employeeProfile?.communityInterests ?? [];
@@ -110,9 +114,13 @@ const EmployeeVerificationSection = ({
             })}
       </p>
       <div className={grid({ context })}>
-        <Card className="grid gap-3">
+        <Card
+          className="grid gap-3"
+          role="group"
+          aria-labelledby={workEmailCardHeadingId}
+        >
           <div className="flex min-h-8.5 flex-col gap-3 wrap-break-word">
-            <p className="font-bold">
+            <p className="font-bold" id={workEmailCardHeadingId}>
               {intl.formatMessage({
                 defaultMessage: "Work email verification",
                 id: "1zsfA7",
@@ -202,9 +210,13 @@ const EmployeeVerificationSection = ({
             </div>
           )}
         </Card>
-        <Card className="grid gap-3">
+        <Card
+          className="grid gap-3"
+          role="group"
+          aria-labelledby={workExperienceCardHeadingId}
+        >
           <div className="flex min-h-8.5 flex-col gap-3">
-            <p className="font-bold">
+            <p className="font-bold" id={workExperienceCardHeadingId}>
               {intl.formatMessage({
                 defaultMessage: "Current work experience",
                 id: "b9aCAt",
@@ -280,9 +292,13 @@ const EmployeeVerificationSection = ({
           )}
         </Card>
         {context === "applicant" && (
-          <Card className="grid gap-3">
+          <Card
+            className="grid gap-3"
+            role="group"
+            aria-labelledby={communityCardHeadingId}
+          >
             <div className="flex min-h-8.5 flex-col gap-3">
-              <p className="font-bold">
+              <p className="font-bold" id={communityCardHeadingId}>
                 {intl.formatMessage({
                   defaultMessage: "Functional communities",
                   id: "QuVtMh",


### PR DESCRIPTION
Related to (but does not close) #16203 

## 👋 Introduction

This is the first in a series of "remove SIC" PRs.
This updates the Playwright tests for the new CanadaLogin version of the app.

## 🕵️ Details

1. Flips the feature flag to default true
1. Updates the employee verification section of the make it easier to check the verification checkmarks (and improves a11y)
2. Allows login fixture to provide name and email on login (like CanadaLogin does)
3. Some tests moved around since email verification moved from settings to employee profile
4. Can no longer manually update name or contact email


## 🧪 Testing

- [ ] All tests reliably pass
- [ ] Changes make sense
- [ ] Employee verification section of employee profile still works

