### PR TITLE
[Fix] Ul/Ol add bottom margin to the last item in a list

### DIFF
--- a/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
+++ b/apps/web/src/pages/CertificationExamVouchersPage/CertificationExamVouchersPage.tsx
@@ -140,58 +140,56 @@ export const Component = () => {
               description: "First paragraph of certification topics section",
             })}
           </p>
-          <p className="mb-3">
-            <Ul space="md">
-              <li>
-                {intl.formatMessage({
-                  defaultMessage: "IT project management",
-                  id: "ZiCXd1",
-                  description:
-                    "First item in list of certification topics section",
-                })}
-              </li>
-              <li>
-                {intl.formatMessage({
-                  defaultMessage: "Business analysis",
-                  id: "+BeD0v",
-                  description:
-                    "Second item in list of certification topics section",
-                })}
-              </li>
-              <li>
-                {intl.formatMessage({
-                  defaultMessage: "Cloud computing",
-                  id: "e6PlO0",
-                  description:
-                    "Third item in list of certification topics section",
-                })}
-              </li>
-              <li>
-                {intl.formatMessage({
-                  defaultMessage: "Cyber security",
-                  id: "hSoZzH",
-                  description:
-                    "Fourth item in list of certification topics section",
-                })}
-              </li>
-              <li>
-                {intl.formatMessage({
-                  defaultMessage: "Enterprise architecture",
-                  id: "GxrfIv",
-                  description:
-                    "Fifth item in list of certification topics section",
-                })}
-              </li>
-              <li>
-                {intl.formatMessage({
-                  defaultMessage: "DevOps",
-                  id: "zeLVU6",
-                  description:
-                    "Sixth item in list of certification topics section",
-                })}
-              </li>
-            </Ul>
-          </p>
+          <Ul space="md" className="mb-3">
+            <li>
+              {intl.formatMessage({
+                defaultMessage: "IT project management",
+                id: "ZiCXd1",
+                description:
+                  "First item in list of certification topics section",
+              })}
+            </li>
+            <li>
+              {intl.formatMessage({
+                defaultMessage: "Business analysis",
+                id: "+BeD0v",
+                description:
+                  "Second item in list of certification topics section",
+              })}
+            </li>
+            <li>
+              {intl.formatMessage({
+                defaultMessage: "Cloud computing",
+                id: "e6PlO0",
+                description:
+                  "Third item in list of certification topics section",
+              })}
+            </li>
+            <li>
+              {intl.formatMessage({
+                defaultMessage: "Cyber security",
+                id: "hSoZzH",
+                description:
+                  "Fourth item in list of certification topics section",
+              })}
+            </li>
+            <li>
+              {intl.formatMessage({
+                defaultMessage: "Enterprise architecture",
+                id: "GxrfIv",
+                description:
+                  "Fifth item in list of certification topics section",
+              })}
+            </li>
+            <li>
+              {intl.formatMessage({
+                defaultMessage: "DevOps",
+                id: "zeLVU6",
+                description:
+                  "Sixth item in list of certification topics section",
+              })}
+            </li>
+          </Ul>
           <p className="mb-3">
             {intl.formatMessage({
               defaultMessage:
@@ -231,45 +229,43 @@ export const Component = () => {
                 "Second paragraph of eligibility requirements section",
             })}
           </p>
-          <p className="mb-3">
-            <Ul space="md">
-              <li>
-                {intl.formatMessage({
-                  defaultMessage:
-                    "Be IT-classified or acting in an IT role for a minimum of four months plus one day.",
-                  id: "jjwS3G",
-                  description:
-                    "First item in list of eligibility requirements section",
-                })}
-              </li>
-              <li>
-                {intl.formatMessage({
-                  defaultMessage: "Have an active Navigar account.",
-                  id: "saX5lc",
-                  description:
-                    "Second item in list of eligibility requirements section",
-                })}
-              </li>
-              <li>
-                {intl.formatMessage({
-                  defaultMessage:
-                    "Have completed any necessary preparatory training to support successful exam completion.",
-                  id: "UePGN0",
-                  description:
-                    "Fourth item in list of eligibility requirements section",
-                })}
-              </li>
-              <li>
-                {intl.formatMessage({
-                  defaultMessage:
-                    "Prepared to write the exam within 60 days of submitting your application.",
-                  id: "dSr8pX",
-                  description:
-                    "Fifth item in list of eligibility requirements section",
-                })}
-              </li>
-            </Ul>
-          </p>
+          <Ul space="md" className="mb-3">
+            <li>
+              {intl.formatMessage({
+                defaultMessage:
+                  "Be IT-classified or acting in an IT role for a minimum of four months plus one day.",
+                id: "jjwS3G",
+                description:
+                  "First item in list of eligibility requirements section",
+              })}
+            </li>
+            <li>
+              {intl.formatMessage({
+                defaultMessage: "Have an active Navigar account.",
+                id: "saX5lc",
+                description:
+                  "Second item in list of eligibility requirements section",
+              })}
+            </li>
+            <li>
+              {intl.formatMessage({
+                defaultMessage:
+                  "Have completed any necessary preparatory training to support successful exam completion.",
+                id: "UePGN0",
+                description:
+                  "Fourth item in list of eligibility requirements section",
+              })}
+            </li>
+            <li>
+              {intl.formatMessage({
+                defaultMessage:
+                  "Prepared to write the exam within 60 days of submitting your application.",
+                id: "dSr8pX",
+                description:
+                  "Fifth item in list of eligibility requirements section",
+              })}
+            </li>
+          </Ul>
         </div>
         <div className="mb-18">
           <Heading

--- a/apps/web/src/pages/DNDDigitalCareersPage/DNDDigitalCareersPage.tsx
+++ b/apps/web/src/pages/DNDDigitalCareersPage/DNDDigitalCareersPage.tsx
@@ -217,7 +217,7 @@ export const Component = () => {
             description: "Lead-in text for specific skills DSG is looking for",
           }) + intl.formatMessage(commonMessages.dividingColon)}
         </p>
-        <Ul space="md" className="grid max-w-md sm:grid-cols-2 sm:gap-x-6">
+        <Ul className="grid max-w-md gap-y-1.5 sm:grid-cols-2 sm:gap-x-6">
           <li>
             {intl.formatMessage({
               defaultMessage: "cyber security",

--- a/apps/web/src/pages/InstructorLedTrainingPage/InstructorLedTrainingPage.tsx
+++ b/apps/web/src/pages/InstructorLedTrainingPage/InstructorLedTrainingPage.tsx
@@ -353,41 +353,39 @@ export const Component = () => {
             description: "Second paragraph of apply section",
           })}
         </p>
-        <p className="mb-3">
-          <Ul space="md">
-            <li>
-              {intl.formatMessage({
-                defaultMessage:
-                  "Be IT-classified or acting in an IT role for a minimum of four months plus one day",
-                id: "A66erX",
-                description: "First item in list of apply section",
-              })}
-            </li>
-            <li>
-              {intl.formatMessage({
-                defaultMessage: "Have an active Navigar account",
-                id: "A5HTBD",
-                description: "Second item in list of apply section",
-              })}
-            </li>
-            <li>
-              {intl.formatMessage({
-                defaultMessage:
-                  "Have completed all required prerequisites (course-dependent)",
-                id: "a3GTSe",
-                description: "Third item in list of apply section",
-              })}
-            </li>
-            <li>
-              {intl.formatMessage({
-                defaultMessage:
-                  "Be available to attend at least 80% of the scheduled training",
-                id: "hUf6+2",
-                description: "Fourth item in list of apply section",
-              })}
-            </li>
-          </Ul>
-        </p>
+        <Ul space="md" className="mb-3">
+          <li>
+            {intl.formatMessage({
+              defaultMessage:
+                "Be IT-classified or acting in an IT role for a minimum of four months plus one day",
+              id: "A66erX",
+              description: "First item in list of apply section",
+            })}
+          </li>
+          <li>
+            {intl.formatMessage({
+              defaultMessage: "Have an active Navigar account",
+              id: "A5HTBD",
+              description: "Second item in list of apply section",
+            })}
+          </li>
+          <li>
+            {intl.formatMessage({
+              defaultMessage:
+                "Have completed all required prerequisites (course-dependent)",
+              id: "a3GTSe",
+              description: "Third item in list of apply section",
+            })}
+          </li>
+          <li>
+            {intl.formatMessage({
+              defaultMessage:
+                "Be available to attend at least 80% of the scheduled training",
+              id: "hUf6+2",
+              description: "Fourth item in list of apply section",
+            })}
+          </li>
+        </Ul>
         <div
           role="group"
           aria-labelledby="langFilter"

--- a/apps/web/src/pages/TermsAndConditions/TermsAndConditions.tsx
+++ b/apps/web/src/pages/TermsAndConditions/TermsAndConditions.tsx
@@ -663,7 +663,7 @@ export const Component = () => {
                   description: "Comments or contributions list title",
                 })}
               </p>
-              <Ul space="md">
+              <Ul space="md" className="mb-3">
                 {comments.map((comment) => (
                   <li key={uniqueId()}>{comment}</li>
                 ))}

--- a/packages/ui/src/components/List/List.stories.tsx
+++ b/packages/ui/src/components/List/List.stories.tsx
@@ -1,0 +1,104 @@
+import type { Meta, StoryFn } from "@storybook/react-vite";
+
+import { allModes } from "@gc-digital-talent/storybook-helpers";
+
+import type { ListVariants } from "./styles";
+import Ol from "./Ol";
+import Ul from "./Ul";
+
+const spaces: ListVariants["space"][] = ["sm", "md", "lg", "xl"];
+
+// A visible sibling so the gap below the last item is legible in a snapshot.
+const Boundary = () => (
+  <div className="border-t border-error bg-error/10 p-1.5 text-sm">
+    Following content
+  </div>
+);
+
+export default {
+  component: Ul,
+  parameters: {
+    chromatic: {
+      modes: {
+        light: allModes.light,
+        dark: allModes.dark,
+      },
+    },
+  },
+} as Meta<typeof Ul>;
+
+const Template: StoryFn<typeof Ul> = () => (
+  <div className="flex flex-col gap-12">
+    {spaces.map((space) => (
+      <div key={space}>
+        <p className="mb-3 font-bold">{`space="${space}"`}</p>
+        <div className="grid gap-6 sm:grid-cols-3">
+          <div>
+            <Ul space={space}>
+              <li>Unordered one</li>
+              <li>Unordered two</li>
+              <li>Unordered three</li>
+            </Ul>
+            <Boundary />
+          </div>
+          <div>
+            <Ol space={space}>
+              <li>Ordered one</li>
+              <li>Ordered two</li>
+              <li>Ordered three</li>
+            </Ol>
+            <Boundary />
+          </div>
+          <div>
+            <Ul space={space} unStyled>
+              <li>Unstyled one</li>
+              <li>Unstyled two</li>
+              <li>Unstyled three</li>
+            </Ul>
+            <Boundary />
+          </div>
+        </div>
+      </div>
+    ))}
+    <div>
+      <p className="mb-3 font-bold">Nested</p>
+      <div className="grid gap-6 sm:grid-cols-3">
+        <div>
+          <Ul space="md">
+            <li>
+              Parent one
+              <Ul space="md">
+                <li>Child one</li>
+                <li>Child two</li>
+              </Ul>
+            </li>
+            <li>
+              Parent two
+              <Ul space="md">
+                <li>Child one</li>
+                <li>Child two</li>
+              </Ul>
+            </li>
+          </Ul>
+          <Boundary />
+        </div>
+        <div>
+          <Ol space="md" inside>
+            <li>Inside one</li>
+            <li>Inside two</li>
+          </Ol>
+          <Boundary />
+        </div>
+        <div>
+          <Ul space="md" noIndent>
+            <li>No indent one</li>
+            <li>No indent two</li>
+          </Ul>
+          <Boundary />
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export const Default = Template.bind({});

--- a/packages/ui/src/components/List/styles.ts
+++ b/packages/ui/src/components/List/styles.ts
@@ -9,10 +9,10 @@ export const list = tv({
       unordered: "list-disc [&_ul]:list-[circle]",
     },
     space: {
-      sm: "[&_li]:mb-0.75",
-      md: "[&_li]:mb-1.5",
-      lg: "[&_li]:mb-3",
-      xl: "[&_li]:mb-6",
+      sm: "[&_li]:not-last:mb-0.75",
+      md: "[&_li]:not-last:mb-1.5",
+      lg: "[&_li]:not-last:mb-3",
+      xl: "[&_li]:not-last:mb-6",
     },
     unStyled: {
       true: "",

--- a/packages/ui/src/components/TableOfContents/List.tsx
+++ b/packages/ui/src/components/TableOfContents/List.tsx
@@ -5,7 +5,7 @@ import { tv } from "tailwind-variants";
 export type ListItemProps = HTMLProps<HTMLLIElement>;
 
 export const ListItem = ({ children, ...rest }: ListItemProps) => (
-  <li className="mb-1.5" {...rest}>
+  <li className="not-last:mb-1.5" {...rest}>
     {children}
   </li>
 );


### PR DESCRIPTION
🤖 Resolves #17232

## 👋 Introduction

The `Ul` and `Ol` components applied a bottom margin to every list item, including the last one, so every list using the `space` prop rendered with surplus whitespace underneath it. This scopes that margin to all but the last item. I checked all 108 call sites that pass `space` for anything leaning on the extra space, and only one was — the comments list on the Terms and Conditions page, which now carries its own bottom margin. I also added a Storybook story, since the List components had none. A final commit fixes three unrelated list defects I ran into while auditing the call sites; it's self-contained and can be dropped if you'd rather see it separately.

## 🧪 Testing

Nearly every diff should look the same in kind: slightly less whitespace *below* a list — 3px at `space="sm"`, 6px at `md`, 12px at `lg`, 24px at `xl`. Anything that isn't that is worth a second look.

- **The failure mode to hunt for is over-tightening** — list text now flush against a container's bottom edge or the paragraph below it.
- **Lists followed by a heading should be unchanged.** The stray margin was already collapsing into the heading's larger `mt-9`, so it was never visible there. A diff on one of those means something is off.
- Densest list usage, worth a direct look: Accessibility Statement, Terms and Conditions, Roles and Permissions, IT Training Fund, Application Review, and the Applicant / Community / Admin dashboards.

For the `adjacent defects` commit:

1. **Certification Exam Vouchers** and **Instructor-Led Training** should render *identically* — only the DOM changed. The check is the console: React no longer warns `<ul> cannot appear as a descendant of <p>`.
2. **DND Digital Careers** skills grid should be unchanged; row spacing now comes from `gap-y-1.5` instead of item margins.
3. **Table of contents sidebar** should show no diff — that margin was already collapsing away. Fixed as the same latent bug, not because anything looked wrong.

## 📸 Screenshot

The new List story at the same viewport. The "before" build reverts only the `styles.ts` variant, so the two are directly comparable.

### Before

<!-- 01-before.png -->

Gap below the last item, growing with the `space` value — clearest at `space="xl"`.

### After

<!-- 02-after.png -->

Flush at every `space` value, with the spacing *between* items unchanged.

### Measured

A trailing `li` margin collapses out of the `ul`'s box, so the gap between the list and the block below it is exactly the stray margin:

| `space` | Before | After |
| --- | --- | --- |
| `sm` | 3px | **0px** |
| `md` | 6px | **0px** |
| `lg` | 12px | **0px** |
| `xl` | 24px | **0px** |
| nested | 6px | **0px** |

Same for `Ul`, `Ol` and `unStyled` — 15 cases, all 0px after.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 5 (1M context)
