### PR TITLE
[Platform] Free more space in vitest flow

### DIFF
--- a/.github/actions/reclaim-space/action.yml
+++ b/.github/actions/reclaim-space/action.yml
@@ -15,4 +15,4 @@ runs:
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           docker system prune -af --volumes || true
           df -h
-      shell: bash
+        shell: bash

--- a/.github/actions/reclaim-space/action.yml
+++ b/.github/actions/reclaim-space/action.yml
@@ -2,17 +2,17 @@ name: "Reclaim space on runner"
 runs:
   using: "composite"
   steps:
-    - name: Reclaim space on runner
-      run: |
-        sudo rm -rf /usr/local/lib/android
-        rm -rf /usr/share/dotnet
-        rm -rf /usr/local/share/boost
-        rm -rf /opt/ghc
-        sudo rm -rf /usr/local/share/powershell
-        sudo rm -rf /usr/share/swift
-        sudo rm -rf /usr/local/.ghcup
-        sudo rm -rf /usr/lib/jvm
-        sudo rm -rf /opt/hostedtoolcache/CodeQL
-        docker system prune -af --volumes || true
-        df -h
-    shell: bash
+      - name: Reclaim space on runner
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          rm -rf /usr/share/dotnet
+          rm -rf /usr/local/share/boost
+          rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/lib/jvm
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          docker system prune -af --volumes || true
+          df -h
+      shell: bash

--- a/.github/actions/reclaim-space/action.yml
+++ b/.github/actions/reclaim-space/action.yml
@@ -1,0 +1,18 @@
+name: "Reclaim space on runner"
+runs:
+  using: "composite"
+  steps:
+    - name: Reclaim space on runner
+      run: |
+        sudo rm -rf /usr/local/lib/android
+        rm -rf /usr/share/dotnet
+        rm -rf /usr/local/share/boost
+        rm -rf /opt/ghc
+        sudo rm -rf /usr/local/share/powershell
+        sudo rm -rf /usr/share/swift
+        sudo rm -rf /usr/local/.ghcup
+        sudo rm -rf /usr/lib/jvm
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        docker system prune -af --volumes || true
+        df -h
+    shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: ./.github/actions/reclaim-space
+
+      - name: Reclaim space on runner
+        uses: ./.github/actions/reclaim-space
+
       - name: "Copy .env"
         working-directory: "./apps/web"
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,19 +35,8 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
 
     steps:
-      - name: Reclaim space on runner
-        run: |
-          sudo rm -rf /usr/local/android
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/share/boost
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/powershell
-          sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/local/.ghcup
-          sudo rm -rf /usr/lib/jvm
-          df -h
-
       - uses: actions/checkout@v7
+      - uses: ./.github/actions/reclaim-space
       - name: "Copy .env"
         working-directory: "./apps/web"
         run: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -47,12 +47,9 @@ jobs:
       GCNOTIFY_TEMPLATE_NOMINATION_RECEIVED_NOMINATOR_FR: ${{ vars.GCNOTIFY_TEMPLATE_NOMINATION_RECEIVED_NOMINATOR_FR }}
       GCNOTIFY_TEMPLATE_NOMINATION_RECEIVED_NOMINATOR_ENFR: ${{ vars.GCNOTIFY_TEMPLATE_NOMINATION_RECEIVED_NOMINATOR_ENFR }}
     steps:
-      # See: https://github.com/satackey/action-docker-layer-caching/issues/139#issuecomment-1007316528
-      - name: reclaim space on runner
-        run: rm -rf /usr/local/android /usr/share/dotnet /usr/local/share/boost /opt/ghc
-
       - name: Checkout
         uses: actions/checkout@v7
+      - uses: ./.github/actions/reclaim-space
 
       # We no longer user docker layer caching as it made runs take longer.
       # See: https://github.com/satackey/action-docker-layer-caching/issues/305

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -49,7 +49,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - uses: ./.github/actions/reclaim-space
+
+      - name: Reclaim space on runner
+        uses: ./.github/actions/reclaim-space
 
       # We no longer user docker layer caching as it made runs take longer.
       # See: https://github.com/satackey/action-docker-layer-caching/issues/305

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Reclaim space on runner
         run: |
-          rm -rf /usr/local/android
+          sudo rm -rf /usr/local/lib/android
           rm -rf /usr/share/dotnet
           rm -rf /usr/local/share/boost
           rm -rf /opt/ghc
@@ -32,6 +32,8 @@ jobs:
           sudo rm -rf /usr/share/swift
           sudo rm -rf /usr/local/.ghcup
           sudo rm -rf /usr/lib/jvm
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          docker system prune -af --volumes || true
           df -h
 
       - uses: actions/checkout@v7

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -23,7 +23,9 @@ jobs:
         id: cpu-cores
 
       - uses: actions/checkout@v7
-      - uses: ./.github/actions/reclaim-space
+
+      - name: Reclaim space on runner
+        uses: ./.github/actions/reclaim-space
 
       - name: "Copy .env"
         working-directory: "./apps/web"

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -22,21 +22,8 @@ jobs:
         uses: SimenB/github-actions-cpu-cores@v3
         id: cpu-cores
 
-      - name: Reclaim space on runner
-        run: |
-          sudo rm -rf /usr/local/lib/android
-          rm -rf /usr/share/dotnet
-          rm -rf /usr/local/share/boost
-          rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/powershell
-          sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/local/.ghcup
-          sudo rm -rf /usr/lib/jvm
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          docker system prune -af --volumes || true
-          df -h
-
       - uses: actions/checkout@v7
+      - uses: ./.github/actions/reclaim-space
 
       - name: "Copy .env"
         working-directory: "./apps/web"

--- a/.github/workflows/webkit-playwright.yml
+++ b/.github/workflows/webkit-playwright.yml
@@ -36,12 +36,9 @@ jobs:
       GCNOTIFY_TEMPLATE_NOMINATION_RECEIVED_NOMINATOR_FR: ${{ vars.GCNOTIFY_TEMPLATE_NOMINATION_RECEIVED_NOMINATOR_FR }}
       GCNOTIFY_TEMPLATE_NOMINATION_RECEIVED_NOMINATOR_ENFR: ${{ vars.GCNOTIFY_TEMPLATE_NOMINATION_RECEIVED_NOMINATOR_ENFR }}
     steps:
-      # See: https://github.com/satackey/action-docker-layer-caching/issues/139#issuecomment-1007316528
-      - name: reclaim space on runner
-        run: rm -rf /usr/local/android /usr/share/dotnet /usr/local/share/boost /opt/ghc
-
       - name: Checkout
         uses: actions/checkout@v7
+      - uses: ./.github/actions/reclaim-space
 
       # We no longer user docker layer caching as it made runs take longer.
       # See: https://github.com/satackey/action-docker-layer-caching/issues/305

--- a/.github/workflows/webkit-playwright.yml
+++ b/.github/workflows/webkit-playwright.yml
@@ -38,7 +38,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - uses: ./.github/actions/reclaim-space
+
+      - name: Reclaim space on runner
+        uses: ./.github/actions/reclaim-space
 
       # We no longer user docker layer caching as it made runs take longer.
       # See: https://github.com/satackey/action-docker-layer-caching/issues/305


### PR DESCRIPTION
🤖 Resolves #17401 

## 👋 Introduction

Updates the "reclaim runner space" step to reclaim more space.  Available space went from 103GB to 116GB. (29% used down to 21% used.)  However, the run time goes up from 9s to 40s.  Not a clear value-add.  :face_with_diagonal_mouth: 

## 🕵️ Details

Rather thank copy-pasting these changes to our various workflow files I factored it out to a composite action that can be shared.
https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action

Note that the order of the steps change.  The composite action has to run after "checkout" since the action is in the codebase.

## 🧪 Testing

- [ ] Code looks good
- [ ] All workflows pass