### PR TITLE
[Bug] Apply CSP nonce to dialog scroll-lock styles

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -56,6 +56,7 @@
     "@tailwindcss/vite": "^4.3.3",
     "@tanstack/react-table": "^8.21.3",
     "date-fns": "^4.4.0",
+    "get-nonce": "^1.0.1",
     "graphql": "^16.14.2",
     "lodash": "^4.18.1",
     "motion": "^12.42.2",

--- a/apps/web/src/entry.client.tsx
+++ b/apps/web/src/entry.client.tsx
@@ -2,6 +2,10 @@ import { StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";
 
+import { applyCspNonce } from "./utils/csp";
+
+applyCspNonce();
+
 hydrateRoot(
   document,
   <StrictMode>

--- a/apps/web/src/pages/SearchRequests/RequestConfirmationPage/RequestConfirmationPage.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestConfirmationPage/RequestConfirmationPage.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { useRef } from "react";
 import { defineMessage, useIntl } from "react-intl";
 import { useReactToPrint } from "react-to-print";
+import { getNonce } from "get-nonce";
 
 import {
   Notice,
@@ -76,6 +77,9 @@ export const Component = () => {
   const handlePrint = useReactToPrint({
     contentRef: componentRef,
     pageStyle: printStyles,
+    // Printing injects `pageStyle` as a <style> tag, which our CSP blocks
+    // without the nonce the app shares through `get-nonce` at startup.
+    nonce: getNonce(),
     documentTitle: intl.formatMessage({
       defaultMessage: "Request submitted",
       id: "0zo274",

--- a/apps/web/src/utils/csp.test.ts
+++ b/apps/web/src/utils/csp.test.ts
@@ -2,6 +2,14 @@ import { getNonce, setNonce } from "get-nonce";
 
 import { applyCspNonce } from "./csp";
 
+/**
+ * Limitation: jsdom has no CSP, so it never blanks the `nonce` content
+ * attribute the way a real browser does. Reading the attribute instead of the
+ * `nonce` property would therefore still pass here while silently breaking in
+ * production. That swap can only be caught in a browser served the CSP header
+ * — see the manual steps in the pull request.
+ */
+
 const addElementWithNonce = (nonce: string) => {
   const script = document.createElement("script");
   script.setAttribute("nonce", nonce);

--- a/apps/web/src/utils/csp.test.ts
+++ b/apps/web/src/utils/csp.test.ts
@@ -1,0 +1,30 @@
+import { getNonce, setNonce } from "get-nonce";
+
+import { applyCspNonce } from "./csp";
+
+const addElementWithNonce = (nonce: string) => {
+  const script = document.createElement("script");
+  script.setAttribute("nonce", nonce);
+  document.head.append(script);
+};
+
+describe("applyCspNonce", () => {
+  beforeEach(() => {
+    document.head.innerHTML = "";
+    setNonce(""); // falsy, so `getNonce` falls back to reporting no nonce
+  });
+
+  it("shares the document nonce with get-nonce consumers", () => {
+    addElementWithNonce("abc123");
+    applyCspNonce();
+
+    expect(getNonce()).toBe("abc123");
+  });
+
+  it("ignores the un-substituted placeholder", () => {
+    addElementWithNonce("**CSP_NONCE**");
+    applyCspNonce();
+
+    expect(getNonce()).toBeUndefined();
+  });
+});

--- a/apps/web/src/utils/csp.ts
+++ b/apps/web/src/utils/csp.ts
@@ -1,0 +1,26 @@
+import { setNonce } from "get-nonce";
+
+/**
+ * Placeholder that nginx swaps for the per-request nonce when it serves
+ * `index.html`. If it reaches the browser un-substituted (dev server, tests)
+ * there is no real nonce to share.
+ */
+const NONCE_PLACEHOLDER = "**CSP_NONCE**";
+
+/**
+ * Hand the nonce to `react-style-singleton`, which `react-remove-scroll` uses
+ * to inject its scroll-lock `<style>` tag when a modal Radix dialog opens.
+ * Without it that tag is blocked by `style-src-elem`.
+ *
+ * The nonce is only injected into `index.html`, never into the hashed JS
+ * bundles, so it has to be read back off the document. Browsers blank the
+ * `nonce` content attribute once the element is parsed, but the `nonce` IDL
+ * property keeps the real value.
+ */
+export const applyCspNonce = (): void => {
+  const nonce = document.querySelector<HTMLElement>("[nonce]")?.nonce;
+
+  if (nonce && nonce !== NONCE_PLACEHOLDER) {
+    setNonce(nonce);
+  }
+};

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -33,6 +33,7 @@
     "@tiptap/starter-kit": "^3.28.0",
     "date-fns": "^4.4.0",
     "downshift": "^9.4.0",
+    "get-nonce": "^1.0.1",
     "lodash": "^4.18.1",
     "motion": "^12.42.2",
     "tailwind-merge": "^3.6.0",

--- a/packages/forms/src/components/RichTextInput/ControlledInput.tsx
+++ b/packages/forms/src/components/RichTextInput/ControlledInput.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useEffect } from "react";
 import { useEditor, EditorContent } from "@tiptap/react";
+import { getNonce } from "get-nonce";
 import type {
   ControllerRenderProps,
   FieldValues,
@@ -73,6 +74,9 @@ const ControlledInput = ({
     content,
     editorProps,
     editable,
+    // Tiptap injects its own <style> tag, which our CSP blocks unless it
+    // carries the nonce the app shares through `get-nonce` at startup.
+    injectNonce: getNonce(),
     onUpdate: ({ editor: submittedEditor }) => {
       let html = submittedEditor.getHTML();
       // If you remove existing comment, editor leaves behind

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -678,6 +678,9 @@ importers:
       downshift:
         specifier: ^9.4.0
         version: 9.4.0(react@19.2.8)
+      get-nonce:
+        specifier: ^1.0.1
+        version: 1.0.1
       lodash:
         specifier: ^4.18.1
         version: 4.18.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
+      get-nonce:
+        specifier: ^1.0.1
+        version: 1.0.1
       graphql:
         specifier: ^16.14.2
         version: 16.14.2


### PR DESCRIPTION
🤖 Resolves #17182

## 👋 Introduction

Opening any dialog produced a content security policy error in the browser console. The policy only permits stylesheets carrying a one-time token issued per page load, and the library behind our dialogs was inserting one without it, so the browser blocked it.

That blocked stylesheet is also what holds the page still while a dialog is open, so it had been failing silently too. With the token applied, the background no longer scrolls behind an open dialog, and scrolling inside a dialog no longer carries over to the page underneath once it hits the end.

## 🕵️ Details

**Solution**

At client startup the nonce is read off the document and handed to `get-nonce`, the module `react-style-singleton` consults when it builds its `<style>` tag. Radix's dialog reaches that code through `react-remove-scroll`, so one call at the entry point covers every dialog in the app. It has to be read from the DOM because nginx only substitutes the nonce into `index.html`, never into the hashed JS bundles, so there is nothing to bake in at build time.

**Justification**

The Radix PR linked from the issue adds a `nonce` prop, but only to `ScrollArea.Viewport` and `Select.Viewport`; neither package is in our tree, and `react-remove-scroll` exposes no equivalent prop, which leaves the `get-nonce` singleton as the supported hook. Copying `setNonce` locally would not work — the value has to land in that module's own variable, because that is the one the library reads back. `get-nonce` was already installed transitively, so declaring it directly adds no install weight and stops the import depending on hoisting. The one dependency-free alternative, setting `window.__webpack_nonce__`, was rejected as it needs a global declaration for a webpack-named hook that Vite never sets.

**Investigation and testing**

The stack trace in the issue pointed at `insertStyleTag` in `react-style-singleton`, which reads the nonce at tag-creation time, so the fix only has to run before the first dialog opens. In Chromium against the local stack, every dialog trigger on a job advertisement page plus an open/close/reopen cycle produced zero `securitypolicyviolation` events, while a control build with only the nonce lookup broken reproduces the error and leaves body `overflow: visible` instead of `hidden`. Nonce hiding still applies to the injected tag — `getAttribute("nonce")` returns `""`, matching the parsed elements — so the nonce is no more exposed to CSS-based exfiltration than it was before. Retested by hand in Firefox, including an admin form dialog closing on submit.

## 🧪 Testing

1. Open `/en/jobs`, click any job, and open the browser console.
2. Click **Learn more about skill levels**. No `style-src-elem` error should appear.
3. With the dialog open, run `[...document.querySelectorAll('style')].map(s => s.nonce)` — it should print one non-empty value. (The Elements panel shows `nonce=""`; only the JS property carries the real value.)
4. Still with the dialog open, scroll the page behind it. It should not move.
5. Close the dialog and scroll again. Normal scrolling should return, on this and on any dialog that closes by submitting a form.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 5 (1M context)
