### PR TITLE
[Feature] Increase customized instructions word count

### DIFF
--- a/apps/web/src/pages/TalentEvents/components/constants.ts
+++ b/apps/web/src/pages/TalentEvents/components/constants.ts
@@ -2,7 +2,7 @@ import type { Locales } from "@gc-digital-talent/i18n";
 
 import { FRENCH_WORDS_PER_ENGLISH_WORD } from "~/constants/talentSearchConstants";
 
-const INSTRUCTIONS_MAX_WORDS_EN = 75;
+const INSTRUCTIONS_MAX_WORDS_EN = 250;
 
 export const instructionsWordCountLimits: Record<Locales, number> = {
   en: INSTRUCTIONS_MAX_WORDS_EN,


### PR DESCRIPTION
🤖 Resolves  #17581

## 👋 Introduction

This PR increases the maximum word count for the "customized instructions" field in the Talent Nomination Event form  to 250 words for English and 350 words for French.


## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `community@test.com`
3. Navigate to `admin/talent-events`
4. Create a talent nomination event
5. Verify in the Customized instruction text you can enter 250 words (english) and 350 words (french)

## 📸 Screenshot

<img width="643" height="254" alt="image" src="https://github.com/user-attachments/assets/a2ea190c-487b-48ce-99b7-9352f8e38fbe" />
