### PR TITLE
[Refactor] Update playwright graphql imports

### DIFF
--- a/apps/playwright/fixtures/Department.ts
+++ b/apps/playwright/fixtures/Department.ts
@@ -4,8 +4,8 @@ import type {
   CreateDepartmentInput,
   LocalizedStringInput,
   UpdateDepartmentInput,
-} from "@gc-digital-talent/graphql";
-import { DepartmentSize } from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
+import { DepartmentSize } from "@gc-digital-talent/graphql/schema-types";
 
 import dConfig from "~/constants/config";
 import { loginBySub } from "~/utils/auth";

--- a/apps/playwright/fixtures/ExperiencePage.ts
+++ b/apps/playwright/fixtures/ExperiencePage.ts
@@ -7,7 +7,7 @@ import type {
   CommunityExperienceInput,
   AwardExperienceInput,
   EducationExperienceInput,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 
 import AppPage from "./AppPage";
 

--- a/apps/playwright/fixtures/GenericTableValidationFixture.ts
+++ b/apps/playwright/fixtures/GenericTableValidationFixture.ts
@@ -7,8 +7,8 @@ import type {
   PlacementType,
   ScreeningStage,
   WorkRegion,
-} from "@gc-digital-talent/graphql";
-import { ApplicationStatus } from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
+import { ApplicationStatus } from "@gc-digital-talent/graphql/schema-types";
 
 import type { GraphQLContext } from "~/utils/graphql";
 import { getPoolCandidatesTable } from "~/utils/candidateAssessment";

--- a/apps/playwright/fixtures/PoolPage.ts
+++ b/apps/playwright/fixtures/PoolPage.ts
@@ -1,4 +1,7 @@
-import type { PoolSkill, SkillCategory } from "@gc-digital-talent/graphql";
+import type {
+  PoolSkill,
+  SkillCategory,
+} from "@gc-digital-talent/graphql/schema-types";
 
 import { expect } from "~/fixtures";
 

--- a/apps/playwright/fixtures/ProfilePage.ts
+++ b/apps/playwright/fixtures/ProfilePage.ts
@@ -1,7 +1,10 @@
 import type { Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 
-import { FlexibleWorkLocation, WorkRegion } from "@gc-digital-talent/graphql";
+import {
+  FlexibleWorkLocation,
+  WorkRegion,
+} from "@gc-digital-talent/graphql/schema-types";
 
 import AppPage from "./AppPage";
 import LocationPreferenceUpdatePage from "./locationPreferenceUpdatePage";

--- a/apps/playwright/fixtures/ReferralStatusPage.ts
+++ b/apps/playwright/fixtures/ReferralStatusPage.ts
@@ -1,7 +1,7 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 
-import type { PlacementType } from "@gc-digital-talent/graphql";
-import { PauseReferralsLength } from "@gc-digital-talent/graphql";
+import type { PlacementType } from "@gc-digital-talent/graphql/schema-types";
+import { PauseReferralsLength } from "@gc-digital-talent/graphql/schema-types";
 
 import { getFutureDateByMonths } from "~/utils/id";
 

--- a/apps/playwright/fixtures/TalentSearch.ts
+++ b/apps/playwright/fixtures/TalentSearch.ts
@@ -5,8 +5,11 @@ import type {
   Classification,
   Skill,
   WorkStream,
-} from "@gc-digital-talent/graphql";
-import { FlexibleWorkLocation, WorkRegion } from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
+import {
+  FlexibleWorkLocation,
+  WorkRegion,
+} from "@gc-digital-talent/graphql/schema-types";
 
 import AppPage from "./AppPage";
 import LocationPreferenceUpdatePage from "./locationPreferenceUpdatePage";

--- a/apps/playwright/fixtures/locationPreferenceUpdatePage.ts
+++ b/apps/playwright/fixtures/locationPreferenceUpdatePage.ts
@@ -2,7 +2,10 @@ import { expect } from "@playwright/test";
 import type { Locator, Page } from "@playwright/test";
 import type { Key } from "react";
 
-import { FlexibleWorkLocation, WorkRegion } from "@gc-digital-talent/graphql";
+import {
+  FlexibleWorkLocation,
+  WorkRegion,
+} from "@gc-digital-talent/graphql/schema-types";
 
 import { loginBySub } from "~/utils/auth";
 

--- a/apps/playwright/tests/admin/application-download.spec.ts
+++ b/apps/playwright/tests/admin/application-download.spec.ts
@@ -1,5 +1,8 @@
 import { FAR_PAST_DATE, PAST_DATE } from "@gc-digital-talent/date-helpers";
-import type { PoolCandidate, User } from "@gc-digital-talent/graphql";
+import type {
+  PoolCandidate,
+  User,
+} from "@gc-digital-talent/graphql/schema-types";
 import {
   ArmedForcesStatus,
   CitizenshipStatus,
@@ -8,7 +11,7 @@ import {
   ProvinceOrTerritory,
   SkillCategory,
   WorkRegion,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 
 import { test, expect } from "~/fixtures";
 import ExcelDocument from "~/fixtures/ExcelDocument";

--- a/apps/playwright/tests/admin/candidate-assessment.spec.ts
+++ b/apps/playwright/tests/admin/candidate-assessment.spec.ts
@@ -1,4 +1,8 @@
-import type { PoolCandidate, Skill, User } from "@gc-digital-talent/graphql";
+import type {
+  PoolCandidate,
+  Skill,
+  User,
+} from "@gc-digital-talent/graphql/schema-types";
 import {
   ApplicationStatus,
   ArmedForcesStatus,
@@ -15,7 +19,7 @@ import {
   SkillCategory,
   WorkRegion,
   CandidateRemovalReason,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 import {
   FAR_FUTURE_DATE,
   FAR_PAST_DATE,

--- a/apps/playwright/tests/admin/candidate-table-validation.spec.ts
+++ b/apps/playwright/tests/admin/candidate-table-validation.spec.ts
@@ -3,7 +3,10 @@ import {
   FAR_PAST_DATE,
   PAST_DATE,
 } from "@gc-digital-talent/date-helpers";
-import type { PoolCandidate, User } from "@gc-digital-talent/graphql";
+import type {
+  PoolCandidate,
+  User,
+} from "@gc-digital-talent/graphql/schema-types";
 import {
   ApplicationStatus,
   ArmedForcesStatus,
@@ -17,7 +20,7 @@ import {
   ScreeningStage,
   SkillCategory,
   WorkRegion,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 
 import testConfig from "~/constants/config";
 import { expect, test } from "~/fixtures";

--- a/apps/playwright/tests/admin/department-action-create.spec.ts
+++ b/apps/playwright/tests/admin/department-action-create.spec.ts
@@ -1,4 +1,4 @@
-import { DepartmentSize } from "@gc-digital-talent/graphql";
+import { DepartmentSize } from "@gc-digital-talent/graphql/schema-types";
 
 import { test, expect } from "~/fixtures";
 import Department from "~/fixtures/Department";

--- a/apps/playwright/tests/admin/department-action-update.spec.ts
+++ b/apps/playwright/tests/admin/department-action-update.spec.ts
@@ -1,4 +1,4 @@
-import { DepartmentSize } from "@gc-digital-talent/graphql";
+import { DepartmentSize } from "@gc-digital-talent/graphql/schema-types";
 
 import { test, expect } from "~/fixtures";
 import Department from "~/fixtures/Department";

--- a/apps/playwright/tests/admin/location-preference-validation.spec.ts
+++ b/apps/playwright/tests/admin/location-preference-validation.spec.ts
@@ -1,4 +1,7 @@
-import type { PoolCandidate, User } from "@gc-digital-talent/graphql";
+import type {
+  PoolCandidate,
+  User,
+} from "@gc-digital-talent/graphql/schema-types";
 import {
   ArmedForcesStatus,
   CitizenshipStatus,
@@ -10,7 +13,7 @@ import {
   ProvinceOrTerritory,
   SkillCategory,
   WorkRegion,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 import {
   FAR_PAST_DATE,
   PAST_DATE,

--- a/apps/playwright/tests/admin/placement-referral.spec.ts
+++ b/apps/playwright/tests/admin/placement-referral.spec.ts
@@ -1,4 +1,8 @@
-import type { PoolCandidate, Skill, User } from "@gc-digital-talent/graphql";
+import type {
+  PoolCandidate,
+  Skill,
+  User,
+} from "@gc-digital-talent/graphql/schema-types";
 import {
   ArmedForcesStatus,
   CitizenshipStatus,
@@ -9,7 +13,7 @@ import {
   ProvinceOrTerritory,
   SkillCategory,
   WorkRegion,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 import {
   FAR_FUTURE_DATE,
   FAR_PAST_DATE,

--- a/apps/playwright/tests/admin/pool-candidate-actions.spec.ts
+++ b/apps/playwright/tests/admin/pool-candidate-actions.spec.ts
@@ -1,4 +1,8 @@
-import type { PoolCandidate, Skill, User } from "@gc-digital-talent/graphql";
+import type {
+  PoolCandidate,
+  Skill,
+  User,
+} from "@gc-digital-talent/graphql/schema-types";
 import {
   ArmedForcesStatus,
   CitizenshipStatus,
@@ -7,7 +11,7 @@ import {
   ProvinceOrTerritory,
   SkillCategory,
   WorkRegion,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 import { FAR_PAST_DATE, PAST_DATE } from "@gc-digital-talent/date-helpers";
 
 import { test, expect } from "~/fixtures";

--- a/apps/playwright/tests/admin/process-action-create.spec.ts
+++ b/apps/playwright/tests/admin/process-action-create.spec.ts
@@ -2,7 +2,7 @@ import {
   AssessmentStepType,
   SkillCategory,
   SkillLevel,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 
 import testConfig from "~/constants/config";
 import { expect, test } from "~/fixtures";

--- a/apps/playwright/tests/admin/process-activity-log.spec.ts
+++ b/apps/playwright/tests/admin/process-activity-log.spec.ts
@@ -4,7 +4,7 @@ import {
   FAR_PAST_DATE,
   PAST_DATE,
 } from "@gc-digital-talent/date-helpers";
-import type { Skill, User } from "@gc-digital-talent/graphql";
+import type { Skill, User } from "@gc-digital-talent/graphql/schema-types";
 import {
   ArmedForcesStatus,
   CandidateRemovalReason,
@@ -15,7 +15,7 @@ import {
   ProvinceOrTerritory,
   SkillCategory,
   WorkRegion,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 
 import testConfig from "~/constants/config";
 import { expect, test } from "~/fixtures";

--- a/apps/playwright/tests/admin/process-permissions.spec.ts
+++ b/apps/playwright/tests/admin/process-permissions.spec.ts
@@ -1,4 +1,4 @@
-import type { Pool } from "@gc-digital-talent/graphql";
+import type { Pool } from "@gc-digital-talent/graphql/schema-types";
 
 import { test, expect } from "~/fixtures";
 import { loginBySub } from "~/utils/auth";

--- a/apps/playwright/tests/admin/process-published-action-update.spec.ts
+++ b/apps/playwright/tests/admin/process-published-action-update.spec.ts
@@ -1,5 +1,5 @@
-import type { Pool } from "@gc-digital-talent/graphql";
-import { SkillCategory } from "@gc-digital-talent/graphql";
+import type { Pool } from "@gc-digital-talent/graphql/schema-types";
+import { SkillCategory } from "@gc-digital-talent/graphql/schema-types";
 
 import { test, expect } from "~/fixtures";
 import { getSkills } from "~/utils/skills";

--- a/apps/playwright/tests/admin/snapshot.spec.ts
+++ b/apps/playwright/tests/admin/snapshot.spec.ts
@@ -1,5 +1,8 @@
 import { FAR_PAST_DATE, PAST_DATE } from "@gc-digital-talent/date-helpers";
-import type { PoolCandidate, Skill } from "@gc-digital-talent/graphql";
+import type {
+  PoolCandidate,
+  Skill,
+} from "@gc-digital-talent/graphql/schema-types";
 import {
   ArmedForcesStatus,
   CitizenshipStatus,
@@ -8,7 +11,7 @@ import {
   ProvinceOrTerritory,
   SkillCategory,
   WorkRegion,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 
 import { test, expect } from "~/fixtures";
 import { createAndSubmitApplication } from "~/utils/applications";

--- a/apps/playwright/tests/admin/talent-nomination.spec.ts
+++ b/apps/playwright/tests/admin/talent-nomination.spec.ts
@@ -1,5 +1,5 @@
 import { nowUTCDateTime } from "@gc-digital-talent/date-helpers";
-import type { Skill } from "@gc-digital-talent/graphql";
+import type { Skill } from "@gc-digital-talent/graphql/schema-types";
 
 import { test, expect } from "~/fixtures";
 import TalentManagement from "~/fixtures/TalentManagement";

--- a/apps/playwright/tests/admin/talent-requests-validation.spec.ts
+++ b/apps/playwright/tests/admin/talent-requests-validation.spec.ts
@@ -9,7 +9,7 @@ import type {
   Skill,
   User,
   WorkStream,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 import {
   EstimatedLanguageAbility,
   FlexibleWorkLocation,
@@ -19,7 +19,7 @@ import {
   PlacementType,
   SkillCategory,
   WorkRegion,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 
 import { test, expect } from "~/fixtures";
 import { getSkills } from "~/utils/skills";

--- a/apps/playwright/tests/admin/user-action-soft-delete.spec.ts
+++ b/apps/playwright/tests/admin/user-action-soft-delete.spec.ts
@@ -1,4 +1,4 @@
-import type { User } from "@gc-digital-talent/graphql";
+import type { User } from "@gc-digital-talent/graphql/schema-types";
 
 import { test, expect } from "~/fixtures";
 import AdminUser from "~/fixtures/AdminUser";

--- a/apps/playwright/tests/admin/user-info.spec.ts
+++ b/apps/playwright/tests/admin/user-info.spec.ts
@@ -1,7 +1,7 @@
 import type { Page } from "@playwright/test";
 
-import type { User } from "@gc-digital-talent/graphql";
-import { SkillCategory } from "@gc-digital-talent/graphql";
+import type { User } from "@gc-digital-talent/graphql/schema-types";
+import { SkillCategory } from "@gc-digital-talent/graphql/schema-types";
 import { FAR_PAST_DATE } from "@gc-digital-talent/date-helpers";
 
 import { test, expect } from "~/fixtures";

--- a/apps/playwright/tests/admin/user-search.spec.ts
+++ b/apps/playwright/tests/admin/user-search.spec.ts
@@ -1,4 +1,4 @@
-import type { User } from "@gc-digital-talent/graphql";
+import type { User } from "@gc-digital-talent/graphql/schema-types";
 
 import { expect, test } from "~/fixtures";
 import { loginBySub } from "~/utils/auth";

--- a/apps/playwright/tests/admin/user-skills.spec.ts
+++ b/apps/playwright/tests/admin/user-skills.spec.ts
@@ -1,5 +1,5 @@
 import { FAR_PAST_DATE } from "@gc-digital-talent/date-helpers";
-import type { Skill, User } from "@gc-digital-talent/graphql";
+import type { Skill, User } from "@gc-digital-talent/graphql/schema-types";
 
 import { test, expect } from "~/fixtures";
 import AdminUser from "~/fixtures/AdminUser";

--- a/apps/playwright/tests/applicant/applicant-dashboard.spec.ts
+++ b/apps/playwright/tests/applicant/applicant-dashboard.spec.ts
@@ -7,7 +7,7 @@ import {
   GovPositionType,
   ProvinceOrTerritory,
   WorkRegion,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 import { nowUTCDateTime } from "@gc-digital-talent/date-helpers";
 
 import { getClassifications } from "~/utils/classification";

--- a/apps/playwright/tests/applicant/applicant-settings.spec.ts
+++ b/apps/playwright/tests/applicant/applicant-settings.spec.ts
@@ -1,5 +1,5 @@
 import { nowUTCDateTime } from "@gc-digital-talent/date-helpers";
-import type { User } from "@gc-digital-talent/graphql";
+import type { User } from "@gc-digital-talent/graphql/schema-types";
 
 import { test, expect } from "~/fixtures";
 import EmployeeProfile from "~/fixtures/EmployeeProfile";

--- a/apps/playwright/tests/applicant/application-card.spec.ts
+++ b/apps/playwright/tests/applicant/application-card.spec.ts
@@ -4,11 +4,14 @@ import {
   PAST_DATE,
   rawFormat,
 } from "@gc-digital-talent/date-helpers";
-import type { PoolCandidate, User } from "@gc-digital-talent/graphql";
+import type {
+  PoolCandidate,
+  User,
+} from "@gc-digital-talent/graphql/schema-types";
 import {
   CandidateRemovalReason,
   SkillCategory,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 
 import { test, expect } from "~/fixtures";
 import ApplicantDashboardPage from "~/fixtures/ApplicantDashboardPage";

--- a/apps/playwright/tests/applicant/application.spec.ts
+++ b/apps/playwright/tests/applicant/application.spec.ts
@@ -1,4 +1,4 @@
-import type { Skill, User } from "@gc-digital-talent/graphql";
+import type { Skill, User } from "@gc-digital-talent/graphql/schema-types";
 import {
   ArmedForcesStatus,
   CitizenshipStatus,
@@ -7,7 +7,7 @@ import {
   ProvinceOrTerritory,
   SkillCategory,
   WorkRegion,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 import { PAST_DATE } from "@gc-digital-talent/date-helpers";
 
 import { test, expect } from "~/fixtures";

--- a/apps/playwright/tests/applicant/block-job-applications.spec.ts
+++ b/apps/playwright/tests/applicant/block-job-applications.spec.ts
@@ -2,7 +2,7 @@ import type {
   Classification,
   Skill,
   WorkStream,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 import {
   ArmedForcesStatus,
   CitizenshipStatus,
@@ -11,7 +11,7 @@ import {
   ProvinceOrTerritory,
   SkillCategory,
   WorkRegion,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 
 import { test, expect } from "~/fixtures";
 import { loginBySub } from "~/utils/auth";

--- a/apps/playwright/tests/applicant/community-interest.spec.ts
+++ b/apps/playwright/tests/applicant/community-interest.spec.ts
@@ -1,4 +1,7 @@
-import type { Community, WorkStream } from "@gc-digital-talent/graphql";
+import type {
+  Community,
+  WorkStream,
+} from "@gc-digital-talent/graphql/schema-types";
 
 import CommunityInterest from "~/fixtures/CommunityInterest";
 import ApplicantDashboard from "~/fixtures/ApplicantDashboardPage";

--- a/apps/playwright/tests/applicant/development-program-interest.spec.ts
+++ b/apps/playwright/tests/applicant/development-program-interest.spec.ts
@@ -2,8 +2,8 @@ import type {
   CommunityInterest,
   DevelopmentProgram,
   EducationExperience,
-} from "@gc-digital-talent/graphql";
-import { DevelopmentProgramParticipationStatus } from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
+import { DevelopmentProgramParticipationStatus } from "@gc-digital-talent/graphql/schema-types";
 
 import { test, expect } from "~/fixtures";
 import graphql from "~/utils/graphql";

--- a/apps/playwright/tests/applicant/location-preference-update.spec.ts
+++ b/apps/playwright/tests/applicant/location-preference-update.spec.ts
@@ -1,6 +1,9 @@
 /* eslint-disable playwright/no-conditional-in-test */
-import type { User } from "@gc-digital-talent/graphql";
-import { FlexibleWorkLocation, WorkRegion } from "@gc-digital-talent/graphql";
+import type { User } from "@gc-digital-talent/graphql/schema-types";
+import {
+  FlexibleWorkLocation,
+  WorkRegion,
+} from "@gc-digital-talent/graphql/schema-types";
 
 import { expect, test } from "~/fixtures";
 import LocationPreferenceUpdatePage from "~/fixtures/locationPreferenceUpdatePage";

--- a/apps/playwright/tests/notifications.spec.ts
+++ b/apps/playwright/tests/notifications.spec.ts
@@ -1,4 +1,4 @@
-import type { Skill, User } from "@gc-digital-talent/graphql";
+import type { Skill, User } from "@gc-digital-talent/graphql/schema-types";
 import {
   ArmedForcesStatus,
   CitizenshipStatus,
@@ -7,7 +7,7 @@ import {
   ProvinceOrTerritory,
   SkillCategory,
   WorkRegion,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 import { FAR_PAST_DATE, PAST_DATE } from "@gc-digital-talent/date-helpers";
 
 import { test, expect } from "~/fixtures";

--- a/apps/playwright/utils/applications.ts
+++ b/apps/playwright/utils/applications.ts
@@ -7,8 +7,8 @@ import type {
   QualifyAndPlaceCandidateInput,
   QualifyCandidateInput,
   UpdatePoolCandidateScreeningStageInput,
-} from "@gc-digital-talent/graphql";
-import { EducationRequirementOption } from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
+import { EducationRequirementOption } from "@gc-digital-talent/graphql/schema-types";
 
 import type { GraphQLRequestFunc, GraphQLResponse } from "./graphql";
 

--- a/apps/playwright/utils/candidateAssessment.ts
+++ b/apps/playwright/utils/candidateAssessment.ts
@@ -3,7 +3,7 @@ import type {
   CreateAssessmentResultInput,
   PoolCandidate,
   PoolCandidateAdminView,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 
 import type { GraphQLRequestFunc, GraphQLResponse } from "./graphql";
 

--- a/apps/playwright/utils/classification.ts
+++ b/apps/playwright/utils/classification.ts
@@ -1,4 +1,4 @@
-import type { Classification } from "@gc-digital-talent/graphql";
+import type { Classification } from "@gc-digital-talent/graphql/schema-types";
 
 import type { GraphQLRequestFunc, GraphQLResponse } from "./graphql";
 

--- a/apps/playwright/utils/communities.ts
+++ b/apps/playwright/utils/communities.ts
@@ -5,7 +5,7 @@ import type {
   CreateCommunityInput,
   CreateCommunityInterestWithDevelopmentProgramsInput,
   DevelopmentProgram,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 
 import type { GraphQLRequestFunc, GraphQLResponse } from "./graphql";
 import { generateUniqueTestId } from "./id";

--- a/apps/playwright/utils/departments.ts
+++ b/apps/playwright/utils/departments.ts
@@ -1,7 +1,7 @@
 import type {
   CreateDepartmentInput,
   Department,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 
 import type { GraphQLRequestFunc, GraphQLResponse } from "./graphql";
 

--- a/apps/playwright/utils/experiences.ts
+++ b/apps/playwright/utils/experiences.ts
@@ -3,7 +3,7 @@ import type {
   EducationExperienceInput,
   WorkExperience,
   WorkExperienceInput,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 
 import type { GraphQLRequestFunc, GraphQLResponse } from "./graphql";
 

--- a/apps/playwright/utils/pools.ts
+++ b/apps/playwright/utils/pools.ts
@@ -6,7 +6,7 @@ import type {
   Pool,
   PoolSkill,
   UpdatePoolInput,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 import {
   AssessmentStepType,
   PoolAreaOfSelection,
@@ -17,7 +17,7 @@ import {
   SecurityStatus,
   SkillCategory,
   SkillLevel,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 import { FAR_FUTURE_DATE } from "@gc-digital-talent/date-helpers";
 
 import type { GraphQLRequestFunc, GraphQLResponse } from "./graphql";

--- a/apps/playwright/utils/roles.ts
+++ b/apps/playwright/utils/roles.ts
@@ -1,4 +1,4 @@
-import type { Role } from "@gc-digital-talent/graphql";
+import type { Role } from "@gc-digital-talent/graphql/schema-types";
 
 import type { GraphQLContext } from "./graphql";
 

--- a/apps/playwright/utils/skills.ts
+++ b/apps/playwright/utils/skills.ts
@@ -1,4 +1,4 @@
-import type { Skill } from "@gc-digital-talent/graphql";
+import type { Skill } from "@gc-digital-talent/graphql/schema-types";
 
 import type { GraphQLRequestFunc, GraphQLResponse } from "./graphql";
 

--- a/apps/playwright/utils/talentNominationEvent.ts
+++ b/apps/playwright/utils/talentNominationEvent.ts
@@ -1,7 +1,7 @@
 import type {
   CreateTalentNominationEventInput,
   TalentNominationEvent,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 
 import type { GraphQLRequestFunc, GraphQLResponse } from "./graphql";
 import { getCommunities } from "./communities";

--- a/apps/playwright/utils/user.ts
+++ b/apps/playwright/utils/user.ts
@@ -2,7 +2,7 @@ import type {
   CreateUserInput,
   User,
   UpdateUserAsUserInput,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 import {
   Language,
   ProvinceOrTerritory,
@@ -11,7 +11,7 @@ import {
   ArmedForcesStatus,
   FlexibleWorkLocation,
   WorkRegion,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 
 import type { GraphQLRequestFunc, GraphQLResponse } from "./graphql";
 import { getRoles } from "./roles";

--- a/apps/playwright/utils/workStreams.ts
+++ b/apps/playwright/utils/workStreams.ts
@@ -1,7 +1,7 @@
 import type {
   CreateWorkStreamInput,
   WorkStream,
-} from "@gc-digital-talent/graphql";
+} from "@gc-digital-talent/graphql/schema-types";
 
 import type { GraphQLRequestFunc, GraphQLResponse } from "./graphql";
 import { getCommunities } from "./communities";


### PR DESCRIPTION
Related: #17227

## 👋 Introduction

This is part two of removing the full object types from graphql codegen.

## 🕵️ Details

We heavily rely on them in playwright and since it is not application code, I added this as another exception to the rule like we did with `fake-data`. 

If you object, let me know and I can see about other options. The other one I had in mind is to also generate fragments for this but then they would be in the client-preset generarted code which sort of seemed less desirable? I'm not sure :sweat_smile: 

## 🧪 Testing

1. Confirm playwright still works
2. Confirm no imports from the base graphql package for types
