### PR TITLE
[Fix] Add skill rankings update validation

### DIFF
--- a/api/app/GraphQL/Validators/UpdateUserSkillRankingsInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdateUserSkillRankingsInputValidator.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Validators;
+
+use App\Enums\ErrorCode;
+use App\Rules\ArrayIsUnique;
+use Nuwave\Lighthouse\Validation\Validator;
+
+final class UpdateUserSkillRankingsInputValidator extends Validator
+{
+    /**
+     * Return the validation rules.
+     *
+     * @return array<string, array<mixed>>
+     */
+    public function rules(): array
+    {
+        $rules = ['nullable', 'array', 'exists:skills,id', new ArrayIsUnique()];
+
+        return [
+            'topTechnicalSkillsRanked' => $rules,
+            'topBehaviouralSkillsRanked' => $rules,
+            'improveTechnicalSkillsRanked' => $rules,
+            'improveBehaviouralSkillsRanked' => $rules,
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'topTechnicalSkillsRanked.exists' => ErrorCode::SKILL_NOT_FOUND->name,
+            'topBehaviouralSkillsRanked.exists' => ErrorCode::SKILL_NOT_FOUND->name,
+            'improveTechnicalSkillsRanked.exists' => ErrorCode::SKILL_NOT_FOUND->name,
+            'improveBehaviouralSkillsRanked.exists' => ErrorCode::SKILL_NOT_FOUND->name,
+        ];
+    }
+}

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -3074,16 +3074,12 @@ input UpdateUserSkillInput {
   whenSkillUsed: WhenSkillUsed @rename(attribute: "when_skill_used")
 }
 
-input UpdateUserSkillRankingsInput {
+input UpdateUserSkillRankingsInput @validator {
   # array of skill ids
   topTechnicalSkillsRanked: [UUID]
-    @rulesForArray(apply: ["nullable", "App\\Rules\\ArrayIsUnique"])
   topBehaviouralSkillsRanked: [UUID]
-    @rulesForArray(apply: ["nullable", "App\\Rules\\ArrayIsUnique"])
   improveTechnicalSkillsRanked: [UUID]
-    @rulesForArray(apply: ["nullable", "App\\Rules\\ArrayIsUnique"])
   improveBehaviouralSkillsRanked: [UUID]
-    @rulesForArray(apply: ["nullable", "App\\Rules\\ArrayIsUnique"])
 }
 
 input WorkExperienceHasMany {

--- a/api/tests/Feature/UserSkillTest.php
+++ b/api/tests/Feature/UserSkillTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Enums\ErrorCode;
+use App\Enums\SkillCategory;
 use App\Enums\SkillLevel;
 use App\Enums\WhenSkillUsed;
 use App\Models\ExperienceSkill;
@@ -14,6 +15,7 @@ use Carbon\Carbon;
 use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
@@ -1055,5 +1057,43 @@ class UserSkillTest extends TestCase
                     ],
                 ]
             )->assertJsonFragment(['id' => $this->user->id]);
+    }
+
+    public function testNonexistentSkillsInShowcase(): void
+    {
+        $technicalSkill = Skill::factory()->create(['category' => SkillCategory::TECHNICAL->name]);
+        $behaviouralSkill = Skill::factory()->create(['category' => SkillCategory::BEHAVIOURAL->name]);
+        $nonexistentSkillId = Str::uuid()->toString();
+
+        $this->actingAs($this->user, 'api')
+            ->graphQL(
+                $this->updateUserSkillRankings,
+                [
+                    'userId' => $this->user->id,
+                    'userSkillRanking' => [
+                        'topTechnicalSkillsRanked' => [$technicalSkill->id, $nonexistentSkillId],
+                        'topBehaviouralSkillsRanked' => [$nonexistentSkillId],
+                        'improveTechnicalSkillsRanked' => [$nonexistentSkillId],
+                        'improveBehaviouralSkillsRanked' => [$nonexistentSkillId],
+                    ],
+                ]
+            )
+            ->assertGraphQLValidationError('userSkillRanking.topTechnicalSkillsRanked', ErrorCode::SKILL_NOT_FOUND->name)
+            ->assertGraphQLValidationError('userSkillRanking.topBehaviouralSkillsRanked', ErrorCode::SKILL_NOT_FOUND->name)
+            ->assertGraphQLValidationError('userSkillRanking.improveTechnicalSkillsRanked', ErrorCode::SKILL_NOT_FOUND->name)
+            ->assertGraphQLValidationError('userSkillRanking.improveBehaviouralSkillsRanked', ErrorCode::SKILL_NOT_FOUND->name);
+
+        $this->actingAs($this->user, 'api')
+            ->graphQL(
+                $this->updateUserSkillRankings,
+                [
+                    'userId' => $this->user->id,
+                    'userSkillRanking' => [
+                        'topTechnicalSkillsRanked' => [$technicalSkill->id],
+                        'topBehaviouralSkillsRanked' => [$behaviouralSkill->id],
+                    ],
+                ]
+            )
+            ->assertJsonFragment(['topSkillsRank' => 1]);
     }
 }


### PR DESCRIPTION
🤖 Resolves #17407 

## 👋 Introduction

Adds validation for the mutation to update skill rankings. Adds a rule to ensure skills exit as well.

## 🧪 Testing

1. Attempt to update a skill ranking for a non-existant skill
2. Confirm you get a validation error
3. Confirm test coverage exists