### PR TITLE
[Refactor] Replace at level labels

### DIFF
--- a/api/lang/en/talent_request_source.php
+++ b/api/lang/en/talent_request_source.php
@@ -2,6 +2,6 @@
 
 return [
     'qualified_in_pool' => 'Qualified in pool',
-    'at_level' => 'At level',
+    'at_level' => 'Community employees',
     'advancement' => 'Advancement',
 ];

--- a/api/lang/fr/talent_request_source.php
+++ b/api/lang/fr/talent_request_source.php
@@ -2,6 +2,6 @@
 
 return [
     'qualified_in_pool' => 'Qualification dans un bassin',
-    'at_level' => 'De même niveau',
+    'at_level' => 'Employés de la collectivité',
     'advancement' => 'Avancement',
 ];

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3979,10 +3979,6 @@
     "defaultMessage": "Utilisez le bouton « Ajouter un membre » pour commencer.",
     "description": "Instructions for adding a member to a community."
   },
-  "DsQWRx": {
-    "defaultMessage": "Employés de la collectivité",
-    "description": "Label for the at-level talent source"
-  },
   "DsUtfO": {
     "defaultMessage": "Mise en œuvre de 573 entretiens personnalisés de gestion et d’accompagnement de carrière avec des candidats à l’emploi et des cadres au cours de l’exercice financier de 2022-2023.",
     "description": "Description of digital community support"

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6679,6 +6679,10 @@
     "defaultMessage": "Modèles d'emplois",
     "description": "Text for the breadcrumb navigation link"
   },
+  "P1yFCo": {
+    "defaultMessage": "Candidats du bassin",
+    "description": "Label for the qualified in pool talent source"
+  },
   "P3WkJv": {
     "defaultMessage": "Ajoutez jusqu’à trois questions dans votre processus de candidature.",
     "description": "Helper message indicating max screening questions allowed"
@@ -14513,10 +14517,6 @@
   "uP+q43": {
     "defaultMessage": "Lieu de travail",
     "description": "Heading for work location section of the search form."
-  },
-  "uQEmGf": {
-    "defaultMessage": "Candidats du bassin",
-    "description": "Label for the qualified in pool talent source"
   },
   "uQaK9e": {
     "defaultMessage": "Avancement",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -6675,10 +6675,6 @@
     "defaultMessage": "Modèles d'emplois",
     "description": "Text for the breadcrumb navigation link"
   },
-  "P1yFCo": {
-    "defaultMessage": "Candidats du bassin",
-    "description": "Label for the qualified in pool talent source"
-  },
   "P3WkJv": {
     "defaultMessage": "Ajoutez jusqu’à trois questions dans votre processus de candidature.",
     "description": "Helper message indicating max screening questions allowed"

--- a/apps/web/src/messages/talentRequestMessages.ts
+++ b/apps/web/src/messages/talentRequestMessages.ts
@@ -161,11 +161,6 @@ const messages = defineMessages({
     id: "5bRS8b",
     description: "Label for the talent source(s) selected on a talent request.",
   },
-  qualifiedInPoolLabel: {
-    defaultMessage: "Pool candidates",
-    id: "P1yFCo",
-    description: "Label for the qualified in pool talent source",
-  },
 });
 
 export default messages;

--- a/apps/web/src/messages/talentRequestMessages.ts
+++ b/apps/web/src/messages/talentRequestMessages.ts
@@ -162,8 +162,8 @@ const messages = defineMessages({
     description: "Label for the talent source(s) selected on a talent request.",
   },
   qualifiedInPoolLabel: {
-    defaultMessage: "Pool Candidates",
-    id: "uQEmGf",
+    defaultMessage: "Pool candidates",
+    id: "P1yFCo",
     description: "Label for the qualified in pool talent source",
   },
   atLevelLabel: {

--- a/apps/web/src/messages/talentRequestMessages.ts
+++ b/apps/web/src/messages/talentRequestMessages.ts
@@ -166,11 +166,6 @@ const messages = defineMessages({
     id: "P1yFCo",
     description: "Label for the qualified in pool talent source",
   },
-  atLevelLabel: {
-    defaultMessage: "Community employees",
-    id: "DsQWRx",
-    description: "Label for the at-level talent source",
-  },
 });
 
 export default messages;

--- a/apps/web/src/pages/TalentRequests/components/TalentRequestSourcesCard.tsx
+++ b/apps/web/src/pages/TalentRequests/components/TalentRequestSourcesCard.tsx
@@ -80,13 +80,6 @@ const TalentRequestSourcesCard = ({
   const selectedTalentSources = unpackMaybes(
     applicantFilter?.talentSources?.map((source) => source?.value),
   );
-  const talentSourceLabel = (source: LocalizedTalentRequestSource) => {
-    if (source.value === TalentRequestSource.QualifiedInPool) {
-      return intl.formatMessage(talentRequestMessages.qualifiedInPoolLabel);
-    }
-
-    return source.label?.localized ?? notProvided;
-  };
 
   return (
     <TalentRequestSectionCard
@@ -128,7 +121,8 @@ const TalentRequestSourcesCard = ({
                   trueLabel={intl.formatMessage(commonMessages.selected)}
                   falseLabel={intl.formatMessage(commonMessages.notSelected)}
                 >
-                  {talentSourceLabel(source)}
+                  {source.label.localized ??
+                    intl.formatMessage(commonMessages.notAvailable)}
                 </BoolCheckIcon>
               </li>
             ))}

--- a/apps/web/src/pages/TalentRequests/components/TalentRequestSourcesCard.tsx
+++ b/apps/web/src/pages/TalentRequests/components/TalentRequestSourcesCard.tsx
@@ -1,4 +1,4 @@
-import { useIntl, type MessageDescriptor } from "react-intl";
+import { useIntl } from "react-intl";
 import FolderOpenIcon from "@heroicons/react/24/outline/FolderOpenIcon";
 
 import {
@@ -80,12 +80,12 @@ const TalentRequestSourcesCard = ({
   const selectedTalentSources = unpackMaybes(
     applicantFilter?.talentSources?.map((source) => source?.value),
   );
-  const talentSourceLabels: Partial<
-    Record<TalentRequestSource, MessageDescriptor>
-  > = {
-    [TalentRequestSource.QualifiedInPool]:
-      talentRequestMessages.qualifiedInPoolLabel,
-    [TalentRequestSource.AtLevel]: talentRequestMessages.atLevelLabel,
+  const talentSourceLabel = (source: LocalizedTalentRequestSource) => {
+    if (source.value === TalentRequestSource.QualifiedInPool) {
+      return intl.formatMessage(talentRequestMessages.qualifiedInPoolLabel);
+    }
+
+    return source.label?.localized ?? notProvided;
   };
 
   return (
@@ -121,24 +121,17 @@ const TalentRequestSourcesCard = ({
           label={intl.formatMessage(talentRequestMessages.talentSource)}
         >
           <Ul unStyled noIndent inside>
-            {talentSourceOptionsFiltered.map((source) => {
-              const messageDescriptor = talentSourceLabels[source.value];
-              const label = messageDescriptor
-                ? intl.formatMessage(messageDescriptor)
-                : (source.label?.localized ?? notProvided);
-
-              return (
-                <li key={source.value}>
-                  <BoolCheckIcon
-                    value={selectedTalentSources.includes(source.value)}
-                    trueLabel={intl.formatMessage(commonMessages.selected)}
-                    falseLabel={intl.formatMessage(commonMessages.notSelected)}
-                  >
-                    {label}
-                  </BoolCheckIcon>
-                </li>
-              );
-            })}
+            {talentSourceOptionsFiltered.map((source) => (
+              <li key={source.value}>
+                <BoolCheckIcon
+                  value={selectedTalentSources.includes(source.value)}
+                  trueLabel={intl.formatMessage(commonMessages.selected)}
+                  falseLabel={intl.formatMessage(commonMessages.notSelected)}
+                >
+                  {talentSourceLabel(source)}
+                </BoolCheckIcon>
+              </li>
+            ))}
           </Ul>
         </FieldDisplay>
         <FieldDisplay


### PR DESCRIPTION
🤖 Resolves #17564 

## 👋 Introduction

Replaces the talent source label "At level" with "Community employees" to more accuratly reflect its function.

Also, removes the single label override to qualified in pool.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to a talent request
4. Confirm the talent source label for at level is "Community employees"

## 📸 Screenshot

<img width="309" height="162" alt="swappy-20260728_084422" src="https://github.com/user-attachments/assets/3230e323-02a6-4161-99f6-1df0fa598d26" />
<img width="285" height="129" alt="swappy-20260728_084436" src="https://github.com/user-attachments/assets/33103fc7-062f-411e-aa2a-879b59231daf" />

