### PR TITLE
[Fix] Slow community interest query

### DIFF
--- a/api/app/Builders/CommunityInterestBuilder.php
+++ b/api/app/Builders/CommunityInterestBuilder.php
@@ -20,31 +20,29 @@ class CommunityInterestBuilder extends Builder implements TalentRequestMatchable
     {
         $filters ??= [];
         $qualifiedInClassifications = $filters['qualifiedInClassifications'] ?? null;
-
-        if (! empty($qualifiedInClassifications)) {
-            $this->whereHas('user', function (Builder $userQuery) use ($qualifiedInClassifications) {
-                /** @var UserBuilder $userQuery */
-                $userQuery->whereHas('currentClassification', function (Builder $classQuery) use ($qualifiedInClassifications) {
-                    $classQuery->where(function (Builder $q) use ($qualifiedInClassifications) {
-                        foreach ($qualifiedInClassifications as $classification) {
-                            $q->orWhere(function (Builder $q) use ($classification) {
-                                $q->where('group', $classification['group'])
-                                    ->where('level', $classification['level']);
-                            });
-                        }
-                    });
-                })->whereIsVerifiedGovEmployee();
-            });
-        }
-
         $community = $filters['community'] ?? null;
         $communityId = is_array($community) ? ($community['id'] ?? null) : $community;
 
-        $this->workStreams(array_column($filters['qualifiedInWorkStreams'] ?? [], 'id'));
-        $this->communities($communityId ? [$communityId] : null);
-        $this->where('consent_to_share_profile', true);
-
-        return $this;
+        return $this
+            ->whereHas('user', function (Builder $userQuery) use ($qualifiedInClassifications) {
+                /** @var UserBuilder $userQuery */
+                $userQuery->whereIsVerifiedGovEmployee()
+                    ->when($qualifiedInClassifications, function (UserBuilder $query, array $classifications) {
+                        $query->whereHas('currentClassification', function (Builder $classQuery) use ($classifications) {
+                            $classQuery->where(function (Builder $q) use ($classifications) {
+                                foreach ($classifications as $classification) {
+                                    $q->orWhere(function (Builder $q) use ($classification) {
+                                        $q->where('group', $classification['group'])
+                                            ->where('level', $classification['level']);
+                                    });
+                                }
+                            });
+                        });
+                    });
+            })
+            ->workStreams(array_column($filters['qualifiedInWorkStreams'] ?? [], 'id'))
+            ->communities($communityId ? [$communityId] : null)
+            ->where('consent_to_share_profile', true);
     }
 
     // scope the query to CommunityInterests the current user can view

--- a/api/app/Builders/CommunityInterestBuilder.php
+++ b/api/app/Builders/CommunityInterestBuilder.php
@@ -19,30 +19,40 @@ class CommunityInterestBuilder extends Builder implements TalentRequestMatchable
     public function whereMatchesTalentRequest(?array $filters): self
     {
         $filters ??= [];
-        $qualifiedInClassifications = $filters['qualifiedInClassifications'] ?? null;
         $community = $filters['community'] ?? null;
         $communityId = is_array($community) ? ($community['id'] ?? null) : $community;
 
+        $userIds = $this->atLevelUserIds($filters['qualifiedInClassifications'] ?? null);
+
+        // Match the ids as one Postgres array value, so the number of ids has no limit.
+        $userIdArray = '{'.$userIds->implode(',').'}';
+
         return $this
-            ->whereHas('user', function (Builder $userQuery) use ($qualifiedInClassifications) {
-                /** @var UserBuilder $userQuery */
-                $userQuery->whereIsVerifiedGovEmployee()
-                    ->when($qualifiedInClassifications, function (UserBuilder $query, array $classifications) {
-                        $query->whereHas('currentClassification', function (Builder $classQuery) use ($classifications) {
-                            $classQuery->where(function (Builder $q) use ($classifications) {
-                                foreach ($classifications as $classification) {
-                                    $q->orWhere(function (Builder $q) use ($classification) {
-                                        $q->where('group', $classification['group'])
-                                            ->where('level', $classification['level']);
-                                    });
-                                }
-                            });
-                        });
-                    });
-            })
+            ->whereRaw('community_interests.user_id = any(?::uuid[])', [$userIdArray])
             ->workStreams(array_column($filters['qualifiedInWorkStreams'] ?? [], 'id'))
             ->communities($communityId ? [$communityId] : null)
             ->where('consent_to_share_profile', true);
+    }
+
+    // Ids of verified gov employees whose current classification is one of the requested pairs.
+    private function atLevelUserIds(?array $qualifiedInClassifications)
+    {
+        return User::query()
+            ->whereIsVerifiedGovEmployee()
+            ->when($qualifiedInClassifications, function (Builder $query, array $classifications) {
+                /** @var UserBuilder $query */
+                $query->whereHas('currentClassification', function (Builder $classQuery) use ($classifications) {
+                    $classQuery->where(function (Builder $q) use ($classifications) {
+                        foreach ($classifications as $classification) {
+                            $q->orWhere(function (Builder $q) use ($classification) {
+                                $q->where('group', $classification['group'])
+                                    ->where('level', $classification['level']);
+                            });
+                        }
+                    });
+                });
+            })
+            ->pluck('id');
     }
 
     // scope the query to CommunityInterests the current user can view

--- a/api/app/Builders/CommunityInterestBuilder.php
+++ b/api/app/Builders/CommunityInterestBuilder.php
@@ -22,7 +22,7 @@ class CommunityInterestBuilder extends Builder implements TalentRequestMatchable
         $community = $filters['community'] ?? null;
         $communityId = is_array($community) ? ($community['id'] ?? null) : $community;
 
-        $userIds = $this->atLevelUserIds($filters['qualifiedInClassifications'] ?? null);
+        $userIds = $this->atLevelUserIds($filters);
 
         // Match the ids as one Postgres array value, so the number of ids has no limit.
         $userIdArray = '{'.$userIds->implode(',').'}';
@@ -34,11 +34,16 @@ class CommunityInterestBuilder extends Builder implements TalentRequestMatchable
             ->where('consent_to_share_profile', true);
     }
 
-    // Ids of verified gov employees whose current classification is one of the requested pairs.
-    private function atLevelUserIds(?array $qualifiedInClassifications)
+    // Ids of the users who match "at level": verified gov employees at a requested classification
+    // who also pass the request's user-level filters. Because these ids carry the full user match,
+    // callers do not need a second user check.
+    private function atLevelUserIds(array $filters)
     {
+        $qualifiedInClassifications = $filters['qualifiedInClassifications'] ?? null;
+
         return User::query()
             ->whereIsVerifiedGovEmployee()
+            ->whereUserAttributesMatchTalentRequest($filters)
             ->when($qualifiedInClassifications, function (Builder $query, array $classifications) {
                 /** @var UserBuilder $query */
                 $query->whereHas('currentClassification', function (Builder $classQuery) use ($classifications) {

--- a/api/app/Builders/UserBuilder.php
+++ b/api/app/Builders/UserBuilder.php
@@ -341,19 +341,7 @@ class UserBuilder extends Builder
             }
         });
 
-        // user-level attribute and location filters
-        $this->whereHasDiploma($filters['hasDiploma'] ?? null)
-            ->whereEquityIn($filters['equity'] ?? null)
-            ->whereLanguageAbility($filters['languageAbility'] ?? null)
-            ->whereOperationalRequirementsIn($filters['operationalRequirements'] ?? null)
-            ->wherePositionDurationIn($filters['positionDuration'] ?? null)
-            ->whereSkillsAdditive($skillIds)
-            ->whereSkillsIntersectional($filters['skillsIntersectional'] ?? [])
-            ->whereFlexibleLocationAndRegionSpecialMatching(
-                $filters['locationPreferences'] ?? null,
-                $filters['flexibleWorkLocations'] ?? null
-            );
-
+        $this->whereUserAttributesMatchTalentRequest($filters);
         $this->addSkillCountSelect($skillIds);
         $this->withTalentRequestMatches($filters);
 
@@ -364,6 +352,24 @@ class UserBuilder extends Builder
         }
 
         return $this;
+    }
+
+    // Only the request's user-level attribute and location filters.
+    public function whereUserAttributesMatchTalentRequest(?array $args): self
+    {
+        $filters = $args ? ($args['applicantFilter'] ?? $args) : [];
+
+        return $this->whereHasDiploma($filters['hasDiploma'] ?? null)
+            ->whereEquityIn($filters['equity'] ?? null)
+            ->whereLanguageAbility($filters['languageAbility'] ?? null)
+            ->whereOperationalRequirementsIn($filters['operationalRequirements'] ?? null)
+            ->wherePositionDurationIn($filters['positionDuration'] ?? null)
+            ->whereSkillsAdditive($filters['skills'] ?? [])
+            ->whereSkillsIntersectional($filters['skillsIntersectional'] ?? [])
+            ->whereFlexibleLocationAndRegionSpecialMatching(
+                $filters['locationPreferences'] ?? null,
+                $filters['flexibleWorkLocations'] ?? null
+            );
     }
 
     public function withTalentRequestMatches(array $filters): self

--- a/api/app/GraphQL/Queries/CountTalentRequestMatchesByCommunity.php
+++ b/api/app/GraphQL/Queries/CountTalentRequestMatchesByCommunity.php
@@ -48,9 +48,10 @@ final class CountTalentRequestMatchesByCommunity
         }
 
         if (in_array(TalentRequestSource::AT_LEVEL, $selected, true)) {
+            // whereMatchesTalentRequest already limits to users who fully match, so no second
+            // user check is needed here.
             $subQueries[] = CommunityInterest::query()
                 ->whereMatchesTalentRequest($applicantFilter)
-                ->whereHas('user', fn ($user) => $user->whereMatchesTalentRequest($filters))
                 ->select('community_interests.user_id', 'community_interests.community_id')
                 ->selectRaw("'interest' as source");
         }

--- a/api/database/migrations/2026_07_22_150810_add_index_to_users_current_classification.php
+++ b/api/database/migrations/2026_07_22_150810_add_index_to_users_current_classification.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+return new class() extends Migration
 {
     public function up(): void
     {

--- a/api/database/migrations/2026_07_22_150810_add_index_to_users_current_classification.php
+++ b/api/database/migrations/2026_07_22_150810_add_index_to_users_current_classification.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->index('computed_classification');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropIndex(['computed_classification']);
+        });
+    }
+};

--- a/api/tests/Feature/TalentRequestMatchesTest.php
+++ b/api/tests/Feature/TalentRequestMatchesTest.php
@@ -1122,7 +1122,11 @@ class TalentRequestMatchesTest extends TestCase
     {
         $community = Community::factory()->create();
 
-        $user = User::factory()->create();
+        $user = User::factory()->create([
+            'work_email' => 'verified.employee@gc.ca',
+            'work_email_verified_at' => now(),
+            'computed_is_gov_employee' => true,
+        ]);
         $interest = CommunityInterest::factory()->consented()->create([
             'user_id' => $user->id,
             'community_id' => $community->id,
@@ -1142,7 +1146,11 @@ class TalentRequestMatchesTest extends TestCase
     {
         $community = Community::factory()->create();
 
-        $consented = User::factory()->create();
+        $consented = User::factory()->create([
+            'work_email' => 'verified.employee@gc.ca',
+            'work_email_verified_at' => now(),
+            'computed_is_gov_employee' => true,
+        ]);
         CommunityInterest::factory()->consented()->create([
             'user_id' => $consented->id,
             'community_id' => $community->id,
@@ -1165,7 +1173,11 @@ class TalentRequestMatchesTest extends TestCase
         $matching = Community::factory()->create();
         $other = Community::factory()->create();
 
-        $included = User::factory()->create();
+        $included = User::factory()->create([
+            'work_email' => 'verified.employee@gc.ca',
+            'work_email_verified_at' => now(),
+            'computed_is_gov_employee' => true,
+        ]);
         CommunityInterest::factory()->consented()->create([
             'user_id' => $included->id,
             'community_id' => $matching->id,
@@ -1215,7 +1227,11 @@ class TalentRequestMatchesTest extends TestCase
         // QUALIFIED_IN_POOL only — no community interest
         $this->matchingUser($pool);
 
-        $atLevelUser = User::factory()->create();
+        $atLevelUser = User::factory()->create([
+            'work_email' => 'verified.employee@gc.ca',
+            'work_email_verified_at' => now(),
+            'computed_is_gov_employee' => true,
+        ]);
         $interest = CommunityInterest::factory()->consented()->create([
             'user_id' => $atLevelUser->id,
             'community_id' => $community->id,
@@ -1234,7 +1250,11 @@ class TalentRequestMatchesTest extends TestCase
     {
         $community = Community::factory()->withWorkStreams()->create();
 
-        $user = User::factory()->create();
+        $user = User::factory()->create([
+            'work_email' => 'verified.employee@gc.ca',
+            'work_email_verified_at' => now(),
+            'computed_is_gov_employee' => true,
+        ]);
         $interest = CommunityInterest::factory()->consented()->withWorkStreams()->for($user)->for($community)->create();
         $workStreamId = $interest->workStreams()->first()->id;
 
@@ -1317,7 +1337,11 @@ class TalentRequestMatchesTest extends TestCase
 
         $poolUser = $this->matchingUser($pool);
 
-        $atLevelUser = User::factory()->create();
+        $atLevelUser = User::factory()->create([
+            'work_email' => 'verified.employee@gc.ca',
+            'work_email_verified_at' => now(),
+            'computed_is_gov_employee' => true,
+        ]);
         CommunityInterest::factory()->consented()->create([
             'user_id' => $atLevelUser->id,
             'community_id' => $community->id,


### PR DESCRIPTION
🤖 Resolves #17496 

## 👋 Introduction

Fixes an issue where the query for matching community interests to a talent request was slow.

## 🕵️ Details

The main fix was adding the index to `computed_classification`. I was refactoring the scope to test but that did not do much for us. However, i did leave some of refactoring in since it made it easier to read so, hopefully that is okay :sweat_smile: 

## 🧪 Testing

1. Run migration `make artisan migrate`
2. Seed alot of matching community interests tracked users (1000 or so should be fine)
3. Login as `admin@test.com`
4. Navigate to the candidate tracking tab for that talent request
5. Increase page size of the tracked users and matching candidates components
6. Confirm the query does not time out and completes in a reasonable time (hopeulf under 10s :crossed_fingers: )