### PR TITLE
[Refactor] Add index for slow SQL

### DIFF
--- a/api/database/migrations/2026_07_22_181152_add_education_index.php
+++ b/api/database/migrations/2026_07_22_181152_add_education_index.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('pool_candidate_education_requirement_experience', function (Blueprint $table) {
+            $table->index(
+                'pool_candidate_id',
+                name: 'pool_candidate_education_requirement_experience_idx1' // the auto-generated name gets truncated and is not useful
+            );
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('pool_candidate_education_requirement_experience', function (Blueprint $table) {
+            $table->dropIndex('pool_candidate_education_requirement_experience_idx1');
+        });
+    }
+};


### PR DESCRIPTION
🤖 Resolves #17306 

## 👋 Introduction

Adds an index to speed up some slow SQL.

## 🧪 Testing

1. Seed a bunch of pool candidates.
2. Ensure you have a bunch of rows in `pool_candidate_education_requirement_experience`.  I tested with about 1500.
3. Test with the SQL before and after the migration.  
    - [ ] Confirm it's moved from a seq scan to an index scan
    - [ ] Confirm the execution is faster

Some testing sql :point_down: 
```sql
explain analyze 
select "experience_id" from "pool_candidate_education_requirement_experience" 
where "pool_candidate_id" = 'cec83ad5-d3a0-4a5b-aba9-39ee1076193e'
```

## 📸 Screenshot

<img width="1581" height="561" alt="image" src="https://github.com/user-attachments/assets/cb7a14ac-1c60-48d2-8e5c-b39ab16e995f" />


## 🚚 Deployment

https://github.com/GCTC-NTGC/gc-digital-talent/issues/17509