### PR TITLE
[Refactor] Add download without contact info to tracked users inbox

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -10974,10 +10974,6 @@
     "defaultMessage": "Commencez par compléter l'information de base de votre compte.",
     "description": "Subtitle for the registration pages"
   },
-  "g0nMAt": {
-    "defaultMessage": "Télécharger la sélection au format Word (.docx)",
-    "description": "Menu option to download selected tracked users as a document"
-  },
   "g1WB3B": {
     "defaultMessage": "Ajouter une expérience",
     "description": "Title for add experience page"

--- a/apps/web/src/pages/TalentRequests/components/TalentRequestTrackedUsersInbox/TalentRequestTrackedUsersInbox.tsx
+++ b/apps/web/src/pages/TalentRequests/components/TalentRequestTrackedUsersInbox/TalentRequestTrackedUsersInbox.tsx
@@ -198,11 +198,11 @@ const TalentRequestTrackedUsersInbox = ({
     downloadExcel({ ids: selectedUserIds });
   };
 
-  const handleDownloadDocument = () => {
+  const handleDownloadDocument = (anonymous: boolean) => {
     if (selectedUserIds.length === 1) {
-      downloadDoc({ id: selectedUserIds[0], anonymous: false });
+      downloadDoc({ id: selectedUserIds[0], anonymous });
     } else {
-      downloadZip({ ids: selectedUserIds, anonymous: false });
+      downloadZip({ ids: selectedUserIds, anonymous });
     }
   };
 
@@ -339,12 +339,19 @@ const TalentRequestTrackedUsersInbox = ({
                   "Menu option to download selected tracked users as a spreadsheet",
               })}
             </DropdownMenu.Item>
-            <DropdownMenu.Item onClick={handleDownloadDocument}>
+            <DropdownMenu.Item onClick={() => handleDownloadDocument(false)}>
               {intl.formatMessage({
-                defaultMessage: "Download selected as a document (.docx)",
-                id: "g0nMAt",
+                defaultMessage: "Download profile",
+                id: "lVOZ5k",
+                description: "Button label for downloading user profiles",
+              })}
+            </DropdownMenu.Item>
+            <DropdownMenu.Item onClick={() => handleDownloadDocument(true)}>
+              {intl.formatMessage({
+                defaultMessage: "Download profile without contact information",
+                id: "wZP4RN",
                 description:
-                  "Menu option to download selected tracked users as a document",
+                  "Button label for downloading anonymized user profiles",
               })}
             </DropdownMenu.Item>
           </DropdownMenu.Popup>

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
@@ -200,10 +200,7 @@ const UserTable = ({ title }: UserTableProps) => {
     if (selectedRows.length === 1) {
       downloadDoc({ id: selectedRows[0], anonymous });
     } else {
-      downloadZip({
-        ids: selectedRows,
-        anonymous,
-      });
+      downloadZip({ ids: selectedRows, anonymous });
     }
   };
 


### PR DESCRIPTION
🤖 Resolves #17500 

## 👋 Introduction

- Adds download without contact info to the Candidate Tracking inbox

## 🧪 Testing

1. Build font-end
2. Login as admin
3. Go to candidate tracking tab on talent request
4. Select one user in inbox (might need to change status to find one)
5. Ensure downloading works with contact and without contact info
6. Select more than one user
7. Ensure downloading zip works with contact and without contact info

## 📸 Screenshot

<img width="1055" height="791" alt="image" src="https://github.com/user-attachments/assets/005e21b6-6c96-491e-b63e-af9b3825a0e1" />
