### PR TITLE
[Fix] `ScrollToLink` to scroll nearest scrollable parent

### DIFF
--- a/packages/ui/src/components/Link/ScrollToLink.tsx
+++ b/packages/ui/src/components/Link/ScrollToLink.tsx
@@ -20,25 +20,18 @@ const scrollToSection = (
   offsetEl?: HTMLElement | null,
 ) => {
   if (section) {
-    if (offsetEl) {
-      setTimeout(() => {
-        window.scrollTo({
-          behavior: "smooth",
-          top:
-            section.getBoundingClientRect().top -
-            document.body.getBoundingClientRect().top -
-            // NOTE: 16 adds a bit of a gap so text doesn't touch element
-            (offsetEl.getBoundingClientRect().height + 16),
-        });
-      }, 10);
-    } else {
-      setTimeout(() => {
-        section.scrollIntoView({
-          behavior: "smooth",
-          block: "start",
-        });
-      }, 10);
-    }
+    setTimeout(() => {
+      if (offsetEl) {
+        // NOTE: 16 adds a bit of a gap so text doesn't touch element
+        const offset = offsetEl.getBoundingClientRect().height + 16;
+        section.style.scrollMarginTop = `${offset}px`;
+      }
+
+      section.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }, 10);
   }
 };
 


### PR DESCRIPTION
🤖 Resolves #17246 

## 👋 Introduction

Updates the `ScrollToLink` component to prefer scrolling the nearest scrollable element rather than always the window.

## 🕵️ Details

This replaces `scrollTo` with `[scrollIntoView](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView)` which scrolls the nearest scrollable ancestor.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to view a candidates application
4. Open the skill assessment dialog
5. Attempt to submit the form with an error
6. Activate the link in the error summary
7. Confirm the dialog gets scrolled and not the page behind it
8. Navigate to any page with a table of contents
9. Confirm no regression in the scrolling on the table of contents links