### PR TITLE
[Bug] Talent nominations excel matches table

### DIFF
--- a/api/app/Generators/NominationsExcelGenerator.php
+++ b/api/app/Generators/NominationsExcelGenerator.php
@@ -772,8 +772,7 @@ class NominationsExcelGenerator extends ExcelGenerator implements FileGeneratorI
 
         /** @var Builder<TalentNominationGroup> $query */
         $query
-            ->authorizedToView(['userId' => $this->authenticatedUserId])
-            ->isVerifiedGovEmployee();
+            ->authorizedToView(['userId' => $this->authenticatedUserId]);
 
         return $query;
 


### PR DESCRIPTION
🤖 Resolves  #17508

## 👋 Introduction

This PR fixes a mismatch between the talent nominations UI table and the excel download. Nominees who had not verified their work email were being filtered out of the download even though they were visible in the UI. This caused the excel download to show fewer nominees than the table.
The issue was caused by `isVerifiedGovEmployee` in the nominations excel download. It was filtering out nominees who hadn't verified their work email yet. 


## 🧪 Testing

1. Build and log in as `community@test.com`
2. Navigate to a talent nomination event (one that has more than 10 nominees)
3. Select all nominees and click Download Excel / Download full dataset
4. Open the download and verify the nominee list in the UI are the same in the export


## 📸 Screenshot

<img width="881" height="452" alt="image" src="https://github.com/user-attachments/assets/8aea9770-242c-429d-9a91-e2d829719e02" />

