### PR TITLE
[Fix] Hide talent source input

### DIFF
--- a/apps/playwright/fixtures/TalentSearch.ts
+++ b/apps/playwright/fixtures/TalentSearch.ts
@@ -67,8 +67,6 @@ class TalentSearch extends AppPage {
   ) {
     const poolCard = await this.poolCardVisibility(poolName);
 
-    await this.page.getByRole("checkbox", { name: /pool candidates/i }).click();
-
     const selectedClassification = classification.groupAndLevel;
     const classificationFilter = this.page.getByRole("combobox", {
       name: /classification/i,

--- a/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -1,4 +1,4 @@
-import { useIntl, type MessageDescriptor } from "react-intl";
+import { useIntl } from "react-intl";
 
 import {
   notEmpty,
@@ -18,10 +18,7 @@ import type {
   LocalizedEnumString,
   LocalizedTalentRequestSource,
 } from "@gc-digital-talent/graphql";
-import {
-  FlexibleWorkLocation,
-  TalentRequestSource,
-} from "@gc-digital-talent/graphql";
+import { FlexibleWorkLocation } from "@gc-digital-talent/graphql";
 
 import { getShortPoolTitleHtml } from "~/utils/poolUtils";
 import { wrapAbbr } from "~/utils/nameUtils";
@@ -44,7 +41,6 @@ const ApplicantFilters = ({
   applicantFilter,
   selectedClassifications,
   flexibleWorkLocationOptions,
-  talentSourceOptions = [],
 }: {
   applicantFilter?: PartialApplicantFilter | null;
   selectedClassifications?: (
@@ -53,7 +49,6 @@ const ApplicantFilters = ({
     | undefined
   )[];
   flexibleWorkLocationOptions: LocalizedEnumString[];
-  talentSourceOptions?: LocalizedTalentRequestSource[];
 }) => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -126,21 +121,6 @@ const ApplicantFilters = ({
     applicantFilter?.qualifiedInWorkStreams?.flatMap((stream) => stream?.name),
   ).map((label) => getLocalizedName(label, intl));
 
-  // TODO: remove this filter once Advancement is implemented, see #17382
-  const talentSourceOptionsFiltered = talentSourceOptions.filter(
-    (source) => source.value !== TalentRequestSource.Advancement,
-  );
-  const filterTalentSources = unpackMaybes(
-    applicantFilter?.talentSources?.map((source) => source?.value),
-  );
-  const talentSourceLabels: Partial<
-    Record<TalentRequestSource, MessageDescriptor>
-  > = {
-    [TalentRequestSource.QualifiedInPool]:
-      talentRequestMessages.qualifiedInPoolLabel,
-    [TalentRequestSource.AtLevel]: talentRequestMessages.atLevelLabel,
-  };
-
   const communityName: string = applicantFilter?.community
     ? getLocalizedName(applicantFilter.community.name, intl)
     : intl.formatMessage({
@@ -161,34 +141,6 @@ const ApplicantFilters = ({
     <section className="grid gap-6 xs:grid-cols-2">
       <div>
         <div>
-          <FilterBlock
-            title={intl.formatMessage(talentRequestMessages.talentSource)}
-            content={
-              <Ul unStyled noIndent inside>
-                {talentSourceOptionsFiltered.map((source) => {
-                  const messageDescriptor = talentSourceLabels[source.value];
-                  const label = messageDescriptor
-                    ? intl.formatMessage(messageDescriptor)
-                    : (source.label?.localized ??
-                      intl.formatMessage(commonMessages.notAvailable));
-
-                  return (
-                    <li key={source.value}>
-                      <BoolCheckIcon
-                        value={filterTalentSources.includes(source.value)}
-                        trueLabel={intl.formatMessage(commonMessages.selected)}
-                        falseLabel={intl.formatMessage(
-                          commonMessages.notSelected,
-                        )}
-                      >
-                        {label}
-                      </BoolCheckIcon>
-                    </li>
-                  );
-                })}
-              </Ul>
-            }
-          />
           <FilterBlock
             title={intl.formatMessage(talentRequestMessages.community)}
             content={communityName}
@@ -342,7 +294,6 @@ const SearchRequestFilters = ({
   filters,
   selectedClassifications,
   flexibleWorkLocationOptions,
-  talentSourceOptions,
 }: SearchRequestFiltersProps) => {
   const intl = useIntl();
   let poolCandidateFilter;
@@ -352,7 +303,6 @@ const SearchRequestFilters = ({
         applicantFilter={filters}
         selectedClassifications={selectedClassifications}
         flexibleWorkLocationOptions={flexibleWorkLocationOptions}
-        talentSourceOptions={talentSourceOptions}
       />
     );
   }

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -12618,10 +12618,6 @@
     "defaultMessage": "2. <strong>Balayez le code QR</strong> ou <strong>saisissez votre code secret</strong> au moyen de votre application d’authentification à deux facteurs.",
     "description": "Text for second sign up -> mfa step."
   },
-  "mXWCC2": {
-    "defaultMessage": "Employés de même niveau disposés à accepter une mutation latérale",
-    "description": "Checklist option explanatory note"
-  },
   "mYnQH4": {
     "defaultMessage": "Ce processus n'a pas de plan d'évaluation.",
     "description": "A process has no assessment plan"
@@ -14325,10 +14321,6 @@
   "tUIvbq": {
     "defaultMessage": "Adresse courriel non confirmée",
     "description": "The email address has not been verified to be owned by user"
-  },
-  "tUObm7": {
-    "defaultMessage": "Candidats qualifiés du bassin",
-    "description": "Checklist option explanatory note"
   },
   "tXLRmG": {
     "defaultMessage": "Je ne suis pas à la recherche d'une promotion ou d'un avancement pour l'instant.",

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -705,7 +705,6 @@ export const RequestForm = ({
             flexibleWorkLocationOptions={unpackMaybes(
               optionsData?.flexibleWorkLocations,
             )}
-            talentSourceOptions={talentSourceOptionsData}
           />
           <Separator />
           <p className="mb-6 font-bold">

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/FormFields.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/FormFields.tsx
@@ -16,7 +16,6 @@ import {
   errorMessages,
   getEmploymentEquityGroup,
   getLocalizedName,
-  narrowEnumType,
   sortFlexibleWorkLocations,
   sortWorkRegion,
 } from "@gc-digital-talent/i18n";
@@ -27,7 +26,6 @@ import type {
 } from "@gc-digital-talent/graphql";
 import {
   FlexibleWorkLocation,
-  TalentRequestSource,
   WorkRegion,
   graphql,
 } from "@gc-digital-talent/graphql";
@@ -160,47 +158,6 @@ const FormFields = ({
       label: loc.label,
     };
   });
-
-  const talentSourceOptionsData = narrowEnumType(
-    unpackMaybes(data?.talentSources),
-    "TalentRequestSource",
-  )
-    // TODO: remove this filter once Advancement is implemented, see #17382
-    .filter((source) => source.value !== TalentRequestSource.Advancement);
-
-  const talentSourceOptions: CheckboxOption[] = talentSourceOptionsData.map(
-    (source) => {
-      if (source.value === TalentRequestSource.QualifiedInPool) {
-        return {
-          value: source.value,
-          label: intl.formatMessage(talentRequestMessages.qualifiedInPoolLabel),
-          contentBelow: intl.formatMessage({
-            defaultMessage: "Candidates qualified in a pool",
-            id: "tUObm7",
-            description: "Checklist option explanatory note",
-          }),
-        };
-      }
-      if (source.value === TalentRequestSource.AtLevel) {
-        return {
-          value: source.value,
-          label: intl.formatMessage(talentRequestMessages.atLevelLabel),
-          contentBelow: intl.formatMessage({
-            defaultMessage:
-              "At-level GC employees who have self-identified as interested in lateral movement",
-            id: "mXWCC2",
-            description: "Checklist option explanatory note",
-          }),
-        };
-      }
-      return {
-        value: source.value,
-        label:
-          source.label?.localized ??
-          intl.formatMessage(commonMessages.notAvailable),
-      };
-    },
-  );
 
   return (
     <>

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/FormFields.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/FormFields.tsx
@@ -6,6 +6,7 @@ import type { CheckboxOption } from "@gc-digital-talent/forms";
 import {
   Checklist,
   Field,
+  HiddenInput,
   RadioGroup,
   Select,
   localizedEnumToOptions,
@@ -215,16 +216,7 @@ const FormFields = ({
         })}
       >
         <div className="flex flex-col gap-y-6">
-          <Checklist
-            idPrefix="talentSources"
-            id="talentSources"
-            name="talentSources"
-            legend={intl.formatMessage(talentRequestMessages.talentSource)}
-            items={talentSourceOptions}
-            rules={{
-              required: intl.formatMessage(errorMessages.required),
-            }}
-          />
+          <HiddenInput name="talentSources" />
           <p>
             {intl.formatMessage({
               defaultMessage:

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -56,20 +56,22 @@ export const SearchForm = ({
   // set some fields to a desired default (form)
   const defaultValuesAdjusted = {
     ...defaultValues,
+    talentSources: [TalentRequestSource.QualifiedInPool],
     flexibleWorkLocations: [
       FlexibleWorkLocation.Remote,
       FlexibleWorkLocation.Hybrid,
     ],
-  };
+  } satisfies FormValues;
 
   // set some fields to a desired default (query)
   const initialFiltersAdjusted = {
     ...initialFilters,
+    talentSources: [TalentRequestSource.QualifiedInPool],
     flexibleWorkLocations: [
       FlexibleWorkLocation.Remote,
       FlexibleWorkLocation.Hybrid,
     ],
-  };
+  } satisfies ApplicantFilterInput;
 
   const [applicantFilter, setApplicantFilter] = useState<ApplicantFilterInput>(
     initialFiltersAdjusted,


### PR DESCRIPTION
🤖 Resolves #17494 

## 👋 Introduction

Hides the talent source selection and hardcodes the value to the "Qualified in pool" talent source only.

## 🕵️ Details

The users indicated that while having community interests can be helpful, its not exactyl right and don't need to give the users the ability to select one. This hardcodes the talent source so that the new talent source is only used by the discretion of the recruiter.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Navigate to `/search`
3. Confirm talent sources input no longer exists
4. Confirm request gets subnmitted with only qualifed in pools talent source
5. Confirm no references to community talent/users/at level appears on the search page