### PR TITLE
[Debt] Remove full graphql object types 1.5

### DIFF
--- a/packages/auth/src/components/AuthorizationContainer.tsx
+++ b/packages/auth/src/components/AuthorizationContainer.tsx
@@ -1,13 +1,11 @@
 import type { ReactNode } from "react";
 import { createContext, useMemo } from "react";
 
-import type { RoleAssignment, UserAuthInfo } from "@gc-digital-talent/graphql";
-
-type SimpleRoleAssignment = Exclude<RoleAssignment, "teamable">;
+import type { AuthRoleAssignment, AuthUserInfo } from "../types";
 
 export interface AuthorizationState {
-  roleAssignments: SimpleRoleAssignment[] | null;
-  userAuthInfo?: UserAuthInfo | null;
+  roleAssignments: AuthRoleAssignment[] | null;
+  userAuthInfo?: AuthUserInfo | null;
   isLoaded: boolean;
 }
 
@@ -18,8 +16,8 @@ export const AuthorizationContext = createContext<AuthorizationState>({
 });
 
 interface AuthorizationContainerProps {
-  roleAssignments: SimpleRoleAssignment[] | null;
-  userAuthInfo?: UserAuthInfo | null;
+  roleAssignments: AuthRoleAssignment[] | null;
+  userAuthInfo?: AuthUserInfo | null;
   isLoaded: boolean;
   children?: ReactNode;
 }

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -1,5 +1,31 @@
+import type { LocalizedString, Permission } from "@gc-digital-talent/graphql";
+
 export interface AuthenticationState {
   loggedIn: boolean;
   logout: (postLogoutUri?: string) => void;
   refreshTokenSet: () => Promise<void>;
+}
+
+export interface AuthRole {
+  name: string;
+  isTeamBased?: boolean | null;
+  permissions?: Permission[] | null;
+  displayName?: LocalizedString | null;
+}
+
+export interface AuthTeam {
+  id: string;
+  name?: string | null;
+}
+
+export interface AuthRoleAssignment {
+  id: string;
+  role?: AuthRole | null;
+  team?: AuthTeam | null;
+}
+
+export interface AuthUserInfo {
+  id: string;
+  deletedDate?: string | null;
+  roleAssignments?: (AuthRoleAssignment | null)[] | null;
 }

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -6,7 +6,7 @@ export interface AuthenticationState {
   refreshTokenSet: () => Promise<void>;
 }
 
-export interface AuthRole {
+interface AuthRole {
   id: string;
   name: string;
   isTeamBased?: boolean | null;
@@ -14,7 +14,7 @@ export interface AuthRole {
   displayName?: LocalizedString | null;
 }
 
-export interface AuthTeam {
+interface AuthTeam {
   id: string;
   name: string;
 }

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -7,6 +7,7 @@ export interface AuthenticationState {
 }
 
 export interface AuthRole {
+  id: string;
   name: string;
   isTeamBased?: boolean | null;
   permissions?: Permission[] | null;
@@ -15,7 +16,7 @@ export interface AuthRole {
 
 export interface AuthTeam {
   id: string;
-  name?: string | null;
+  name: string;
 }
 
 export interface AuthRoleAssignment {

--- a/packages/auth/src/utils/checkPermissions.test.ts
+++ b/packages/auth/src/utils/checkPermissions.test.ts
@@ -1,13 +1,13 @@
-import type { RoleAssignment } from "@gc-digital-talent/graphql";
 import { Permission } from "@gc-digital-talent/graphql";
 
 import { ROLE_NAME } from "../const";
+import type { AuthRoleAssignment } from "../types";
 import checkPermissions from "./checkPermissions";
 
 describe("checkPermissions", () => {
   const f = checkPermissions;
 
-  const mockPlatformAdmin: RoleAssignment = {
+  const mockPlatformAdmin: AuthRoleAssignment = {
     id: "a1",
     role: {
       id: "r1",
@@ -21,7 +21,7 @@ describe("checkPermissions", () => {
     team: null,
   };
 
-  const mockCommunityRecruiter: RoleAssignment = {
+  const mockCommunityRecruiter: AuthRoleAssignment = {
     id: "a2",
     role: {
       id: "r2",

--- a/packages/auth/src/utils/checkPermissions.ts
+++ b/packages/auth/src/utils/checkPermissions.ts
@@ -1,4 +1,6 @@
-import type { Permission, RoleAssignment } from "@gc-digital-talent/graphql";
+import type { Permission } from "@gc-digital-talent/graphql";
+
+import type { AuthRoleAssignment } from "../types";
 
 export interface PermissionRequirement {
   permission: Permission;
@@ -13,10 +15,13 @@ export interface PermissionRequirement {
  */
 const checkPermissions = (
   requirements: PermissionRequirement | PermissionRequirement[],
-  roleAssignments: (RoleAssignment | null | undefined)[] | null | undefined,
+  roleAssignments:
+    | (AuthRoleAssignment | null | undefined)[]
+    | null
+    | undefined,
 ): boolean => {
   const assignments = (roleAssignments ?? []).filter(
-    (a): a is RoleAssignment => !!a && !!a.role,
+    (a): a is AuthRoleAssignment => !!a && !!a.role,
   );
 
   const reqs = Array.isArray(requirements) ? requirements : [requirements];

--- a/packages/auth/src/utils/checkPermissions.ts
+++ b/packages/auth/src/utils/checkPermissions.ts
@@ -15,10 +15,7 @@ export interface PermissionRequirement {
  */
 const checkPermissions = (
   requirements: PermissionRequirement | PermissionRequirement[],
-  roleAssignments:
-    | (AuthRoleAssignment | null | undefined)[]
-    | null
-    | undefined,
+  roleAssignments: (AuthRoleAssignment | null | undefined)[] | null | undefined,
 ): boolean => {
   const assignments = (roleAssignments ?? []).filter(
     (a): a is AuthRoleAssignment => !!a && !!a.role,

--- a/packages/auth/src/utils/hasRequiredRoles.test.ts
+++ b/packages/auth/src/utils/hasRequiredRoles.test.ts
@@ -1,19 +1,18 @@
-import type { RoleAssignment } from "@gc-digital-talent/graphql";
-
 import { ROLE_NAME } from "../const";
+import type { AuthRoleAssignment } from "../types";
 import { hasRequiredRoles } from "./hasRequiredRoles";
 
 describe("Has required roles", () => {
   const f = hasRequiredRoles;
 
   // Re-usable mock data
-  const mockProcessOperator: RoleAssignment = {
+  const mockProcessOperator: AuthRoleAssignment = {
     id: "a1",
     role: { id: "r1", name: ROLE_NAME.ProcessOperator, isTeamBased: true },
     team: { id: "team-alpha", name: "Alpha Team" },
   };
 
-  const mockPlatformAdmin: RoleAssignment = {
+  const mockPlatformAdmin: AuthRoleAssignment = {
     id: "a2",
     role: { id: "r2", name: ROLE_NAME.PlatformAdmin, isTeamBased: false },
     team: null,
@@ -118,7 +117,7 @@ describe("Has required roles", () => {
   });
 
   test("fails if assignment is missing a team but role is team-based", () => {
-    const brokenAssignment: RoleAssignment = {
+    const brokenAssignment: AuthRoleAssignment = {
       id: "err-1",
       role: { id: "r1", name: ROLE_NAME.ProcessOperator, isTeamBased: true },
       team: null, // Data error

--- a/packages/auth/src/utils/hasRequiredRoles.ts
+++ b/packages/auth/src/utils/hasRequiredRoles.ts
@@ -1,6 +1,5 @@
-import type { RoleAssignment } from "@gc-digital-talent/graphql";
-
 import type { RoleName } from "../const";
+import type { AuthRoleAssignment } from "../types";
 
 export interface RoleRequirement {
   name: RoleName;
@@ -9,7 +8,7 @@ export interface RoleRequirement {
 
 export interface HasRequiredRolesArgs {
   toCheck: RoleRequirement | RoleRequirement[];
-  userRoles: (RoleAssignment | null | undefined)[] | null | undefined;
+  userRoles: (AuthRoleAssignment | null | undefined)[] | null | undefined;
   /** * When true, if a role is team-based, a matching teamId MUST be provided
    * in the requirement or the check fails.
    */
@@ -22,7 +21,7 @@ export const hasRequiredRoles = ({
   strict = false, // Default to loose for backward compatibility/flexibility
 }: HasRequiredRolesArgs): boolean => {
   const assignments = (userRoles ?? []).filter(
-    (a): a is RoleAssignment => !!a && !!a.role,
+    (a): a is AuthRoleAssignment => !!a && !!a.role,
   );
 
   const requirements = Array.isArray(toCheck) ? toCheck : [toCheck];

--- a/packages/auth/src/utils/hasRole.ts
+++ b/packages/auth/src/utils/hasRole.ts
@@ -1,7 +1,7 @@
 import { unpackMaybes } from "@gc-digital-talent/helpers";
-import type { RoleAssignment } from "@gc-digital-talent/graphql";
 
 import type { RoleName } from "../const";
+import type { AuthRoleAssignment } from "../types";
 
 /**
  * @deprecated Use `hasRequiredRoles` instead.
@@ -9,7 +9,7 @@ import type { RoleName } from "../const";
  */
 const hasRole = (
   checkRole: RoleName | RoleName[],
-  userRoles: (RoleAssignment | null | undefined)[] | null | undefined,
+  userRoles: (AuthRoleAssignment | null | undefined)[] | null | undefined,
   teamIds?: string[],
 ): boolean => {
   const assignments = unpackMaybes(userRoles);

--- a/packages/auth/src/utils/hasRoles.test.ts
+++ b/packages/auth/src/utils/hasRoles.test.ts
@@ -7,9 +7,8 @@ describe("hasRole tests", () => {
 
   test("single role and user missing it", () => {
     const testRole: RoleName = "base_user";
-    const testUserRoles = [];
 
-    expect(f(testRole, testUserRoles)).toBeFalsy();
+    expect(f(testRole, [])).toBeFalsy();
   });
 
   test("single role and user has it", () => {
@@ -29,9 +28,8 @@ describe("hasRole tests", () => {
 
   test("array of roles and user missing all of them", () => {
     const testRole: RoleName[] = ["base_user", "community_admin"];
-    const testUserRoles = [];
 
-    expect(f(testRole, testUserRoles)).toBeFalsy();
+    expect(f(testRole, [])).toBeFalsy();
   });
 
   test("array of roles and user has one", () => {

--- a/packages/auth/src/utils/hasRoles.test.ts
+++ b/packages/auth/src/utils/hasRoles.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-deprecated */
-import type { RoleAssignment } from "@gc-digital-talent/graphql";
-
 import type { RoleName } from "../const";
+import type { AuthRoleAssignment } from "../types";
 import hasRole from "./hasRole";
 
 describe("hasRole tests", () => {
@@ -10,7 +9,7 @@ describe("hasRole tests", () => {
   test("single role and user missing it", () => {
     const testRole: RoleName = "base_user";
     const testUserRoles:
-      (RoleAssignment | null | undefined)[] | null | undefined = [];
+      (AuthRoleAssignment | null | undefined)[] | null | undefined = [];
 
     expect(f(testRole, testUserRoles)).toBeFalsy();
   });
@@ -18,7 +17,7 @@ describe("hasRole tests", () => {
   test("single role and user has it", () => {
     const testRole: RoleName = "base_user";
     const testUserRoles:
-      (RoleAssignment | null | undefined)[] | null | undefined = [
+      (AuthRoleAssignment | null | undefined)[] | null | undefined = [
       {
         id: "id-123",
         role: {
@@ -34,7 +33,7 @@ describe("hasRole tests", () => {
   test("array of roles and user missing all of them", () => {
     const testRole: RoleName[] = ["base_user", "community_admin"];
     const testUserRoles:
-      (RoleAssignment | null | undefined)[] | null | undefined = [];
+      (AuthRoleAssignment | null | undefined)[] | null | undefined = [];
 
     expect(f(testRole, testUserRoles)).toBeFalsy();
   });
@@ -42,7 +41,7 @@ describe("hasRole tests", () => {
   test("array of roles and user has one", () => {
     const testRole: RoleName[] = ["base_user", "community_admin"];
     const testUserRoles:
-      (RoleAssignment | null | undefined)[] | null | undefined = [
+      (AuthRoleAssignment | null | undefined)[] | null | undefined = [
       {
         id: "id-123",
         role: {
@@ -58,7 +57,7 @@ describe("hasRole tests", () => {
   test("array of roles and user has null role assignments", () => {
     const testRole: RoleName[] = ["base_user", "community_admin"];
     const testUserRoles:
-      (RoleAssignment | null | undefined)[] | null | undefined = null;
+      (AuthRoleAssignment | null | undefined)[] | null | undefined = null;
 
     expect(f(testRole, testUserRoles)).toBeFalsy();
   });
@@ -67,7 +66,7 @@ describe("hasRole tests", () => {
     const testRole: RoleName = "process_operator";
     const teamIds = ["pool-team-1"];
     const testUserRoles:
-      (RoleAssignment | null | undefined)[] | null | undefined = [
+      (AuthRoleAssignment | null | undefined)[] | null | undefined = [
       {
         id: "id-1",
         role: {
@@ -86,7 +85,7 @@ describe("hasRole tests", () => {
     const testRole: RoleName = "process_operator";
     const teamIds = ["pool-team-1"];
     const testUserRoles:
-      (RoleAssignment | null | undefined)[] | null | undefined = [
+      (AuthRoleAssignment | null | undefined)[] | null | undefined = [
       {
         id: "id-2",
         role: {
@@ -105,7 +104,7 @@ describe("hasRole tests", () => {
     const testRole: RoleName = "platform_admin";
     const teamIds = ["pool-team-1"];
     const testUserRoles:
-      (RoleAssignment | null | undefined)[] | null | undefined = [
+      (AuthRoleAssignment | null | undefined)[] | null | undefined = [
       {
         id: "id-3",
         role: {
@@ -125,7 +124,7 @@ describe("hasRole tests", () => {
     // Check against both Pool team and Community team
     const teamIds = ["pool-team-1", "community-team-2"];
     const testUserRoles:
-      (RoleAssignment | null | undefined)[] | null | undefined = [
+      (AuthRoleAssignment | null | undefined)[] | null | undefined = [
       {
         id: "id-4",
         role: {
@@ -144,7 +143,7 @@ describe("hasRole tests", () => {
   test("team-based role passes if no teamIds are provided to the check", () => {
     const testRole: RoleName = "process_operator";
     const testUserRoles:
-      (RoleAssignment | null | undefined)[] | null | undefined = [
+      (AuthRoleAssignment | null | undefined)[] | null | undefined = [
       {
         id: "id-5",
         role: {

--- a/packages/auth/src/utils/hasRoles.test.ts
+++ b/packages/auth/src/utils/hasRoles.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-deprecated */
 import type { RoleName } from "../const";
-import type { AuthRoleAssignment } from "../types";
 import hasRole from "./hasRole";
 
 describe("hasRole tests", () => {
@@ -8,16 +7,14 @@ describe("hasRole tests", () => {
 
   test("single role and user missing it", () => {
     const testRole: RoleName = "base_user";
-    const testUserRoles:
-      (AuthRoleAssignment | null | undefined)[] | null | undefined = [];
+    const testUserRoles = [];
 
     expect(f(testRole, testUserRoles)).toBeFalsy();
   });
 
   test("single role and user has it", () => {
     const testRole: RoleName = "base_user";
-    const testUserRoles:
-      (AuthRoleAssignment | null | undefined)[] | null | undefined = [
+    const testUserRoles = [
       {
         id: "id-123",
         role: {
@@ -32,16 +29,14 @@ describe("hasRole tests", () => {
 
   test("array of roles and user missing all of them", () => {
     const testRole: RoleName[] = ["base_user", "community_admin"];
-    const testUserRoles:
-      (AuthRoleAssignment | null | undefined)[] | null | undefined = [];
+    const testUserRoles = [];
 
     expect(f(testRole, testUserRoles)).toBeFalsy();
   });
 
   test("array of roles and user has one", () => {
     const testRole: RoleName[] = ["base_user", "community_admin"];
-    const testUserRoles:
-      (AuthRoleAssignment | null | undefined)[] | null | undefined = [
+    const testUserRoles = [
       {
         id: "id-123",
         role: {
@@ -56,8 +51,7 @@ describe("hasRole tests", () => {
 
   test("array of roles and user has null role assignments", () => {
     const testRole: RoleName[] = ["base_user", "community_admin"];
-    const testUserRoles:
-      (AuthRoleAssignment | null | undefined)[] | null | undefined = null;
+    const testUserRoles = null;
 
     expect(f(testRole, testUserRoles)).toBeFalsy();
   });
@@ -65,8 +59,7 @@ describe("hasRole tests", () => {
   test("team based role and user has it for the correct team", () => {
     const testRole: RoleName = "process_operator";
     const teamIds = ["pool-team-1"];
-    const testUserRoles:
-      (AuthRoleAssignment | null | undefined)[] | null | undefined = [
+    const testUserRoles = [
       {
         id: "id-1",
         role: {
@@ -84,8 +77,7 @@ describe("hasRole tests", () => {
   test("team-based role and user has it for a different team", () => {
     const testRole: RoleName = "process_operator";
     const teamIds = ["pool-team-1"];
-    const testUserRoles:
-      (AuthRoleAssignment | null | undefined)[] | null | undefined = [
+    const testUserRoles = [
       {
         id: "id-2",
         role: {
@@ -103,8 +95,7 @@ describe("hasRole tests", () => {
   test("global role bypasses team check even with teamIds provided", () => {
     const testRole: RoleName = "platform_admin";
     const teamIds = ["pool-team-1"];
-    const testUserRoles:
-      (AuthRoleAssignment | null | undefined)[] | null | undefined = [
+    const testUserRoles = [
       {
         id: "id-3",
         role: {
@@ -123,8 +114,7 @@ describe("hasRole tests", () => {
     const testRole: RoleName = "community_talent_coordinator";
     // Check against both Pool team and Community team
     const teamIds = ["pool-team-1", "community-team-2"];
-    const testUserRoles:
-      (AuthRoleAssignment | null | undefined)[] | null | undefined = [
+    const testUserRoles = [
       {
         id: "id-4",
         role: {
@@ -142,8 +132,7 @@ describe("hasRole tests", () => {
   // Existing functionality maintained
   test("team-based role passes if no teamIds are provided to the check", () => {
     const testRole: RoleName = "process_operator";
-    const testUserRoles:
-      (AuthRoleAssignment | null | undefined)[] | null | undefined = [
+    const testUserRoles = [
       {
         id: "id-5",
         role: {

--- a/packages/forms/src/components/DateInput/DateInput.stories.tsx
+++ b/packages/forms/src/components/DateInput/DateInput.stories.tsx
@@ -11,7 +11,6 @@ import {
   formDateStringToDate,
   DATE_FORMAT_STRING,
 } from "@gc-digital-talent/date-helpers";
-import type { Pool } from "@gc-digital-talent/graphql";
 import { Pending } from "@gc-digital-talent/ui";
 import { fakePools } from "@gc-digital-talent/fake-data";
 import { allModes } from "@gc-digital-talent/storybook-helpers";
@@ -186,19 +185,23 @@ const RenderDependantTemplate: StoryFn<DateInputArgs> = (args) => {
 
 export const HideInputWhenInvalid = RenderDependantTemplate.bind({});
 
+interface MockPool {
+  closingDate?: string | null;
+}
+
 interface AsyncArgs extends DateInputProps {
-  mockQuery: () => Promise<Pool>;
+  mockQuery: () => Promise<MockPool>;
 }
 
 const AsyncTemplate: StoryFn<AsyncArgs> = (args) => {
   const intl = useIntl();
   const { mockQuery, ...rest } = args;
   const [fetching, setFetching] = useState<boolean>(true);
-  const [pool, setPool] = useState<Pool | null>(null);
+  const [pool, setPool] = useState<MockPool | null>(null);
 
   useEffect(() => {
     mockQuery()
-      .then((res: Pool) => {
+      .then((res: MockPool) => {
         setPool(res);
       })
       .catch((err) => {
@@ -237,7 +240,7 @@ const mockPool = fakePools(1)[0];
 
 export const AsyncDefaultValue = AsyncTemplate.bind({});
 AsyncDefaultValue.args = {
-  mockQuery: async (): Promise<Pool> => {
+  mockQuery: async (): Promise<MockPool> => {
     return new Promise((resolve) => {
       setTimeout(() => {
         resolve(mockPool);

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -1,2 +1,7 @@
 export * from "./gql";
 export * from "./gql/graphql";
+
+export type {
+  LocalizedString,
+  LocalizedEnumString,
+} from "./gql/schema-types";


### PR DESCRIPTION
## 👋 Introduction

Removes full object types from the following packages:

 - `auth`
 - `forms`
 - `i18n`

## 🕵️ Details

This tehcnially the second PR since some setup had to occur in the first PR https://github.com/GCTC-NTGC/gc-digital-talent/pull/17552

## 🧪 Testing

1. Confirm types are still accurate
2. Confirm no type errors
3. Confirm app still builds and functions