### PR TITLE
Git ignore mcp.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage
 
 .claude/settings.local.json
 CLAUDE.local.md
+.mcp.json


### PR DESCRIPTION
## 👋 Introduction

I've been playing around [MCP](https://modelcontextprotocol.io/docs/getting-started/intro) lately.  This PR git ignores the file so people can experiment without making their workspaces dirty.  If we decide that some team-wide settings are needed we can unignore it.

## 🕵️ Details

I've been managing my custom files in a dotfiles directory that looks like this:
```
dotfiles/gc-digital-talent
dotfiles/gc-digital-talent/CLAUDE.local.md
dotfiles/gc-digital-talent/.mcp.json
dotfiles/gc-digital-talent/.claude
dotfiles/gc-digital-talent/.claude/settings.local.json
```

When I start a new workspace I use [stow](https://man.archlinux.org/man/stow.8) to symlink in my custom files. 
`stow -d ~/dotfiles -t . -S gc-digital-talent`

My mcp file looks like this right now:
```json
{
  "mcpServers": {
    "playwright": {
      "command": "npx",
      "args": ["@playwright/mcp@latest"]
    },
    "postgres": {
      "command": "npx",
      "args": [
        "-y",
        "@modelcontextprotocol/server-postgres",
        "postgresql://postgres:password1234@localhost:5432/gctalent"
      ]
    },
    "context7": {
      "command": "npx",
      "args": ["-y", "@upstash/context7-mcp"]
    },
    "figma": {
      "type": "http",
      "url": "https://mcp.figma.com/mcp"
    }
  }
}

```

## 🧪 Testing

1. `touch .mcp.json`
2. `git status`
- [ ] working tree clean

## 📸 Screenshot

<img width="786" height="278" alt="image" src="https://github.com/user-attachments/assets/0088e762-0542-47be-a0d0-12cc6ef0c8ed" />
