### PR TITLE
[Fix] Validate response to pool question

### DIFF
--- a/api/app/GraphQL/Validators/Mutation/UpdateApplicationValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/UpdateApplicationValidator.php
@@ -18,10 +18,12 @@ final class UpdateApplicationValidator extends Validator
     {
         $applicationId = $this->arg('id');
 
-        $userId = PoolCandidate::query()
-            ->select('user_id')
-            ->findOrFail($applicationId)
-            ->user_id;
+        $application = PoolCandidate::query()
+            ->select(['user_id', 'pool_id'])
+            ->findOrFail($applicationId);
+
+        $userId = $application->user_id;
+        $poolId = $application->pool_id;
 
         return [
             'application.educationRequirementAwardExperiences.sync.*' => [
@@ -50,11 +52,17 @@ final class UpdateApplicationValidator extends Validator
             'application.generalQuestionResponses.delete.*' => [
                 Rule::exists('general_question_responses', 'id')->where('pool_candidate_id', $applicationId),
             ],
+            'application.generalQuestionResponses.create.*.generalQuestion.connect' => [
+                Rule::exists('general_questions', 'id')->where('pool_id', $poolId),
+            ],
             'application.screeningQuestionResponses.update.*.id' => [
                 Rule::exists('screening_question_responses', 'id')->where('pool_candidate_id', $applicationId),
             ],
             'application.screeningQuestionResponses.delete.*' => [
                 Rule::exists('screening_question_responses', 'id')->where('pool_candidate_id', $applicationId),
+            ],
+            'application.screeningQuestionResponses.create.*.screeningQuestion.connect' => [
+                Rule::exists('screening_questions', 'id')->where('pool_id', $poolId),
             ],
         ];
     }

--- a/api/tests/Feature/GeneralQuestionResponsesTest.php
+++ b/api/tests/Feature/GeneralQuestionResponsesTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Enums\ApplicationStatus;
 use App\Models\Community;
+use App\Models\GeneralQuestion;
 use App\Models\GeneralQuestionResponse;
 use App\Models\Pool;
 use App\Models\PoolCandidate;
@@ -76,7 +77,7 @@ class GeneralQuestionResponsesTest extends TestCase
 
     public function testCreatingGeneralQuestionResponses(): void
     {
-        $application = PoolCandidate::factory()->create([
+        $application = PoolCandidate::factory()->for($this->pool)->create([
             'application_status' => ApplicationStatus::DRAFT->name,
             'user_id' => $this->processOperator->id,
         ]);
@@ -123,7 +124,7 @@ class GeneralQuestionResponsesTest extends TestCase
 
     public function testUpdatingGeneralQuestionResponses(): void
     {
-        $application = PoolCandidate::factory()->create([
+        $application = PoolCandidate::factory()->for($this->pool)->create([
             'application_status' => ApplicationStatus::DRAFT->name,
             'user_id' => $this->processOperator->id,
         ]);
@@ -169,7 +170,7 @@ class GeneralQuestionResponsesTest extends TestCase
 
     public function testDeletingGeneralQuestionResponses(): void
     {
-        $application = PoolCandidate::factory()->create([
+        $application = PoolCandidate::factory()->for($this->pool)->create([
             'application_status' => ApplicationStatus::DRAFT->name,
             'user_id' => $this->processOperator->id,
         ]);
@@ -294,5 +295,34 @@ class GeneralQuestionResponsesTest extends TestCase
         );
 
         assertNotNull(GeneralQuestionResponse::find($victimResponse->id), 'Victim response should not be deleted');
+    }
+
+    public function testCannotCreateGeneralQuestionResponseForQuestionFromDifferentPool(): void
+    {
+        $application = PoolCandidate::factory()->for($this->pool)->create([
+            'application_status' => ApplicationStatus::DRAFT->name,
+            'user_id' => $this->processOperator->id,
+        ]);
+
+        $otherPoolQuestion = GeneralQuestion::factory()->create();
+
+        $this->actingAs($this->processOperator, 'api')->graphQL($this->updateApplication, [
+            'id' => $application->id,
+            'application' => [
+                'generalQuestionResponses' => [
+                    'create' => [
+                        [
+                            'generalQuestion' => [
+                                'connect' => $otherPoolQuestion->id,
+                            ],
+                            'answer' => 'the answer',
+                        ],
+                    ],
+                ],
+            ],
+        ])->assertGraphQLValidationError(
+            'application.generalQuestionResponses.create.0.generalQuestion.connect',
+            'The selected application.generalQuestionResponses.create.0.generalQuestion.connect is invalid.'
+        );
     }
 }

--- a/api/tests/Feature/ScreeningQuestionsTest.php
+++ b/api/tests/Feature/ScreeningQuestionsTest.php
@@ -451,4 +451,36 @@ class ScreeningQuestionsTest extends TestCase
 
         assertNotNull(ScreeningQuestionResponse::find($victimResponse->id), 'Victim response should not be deleted');
     }
+
+    public function testCannotCreateScreeningQuestionResponseForQuestionFromDifferentPool(): void
+    {
+        $application = PoolCandidate::factory()->for($this->publishedPool)->create([
+            'application_status' => ApplicationStatus::DRAFT->name,
+            'user_id' => $this->applicantUser->id,
+        ]);
+
+        $otherPool = Pool::factory()->withScreeningQuestions()->create([
+            'community_id' => $this->community->id,
+        ]);
+        $otherPoolQuestionId = $otherPool->screeningQuestions->first()->id;
+
+        $this->actingAs($this->applicantUser, 'api')->graphQL($this->updateApplication, [
+            'id' => $application->id,
+            'application' => [
+                'screeningQuestionResponses' => [
+                    'create' => [
+                        [
+                            'screeningQuestion' => [
+                                'connect' => $otherPoolQuestionId,
+                            ],
+                            'answer' => 'the answer',
+                        ],
+                    ],
+                ],
+            ],
+        ])->assertGraphQLValidationError(
+            'application.screeningQuestionResponses.create.0.screeningQuestion.connect',
+            'The selected application.screeningQuestionResponses.create.0.screeningQuestion.connect is invalid.'
+        );
+    }
 }


### PR DESCRIPTION
🤖 Resolves #17405

## 👋 Introduction

Adds validation to ensure users are responding to questions on the exact pool they are replying to.

## 🕵️ Details

Previously, a user could create a response to a question from a different pool. This adds the validaiton to prevent that by checking that the ID with the mathcing pool ID of the applicaiton exists.

## 🧪 Testing

1. Login as any user
2. Start an application
3. Manually submit an `updateApplication` mutation to that application attempting to respond to a question on a pool different than the one you were applying to
4. Confirm that you get a validation error