### PR TITLE
[Feature] Nine box selections in nomination

### DIFF
--- a/api/app/GraphQL/Validators/UpdateTalentNominationInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdateTalentNominationInputValidator.php
@@ -12,6 +12,7 @@ use App\Enums\TalentNominationUserReview;
 use App\Models\SkillFamily;
 use App\Models\TalentNomination;
 use App\Rules\GovernmentEmailRegex;
+use App\Rules\TalentEventOpenForUpdatingNominations;
 use Illuminate\Validation\Rule;
 use Nuwave\Lighthouse\Validation\Validator;
 
@@ -27,6 +28,7 @@ final class UpdateTalentNominationInputValidator extends Validator
         $event = TalentNomination::find($this->arg('id'))?->talentNominationEvent;
 
         return [
+            'id' => [new TalentEventOpenForUpdatingNominations()],
             'insertSubmittedStep' => [
                 Rule::in(array_column(TalentNominationStep::cases(), 'name')),
                 // can only review and submit using the submit mutation

--- a/api/app/GraphQL/Validators/UpdateTalentNominationInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdateTalentNominationInputValidator.php
@@ -136,13 +136,13 @@ final class UpdateTalentNominationInputValidator extends Validator
             'skills.sync.*' => [Rule::in(SkillFamily::where('key', 'klc')->sole()->skills->pluck('id')->toArray())],
             'additionalComments' => ['nullable', 'string'],
             'nineBoxPerformance' => [
-                Rule::when(fn () => $event?->includeNineBox,
+                Rule::when(fn () => $event?->include_nine_box,
                     [Rule::in(array_column(NineBoxRating::cases(), 'name'))],
                     ['prohibited']
                 ),
             ],
             'nineBoxLeadershipPotential' => [
-                Rule::when(fn () => $event?->includeNineBox,
+                Rule::when(fn () => $event?->include_nine_box,
                     [Rule::in(array_column(NineBoxRating::cases(), 'name'))],
                     ['prohibited']
                 ),
@@ -164,6 +164,10 @@ final class UpdateTalentNominationInputValidator extends Validator
             'skills.sync.exists' => ErrorCode::SKILL_NOT_FOUND->name,
             'skills.sync.*.in' => ErrorCode::SKILL_NOT_KLC->name,
             'skills.sync.prohibited' => ErrorCode::SKILLS_NOT_ALLOWED_FOR_EVENT->name,
+            'nineBoxPerformance.in' => ErrorCode::ENUM_NOT_FOUND->name,
+            'nineBoxPerformance.prohibited' => ErrorCode::NINE_BOX_RATINGS_PROHIBITED_FOR_EVENT->name,
+            'nineBoxLeadershipPotential.in' => ErrorCode::ENUM_NOT_FOUND->name,
+            'nineBoxLeadershipPotential.prohibited' => ErrorCode::NINE_BOX_RATINGS_PROHIBITED_FOR_EVENT->name,
         ];
     }
 }

--- a/api/app/GraphQL/Validators/UpdateTalentNominationInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdateTalentNominationInputValidator.php
@@ -128,7 +128,7 @@ final class UpdateTalentNominationInputValidator extends Validator
                 'array',
                 'exists:skills,id',
                 'distinct',
-                Rule::when(fn () => $event?->talentNominationEvent->include_leadership_competencies,
+                Rule::when(fn () => $event?->include_leadership_competencies,
                     ['max:3'],
                     ['prohibited']
                 ),
@@ -136,13 +136,13 @@ final class UpdateTalentNominationInputValidator extends Validator
             'skills.sync.*' => [Rule::in(SkillFamily::where('key', 'klc')->sole()->skills->pluck('id')->toArray())],
             'additionalComments' => ['nullable', 'string'],
             'nineBoxPerformance' => [
-                Rule::when(fn () => $event?->talentNominationEvent->includeNineBox,
+                Rule::when(fn () => $event?->includeNineBox,
                     [Rule::in(array_column(NineBoxRating::cases(), 'name'))],
                     ['prohibited']
                 ),
             ],
             'nineBoxLeadershipPotential' => [
-                Rule::when(fn () => $event?->talentNominationEvent->includeNineBox,
+                Rule::when(fn () => $event?->includeNineBox,
                     [Rule::in(array_column(NineBoxRating::cases(), 'name'))],
                     ['prohibited']
                 ),

--- a/api/app/GraphQL/Validators/UpdateTalentNominationInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdateTalentNominationInputValidator.php
@@ -3,6 +3,7 @@
 namespace App\GraphQL\Validators;
 
 use App\Enums\ErrorCode;
+use App\Enums\NineBoxRating;
 use App\Enums\TalentNominationLateralMovementOption;
 use App\Enums\TalentNominationNomineeRelationshipToNominator;
 use App\Enums\TalentNominationStep;
@@ -23,6 +24,8 @@ final class UpdateTalentNominationInputValidator extends Validator
      */
     public function rules(): array
     {
+        $event = TalentNomination::find($this->arg('id'))?->talentNominationEvent;
+
         return [
             'insertSubmittedStep' => [
                 Rule::in(array_column(TalentNominationStep::cases(), 'name')),
@@ -125,13 +128,25 @@ final class UpdateTalentNominationInputValidator extends Validator
                 'array',
                 'exists:skills,id',
                 'distinct',
-                Rule::when(fn ($args) => TalentNomination::find($args['id'])?->talentNominationEvent->include_leadership_competencies,
+                Rule::when(fn () => $event?->talentNominationEvent->include_leadership_competencies,
                     ['max:3'],
                     ['prohibited']
                 ),
             ],
             'skills.sync.*' => [Rule::in(SkillFamily::where('key', 'klc')->sole()->skills->pluck('id')->toArray())],
             'additionalComments' => ['nullable', 'string'],
+            'nineBoxPerformance' => [
+                Rule::when(fn () => $event?->talentNominationEvent->includeNineBox,
+                    [Rule::in(array_column(NineBoxRating::cases(), 'name'))],
+                    ['prohibited']
+                ),
+            ],
+            'nineBoxLeadershipPotential' => [
+                Rule::when(fn () => $event?->talentNominationEvent->includeNineBox,
+                    [Rule::in(array_column(NineBoxRating::cases(), 'name'))],
+                    ['prohibited']
+                ),
+            ],
         ];
     }
 

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1907,8 +1907,7 @@ type Query {
     @guard
     @canResolved(ability: "view", scopes: ["withPolicyEagerLoads"])
   talentRequestTrackedUsers(
-    talentRequestId: UUID!
-      @eq(key: "talent_request_id")
+    talentRequestId: UUID! @eq(key: "talent_request_id")
     where: TalentRequestTrackedUserFilterInput
   ): [TalentRequestTrackedUser!]
     @advancedOrderBy
@@ -2745,6 +2744,7 @@ input CreateTalentNominationInput @validator {
 }
 
 input UpdateTalentNominationInput @validator {
+  id: UUID!
   # can only connect a step, not disconnect or sync
   insertSubmittedStep: TalentNominationStep
   submitterRelationshipToNominator: TalentNominationSubmitterRelationshipToNominator
@@ -4194,8 +4194,6 @@ type Mutation {
     @guard
     @canModel(ability: "create")
   updateTalentNomination(
-    id: UUID!
-      @rules(apply: ["App\\Rules\\TalentEventOpenForUpdatingNominations"])
     talentNomination: UpdateTalentNominationInput! @spread
   ): TalentNomination @update @guard @canFind(ability: "update", find: "id")
   submitTalentNomination(

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -761,7 +761,7 @@ type Mutation {
   createTalentNominationEvent(talentNominationEvent: CreateTalentNominationEventInput!): TalentNominationEvent
   updateTalentNominationEvent(id: UUID!, talentNominationEvent: UpdateTalentNominationEventInput!): TalentNominationEvent
   createTalentNomination(talentNomination: CreateTalentNominationInput!): TalentNomination
-  updateTalentNomination(id: UUID!, talentNomination: UpdateTalentNominationInput!): TalentNomination
+  updateTalentNomination(talentNomination: UpdateTalentNominationInput!): TalentNomination
   submitTalentNomination(id: UUID!): TalentNomination
   updateTalentNominationGroup(id: UUID!, talentNominationGroup: UpdateTalentNominationGroupInput!): TalentNominationGroup
   markNotificationAsRead(id: UUID!): Notification
@@ -2700,6 +2700,7 @@ input CreateTalentNominationInput {
 }
 
 input UpdateTalentNominationInput {
+  id: UUID!
   insertSubmittedStep: TalentNominationStep
   submitterRelationshipToNominator: TalentNominationSubmitterRelationshipToNominator
   submitterRelationshipToNominatorOther: String

--- a/api/tests/Feature/TalentNominationTest.php
+++ b/api/tests/Feature/TalentNominationTest.php
@@ -40,8 +40,8 @@ class TalentNominationTest extends TestCase
     GRAPHQL;
 
     protected $updateMutation = <<<'GRAPHQL'
-    mutation UpdateTalentNomination($id: UUID!, $talentNomination: UpdateTalentNominationInput!) {
-        updateTalentNomination(id: $id, talentNomination: $talentNomination) {
+    mutation UpdateTalentNomination($talentNomination: UpdateTalentNominationInput!) {
+        updateTalentNomination(talentNomination: $talentNomination) {
                 id
             }
         }
@@ -148,8 +148,8 @@ class TalentNominationTest extends TestCase
 
         $response = $this->actingAs($this->employee1, 'api')
             ->graphQL($this->updateMutation, [
-                'id' => $nomination->id,
                 'talentNomination' => [
+                    'id' => $nomination->id,
                     'additionalComments' => 'New comments',
                 ],
             ]);
@@ -175,8 +175,8 @@ class TalentNominationTest extends TestCase
 
         $response = $this->actingAs($this->employee2, 'api')
             ->graphQL($this->updateMutation, [
-                'id' => $nomination->id,
                 'talentNomination' => [
+                    'id' => $nomination->id,
                     'additionalComments' => 'New comments',
                 ],
             ]);
@@ -196,8 +196,8 @@ class TalentNominationTest extends TestCase
 
         $response = $this->actingAs($this->employee1, 'api')
             ->graphQL($this->updateMutation, [
-                'id' => $nomination->id,
                 'talentNomination' => [
+                    'id' => $nomination->id,
                     'additionalComments' => 'New comments',
                 ],
             ]);
@@ -279,8 +279,8 @@ class TalentNominationTest extends TestCase
 
         $response = $this->actingAs($this->employee1, 'api')
             ->graphQL($this->updateMutation, [
-                'id' => $nomination->id,
                 'talentNomination' => [
+                    'id' => $nomination->id,
                     'skills' => [
                         'sync' => [$nonKlcSkillId],
                     ],
@@ -463,11 +463,11 @@ class TalentNominationTest extends TestCase
         // updating operations (update/submit) for a nomination fails if the event is closed
         $this->actingAs($this->employee1, 'api')
             ->graphQL($this->updateMutation, [
-                'id' => $nomination->id,
                 'talentNomination' => [
+                    'id' => $nomination->id,
                     'additionalComments' => 'New comments',
                 ],
-            ])->assertGraphQLValidationError('id', ErrorCode::TALENT_EVENT_IS_CLOSED->name);
+            ])->assertGraphQLValidationError('talentNomination.id', ErrorCode::TALENT_EVENT_IS_CLOSED->name);
 
         $this->actingAs($this->employee1, 'api')
             ->graphQL($this->submitMutation, [

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2359,7 +2359,7 @@
     "defaultMessage": "Nous avons reçu votre demande",
     "description": "Paragraph one, message to user the request was received"
   },
-  "7Ep9gj": {
+  "uXu/Vu": {
     "defaultMessage": "Ce candidat excelle dans son rôle actuel et démontre un potentiel de leadership exceptionnel. Il cadre parfaitement avec les plans de relève à court terme pour ces fonctions, ainsi qu’avec les bassins de relève à moyen et à long terme.",
     "description": "Nine-box recommendation description for high performance and high leadership potential"
   },
@@ -4291,7 +4291,7 @@
     "defaultMessage": "Prochain type de poste de {firstName}",
     "description": "Title for next role dialog"
   },
-  "F8y1Em": {
+  "4nRmpf": {
     "defaultMessage": "Ce candidat devrait se concentrer sur son amélioration. Son faible rendement et la faible possibilité qu’il améliore son potentiel de leadership pourraient justifier une réaffectation ou la prise de mesures de gestion du rendement.",
     "description": "Nine-box recommendation description for low performance and low leadership potential"
   },
@@ -4359,7 +4359,7 @@
     "defaultMessage": "Date limite de présentation des demandes",
     "description": "The application deadline of the training opportunity"
   },
-  "FOVOHH": {
+  "FZ6MRQ": {
     "defaultMessage": "Ce candidat est un contributeur expert. Il est très efficace dans son rôle actuel et possède une expertise approfondie. Il ne cherche peut-être pas à assumer un rôle de leadership élargi et n’est peut-être pas fait pour cela. Toutefois, il est essentiel dans son domaine.",
     "description": "Nine-box recommendation description for high performance and low leadership potential"
   },
@@ -5699,7 +5699,7 @@
     "defaultMessage": "Accéder à ConnexionCanada",
     "description": "CanadaLogin sign up link text on the registration page"
   },
-  "KpMuPk": {
+  "HxLjMP": {
     "defaultMessage": "Ce candidat répond aux attentes en matière de rendement et apporte une contribution régulière, mais il n’a pas démontré de potentiel de leadership. Un rôle lié aux opérations nécessitant un leadership fiable lui conviendrait parfaitement.",
     "description": "Nine-box recommendation description for moderate performance and low leadership potential"
   },
@@ -8178,7 +8178,7 @@
     "defaultMessage": "Passez à l’étape 2.",
     "description": "Text for first registration -> create step."
   },
-  "Uwoinr": {
+  "ulkj7X": {
     "defaultMessage": "Le rendement de ce candidat est inférieur aux attentes, mais son potentiel de leadership est évident. Il pourrait bénéficier d’un soutien ciblé et d’occasions de perfectionnement.",
     "description": "Nine-box recommendation description for low performance and moderate leadership potential"
   },
@@ -9082,7 +9082,7 @@
     "defaultMessage": "Supprimer la notification",
     "description": "Button text to confirm deleting a notification"
   },
-  "YaTEkX": {
+  "uhescL": {
     "defaultMessage": "Nous recommandons que ce candidat soit considéré pour des occasions de perfectionnement",
     "description": "Nine-box recommendation title for development"
   },
@@ -9262,7 +9262,7 @@
     "defaultMessage": "Recommandé",
     "description": "Status for referred candidates"
   },
-  "ZCNqvU": {
+  "Spiz26": {
     "defaultMessage": "Ce candidat a un bon rendement et présente un fort potentiel de leadership. Il est vraisemblablement prêt à participer à des activités de perfectionnement stratégique et à intégrer la relève à moyen et long terme.",
     "description": "Nine-box recommendation description for moderate performance and high leadership potential"
   },
@@ -9822,7 +9822,7 @@
     "defaultMessage": "La mise à jour du rôle a échoué",
     "description": "Alert displayed to user when an error occurs while editing a community member's roles"
   },
-  "bneVEC": {
+  "J8c5xW": {
     "defaultMessage": "Les candidats prometteurs sont des candidats dont le rendement est inférieur aux attentes, mais dont le potentiel de leadership est élevé. Un encadrement, des objectifs plus clairs ou la redéfinition de leur rôle les aideraient à s’épanouir.",
     "description": "Nine-box recommendation description for low performance and high leadership potential"
   },
@@ -10386,7 +10386,7 @@
     "defaultMessage": "{count} candidats répondent à vos critères.",
     "description": "Message announced to assistive technology users when the estimated candidate count changes."
   },
-  "dxBfv7": {
+  "+3bi5L": {
     "defaultMessage": "Ce candidat produit des résultats constants et démontre une capacité à exercer un leadership élargi. Il est probablement prêt à accepter des affectations enrichies ou des rôles interfonctionnels ainsi qu’à intégrer la relève à moyen et à long terme.",
     "description": "Nine-box recommendation description for high performance and moderate leadership potential"
   },
@@ -13674,7 +13674,7 @@
     "defaultMessage": "Mettez à jour et passez en revue les informations relatives à votre parcours professionnel.",
     "description": "Subtitle for the application career timeline introduction page"
   },
-  "qH3qHA": {
+  "IdNL0m": {
     "defaultMessage": "Nous recommandons que ce candidat soit considéré pour des occasions de perfectionnement, une mutation latérale et une promotion.",
     "description": "Nine-box recommendation title for development and lateral and advancement"
   },
@@ -15210,7 +15210,7 @@
     "defaultMessage": "Votre candidature a été retirée de ce processus. Si vous avez des questions, veuillez contacter le service ou l’équipe de recrutement responsable de la publication de l’offre d’emploi.",
     "description": "Status description for an application that was removed from a pool"
   },
-  "wqxKES": {
+  "0ea8yF": {
     "defaultMessage": "Nous recommandons que ce candidat soit considéré pour des occasions de perfectionnement et une mutation latérale.",
     "description": "Nine-box recommendation title for development and lateral"
   },

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -1131,6 +1131,10 @@
     "defaultMessage": "Type de demande d’emploi spéciale",
     "description": "Special application type label"
   },
+  "2E39Xr": {
+    "defaultMessage": "Potentiel élevé",
+    "description": "Option for a high leadership potential rating on the details step"
+  },
   "2FBdeQ": {
     "defaultMessage": "Apprentissage en cours d’emploi",
     "description": "Experience requirement, On the job."
@@ -2355,6 +2359,10 @@
     "defaultMessage": "Nous avons reçu votre demande",
     "description": "Paragraph one, message to user the request was received"
   },
+  "7Ep9gj": {
+    "defaultMessage": "Ce candidat excelle dans son rôle actuel et démontre un potentiel de leadership exceptionnel. Il cadre parfaitement avec les plans de relève à court terme pour ces fonctions, ainsi qu’avec les bassins de relève à moyen et à long terme.",
+    "description": "Nine-box recommendation description for high performance and high leadership potential"
+  },
   "7FtbwK": {
     "defaultMessage": "Gestionnaire",
     "description": "Title displayed on the search request table manager column."
@@ -2483,6 +2491,10 @@
     "defaultMessage": "<strong>Contributeur individuel</strong> : Les conseillers techniques en <abbreviation>TI</abbreviation> (<abbreviation>IT-03</abbreviation>) fournissent des conseils techniques spécialisés, des recommandations et du soutien sur les solutions et les services dans leur domaine d'expertise pour appuyer la prestation de services aux clients et aux intervenants. Les conseillers techniques en <abbreviation>TI</abbreviation> se trouvent dans tous les volets de travail.",
     "description": "IT-03 advisor description"
   },
+  "7xTRE7": {
+    "defaultMessage": "Évaluation de rendement du candidat",
+    "description": "Label for the nominee's performance assessment field"
+  },
   "7yvOlL": {
     "defaultMessage": "Ces compétences doivent être accompagnées d’une note spéciale.",
     "description": "Statement that a special note on a job poster template is required"
@@ -2578,6 +2590,10 @@
   "8J5O+T": {
     "defaultMessage": "Prix que vous avez reçus ou autres façons dont vous avez été reconnu pour avoir dépassé les attentes.",
     "description": "Description for award experience section"
+  },
+  "8KOc7q": {
+    "defaultMessage": "Potentiel faible",
+    "description": "Option for a low leadership potential rating on the details step"
   },
   "8L9eJ3": {
     "defaultMessage": "Le gouvernement du Canada ne se prononcera pas sur des questions de partisanerie ou de politique, et il ne répondra pas aux questions qui contreviennent aux règles énoncées dans cet avis.",
@@ -3551,6 +3567,10 @@
     "defaultMessage": "La plupart des offres d’emploi ne nécessiteront pas de note spéciale. Cette section est réservée à des circonstances particulières. Cette note spéciale peut notamment servir à indiquer si un processus peut être utilisé pour embaucher dans plusieurs classifications ou non et si le processus est limité aux candidatures d’un groupe visé par l’équité en matière d’emploi spécifique.",
     "description": "Describes the 'special note' section of a process' advertisement."
   },
+  "C4OW6h": {
+    "defaultMessage": "Rendement modéré",
+    "description": "Option for a moderate performance rating on the details step"
+  },
   "C780XI": {
     "defaultMessage": "L’étape suivante consiste à s’assurer que votre parcours professionnel est aussi à jour que possible.",
     "description": "Application step to begin working on career timeline, paragraph one"
@@ -3826,6 +3846,10 @@
   "DA7fMg": {
     "defaultMessage": "Identifiant",
     "description": "Title for unique ID of a resource"
+  },
+  "DAOkQv": {
+    "defaultMessage": "Potentiel de leadership du candidat",
+    "description": "Label for the nominee's leadership potential field"
   },
   "DBczOG": {
     "defaultMessage": "Stratégie",
@@ -4267,6 +4291,10 @@
     "defaultMessage": "Prochain type de poste de {firstName}",
     "description": "Title for next role dialog"
   },
+  "F8y1Em": {
+    "defaultMessage": "Ce candidat devrait se concentrer sur son amélioration. Son faible rendement et la faible possibilité qu’il améliore son potentiel de leadership pourraient justifier une réaffectation ou la prise de mesures de gestion du rendement.",
+    "description": "Nine-box recommendation description for low performance and low leadership potential"
+  },
   "F9CQ6E": {
     "defaultMessage": "Une liste préparée à partir du portfolio de compétences qui présente une histoire plus ciblée et personnalisée sur les forces et les domaines d'intérêt de cet utilisateur ou de cette utilisatrice.",
     "description": "Description of a users skill showcase"
@@ -4330,6 +4358,10 @@
   "FO0HTu": {
     "defaultMessage": "Date limite de présentation des demandes",
     "description": "The application deadline of the training opportunity"
+  },
+  "FOVOHH": {
+    "defaultMessage": "Ce candidat est un contributeur expert. Il est très efficace dans son rôle actuel et possède une expertise approfondie. Il ne cherche peut-être pas à assumer un rôle de leadership élargi et n’est peut-être pas fait pour cela. Toutefois, il est essentiel dans son domaine.",
+    "description": "Nine-box recommendation description for high performance and low leadership potential"
   },
   "FPMibV": {
     "defaultMessage": "<strong>Note :</strong> Les résultats tiendront compte de toute personne candidate qui correspond à <strong>l’un ou plusieurs</strong> des groupes d’équité en matière d’emploi sélectionnés",
@@ -5667,6 +5699,10 @@
     "defaultMessage": "Accéder à ConnexionCanada",
     "description": "CanadaLogin sign up link text on the registration page"
   },
+  "KpMuPk": {
+    "defaultMessage": "Ce candidat répond aux attentes en matière de rendement et apporte une contribution régulière, mais il n’a pas démontré de potentiel de leadership. Un rôle lié aux opérations nécessitant un leadership fiable lui conviendrait parfaitement.",
+    "description": "Nine-box recommendation description for moderate performance and low leadership potential"
+  },
   "KqEyqD": {
     "defaultMessage": "Désignation professionnelle",
     "description": "Title for the professional designation requirement."
@@ -6855,6 +6891,10 @@
     "defaultMessage": "{experienceCount, plural, =0 {0 expérience en matière de prix et de reconnaissance} one {# expérience en matière de prix et de reconnaissance} other {# expériences en matière de prix et de reconnaissance}}",
     "description": "list a number of award experiences"
   },
+  "PaJ21r": {
+    "defaultMessage": "Rendement élevé",
+    "description": "Option for a high performance rating on the details step"
+  },
   "PakJF8": {
     "defaultMessage": "Cadres actuels de l’approvisionnement",
     "description": "List item one procurement label"
@@ -7995,6 +8035,10 @@
     "defaultMessage": "Résultats",
     "description": "Heading for the results section of search page."
   },
+  "UKFUv+": {
+    "defaultMessage": "Rendement faible",
+    "description": "Option for a low performance rating on the details step"
+  },
   "UKw7sB": {
     "defaultMessage": "Volet de travail",
     "description": "Label displayed on the pool form stream/job title field."
@@ -8133,6 +8177,10 @@
   "UwU+X9": {
     "defaultMessage": "Passez à l’étape 2.",
     "description": "Text for first registration -> create step."
+  },
+  "Uwoinr": {
+    "defaultMessage": "Le rendement de ce candidat est inférieur aux attentes, mais son potentiel de leadership est évident. Il pourrait bénéficier d’un soutien ciblé et d’occasions de perfectionnement.",
+    "description": "Nine-box recommendation description for low performance and moderate leadership potential"
   },
   "Uwtkv6": {
     "defaultMessage": "Ce à quoi s’attendre après l’admission",
@@ -9034,6 +9082,10 @@
     "defaultMessage": "Supprimer la notification",
     "description": "Button text to confirm deleting a notification"
   },
+  "YaTEkX": {
+    "defaultMessage": "Nous recommandons que ce candidat soit considéré pour des occasions de perfectionnement",
+    "description": "Nine-box recommendation title for development"
+  },
   "Yaxm1W": {
     "defaultMessage": "Date de début",
     "description": "Label displayed on an Experience form for start date input"
@@ -9209,6 +9261,10 @@
   "ZAHz5C": {
     "defaultMessage": "Recommandé",
     "description": "Status for referred candidates"
+  },
+  "ZCNqvU": {
+    "defaultMessage": "Ce candidat a un bon rendement et présente un fort potentiel de leadership. Il est vraisemblablement prêt à participer à des activités de perfectionnement stratégique et à intégrer la relève à moyen et long terme.",
+    "description": "Nine-box recommendation description for moderate performance and high leadership potential"
   },
   "ZCUy93": {
     "defaultMessage": "Erreur : La mise à jour de l’exigence relative aux études a échoué.",
@@ -9765,6 +9821,10 @@
   "bmOZXl": {
     "defaultMessage": "La mise à jour du rôle a échoué",
     "description": "Alert displayed to user when an error occurs while editing a community member's roles"
+  },
+  "bneVEC": {
+    "defaultMessage": "Les candidats prometteurs sont des candidats dont le rendement est inférieur aux attentes, mais dont le potentiel de leadership est élevé. Un encadrement, des objectifs plus clairs ou la redéfinition de leur rôle les aideraient à s’épanouir.",
+    "description": "Nine-box recommendation description for low performance and high leadership potential"
   },
   "bnhqpY": {
     "defaultMessage": "Est équivalent en termes de durée de l’intensité/de l’apprentissage par rapport aux exigences du diplôme",
@@ -10325,6 +10385,14 @@
   "dwe1M+": {
     "defaultMessage": "{count} candidats répondent à vos critères.",
     "description": "Message announced to assistive technology users when the estimated candidate count changes."
+  },
+  "dxBfv7": {
+    "defaultMessage": "Ce candidat produit des résultats constants et démontre une capacité à exercer un leadership élargi. Il est probablement prêt à accepter des affectations enrichies ou des rôles interfonctionnels ainsi qu’à intégrer la relève à moyen et à long terme.",
+    "description": "Nine-box recommendation description for high performance and moderate leadership potential"
+  },
+  "dxK0sS": {
+    "defaultMessage": "Potentiel modéré",
+    "description": "Option for a moderate leadership potential rating on the details step"
   },
   "dxwgXw": {
     "defaultMessage": "communiquent des messages racistes, haineux, sexistes, homophobes ou diffamatoires, ou contiennent du matériel obscène ou pornographique ou y font allusion",
@@ -13038,6 +13106,10 @@
     "defaultMessage": "Vous n'avez rejoint aucune collectivité fonctionnelle.",
     "description": "Label for when user has not expressed interest in any communities"
   },
+  "o96aNX": {
+    "defaultMessage": "Ce candidat est fiable et efficace dans son rôle actuel. Son potentiel de progression est modéré. Un soutien et des occasions de perfectionnement ciblées pourraient lui permettre d’assumer des rôles de leadership plus complexes.",
+    "description": "Nine-box recommendation description for moderate performance and moderate leadership potential"
+  },
   "oAC+SM": {
     "defaultMessage": "Je suis une personne occupant un rôle de cadre supérieur désigné (CSD).",
     "description": "Message when user is a Senior Designated Official"
@@ -13601,6 +13673,10 @@
   "qGSEMx": {
     "defaultMessage": "Mettez à jour et passez en revue les informations relatives à votre parcours professionnel.",
     "description": "Subtitle for the application career timeline introduction page"
+  },
+  "qH3qHA": {
+    "defaultMessage": "Nous recommandons que ce candidat soit considéré pour des occasions de perfectionnement, une mutation latérale et une promotion.",
+    "description": "Nine-box recommendation title for development and lateral and advancement"
   },
   "qKk7Eh": {
     "defaultMessage": "Approvisionnement",
@@ -15133,6 +15209,10 @@
   "wqcWdN": {
     "defaultMessage": "Votre candidature a été retirée de ce processus. Si vous avez des questions, veuillez contacter le service ou l’équipe de recrutement responsable de la publication de l’offre d’emploi.",
     "description": "Status description for an application that was removed from a pool"
+  },
+  "wqxKES": {
+    "defaultMessage": "Nous recommandons que ce candidat soit considéré pour des occasions de perfectionnement et une mutation latérale.",
+    "description": "Nine-box recommendation title for development and lateral"
   },
   "wrKBLf": {
     "defaultMessage": "Autre type d'études",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -35,6 +35,10 @@
     "defaultMessage": "Talents de la collectivité",
     "description": "Label for community talent"
   },
+  "+3bi5L": {
+    "defaultMessage": "Ce candidat produit des résultats constants et démontre une capacité à exercer un leadership élargi. Il est probablement prêt à accepter des affectations enrichies ou des rôles interfonctionnels ainsi qu’à intégrer la relève à moyen et à long terme.",
+    "description": "Nine-box recommendation description for high performance and moderate leadership potential"
+  },
   "+6syC7": {
     "defaultMessage": "Votre fichier est prêt à être téléchargé",
     "description": "Notification for when q requested download is ready"
@@ -726,6 +730,10 @@
   "0dQ62G": {
     "defaultMessage": "Nombre de compétences appariées",
     "description": "Title displayed on the candidate skill count column."
+  },
+  "0ea8yF": {
+    "defaultMessage": "Nous recommandons que ce candidat soit considéré pour des occasions de perfectionnement et une mutation latérale.",
+    "description": "Nine-box recommendation title for development and lateral"
   },
   "0jV7Rn": {
     "defaultMessage": "Complet",
@@ -1774,6 +1782,10 @@
   "4nP41q": {
     "defaultMessage": "Enregistrer et ajouter cette compétence",
     "description": "Button text to save a specific skill to a users profile"
+  },
+  "4nRmpf": {
+    "defaultMessage": "Ce candidat devrait se concentrer sur son amélioration. Son faible rendement et la faible possibilité qu’il améliore son potentiel de leadership pourraient justifier une réaffectation ou la prise de mesures de gestion du rendement.",
+    "description": "Nine-box recommendation description for low performance and low leadership potential"
   },
   "4p0QdF": {
     "defaultMessage": "Fermer",
@@ -4395,6 +4407,10 @@
     "defaultMessage": "Modifier<hidden> le ministère</hidden>",
     "description": "Breadcrumb title for the edit department page link."
   },
+  "FZ6MRQ": {
+    "defaultMessage": "Ce candidat est un contributeur expert. Il est très efficace dans son rôle actuel et possède une expertise approfondie. Il ne cherche peut-être pas à assumer un rôle de leadership élargi et n’est peut-être pas fait pour cela. Toutefois, il est essentiel dans son domaine.",
+    "description": "Nine-box recommendation description for high performance and low leadership potential"
+  },
   "FcHUIQ": {
     "defaultMessage": "J'ai confirmé l'admissibilité de la candidate ou du candidat en contactant la référence secondaire fournie par l'autrice ou l'auteur de la mise en candidature.",
     "description": "Statement of confirmation for reference check"
@@ -4951,6 +4967,10 @@
     "defaultMessage": "Consultez les renseignements détaillés d'un processus de recrutement auquel vous participez et indiquez si vous aimeriez continuer à recevoir des offres d'emploi.",
     "description": "Subtitle for the review recruitment process dialog"
   },
+  "HxLjMP": {
+    "defaultMessage": "Ce candidat répond aux attentes en matière de rendement et apporte une contribution régulière, mais il n’a pas démontré de potentiel de leadership. Un rôle lié aux opérations nécessitant un leadership fiable lui conviendrait parfaitement.",
+    "description": "Nine-box recommendation description for moderate performance and low leadership potential"
+  },
   "Hy2UdW": {
     "defaultMessage": "Vous êtes sur le point de retirer un rôle de cet utilisateur ou cette utilisatrice :<strong>{userName}</strong>",
     "description": "Lead in text for the remove role from user dialog"
@@ -5163,6 +5183,10 @@
     "defaultMessage": "Masquer tout<hidden>es les sections de vos processus</hidden>",
     "description": "Button text to hide all your processes sections"
   },
+  "IdNL0m": {
+    "defaultMessage": "Nous recommandons que ce candidat soit considéré pour des occasions de perfectionnement, une mutation latérale et une promotion.",
+    "description": "Nine-box recommendation title for development and lateral and advancement"
+  },
   "IexFo4": {
     "defaultMessage": "Connaissance de l’autre langue officielle",
     "description": "Second language proficiency label"
@@ -5322,6 +5346,10 @@
   "J8Nltm": {
     "defaultMessage": "Comment vous avez pu mettre en œuvre la compétence « {skillName} » dans le cadre de cette expérience",
     "description": "Heading for a single skill on an experience."
+  },
+  "J8c5xW": {
+    "defaultMessage": "Les candidats prometteurs sont des candidats dont le rendement est inférieur aux attentes, mais dont le potentiel de leadership est élevé. Un encadrement, des objectifs plus clairs ou la redéfinition de leur rôle les aideraient à s’épanouir.",
+    "description": "Nine-box recommendation description for low performance and high leadership potential"
   },
   "J9HjFN": {
     "defaultMessage": "Le Programme a été conçu pour répondre aux efforts de réconciliation et pour bâtir une relation renouvelée qui est fondée sur les droits, le respect, la collaboration et le partenariat avec les peuples autochtones.",
@@ -7670,6 +7698,10 @@
   "SojYxS": {
     "defaultMessage": "Les compétences essentielles ou requises (également appelées critères de mérite) sont les compétences de base dont une personne candidate a besoin pour effectuer le travail. Cette liste comprend des compétences communes qui sont souvent requises dans le cadre de ce poste, mais nous recommandons de ne choisir que les compétences qui sont absolument nécessaires. Une liste plus courte de compétences requises permet de présenter des candidatures plus solides et simplifie le processus d’évaluation.",
     "description": "Description displayed on the job poster template 'essential technical skills' section."
+  },
+  "Spiz26": {
+    "defaultMessage": "Ce candidat a un bon rendement et présente un fort potentiel de leadership. Il est vraisemblablement prêt à participer à des activités de perfectionnement stratégique et à intégrer la relève à moyen et long terme.",
+    "description": "Nine-box recommendation description for moderate performance and high leadership potential"
   },
   "Sth/c4": {
     "defaultMessage": "Prochain type de poste",
@@ -14614,6 +14646,10 @@
     "defaultMessage": "La décision a été annulée avec succès.",
     "description": "Success message when an application decision was reverted"
   },
+  "uXu/Vu": {
+    "defaultMessage": "Ce candidat excelle dans son rôle actuel et démontre un potentiel de leadership exceptionnel. Il cadre parfaitement avec les plans de relève à court terme pour ces fonctions, ainsi qu’avec les bassins de relève à moyen et à long terme.",
+    "description": "Nine-box recommendation description for high performance and high leadership potential"
+  },
   "uaEMMO": {
     "defaultMessage": "Type d'emploi",
     "description": "Label for the employment type radio group"
@@ -14634,6 +14670,10 @@
     "defaultMessage": "Mettre à jour le sujet",
     "description": "Heading for form to update a users subject"
   },
+  "uhescL": {
+    "defaultMessage": "Nous recommandons que ce candidat soit considéré pour des occasions de perfectionnement",
+    "description": "Nine-box recommendation title for development"
+  },
   "uhoPHh": {
     "defaultMessage": "Réglementation",
     "description": "Label for a regulatory department"
@@ -14641,6 +14681,10 @@
   "ukcsxj": {
     "defaultMessage": "Si vous choisissez de vous autodéclarer dans votre profil et que vous postulez un emploi chez Talents numériques du GC, ces renseignements peuvent être utilisés à n’importe quelle étape du processus d’emploi, de la demande initiale à l’évaluation en passant par la nomination. Les gestionnaires d’embauche ou l’équipe de recrutement de Talents numériques du GC pourraient utiliser ces renseignements",
     "description": "Paragraph 2, how self-declaration data is used"
+  },
+  "ulkj7X": {
+    "defaultMessage": "Le rendement de ce candidat est inférieur aux attentes, mais son potentiel de leadership est évident. Il pourrait bénéficier d’un soutien ciblé et d’occasions de perfectionnement.",
+    "description": "Nine-box recommendation description for low performance and moderate leadership potential"
   },
   "uoX7ou": {
     "defaultMessage": "Cette page est accessible en langues autochtones",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2359,10 +2359,6 @@
     "defaultMessage": "Nous avons reçu votre demande",
     "description": "Paragraph one, message to user the request was received"
   },
-  "uXu/Vu": {
-    "defaultMessage": "Ce candidat excelle dans son rôle actuel et démontre un potentiel de leadership exceptionnel. Il cadre parfaitement avec les plans de relève à court terme pour ces fonctions, ainsi qu’avec les bassins de relève à moyen et à long terme.",
-    "description": "Nine-box recommendation description for high performance and high leadership potential"
-  },
   "7FtbwK": {
     "defaultMessage": "Gestionnaire",
     "description": "Title displayed on the search request table manager column."
@@ -4291,10 +4287,6 @@
     "defaultMessage": "Prochain type de poste de {firstName}",
     "description": "Title for next role dialog"
   },
-  "4nRmpf": {
-    "defaultMessage": "Ce candidat devrait se concentrer sur son amélioration. Son faible rendement et la faible possibilité qu’il améliore son potentiel de leadership pourraient justifier une réaffectation ou la prise de mesures de gestion du rendement.",
-    "description": "Nine-box recommendation description for low performance and low leadership potential"
-  },
   "F9CQ6E": {
     "defaultMessage": "Une liste préparée à partir du portfolio de compétences qui présente une histoire plus ciblée et personnalisée sur les forces et les domaines d'intérêt de cet utilisateur ou de cette utilisatrice.",
     "description": "Description of a users skill showcase"
@@ -4358,10 +4350,6 @@
   "FO0HTu": {
     "defaultMessage": "Date limite de présentation des demandes",
     "description": "The application deadline of the training opportunity"
-  },
-  "FZ6MRQ": {
-    "defaultMessage": "Ce candidat est un contributeur expert. Il est très efficace dans son rôle actuel et possède une expertise approfondie. Il ne cherche peut-être pas à assumer un rôle de leadership élargi et n’est peut-être pas fait pour cela. Toutefois, il est essentiel dans son domaine.",
-    "description": "Nine-box recommendation description for high performance and low leadership potential"
   },
   "FPMibV": {
     "defaultMessage": "<strong>Note :</strong> Les résultats tiendront compte de toute personne candidate qui correspond à <strong>l’un ou plusieurs</strong> des groupes d’équité en matière d’emploi sélectionnés",
@@ -5698,10 +5686,6 @@
   "KorMJQ": {
     "defaultMessage": "Accéder à ConnexionCanada",
     "description": "CanadaLogin sign up link text on the registration page"
-  },
-  "HxLjMP": {
-    "defaultMessage": "Ce candidat répond aux attentes en matière de rendement et apporte une contribution régulière, mais il n’a pas démontré de potentiel de leadership. Un rôle lié aux opérations nécessitant un leadership fiable lui conviendrait parfaitement.",
-    "description": "Nine-box recommendation description for moderate performance and low leadership potential"
   },
   "KqEyqD": {
     "defaultMessage": "Désignation professionnelle",
@@ -8178,10 +8162,6 @@
     "defaultMessage": "Passez à l’étape 2.",
     "description": "Text for first registration -> create step."
   },
-  "ulkj7X": {
-    "defaultMessage": "Le rendement de ce candidat est inférieur aux attentes, mais son potentiel de leadership est évident. Il pourrait bénéficier d’un soutien ciblé et d’occasions de perfectionnement.",
-    "description": "Nine-box recommendation description for low performance and moderate leadership potential"
-  },
   "Uwtkv6": {
     "defaultMessage": "Ce à quoi s’attendre après l’admission",
     "description": "Title for the what to expect post admission section"
@@ -9082,10 +9062,6 @@
     "defaultMessage": "Supprimer la notification",
     "description": "Button text to confirm deleting a notification"
   },
-  "uhescL": {
-    "defaultMessage": "Nous recommandons que ce candidat soit considéré pour des occasions de perfectionnement",
-    "description": "Nine-box recommendation title for development"
-  },
   "Yaxm1W": {
     "defaultMessage": "Date de début",
     "description": "Label displayed on an Experience form for start date input"
@@ -9261,10 +9237,6 @@
   "ZAHz5C": {
     "defaultMessage": "Recommandé",
     "description": "Status for referred candidates"
-  },
-  "Spiz26": {
-    "defaultMessage": "Ce candidat a un bon rendement et présente un fort potentiel de leadership. Il est vraisemblablement prêt à participer à des activités de perfectionnement stratégique et à intégrer la relève à moyen et long terme.",
-    "description": "Nine-box recommendation description for moderate performance and high leadership potential"
   },
   "ZCUy93": {
     "defaultMessage": "Erreur : La mise à jour de l’exigence relative aux études a échoué.",
@@ -9821,10 +9793,6 @@
   "bmOZXl": {
     "defaultMessage": "La mise à jour du rôle a échoué",
     "description": "Alert displayed to user when an error occurs while editing a community member's roles"
-  },
-  "J8c5xW": {
-    "defaultMessage": "Les candidats prometteurs sont des candidats dont le rendement est inférieur aux attentes, mais dont le potentiel de leadership est élevé. Un encadrement, des objectifs plus clairs ou la redéfinition de leur rôle les aideraient à s’épanouir.",
-    "description": "Nine-box recommendation description for low performance and high leadership potential"
   },
   "bnhqpY": {
     "defaultMessage": "Est équivalent en termes de durée de l’intensité/de l’apprentissage par rapport aux exigences du diplôme",
@@ -10385,10 +10353,6 @@
   "dwe1M+": {
     "defaultMessage": "{count} candidats répondent à vos critères.",
     "description": "Message announced to assistive technology users when the estimated candidate count changes."
-  },
-  "+3bi5L": {
-    "defaultMessage": "Ce candidat produit des résultats constants et démontre une capacité à exercer un leadership élargi. Il est probablement prêt à accepter des affectations enrichies ou des rôles interfonctionnels ainsi qu’à intégrer la relève à moyen et à long terme.",
-    "description": "Nine-box recommendation description for high performance and moderate leadership potential"
   },
   "dxK0sS": {
     "defaultMessage": "Potentiel modéré",
@@ -13674,10 +13638,6 @@
     "defaultMessage": "Mettez à jour et passez en revue les informations relatives à votre parcours professionnel.",
     "description": "Subtitle for the application career timeline introduction page"
   },
-  "IdNL0m": {
-    "defaultMessage": "Nous recommandons que ce candidat soit considéré pour des occasions de perfectionnement, une mutation latérale et une promotion.",
-    "description": "Nine-box recommendation title for development and lateral and advancement"
-  },
   "qKk7Eh": {
     "defaultMessage": "Approvisionnement",
     "description": "Heading procurement"
@@ -15209,10 +15169,6 @@
   "wqcWdN": {
     "defaultMessage": "Votre candidature a été retirée de ce processus. Si vous avez des questions, veuillez contacter le service ou l’équipe de recrutement responsable de la publication de l’offre d’emploi.",
     "description": "Status description for an application that was removed from a pool"
-  },
-  "0ea8yF": {
-    "defaultMessage": "Nous recommandons que ce candidat soit considéré pour des occasions de perfectionnement et une mutation latérale.",
-    "description": "Nine-box recommendation title for development and lateral"
   },
   "wrKBLf": {
     "defaultMessage": "Autre type d'études",

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
@@ -684,6 +684,7 @@ const transformSubmitData: SubmitDataTransformer<FormValues> = (values) => {
     advancementReference = { disconnect: true };
   }
   return {
+    id: values.id,
     nineBoxPerformance: values.nineBoxPerformance ?? null,
     nineBoxLeadershipPotential: values.nineBoxLeadershipPotential ?? null,
     nominateForAdvancement: hasAdvancement ?? null,
@@ -801,6 +802,7 @@ const Details = ({ detailsQuery, optionsQuery }: DetailsProps) => {
       submitDataTransformer={transformSubmitData}
       preSubmitValidation={preSubmitValidation}
       defaultValues={{
+        id: talentNomination.id,
         nineBoxPerformance: talentNomination?.nineBoxPerformance?.value,
         nineBoxLeadershipPotential:
           talentNomination?.nineBoxLeadershipPotential?.value,

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
@@ -10,6 +10,7 @@ import type {
 import {
   getFragment,
   graphql,
+  NineBoxRating,
   TalentNominationLateralMovementOption,
   TalentNominationStep,
   TalentNominationUserReview,
@@ -104,6 +105,7 @@ const DetailsCommunityDevelopmentProgram_Fragment = graphql(/* GraphQL */ `
 const DetailsTalentNominationEvent_Fragment = graphql(/* GraphQL */ `
   fragment DetailsTalentNominationEvent on TalentNominationEvent {
     id
+    includeNineBox
   }
 `);
 
@@ -113,6 +115,8 @@ type NominationOption =
   | "developmentProgram";
 
 interface FormValues extends BaseFormValues {
+  nineBoxPerformance?: NineBoxRating;
+  nineBoxLeadershipPotential?: NineBoxRating;
   nominationOptions: (NominationOption | null)[];
   advancementReference: string | null;
   advancementReferenceReview?: TalentNominationUserReview;
@@ -209,6 +213,56 @@ const DetailsFields = ({
 
   return (
     <div className="flex flex-col gap-6">
+      {event?.includeNineBox && (
+        <>
+          <RadioGroup
+            idPrefix="nineBoxPerformance"
+            id="nineBoxPerformance"
+            name="nineBoxPerformance"
+            legend={intl.formatMessage(labels.nomineePerformance)}
+            rules={{
+              required: intl.formatMessage(errorMessages.required),
+            }}
+            items={[
+              {
+                value: NineBoxRating.Low,
+                label: intl.formatMessage(labels.lowPerformance),
+              },
+              {
+                value: NineBoxRating.Moderate,
+                label: intl.formatMessage(labels.moderatePerformance),
+              },
+              {
+                value: NineBoxRating.High,
+                label: intl.formatMessage(labels.highPerformance),
+              },
+            ]}
+          />
+          <RadioGroup
+            idPrefix="nineBoxLeadershipPotential"
+            id="nineBoxLeadershipPotential"
+            name="nineBoxLeadershipPotential"
+            legend={intl.formatMessage(labels.nomineeLeadershipPotential)}
+            rules={{
+              required: intl.formatMessage(errorMessages.required),
+            }}
+            items={[
+              {
+                value: NineBoxRating.Low,
+                label: intl.formatMessage(labels.lowPotential),
+              },
+              {
+                value: NineBoxRating.Moderate,
+                label: intl.formatMessage(labels.moderatePotential),
+              },
+              {
+                value: NineBoxRating.High,
+                label: intl.formatMessage(labels.highPotential),
+              },
+            ]}
+          />
+        </>
+      )}
       <Checklist
         idPrefix="nominationOptions"
         name="nominationOptions"
@@ -562,6 +616,12 @@ const NominateTalentDetails_Fragment = graphql(/* GraphQL */ `
       }
       closeDate
     }
+    nineBoxPerformance {
+      value
+    }
+    nineBoxLeadershipPotential {
+      value
+    }
     nominateForAdvancement
     advancementReference {
       id
@@ -615,6 +675,8 @@ const transformSubmitData: SubmitDataTransformer<FormValues> = (values) => {
     advancementReference = { disconnect: true };
   }
   return {
+    nineBoxPerformance: values.nineBoxPerformance ?? null,
+    nineBoxLeadershipPotential: values.nineBoxLeadershipPotential ?? null,
     nominateForAdvancement: hasAdvancement ?? null,
     nominateForLateralMovement: hasLateralMovement ?? null,
     nominateForDevelopmentPrograms: hasDevelopmentProgram ?? null,
@@ -730,6 +792,9 @@ const Details = ({ detailsQuery, optionsQuery }: DetailsProps) => {
       submitDataTransformer={transformSubmitData}
       preSubmitValidation={preSubmitValidation}
       defaultValues={{
+        nineBoxPerformance: talentNomination?.nineBoxPerformance?.value,
+        nineBoxLeadershipPotential:
+          talentNomination?.nineBoxLeadershipPotential?.value,
         nominationOptions,
         advancementReference: defaultReference,
         advancementReferenceReview:

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
@@ -44,6 +44,7 @@ import UpdateForm from "./UpdateForm";
 import SubHeading from "./SubHeading";
 import messages from "../messages";
 import EmployeeSearchWell from "./EmployeeSearchWell";
+import NineBoxDescription from "./NineBoxDescription";
 import labels from "../labels";
 
 const DetailsFieldsOptions_Fragment = graphql(/* GraphQL */ `
@@ -170,11 +171,15 @@ const DetailsFields = ({
     advancementReference,
     lateralMovementOptions,
     communityDevelopmentPrograms,
+    nineBoxPerformance,
+    nineBoxLeadershipPotential,
   ] = watch([
     "nominationOptions",
     "advancementReference",
     "lateralMovementOptions",
     "communityDevelopmentPrograms",
+    "nineBoxPerformance",
+    "nineBoxLeadershipPotential",
   ]);
 
   const noOptionsSelected = nominationOptions?.length === 0;
@@ -260,6 +265,10 @@ const DetailsFields = ({
                 label: intl.formatMessage(labels.highPotential),
               },
             ]}
+          />
+          <NineBoxDescription
+            performance={nineBoxPerformance}
+            leadershipPotential={nineBoxLeadershipPotential}
           />
         </>
       )}

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
@@ -101,6 +101,12 @@ const DetailsCommunityDevelopmentProgram_Fragment = graphql(/* GraphQL */ `
   }
 `);
 
+const DetailsTalentNominationEvent_Fragment = graphql(/* GraphQL */ `
+  fragment DetailsTalentNominationEvent on TalentNominationEvent {
+    id
+  }
+`);
+
 type NominationOption =
   | "advancement"
   | "lateralMovement"
@@ -132,12 +138,14 @@ interface DetailsFieldsProps {
   communityDevelopmentProgramQuery?: FragmentType<
     typeof DetailsCommunityDevelopmentProgram_Fragment
   >[];
+  eventQuery?: FragmentType<typeof DetailsTalentNominationEvent_Fragment>;
 }
 
 const DetailsFields = ({
   optionsQuery,
   employeeQuery,
   communityDevelopmentProgramQuery,
+  eventQuery,
 }: DetailsFieldsProps) => {
   const intl = useIntl();
 
@@ -150,6 +158,7 @@ const DetailsFields = ({
     DetailsCommunityDevelopmentProgram_Fragment,
     communityDevelopmentProgramQuery,
   );
+  const event = getFragment(DetailsTalentNominationEvent_Fragment, eventQuery);
 
   const { watch, resetField: baseReset } = useFormContext<FormValues>();
   const [
@@ -546,6 +555,7 @@ const NominateTalentDetails_Fragment = graphql(/* GraphQL */ `
     id
     talentNominationEvent {
       id
+      ...DetailsTalentNominationEvent
       communityDevelopmentPrograms(trashed: WITH) {
         id
         ...DetailsCommunityDevelopmentProgram
@@ -772,6 +782,7 @@ const Details = ({ detailsQuery, optionsQuery }: DetailsProps) => {
         communityDevelopmentProgramQuery={unpackMaybes(
           talentNomination?.talentNominationEvent?.communityDevelopmentPrograms,
         )}
+        eventQuery={talentNomination?.talentNominationEvent}
       />
     </UpdateForm>
   );

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Instructions.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Instructions.tsx
@@ -144,7 +144,7 @@ const Instructions = ({ instructionsQuery }: InstructionsProps) => {
   }
 
   return (
-    <UpdateForm isPastEvent={isPastEvent}>
+    <UpdateForm isPastEvent={isPastEvent} defaultValues={{ id: data.id }}>
       <SubHeading icon={ClipboardDocumentListIcon}>
         {intl.formatMessage({
           defaultMessage: "Instructions",

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/NineBoxDescription.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/NineBoxDescription.tsx
@@ -1,0 +1,195 @@
+import { defineMessage, useIntl } from "react-intl";
+import type { MessageDescriptor } from "react-intl";
+
+import { NineBoxRating } from "@gc-digital-talent/graphql";
+import { Notice } from "@gc-digital-talent/ui";
+
+interface NineBoxMessages {
+  title: MessageDescriptor;
+  body: MessageDescriptor;
+}
+
+const messages: Record<
+  NineBoxRating,
+  Record<NineBoxRating, NineBoxMessages>
+> = {
+  [NineBoxRating.Low]: {
+    [NineBoxRating.Low]: {
+      title: defineMessage({
+        defaultMessage:
+          "We recommend this employee be nominated for development opportunities",
+        id: "5WRfMY",
+        description:
+          "Nine-box recommendation title for low performance and low leadership potential",
+      }),
+      body: defineMessage({
+        defaultMessage:
+          "This nominee might benefit from a focus in improvement. Low performance and limited leadership growth potential may require reassignment or performance management.",
+        id: "F8y1Em",
+        description:
+          "Nine-box recommendation description for low performance and low leadership potential",
+      }),
+    },
+    [NineBoxRating.Moderate]: {
+      title: defineMessage({
+        defaultMessage:
+          "We recommend this employee be nominated for development opportunities",
+        id: "8Ge1Ni",
+        description:
+          "Nine-box recommendation title for low performance and moderate leadership potential",
+      }),
+      body: defineMessage({
+        defaultMessage:
+          "This nominee's performance is below expectations but their leadership potential is evident. They might benefit from targeted support and development opportunities.",
+        id: "Uwoinr",
+        description:
+          "Nine-box recommendation description for low performance and moderate leadership potential",
+      }),
+    },
+    [NineBoxRating.High]: {
+      title: defineMessage({
+        defaultMessage:
+          "We recommend this employee be nominated for development opportunities and lateral movement",
+        id: "6NKzMy",
+        description:
+          "Nine-box recommendation title for low performance and high leadership potential",
+      }),
+      body: defineMessage({
+        defaultMessage:
+          "Gems are nominees that are performing below expectation by possess high leadership potential. They may benefit from coaching clearer goals, or role realignment to unlock their capabilities.",
+        id: "bneVEC",
+        description:
+          "Nine-box recommendation description for low performance and high leadership potential",
+      }),
+    },
+  },
+  [NineBoxRating.Moderate]: {
+    [NineBoxRating.Low]: {
+      title: defineMessage({
+        defaultMessage:
+          "We recommend this employee be nominated for development opportunities",
+        id: "hBp8jr",
+        description:
+          "Nine-box recommendation title for moderate performance and low leadership potential",
+      }),
+      body: defineMessage({
+        defaultMessage:
+          "This nominee meets performance expectations and contributes steadily but has not yet demonstrated leadership potential. They are best suited for reliable leadership in operations.",
+        id: "KpMuPk",
+        description:
+          "Nine-box recommendation description for moderate performance and low leadership potential",
+      }),
+    },
+    [NineBoxRating.Moderate]: {
+      title: defineMessage({
+        defaultMessage:
+          "We recommend this employee be nominated for development opportunities and lateral movement",
+        id: "0TWmTz",
+        description:
+          "Nine-box recommendation title for moderate performance and moderate leadership potential",
+      }),
+      body: defineMessage({
+        defaultMessage:
+          "This nominee is reliable and effective in their current role and has moderate potential for growth. They could take on more complex leadership roles with support and focused development.",
+        id: "o96aNX",
+        description:
+          "Nine-box recommendation description for moderate performance and moderate leadership potential",
+      }),
+    },
+    [NineBoxRating.High]: {
+      title: defineMessage({
+        defaultMessage:
+          "We recommend this employee be nominated for development opportunities, lateral movement and advancement",
+        id: "2/HHJN",
+        description:
+          "Nine-box recommendation title for moderate performance and high leadership potential",
+      }),
+      body: defineMessage({
+        defaultMessage:
+          "This nominee is a solid performer with strong potential for leadership. They are likely ready for strategic development and medium to long term succession pipelines.",
+        id: "ZCNqvU",
+        description:
+          "Nine-box recommendation description for moderate performance and high leadership potential",
+      }),
+    },
+  },
+  [NineBoxRating.High]: {
+    [NineBoxRating.Low]: {
+      title: defineMessage({
+        defaultMessage:
+          "We recommend this employee be nominated for development opportunities and lateral movement",
+        id: "kU1xVy",
+        description:
+          "Nine-box recommendation title for high performance and low leadership potential",
+      }),
+      body: defineMessage({
+        defaultMessage:
+          "This nominee is an expert contributor - they are highly effective in their current role and have deep expertise. They may not seek or be suited for expanded leadership but they are critical in their domain.",
+        id: "FOVOHH",
+        description:
+          "Nine-box recommendation description for high performance and low leadership potential",
+      }),
+    },
+    [NineBoxRating.Moderate]: {
+      title: defineMessage({
+        defaultMessage:
+          "We recommend this employee be nominated for development opportunities, lateral movement and advancement",
+        id: "nGm0lD",
+        description:
+          "Nine-box recommendation title for high performance and moderate leadership potential",
+      }),
+      body: defineMessage({
+        defaultMessage:
+          "This nominee consistently delivers results and shows capacity for broader leadership. They may be ready for stretch assignments or cross-functional roles and medium to long term succession pipelines.",
+        id: "dxBfv7",
+        description:
+          "Nine-box recommendation description for high performance and moderate leadership potential",
+      }),
+    },
+    [NineBoxRating.High]: {
+      title: defineMessage({
+        defaultMessage:
+          "We recommend this employee be nominated for development opportunities, lateral movement and advancement",
+        id: "t13Jli",
+        description:
+          "Nine-box recommendation title for high performance and high leadership potential",
+      }),
+      body: defineMessage({
+        defaultMessage:
+          "This nominee excels in their current role and demonstrates exceptional leadership potential. They're an ideal candidate for short-term role-specific succession planning and medium to long term succession pipelines.",
+        id: "7Ep9gj",
+        description:
+          "Nine-box recommendation description for high performance and high leadership potential",
+      }),
+    },
+  },
+};
+
+interface NineBoxDescriptionProps {
+  performance?: NineBoxRating;
+  leadershipPotential?: NineBoxRating;
+}
+
+const NineBoxDescription = ({
+  performance,
+  leadershipPotential,
+}: NineBoxDescriptionProps) => {
+  const intl = useIntl();
+
+  if (!performance || !leadershipPotential) {
+    return null;
+  }
+
+  const { title, body } = messages[performance][leadershipPotential];
+
+  return (
+    <Notice.Root>
+      <Notice.Title as="h3">{intl.formatMessage(title)}</Notice.Title>
+      <Notice.Content>
+        <p>{intl.formatMessage(body)}</p>
+      </Notice.Content>
+    </Notice.Root>
+  );
+};
+
+export default NineBoxDescription;

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/NineBoxDescription.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/NineBoxDescription.tsx
@@ -17,14 +17,14 @@ const messages: Record<
     [NineBoxRating.Low]: {
       title: defineMessage({
         defaultMessage:
-          "We recommend this employee be nominated for development opportunities",
-        id: "YaTEkX",
+          "We recommend this employee be nominated for development opportunities.",
+        id: "uhescL",
         description: "Nine-box recommendation title for development",
       }),
       body: defineMessage({
         defaultMessage:
-          "This nominee might benefit from a focus in improvement. Low performance and limited leadership growth potential may require reassignment or performance management.",
-        id: "F8y1Em",
+          "This nominee would benefit from focusing on improvement. Low performance and limited leadership growth potential may require reassignment or performance management.",
+        id: "4nRmpf",
         description:
           "Nine-box recommendation description for low performance and low leadership potential",
       }),
@@ -32,14 +32,14 @@ const messages: Record<
     [NineBoxRating.Moderate]: {
       title: defineMessage({
         defaultMessage:
-          "We recommend this employee be nominated for development opportunities",
-        id: "YaTEkX",
+          "We recommend this employee be nominated for development opportunities.",
+        id: "uhescL",
         description: "Nine-box recommendation title for development",
       }),
       body: defineMessage({
         defaultMessage:
-          "This nominee's performance is below expectations but their leadership potential is evident. They might benefit from targeted support and development opportunities.",
-        id: "Uwoinr",
+          "This nominee's performance is below expectations, but their leadership potential is evident. They might benefit from targeted support and development opportunities.",
+        id: "ulkj7X",
         description:
           "Nine-box recommendation description for low performance and moderate leadership potential",
       }),
@@ -47,15 +47,15 @@ const messages: Record<
     [NineBoxRating.High]: {
       title: defineMessage({
         defaultMessage:
-          "We recommend this employee be nominated for development opportunities and lateral movement",
-        id: "wqxKES",
+          "We recommend this employee be nominated for development opportunities and lateral movement.",
+        id: "0ea8yF",
         description:
           "Nine-box recommendation title for development and lateral",
       }),
       body: defineMessage({
         defaultMessage:
-          "Gems are nominees that are performing below expectation by possess high leadership potential. They may benefit from coaching clearer goals, or role realignment to unlock their capabilities.",
-        id: "bneVEC",
+          "Gems are nominees who are performing below expectation but possess high leadership potential. They may benefit from coaching, clearer goals or role realignment to unlock their capabilities.",
+        id: "J8c5xW",
         description:
           "Nine-box recommendation description for low performance and high leadership potential",
       }),
@@ -65,14 +65,14 @@ const messages: Record<
     [NineBoxRating.Low]: {
       title: defineMessage({
         defaultMessage:
-          "We recommend this employee be nominated for development opportunities",
-        id: "YaTEkX",
+          "We recommend this employee be nominated for development opportunities.",
+        id: "uhescL",
         description: "Nine-box recommendation title for development",
       }),
       body: defineMessage({
         defaultMessage:
-          "This nominee meets performance expectations and contributes steadily but has not yet demonstrated leadership potential. They are best suited for reliable leadership in operations.",
-        id: "KpMuPk",
+          "This nominee meets performance expectations and contributes steadily but has not yet demonstrated leadership potential. They are best suited for roles in operations that need reliable leadership.",
+        id: "HxLjMP",
         description:
           "Nine-box recommendation description for moderate performance and low leadership potential",
       }),
@@ -80,8 +80,8 @@ const messages: Record<
     [NineBoxRating.Moderate]: {
       title: defineMessage({
         defaultMessage:
-          "We recommend this employee be nominated for development opportunities and lateral movement",
-        id: "wqxKES",
+          "We recommend this employee be nominated for development opportunities and lateral movement.",
+        id: "0ea8yF",
         description:
           "Nine-box recommendation title for development and lateral",
       }),
@@ -96,15 +96,15 @@ const messages: Record<
     [NineBoxRating.High]: {
       title: defineMessage({
         defaultMessage:
-          "We recommend this employee be nominated for development opportunities, lateral movement and advancement",
-        id: "qH3qHA",
+          "We recommend this employee be nominated for development opportunities, lateral movement and advancement.",
+        id: "IdNL0m",
         description:
           "Nine-box recommendation title for development and lateral and advancement",
       }),
       body: defineMessage({
         defaultMessage:
-          "This nominee is a solid performer with strong potential for leadership. They are likely ready for strategic development and medium to long term succession pipelines.",
-        id: "ZCNqvU",
+          "This nominee is a solid performer with strong potential for leadership. They are likely ready for strategic development and medium- to long-term succession pipelines.",
+        id: "Spiz26",
         description:
           "Nine-box recommendation description for moderate performance and high leadership potential",
       }),
@@ -114,15 +114,15 @@ const messages: Record<
     [NineBoxRating.Low]: {
       title: defineMessage({
         defaultMessage:
-          "We recommend this employee be nominated for development opportunities and lateral movement",
-        id: "wqxKES",
+          "We recommend this employee be nominated for development opportunities and lateral movement.",
+        id: "0ea8yF",
         description:
           "Nine-box recommendation title for development and lateral",
       }),
       body: defineMessage({
         defaultMessage:
-          "This nominee is an expert contributor - they are highly effective in their current role and have deep expertise. They may not seek or be suited for expanded leadership but they are critical in their domain.",
-        id: "FOVOHH",
+          "This nominee is an expert contributor. They are highly effective in their current role and have deep expertise. They may not seek or be suited for an expanded leadership role, but they are critical in their domain.",
+        id: "FZ6MRQ",
         description:
           "Nine-box recommendation description for high performance and low leadership potential",
       }),
@@ -130,15 +130,15 @@ const messages: Record<
     [NineBoxRating.Moderate]: {
       title: defineMessage({
         defaultMessage:
-          "We recommend this employee be nominated for development opportunities, lateral movement and advancement",
-        id: "qH3qHA",
+          "We recommend this employee be nominated for development opportunities, lateral movement and advancement.",
+        id: "IdNL0m",
         description:
           "Nine-box recommendation title for development and lateral and advancement",
       }),
       body: defineMessage({
         defaultMessage:
-          "This nominee consistently delivers results and shows capacity for broader leadership. They may be ready for stretch assignments or cross-functional roles and medium to long term succession pipelines.",
-        id: "dxBfv7",
+          "This nominee consistently delivers results and shows capacity for broader leadership. They may be ready for stretch assignments or cross-functional roles and medium- to long-term succession pipelines.",
+        id: "+3bi5L",
         description:
           "Nine-box recommendation description for high performance and moderate leadership potential",
       }),
@@ -146,15 +146,15 @@ const messages: Record<
     [NineBoxRating.High]: {
       title: defineMessage({
         defaultMessage:
-          "We recommend this employee be nominated for development opportunities, lateral movement and advancement",
-        id: "qH3qHA",
+          "We recommend this employee be nominated for development opportunities, lateral movement and advancement.",
+        id: "IdNL0m",
         description:
           "Nine-box recommendation title for development and lateral and advancement",
       }),
       body: defineMessage({
         defaultMessage:
-          "This nominee excels in their current role and demonstrates exceptional leadership potential. They're an ideal candidate for short-term role-specific succession planning and medium to long term succession pipelines.",
-        id: "7Ep9gj",
+          "This nominee excels in their current role and demonstrates exceptional leadership potential. They're an ideal candidate for short-term, role-specific succession planning and medium- to long-term succession pipelines.",
+        id: "uXu/Vu",
         description:
           "Nine-box recommendation description for high performance and high leadership potential",
       }),

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/NineBoxDescription.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/NineBoxDescription.tsx
@@ -18,9 +18,8 @@ const messages: Record<
       title: defineMessage({
         defaultMessage:
           "We recommend this employee be nominated for development opportunities",
-        id: "5WRfMY",
-        description:
-          "Nine-box recommendation title for low performance and low leadership potential",
+        id: "YaTEkX",
+        description: "Nine-box recommendation title for development",
       }),
       body: defineMessage({
         defaultMessage:
@@ -34,9 +33,8 @@ const messages: Record<
       title: defineMessage({
         defaultMessage:
           "We recommend this employee be nominated for development opportunities",
-        id: "8Ge1Ni",
-        description:
-          "Nine-box recommendation title for low performance and moderate leadership potential",
+        id: "YaTEkX",
+        description: "Nine-box recommendation title for development",
       }),
       body: defineMessage({
         defaultMessage:
@@ -50,9 +48,9 @@ const messages: Record<
       title: defineMessage({
         defaultMessage:
           "We recommend this employee be nominated for development opportunities and lateral movement",
-        id: "6NKzMy",
+        id: "wqxKES",
         description:
-          "Nine-box recommendation title for low performance and high leadership potential",
+          "Nine-box recommendation title for development and lateral",
       }),
       body: defineMessage({
         defaultMessage:
@@ -68,9 +66,8 @@ const messages: Record<
       title: defineMessage({
         defaultMessage:
           "We recommend this employee be nominated for development opportunities",
-        id: "hBp8jr",
-        description:
-          "Nine-box recommendation title for moderate performance and low leadership potential",
+        id: "YaTEkX",
+        description: "Nine-box recommendation title for development",
       }),
       body: defineMessage({
         defaultMessage:
@@ -84,9 +81,9 @@ const messages: Record<
       title: defineMessage({
         defaultMessage:
           "We recommend this employee be nominated for development opportunities and lateral movement",
-        id: "0TWmTz",
+        id: "wqxKES",
         description:
-          "Nine-box recommendation title for moderate performance and moderate leadership potential",
+          "Nine-box recommendation title for development and lateral",
       }),
       body: defineMessage({
         defaultMessage:
@@ -100,9 +97,9 @@ const messages: Record<
       title: defineMessage({
         defaultMessage:
           "We recommend this employee be nominated for development opportunities, lateral movement and advancement",
-        id: "2/HHJN",
+        id: "qH3qHA",
         description:
-          "Nine-box recommendation title for moderate performance and high leadership potential",
+          "Nine-box recommendation title for development and lateral and advancement",
       }),
       body: defineMessage({
         defaultMessage:
@@ -118,9 +115,9 @@ const messages: Record<
       title: defineMessage({
         defaultMessage:
           "We recommend this employee be nominated for development opportunities and lateral movement",
-        id: "kU1xVy",
+        id: "wqxKES",
         description:
-          "Nine-box recommendation title for high performance and low leadership potential",
+          "Nine-box recommendation title for development and lateral",
       }),
       body: defineMessage({
         defaultMessage:
@@ -134,9 +131,9 @@ const messages: Record<
       title: defineMessage({
         defaultMessage:
           "We recommend this employee be nominated for development opportunities, lateral movement and advancement",
-        id: "nGm0lD",
+        id: "qH3qHA",
         description:
-          "Nine-box recommendation title for high performance and moderate leadership potential",
+          "Nine-box recommendation title for development and lateral and advancement",
       }),
       body: defineMessage({
         defaultMessage:
@@ -150,9 +147,9 @@ const messages: Record<
       title: defineMessage({
         defaultMessage:
           "We recommend this employee be nominated for development opportunities, lateral movement and advancement",
-        id: "t13Jli",
+        id: "qH3qHA",
         description:
-          "Nine-box recommendation title for high performance and high leadership potential",
+          "Nine-box recommendation title for development and lateral and advancement",
       }),
       body: defineMessage({
         defaultMessage:

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Nominator.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Nominator.tsx
@@ -359,6 +359,7 @@ const transformSubmitData: SubmitDataTransformer<FormValues> = (values) => {
     nominator = { disconnect: true };
   }
   return {
+    id: values.id,
     submitterRelationshipToNominator: values.submitterRelationshipToNominator,
     submitterRelationshipToNominatorOther:
       values.submitterRelationshipToNominatorOther,
@@ -436,6 +437,7 @@ const Nominator = ({ nominatorQuery, optionsQuery }: NominatorProps) => {
       submitDataTransformer={transformSubmitData}
       preSubmitValidation={preSubmitValidation}
       defaultValues={{
+        id: talentNomination.id,
         submitter: talentNomination.submitter?.id,
         role: defaultRole,
         nominator: defaultNominator,

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Nominee.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Nominee.tsx
@@ -178,6 +178,7 @@ const NominateTalentNominee_Fragment = graphql(/* GraphQL */ `
 
 const transformSubmitData: SubmitDataTransformer<FormValues> = (values) => {
   return {
+    id: values.id,
     nominee: { connect: values.nominee },
     nomineeReview: values.nomineeReview,
     nomineeRelationshipToNominator: values.nomineeRelationshipToNominator,
@@ -209,6 +210,7 @@ const Nominee = ({ nomineeQuery, optionsQuery }: NomineeProps) => {
     <UpdateForm<FormValues>
       submitDataTransformer={transformSubmitData}
       defaultValues={{
+        id: talentNomination.id,
         nominee: talentNomination.nominee?.id,
         nomineeReview: talentNomination.nomineeReview?.value,
         nomineeRelationshipToNominator:

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Rationale.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Rationale.tsx
@@ -66,6 +66,7 @@ const leadershipSkillsRangeError = defineMessage({
 
 const transformSubmitData: SubmitDataTransformer<FormValues> = (values) => {
   return {
+    id: values.id,
     nominationRationale: values.nominationRationale ?? null,
     skills: { sync: values.skills ?? [] },
     additionalComments: values.additionalComments ?? null,
@@ -100,6 +101,7 @@ const Rationale = ({ rationaleQuery, skillsQuery }: RationaleProps) => {
     <UpdateForm<FormValues>
       submitDataTransformer={transformSubmitData}
       defaultValues={{
+        id: talentNomination.id,
         nominationRationale: talentNomination?.nominationRationale ?? "",
         additionalComments: talentNomination?.additionalComments ?? "",
         skills: unpackMaybes(

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/UpdateForm.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/UpdateForm.tsx
@@ -51,7 +51,9 @@ const UpdateForm = <TFormValues extends BaseFormValues>({
     await update(
       {
         insertSubmittedStep: current,
-        ...(submitDataTransformer ? submitDataTransformer(values) : {}),
+        ...(submitDataTransformer
+          ? submitDataTransformer(values)
+          : { id: values.id }),
       },
       values.intent,
     );

--- a/apps/web/src/pages/TalentNominations/NominateTalent/labels.ts
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/labels.ts
@@ -40,6 +40,49 @@ const labels = defineMessages({
     id: "ACCjnC",
     description: "Label for a nominations nominee",
   },
+  nomineePerformance: {
+    defaultMessage: "Nominee's performance assessment",
+    id: "7xTRE7",
+    description: "Label for the nominee's performance assessment field",
+  },
+  nomineeLeadershipPotential: {
+    defaultMessage: "Nominee's leadership potential",
+    id: "DAOkQv",
+    description: "Label for the nominee's leadership potential field",
+  },
+  lowPerformance: {
+    defaultMessage: "Low performance",
+    id: "UKFUv+",
+    description: "Option for a low performance rating on the details step",
+  },
+  moderatePerformance: {
+    defaultMessage: "Moderate performance",
+    id: "C4OW6h",
+    description: "Option for a moderate performance rating on the details step",
+  },
+  highPerformance: {
+    defaultMessage: "High performance",
+    id: "PaJ21r",
+    description: "Option for a high performance rating on the details step",
+  },
+  lowPotential: {
+    defaultMessage: "Low potential",
+    id: "8KOc7q",
+    description:
+      "Option for a low leadership potential rating on the details step",
+  },
+  moderatePotential: {
+    defaultMessage: "Moderate potential",
+    id: "dxK0sS",
+    description:
+      "Option for a moderate leadership potential rating on the details step",
+  },
+  highPotential: {
+    defaultMessage: "High potential",
+    id: "2E39Xr",
+    description:
+      "Option for a high leadership potential rating on the details step",
+  },
   nominationOptions: {
     defaultMessage: "Nomination options",
     id: "khfdlt",

--- a/apps/web/src/pages/TalentNominations/NominateTalent/types.ts
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/types.ts
@@ -6,4 +6,5 @@ export type SubmitIntent = "save-draft" | "next-step";
 
 export interface BaseFormValues {
   intent: SubmitIntent;
+  id: string;
 }

--- a/apps/web/src/pages/TalentNominations/NominateTalent/useMutations.ts
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/useMutations.ts
@@ -19,10 +19,9 @@ import useCurrentStep from "./useCurrentStep";
 
 const NominateTalentUpdate_Mutation = graphql(/* GraphQL */ `
   mutation NominateTalentUpdate(
-    $id: UUID!
     $talentNomination: UpdateTalentNominationInput!
   ) {
-    updateTalentNomination(id: $id, talentNomination: $talentNomination) {
+    updateTalentNomination(talentNomination: $talentNomination) {
       id
     }
   }
@@ -71,7 +70,7 @@ const useMutations = (options: UseMutationsOptions): UseMutationsReturn => {
     talentNomination,
     intent,
   ) => {
-    return executeUpdateMutation({ id, talentNomination }, queryContext)
+    return executeUpdateMutation({ talentNomination }, queryContext)
       .then(async (res) => {
         if (res.error?.message) {
           throw new Error(res.error.message);


### PR DESCRIPTION
🤖 Resolves #17492 

## 👋 Introduction

Adds the ability to select nine box values during nomination.

## 🕵️ Details

- Adds the two new form fields when the event requires it
- Adds a new component that shows one of the nine messages
- Tightens input validation

Unfortunately, to make the validation work, I had to move the nomination ID into the input type and that required poking it through all of the different steps.  That made a bigger diff than I would have hoped.

## 🧪 Testing

1. Log in as "applicant-employee@test.com"
2. Navigate to `/en/communities/talent-events`
3. Choose an event with nine box
4. Complete the nomination
- [ ] nine box values are saved
- [ ] descriptions are shown for each combination
5. Choose an event without nine box
6. Complete the nomination
- [ ] nine box options are not shown
7. Capture your access token and start up a graphql client like Altair
- [ ] Can't add nine box options for non-9box events
- [ ] Can't omit nine box options for 9box events

SQL query to find events: :point_down: 
```sql
select id, name->>'en', include_nine_box from talent_nomination_events
```

GraphQL query to test updates: :point_down: 
```graphql
mutation NominateTalentUpdate( $talentNomination: UpdateTalentNominationInput!) {
  updateTalentNomination(talentNomination: $talentNomination) {
    id
    __typename
  }
}
#######
{  
  "talentNomination": {    
    "id": "db8c9a9d-de4b-4294-9973-6de06f669f9c",
    "insertSubmittedStep": "NOMINATION_DETAILS",
    "lateralMovementOptions": ["SMALL_DEPARTMENT"],
    "lateralMovementOptionsOther": null,
    "nineBoxLeadershipPotential": "MODERATE",
    "nineBoxPerformance": "MODERATE",
    "nominateForAdvancement": false,
    "nominateForDevelopmentPrograms": false,
    "nominateForLateralMovement": true
  }
}
```

## 📸 Screenshot

<img width="875" height="649" alt="image" src="https://github.com/user-attachments/assets/77ed8167-a060-4c10-a033-9cfc0dcdc6fa" />
