### PR TITLE
[Fix] Update applicant filter factory relationships

### DIFF
--- a/api/database/factories/ApplicantFilterFactory.php
+++ b/api/database/factories/ApplicantFilterFactory.php
@@ -17,7 +17,7 @@ use App\Models\WorkStream;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Collection;
 
-class ApplicantFilterFactory extends Factory
+class ApplicantFilterFactory extends BaseFactory
 {
     /**
      * The name of the factory's corresponding model.
@@ -33,7 +33,7 @@ class ApplicantFilterFactory extends Factory
      */
     public function definition()
     {
-        $community = Community::first();
+        $community = $this->firstOrCreate(Community::class);
 
         return [
             'has_diploma' => $this->faker->boolean(),
@@ -62,7 +62,7 @@ class ApplicantFilterFactory extends Factory
                 TalentRequestSource::class,
                 $this->faker->numberBetween(1, 3)
             ),
-            'community_id' => $community ? $community->id : Community::factory()->create()->id,
+            'community_id' => $community->id,
         ];
     }
 
@@ -95,36 +95,34 @@ class ApplicantFilterFactory extends Factory
     {
         return $this->afterCreating(function (ApplicantFilter $filter) use ($sparse) {
             $minCount = $sparse ? 0 : 1;
-            $classifications = Classification::inRandomOrder()->limit(
-                $this->faker->numberBetween($minCount, 2)
-            )->get();
-            $filter->classifications()->saveMany($classifications);
-            $skills = Skill::inRandomOrder()->limit(
-                $this->faker->numberBetween($minCount, 2)
-            )->get();
-            $filter->skills()->saveMany($skills);
 
-            $pools = Pool::whereNotNull('published_at')->inRandomOrder()->limit(
-                $this->faker->numberBetween($minCount, 1)
-            )->get();
+            $filter->classifications()->saveMany(
+                Classification::inRandomOrder()->limit($this->faker->numberBetween($minCount, 2))->get()
+            );
+
+            $filter->skills()->saveMany(
+                Skill::inRandomOrder()->limit($this->faker->numberBetween($minCount, 2))->get()
+            );
+
+            $pools = $this->faker->boolean($sparse ? 50 : 100)
+                ? collect([$this->existingOrNewPool($filter->community)])
+                : collect();
+
             $filter->pools()->saveMany($pools);
-            $filter->qualifiedInClassifications()->saveMany($pools->flatMap(fn ($pool) => $pool->classification));
-            $streams = $pools->map(fn ($pool) => $pool->workStream);
-            $filter->qualifiedInWorkStreams()->saveMany($streams);
-
-            $ATIP = Community::where('key', 'atip')->first();
-            $digital = Community::where('key', 'digital')->first();
-
-            $isATIP = $streams->contains(fn ($stream) => $stream->key === 'ACCESS_INFORMATION_PRIVACY');
-
-            if ($isATIP && $ATIP?->id) {
-                $filter->community_id = $ATIP->id;
-            } elseif ($digital?->id) {
-                $filter->community_id = $digital->id;
-            }
-
-            $filter->save();
+            $filter->qualifiedInClassifications()->saveMany($pools->pluck('classification')->filter());
+            $filter->qualifiedInWorkStreams()->saveMany($pools->pluck('workStream')->filter());
         });
+    }
+
+    /**
+     * Find a published pool belonging to the given community, or create one if none exist.
+     */
+    private function existingOrNewPool(Community $community): Pool
+    {
+        return $community->pools()
+            ->whereNotNull('published_at')
+            ->inRandomOrder()
+            ->firstOr(fn () => Pool::factory()->published()->for($community)->create());
     }
 
     /**

--- a/api/database/factories/ApplicantFilterFactory.php
+++ b/api/database/factories/ApplicantFilterFactory.php
@@ -9,7 +9,6 @@ use App\Enums\PositionDuration;
 use App\Enums\TalentRequestSource;
 use App\Enums\WorkRegion;
 use App\Models\ApplicantFilter;
-use App\Models\Classification;
 use App\Models\Community;
 use App\Models\Pool;
 use App\Models\Skill;
@@ -96,10 +95,6 @@ class ApplicantFilterFactory extends BaseFactory
         return $this->afterCreating(function (ApplicantFilter $filter) use ($sparse) {
             $minCount = $sparse ? 0 : 1;
 
-            $filter->classifications()->saveMany(
-                Classification::inRandomOrder()->limit($this->faker->numberBetween($minCount, 2))->get()
-            );
-
             $filter->skills()->saveMany(
                 Skill::inRandomOrder()->limit($this->faker->numberBetween($minCount, 2))->get()
             );
@@ -109,6 +104,7 @@ class ApplicantFilterFactory extends BaseFactory
                 : collect();
 
             $filter->pools()->saveMany($pools);
+            $filter->classifications()->saveMany($pools->pluck('classification')->filter());
             $filter->qualifiedInClassifications()->saveMany($pools->pluck('classification')->filter());
             $filter->qualifiedInWorkStreams()->saveMany($pools->pluck('workStream')->filter());
         });

--- a/api/database/factories/TalentRequestFactory.php
+++ b/api/database/factories/TalentRequestFactory.php
@@ -40,7 +40,7 @@ class TalentRequestFactory extends BaseFactory
             'job_title' => $this->faker->jobTitle(),
             'additional_comments' => $this->faker->text(),
             'hr_advisor_email' => $this->faker->unique()->safeEmail,
-            'applicant_filter_id' => ApplicantFilter::factory()->create(['community_id' => $community->id])->id,
+            'applicant_filter_id' => ApplicantFilter::factory()->for($community)->create()->id,
             'manager_job_title' => $this->faker->jobTitle(),
             'position_type' => $this->faker->enum(TalentRequestPositionType::class),
             'reason' => $this->faker->enum(TalentRequestReason::class),
@@ -71,7 +71,6 @@ class TalentRequestFactory extends BaseFactory
         ]);
     }
 
-    // May modify $talentRequest->applicantFilter (attaches pools) to ensure created users match it. See #17380.
     public function withTrackedUsers(int $count = 3): self
     {
         return $this->afterCreating(function (TalentRequest $talentRequest) use ($count) {
@@ -84,7 +83,6 @@ class TalentRequestFactory extends BaseFactory
         });
     }
 
-    // May modify $talentRequest->applicantFilter (attaches pools) to ensure created users match it. See #17380.
     public function withMatchingUsers(int $count = 3): self
     {
         return $this->afterCreating(function (TalentRequest $talentRequest) use ($count) {
@@ -104,22 +102,15 @@ class TalentRequestFactory extends BaseFactory
             && (! $matchesQualifiedInPool || $this->faker->boolean());
 
         if ($matchesQualifiedInPool) {
-            $pool = Pool::factory()->candidatesAvailableInSearch()->create(array_filter([
-                'community_id' => $filter->community_id,
-                'classification_id' => $filter->qualifiedInClassifications->shuffle()->first()?->id,
-                'work_stream_id' => $filter->qualifiedInWorkStreams->shuffle()->first()?->id,
-            ]));
-
-            if ($filter->pools()->exists()) {
-                $filter->pools()->attach($pool->id);
-            }
+            $pool = $filter->pools->isNotEmpty()
+                ? $filter->pools->shuffle()->first()
+                : $this->newMatchingPool($filter);
 
             PoolCandidate::factory()
                 ->availableInSearch()
-                ->createQuietly([
-                    'pool_id' => $pool->id,
-                    'user_id' => $user->id,
-                ]);
+                ->for($pool)
+                ->for($user)
+                ->createQuietly();
         }
 
         if ($matchesAtLevel) {
@@ -157,6 +148,24 @@ class TalentRequestFactory extends BaseFactory
         }
 
         return $user;
+    }
+
+    /**
+     * Create a pool matching the filter's community, classification, and work stream constraints.
+     */
+    private function newMatchingPool(ApplicantFilter $filter): Pool
+    {
+        $pool = Pool::factory()->candidatesAvailableInSearch()->for($filter->community);
+
+        if ($classification = $filter->qualifiedInClassifications->shuffle()->first()) {
+            $pool = $pool->for($classification);
+        }
+
+        if ($workStream = $filter->qualifiedInWorkStreams->shuffle()->first()) {
+            $pool = $pool->for($workStream);
+        }
+
+        return $pool->create();
     }
 
     /**


### PR DESCRIPTION
🤖 Resolves #17380 

## 👋 Introduction

Fixes an inconsistency in the `ApplicantFitlerFactory` and `TalentRequestFactory` so that aplicant filter relationships match the pool.

## 🧪 Testing

1. Run the seeder
2. Confirm applicant filter relationships are consistent (community, classification, work stream) with the pool.
3. Confirm tests suite still passes