### PR TITLE
[Feature] Custom instructions are editable and nullable

### DIFF
--- a/api/database/factories/TalentNominationEventFactory.php
+++ b/api/database/factories/TalentNominationEventFactory.php
@@ -49,7 +49,7 @@ class TalentNominationEventFactory extends Factory
             },
             'include_nine_box' => $this->faker->boolean(),
             'require_reference_for_advancement' => $this->faker->boolean(),
-            'custom_instructions' => $this->faker->localizedString($this->faker->sentences(3, true)),
+            'custom_instructions' => $this->faker->optional()->localizedString($this->faker->sentences(3, true)),
             'contact_email' => $this->faker->email(),
         ];
     }

--- a/apps/web/src/pages/TalentEvents/CreateTalentEventPage.tsx
+++ b/apps/web/src/pages/TalentEvents/CreateTalentEventPage.tsx
@@ -117,6 +117,10 @@ const CreateTalentEventPage = () => {
             })),
           ],
         },
+        customInstructions: {
+          en: formValues.customInstructions.en ?? "",
+          fr: formValues.customInstructions.fr ?? "",
+        },
         contactEmail: formValues.contactEmail,
       },
     })

--- a/apps/web/src/pages/TalentEvents/UpdateTalentEventPage.tsx
+++ b/apps/web/src/pages/TalentEvents/UpdateTalentEventPage.tsx
@@ -174,6 +174,10 @@ const UpdateTalentEventForm = ({
             })),
           ],
         },
+        customInstructions: {
+          en: formValues.customInstructions.en ?? "",
+          fr: formValues.customInstructions.fr ?? "",
+        },
         contactEmail: formValues.contactEmail,
       },
     })

--- a/apps/web/src/pages/TalentEvents/components/ActiveTalentEventForm.tsx
+++ b/apps/web/src/pages/TalentEvents/components/ActiveTalentEventForm.tsx
@@ -462,6 +462,7 @@ const ActiveTalentEventForm = ({
                 description: "label for nomination event instructions",
               })}
               appendLanguageToLabel={"en"}
+              aria-describedby={instructionsDescriptionId}
             />
             <RichTextInput
               id={"customInstructions.fr"}

--- a/apps/web/src/pages/TalentEvents/components/ActiveTalentEventForm.tsx
+++ b/apps/web/src/pages/TalentEvents/components/ActiveTalentEventForm.tsx
@@ -462,7 +462,6 @@ const ActiveTalentEventForm = ({
                 description: "label for nomination event instructions",
               })}
               appendLanguageToLabel={"en"}
-              rules={{ required: intl.formatMessage(errorMessages.required) }}
             />
             <RichTextInput
               id={"customInstructions.fr"}
@@ -474,7 +473,6 @@ const ActiveTalentEventForm = ({
                 description: "label for nomination event instructions",
               })}
               appendLanguageToLabel={"fr"}
-              rules={{ required: intl.formatMessage(errorMessages.required) }}
               aria-describedby={instructionsDescriptionId}
             />
           </div>

--- a/apps/web/src/pages/TalentEvents/components/ActiveTalentEventForm.tsx
+++ b/apps/web/src/pages/TalentEvents/components/ActiveTalentEventForm.tsx
@@ -3,7 +3,7 @@ import type { SubmitHandler } from "react-hook-form";
 import { FormProvider, useFieldArray, useForm } from "react-hook-form";
 import { useMutation } from "urql";
 import { useNavigate } from "react-router";
-import { useState } from "react";
+import { useId, useState } from "react";
 
 import { CardSeparator, Heading, Link, Notice } from "@gc-digital-talent/ui";
 import type { FragmentType } from "@gc-digital-talent/graphql";
@@ -17,9 +17,8 @@ import {
 } from "@gc-digital-talent/i18n";
 import {
   DateInput,
-  htmlToRichTextJSON,
   Input,
-  RichTextRenderer,
+  RichTextInput,
   Submit,
   TextArea,
 } from "@gc-digital-talent/forms";
@@ -51,6 +50,7 @@ import { isCommunity } from "../TalentEvent/util";
 import AddDialog from "./AddDialog";
 import EditDialog from "./EditDialog";
 import RemoveDialog from "./RemoveDialog";
+import { instructionsWordCountLimits } from "./constants";
 
 interface ActiveTalentEventFormProps {
   userQuery: FragmentType<typeof TalentNominationEvent_Fragment>;
@@ -85,7 +85,6 @@ const ActiveTalentEventForm = ({
     customInstructions,
   } = talentNominationEvent;
   const notFound = intl.formatMessage(commonMessages.notFound);
-  const notProvided = intl.formatMessage(commonMessages.notProvided);
 
   const methods = useForm<FormValues>({
     defaultValues: {
@@ -110,6 +109,10 @@ const ActiveTalentEventForm = ({
         }),
       ),
       contactEmail: contactEmail,
+      customInstructions: {
+        en: customInstructions?.en,
+        fr: customInstructions?.fr,
+      },
     },
   });
 
@@ -157,6 +160,7 @@ const ActiveTalentEventForm = ({
           ],
         },
         contactEmail: formValues.contactEmail,
+        customInstructions: formValues.customInstructions,
       },
     })
       .then(async (result) => {
@@ -223,6 +227,8 @@ const ActiveTalentEventForm = ({
 
   const [editOpen, setEditOpen] = useState<string | null>(null);
   const [removeOpen, setRemoveOpen] = useState<string | null>(null);
+
+  const instructionsDescriptionId = useId();
 
   return (
     <>
@@ -437,38 +443,40 @@ const ActiveTalentEventForm = ({
                 </BoolCheckIcon>
               </FieldDisplay>
             </div>
-            <FieldDisplay
+            <div className="xs:col-span-2" id={instructionsDescriptionId}>
+              {intl.formatMessage({
+                defaultMessage:
+                  "The nomination form offers basic instructions at the beginning of each nomination to help guide the nominator through the process. You use the following optional field to include extra context that might be unique to your event.",
+                id: "5jkq2u",
+                description: "description for custom event instructions",
+              })}
+            </div>
+
+            <RichTextInput
+              id={"customInstructions.en"}
+              name={"customInstructions.en"}
+              wordLimit={instructionsWordCountLimits.en}
               label={intl.formatMessage({
                 defaultMessage: "Customized instruction text",
                 id: "f1Kpkp",
                 description: "label for nomination event instructions",
               })}
-              appendLanguageToLabel="en"
-            >
-              {customInstructions?.en ? (
-                <RichTextRenderer
-                  node={htmlToRichTextJSON(customInstructions.en)}
-                />
-              ) : (
-                notProvided
-              )}
-            </FieldDisplay>
-            <FieldDisplay
+              appendLanguageToLabel={"en"}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
+            />
+            <RichTextInput
+              id={"customInstructions.fr"}
+              name={"customInstructions.fr"}
+              wordLimit={instructionsWordCountLimits.fr}
               label={intl.formatMessage({
                 defaultMessage: "Customized instruction text",
                 id: "f1Kpkp",
                 description: "label for nomination event instructions",
               })}
-              appendLanguageToLabel="fr"
-            >
-              {customInstructions?.fr ? (
-                <RichTextRenderer
-                  node={htmlToRichTextJSON(customInstructions.fr)}
-                />
-              ) : (
-                notProvided
-              )}
-            </FieldDisplay>
+              appendLanguageToLabel={"fr"}
+              rules={{ required: intl.formatMessage(errorMessages.required) }}
+              aria-describedby={instructionsDescriptionId}
+            />
           </div>
           {community !== null && (
             <>

--- a/apps/web/src/pages/TalentEvents/components/UpcomingTalentEventForm.tsx
+++ b/apps/web/src/pages/TalentEvents/components/UpcomingTalentEventForm.tsx
@@ -331,7 +331,6 @@ const UpcomingTalentEventForm = ({ query }: UpcomingTalentEventFormProps) => {
             description: "label for nomination event instructions",
           })}
           appendLanguageToLabel={"en"}
-          rules={{ required: intl.formatMessage(errorMessages.required) }}
           aria-describedby={instructionsDescriptionId}
         />
         <RichTextInput
@@ -344,7 +343,6 @@ const UpcomingTalentEventForm = ({ query }: UpcomingTalentEventFormProps) => {
             description: "label for nomination event instructions",
           })}
           appendLanguageToLabel={"fr"}
-          rules={{ required: intl.formatMessage(errorMessages.required) }}
           aria-describedby={instructionsDescriptionId}
         />
       </div>

--- a/apps/web/src/pages/TalentEvents/components/UpcomingTalentEventForm.tsx
+++ b/apps/web/src/pages/TalentEvents/components/UpcomingTalentEventForm.tsx
@@ -9,7 +9,6 @@ import {
   errorMessages,
   getLocale,
   uiMessages,
-  type Locales,
 } from "@gc-digital-talent/i18n";
 import {
   Checkbox,
@@ -25,7 +24,6 @@ import { ROLE_NAME } from "@gc-digital-talent/auth";
 import processMessages from "~/messages/processMessages";
 import DevelopmentProgramCard from "~/components/DevelopmentProgramCard/DevelopmentProgramCard";
 import adminMessages from "~/messages/adminMessages";
-import { FRENCH_WORDS_PER_ENGLISH_WORD } from "~/constants/talentSearchConstants";
 
 import { isCommunity } from "../TalentEvent/util";
 import type { FormValues } from "./formValues";
@@ -33,6 +31,7 @@ import { TalentNominationEvent_Fragment } from "./fragments";
 import AddDialog from "./AddDialog";
 import EditDialog from "./EditDialog";
 import RemoveDialog from "./RemoveDialog";
+import { instructionsWordCountLimits } from "./constants";
 
 const atLeastOne = defineMessage({
   defaultMessage:
@@ -40,8 +39,6 @@ const atLeastOne = defineMessage({
   id: "bShedV",
   description: "Message to add at least one development opportunity",
 });
-
-const TEXT_AREA_MAX_WORDS_EN = 75;
 
 interface UpcomingTalentEventFormProps {
   query?: FragmentType<typeof TalentNominationEvent_Fragment>;
@@ -122,11 +119,6 @@ const UpcomingTalentEventForm = ({ query }: UpcomingTalentEventFormProps) => {
 
   const [editOpen, setEditOpen] = useState<string | null>(null);
   const [removeOpen, setRemoveOpen] = useState<string | null>(null);
-
-  const wordCountLimits: Record<Locales, number> = {
-    en: TEXT_AREA_MAX_WORDS_EN,
-    fr: Math.round(TEXT_AREA_MAX_WORDS_EN * FRENCH_WORDS_PER_ENGLISH_WORD),
-  } as const;
 
   const instructionsDescriptionId = useId();
 
@@ -332,7 +324,7 @@ const UpcomingTalentEventForm = ({ query }: UpcomingTalentEventFormProps) => {
         <RichTextInput
           id={"customInstructions.en"}
           name={"customInstructions.en"}
-          wordLimit={wordCountLimits.en}
+          wordLimit={instructionsWordCountLimits.en}
           label={intl.formatMessage({
             defaultMessage: "Customized instruction text",
             id: "f1Kpkp",
@@ -345,7 +337,7 @@ const UpcomingTalentEventForm = ({ query }: UpcomingTalentEventFormProps) => {
         <RichTextInput
           id={"customInstructions.fr"}
           name={"customInstructions.fr"}
-          wordLimit={wordCountLimits.fr}
+          wordLimit={instructionsWordCountLimits.fr}
           label={intl.formatMessage({
             defaultMessage: "Customized instruction text",
             id: "f1Kpkp",

--- a/apps/web/src/pages/TalentEvents/components/constants.ts
+++ b/apps/web/src/pages/TalentEvents/components/constants.ts
@@ -1,0 +1,10 @@
+import type { Locales } from "@gc-digital-talent/i18n";
+
+import { FRENCH_WORDS_PER_ENGLISH_WORD } from "~/constants/talentSearchConstants";
+
+const INSTRUCTIONS_MAX_WORDS_EN = 75;
+
+export const instructionsWordCountLimits: Record<Locales, number> = {
+  en: INSTRUCTIONS_MAX_WORDS_EN,
+  fr: Math.round(INSTRUCTIONS_MAX_WORDS_EN * FRENCH_WORDS_PER_ENGLISH_WORD),
+} as const;

--- a/packages/forms/src/components/RichTextInput/RichTextInput.tsx
+++ b/packages/forms/src/components/RichTextInput/RichTextInput.tsx
@@ -60,7 +60,7 @@ const RichTextInput = ({
   let wordLimitRule = {};
   if (wordLimit) {
     wordLimitRule = {
-      wordCount: (value: string) =>
+      wordCount: (value: string | null) =>
         countNumberOfWordsAfterReplacingHTML(value) <= wordLimit ||
         intl.formatMessage(errorMessages.overWordLimit, {
           value: wordLimit,

--- a/packages/forms/src/utils.ts
+++ b/packages/forms/src/utils.ts
@@ -180,8 +180,10 @@ export const countNumberOfWords = (text: string): number => {
  * @param text String you want the word count for after removing HTML tags
  * @returns number
  */
-export const countNumberOfWordsAfterReplacingHTML = (text: string): number => {
-  if (text === "") {
+export const countNumberOfWordsAfterReplacingHTML = (
+  text: string | null,
+): number => {
+  if (text === "" || text == null) {
     return 0; // otherwise this sometimes returns "<empty string>"
   }
 


### PR DESCRIPTION
🤖 Resolves #17539 

## 👋 Introduction

Makes changes to the talent nomination event custom instructions:
1. Always editable
2. Always nullable

## 🕵️ Details

Bonus bug fix:
- fixes crash in the rich text input word counter when passed a null

## 🧪 Testing

1. Rebuild app
2. Log in as community@test.com
3. Navigate to the community dashboard and create a bunch of events

### Past event with no custom instructions
- [x] Can create
- [x] Can view
- [x] Can edit with stay with no instructions
- [x] Can edit to add instructions

### Past event with custom instructions
- [x] Can create
- [x] Can view
- [x] Can edit to change instructions
- [x] Can edit to remove instructions


### Future event with no custom instructions
- [x] Can create
- [x] Can view
- [x] Can edit with stay with no instructions
- [x] Can edit to add instructions

### Future event with custom instructions
- [x] Can create
- [x] Can view
- [x] Can edit to change instructions
- [x] Can edit to remove instructions

### Applying

- [x] Can submit a nomination to an event with no instructions
- [x] Can submit a nomination to an event with instructions


## 📸 Screenshot

<img width="954" height="389" alt="image" src="https://github.com/user-attachments/assets/685fc496-9966-4489-ac3a-8c8c81118d83" />
