### PR TITLE
[Bug] Clean leftover GCkey reference

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4483,8 +4483,8 @@
     "defaultMessage": "Divers (anglais ou français)",
     "description": "Various language requirement"
   },
-  "G0AEfY": {
-    "defaultMessage": "Nous vous recommandons de commencer votre demande le plus tôt possible. Ainsi, vous aurez le temps de communiquer avec nous en cas de problème technique. Si vous n'avez pas encore de compte, vous devrez <gcDigitalTalentLink>créer une CléGC</gcDigitalTalentLink> pour commencer votre demande. Prévoyez environ 20 minutes si vous vous inscrivez pour la première fois.",
+  "TsDung": {
+    "defaultMessage": "Nous vous recommandons de commencer votre demande le plus tôt possible. Ainsi, vous aurez le temps de communiquer avec nous en cas de problème technique. Si vous n'avez pas encore de compte, vous devrez <gcDigitalTalentLink>vous inscrire</gcDigitalTalentLink> pour commencer votre demande. Prévoyez environ 10 minutes si vous vous inscrivez pour la première fois.",
     "description": "Text explaining the importance of starting an application early"
   },
   "G1OWMo": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -4483,10 +4483,6 @@
     "defaultMessage": "Divers (anglais ou français)",
     "description": "Various language requirement"
   },
-  "TsDung": {
-    "defaultMessage": "Nous vous recommandons de commencer votre demande le plus tôt possible. Ainsi, vous aurez le temps de communiquer avec nous en cas de problème technique. Si vous n'avez pas encore de compte, vous devrez <gcDigitalTalentLink>vous inscrire</gcDigitalTalentLink> pour commencer votre demande. Prévoyez environ 10 minutes si vous vous inscrivez pour la première fois.",
-    "description": "Text explaining the importance of starting an application early"
-  },
   "G1OWMo": {
     "defaultMessage": "Vous pouvez ajouter des expériences lorsque vous <link>créer une nouvelle expérience de parcours professionnel à l’étape précédente.</link>",
     "description": "Secondary alert message informing user to add experience in application education page."
@@ -7866,6 +7862,10 @@
   "TrbPjE": {
     "defaultMessage": "Vous êtes sur le point de désarchiver ce processus : {poolName}",
     "description": "Text to confirm the process to be un-archived"
+  },
+  "TsDung": {
+    "defaultMessage": "Nous vous recommandons de commencer votre demande le plus tôt possible. Ainsi, vous aurez le temps de communiquer avec nous en cas de problème technique. Si vous n'avez pas encore de compte, vous devrez <gcDigitalTalentLink>vous inscrire</gcDigitalTalentLink> pour commencer votre demande. Prévoyez environ 10 minutes si vous vous inscrivez pour la première fois.",
+    "description": "Text explaining the importance of starting an application early"
   },
   "TtJCR6": {
     "defaultMessage": "Mettez à jour vos préférences",

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -1069,8 +1069,8 @@ export const PoolPoster = ({
                       {intl.formatMessage(
                         {
                           defaultMessage:
-                            "We recommend starting your application as early as possible. This way, you'll have time to contact us in case of any technical issues. If you don't have an account yet, you'll need to <gcDigitalTalentLink>sign up for a GCkey</gcDigitalTalentLink> to start your application. Expect to spend approximately 20 minutes signing up for the first time.",
-                          id: "G0AEfY",
+                            "We recommend starting your application as early as possible. This way, you'll have time to contact us in case of any technical issues. If you don't have an account yet, you'll need to <gcDigitalTalentLink>register</gcDigitalTalentLink> to start your application. Expect to spend approximately 10 minutes signing up for the first time.",
+                          id: "TsDung",
                           description:
                             "Text explaining the importance of starting an application early",
                         },


### PR DESCRIPTION
🤖 Resolves #17576 

## 👋 Introduction

Cleans up a leftover GCkey reference.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

1. Rebuild
2. Visit a pool advertisement page
3. Find the "How early should I start" accordion

- [ ] Says "register" instead of "GCkey"
- [ ] Says 10 minutes instead of 20 minutes
- [ ] French is updated as well

## 📸 Screenshot

<img width="1162" height="700" alt="image" src="https://github.com/user-attachments/assets/2cb45a79-392f-4239-9497-36a822fe1363" />

<img width="1169" height="735" alt="image" src="https://github.com/user-attachments/assets/f4dcc517-9ef0-4270-9e5d-171d1776132e" />
