### PR TITLE
[Fix] Talent request tracked users flaky test

### DIFF
--- a/api/tests/Feature/TalentRequestTrackedUserTest.php
+++ b/api/tests/Feature/TalentRequestTrackedUserTest.php
@@ -1911,7 +1911,9 @@ class TalentRequestTrackedUserTest extends TestCase
     private function seedReferredMatchingUsers(int $count): TalentRequest
     {
         $classification = Classification::factory()->create();
-        $filter = ApplicantFilter::factory()->for($this->community)->create();
+        $filter = ApplicantFilter::factory()->for($this->community)->create([
+            'talent_sources' => [TalentRequestSource::QUALIFIED_IN_POOL->name],
+        ]);
         $filter->qualifiedInClassifications()->sync([$classification->id]);
 
         $request = TalentRequest::factory()


### PR DESCRIPTION
🤖 Resolves #17530 

## 👋 Introduction

Fixes an issue where the test was failing somer of the time.

## 🕵️ Details

We had random talent sources but, were using pool candidates to run the tests. So, if they random sources did not include `QUALIFIED_IN_POOL` then the test would fail. This hardcodes that talent source to keep the test consistent.

## 🧪 Testing

1. Run the test atleast 30 times (doesnt fail too often)
2. Confirm all runs pass