### PR TITLE
[Feature] PHP link checker

### DIFF
--- a/.github/workflows/external-link-checker-php.yml
+++ b/.github/workflows/external-link-checker-php.yml
@@ -1,0 +1,146 @@
+name: LinkChecker (PHP)
+
+on:
+  workflow_dispatch: # allows manual trigger
+  schedule:
+    # Every Wednesday at 2:00 AM UTC
+    - cron: "0 2 * * 3"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-links:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          extensions: bcmath
+          coverage: none
+
+      - name: Install api dependencies
+        working-directory: api
+        run: |
+          cp .env.example .env
+          composer install --prefer-dist --no-scripts
+
+      - name: Run External Link Checker
+        # A non-zero exit here just means broken links were found (see
+        # Command::FAILURE in CheckExternalLinks) -- that's reported via the
+        # issue below, not treated as a CI infrastructure failure.
+        continue-on-error: true
+        working-directory: api
+        run: php artisan app:check-external-links
+
+      - name: Count Broken Links
+        if: always()
+        id: count
+        run: |
+          if [ -f api/storage/app/external-broken-links.json ]; then
+            num=$(jq length api/storage/app/external-broken-links.json)
+          else
+            num=0
+          fi
+          echo "brokenLinksCount=$num" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Report Artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: external-link-check-results-php
+          path: |
+            api/storage/app/external-links.json
+            api/storage/app/external-broken-links.json
+
+      - name: Open or update tracking issue for broken links
+        if: always() && steps.count.outputs.brokenLinksCount != '0'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require("fs");
+
+            const label = "broken-links";
+            const title = "External link checker: broken links detected";
+            const brokenLinks = JSON.parse(
+              fs.readFileSync("api/storage/app/external-broken-links.json", "utf8")
+            );
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const rows = brokenLinks
+              .map((link) => `| ${link.file} | ${link.url} | ${link.status} |`)
+              .join("\n");
+            const body = [
+              `The external link checker found **${brokenLinks.length}** broken link(s) as of this run.`,
+              "",
+              "| File | URL | Status |",
+              "| --- | --- | --- |",
+              rows,
+              "",
+              `[View workflow run](${runUrl})`,
+            ].join("\n");
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: label,
+            });
+
+            if (existing.data.length > 0) {
+              const issue = existing.data[0];
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body,
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Still ${brokenLinks.length} broken link(s) as of this run. See the updated issue description for details.`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: [label],
+              });
+            }
+
+      - name: Close tracking issue if clean
+        if: always() && steps.count.outputs.brokenLinksCount == '0'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const label = "broken-links";
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: label,
+            });
+
+            for (const issue of existing.data) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: "All external links passed as of this run. Closing.",
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: "closed",
+              });
+            }

--- a/.github/workflows/external-link-checker-php.yml
+++ b/.github/workflows/external-link-checker-php.yml
@@ -31,10 +31,6 @@ jobs:
           composer install --prefer-dist --no-scripts
 
       - name: Run External Link Checker
-        # A non-zero exit here just means broken links were found (see
-        # Command::FAILURE in CheckExternalLinks) -- that's reported via the
-        # issue below, not treated as a CI infrastructure failure.
-        continue-on-error: true
         working-directory: api
         run: php artisan app:check-external-links
 

--- a/.github/workflows/external-link-checker-php.yml
+++ b/.github/workflows/external-link-checker-php.yml
@@ -65,9 +65,7 @@ jobs:
           script: |
             const fs = require("fs");
 
-            github.hook.before("request", (options) => {
-              options.headers["X-GitHub-Api-Version"] = "2022-11-28";
-            });
+            const apiVersionHeaders = { "x-github-api-version": "2022-11-28" };
 
             const label = "broken-links";
             const title = "External link checker: broken links detected";
@@ -94,6 +92,7 @@ jobs:
               repo: context.repo.repo,
               state: "open",
               labels: label,
+              headers: apiVersionHeaders,
             });
 
             if (existing.data.length > 0) {
@@ -103,12 +102,14 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: issue.number,
                 body,
+                headers: apiVersionHeaders,
               });
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
                 body: `Still ${brokenLinks.length} broken link(s) as of this run. See the updated issue description for details.`,
+                headers: apiVersionHeaders,
               });
             } else {
               await github.rest.issues.create({
@@ -117,6 +118,7 @@ jobs:
                 title,
                 body,
                 labels: [label],
+                headers: apiVersionHeaders,
               });
             }
 
@@ -125,9 +127,7 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            github.hook.before("request", (options) => {
-              options.headers["X-GitHub-Api-Version"] = "2022-11-28";
-            });
+            const apiVersionHeaders = { "x-github-api-version": "2022-11-28" };
 
             const label = "broken-links";
 
@@ -136,6 +136,7 @@ jobs:
               repo: context.repo.repo,
               state: "open",
               labels: label,
+              headers: apiVersionHeaders,
             });
 
             for (const issue of existing.data) {
@@ -144,11 +145,13 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: issue.number,
                 body: "All external links passed as of this run. Closing.",
+                headers: apiVersionHeaders,
               });
               await github.rest.issues.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
                 state: "closed",
+                headers: apiVersionHeaders,
               });
             }

--- a/.github/workflows/external-link-checker-php.yml
+++ b/.github/workflows/external-link-checker-php.yml
@@ -65,6 +65,10 @@ jobs:
           script: |
             const fs = require("fs");
 
+            github.hook.before("request", (options) => {
+              options.headers["X-GitHub-Api-Version"] = "2022-11-28";
+            });
+
             const label = "broken-links";
             const title = "External link checker: broken links detected";
             const brokenLinks = JSON.parse(
@@ -121,6 +125,10 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
+            github.hook.before("request", (options) => {
+              options.headers["X-GitHub-Api-Version"] = "2022-11-28";
+            });
+
             const label = "broken-links";
 
             const existing = await github.rest.issues.listForRepo({

--- a/.github/workflows/external-link-checker-php.yml
+++ b/.github/workflows/external-link-checker-php.yml
@@ -65,8 +65,6 @@ jobs:
           script: |
             const fs = require("fs");
 
-            const apiVersionHeaders = { "x-github-api-version": "2022-11-28" };
-
             const label = "broken-links";
             const title = "External link checker: broken links detected";
             const brokenLinks = JSON.parse(
@@ -92,7 +90,6 @@ jobs:
               repo: context.repo.repo,
               state: "open",
               labels: label,
-              headers: apiVersionHeaders,
             });
 
             if (existing.data.length > 0) {
@@ -102,14 +99,12 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: issue.number,
                 body,
-                headers: apiVersionHeaders,
               });
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
                 body: `Still ${brokenLinks.length} broken link(s) as of this run. See the updated issue description for details.`,
-                headers: apiVersionHeaders,
               });
             } else {
               await github.rest.issues.create({
@@ -118,7 +113,6 @@ jobs:
                 title,
                 body,
                 labels: [label],
-                headers: apiVersionHeaders,
               });
             }
 
@@ -127,8 +121,6 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const apiVersionHeaders = { "x-github-api-version": "2022-11-28" };
-
             const label = "broken-links";
 
             const existing = await github.rest.issues.listForRepo({
@@ -136,7 +128,6 @@ jobs:
               repo: context.repo.repo,
               state: "open",
               labels: label,
-              headers: apiVersionHeaders,
             });
 
             for (const issue of existing.data) {
@@ -145,13 +136,11 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: issue.number,
                 body: "All external links passed as of this run. Closing.",
-                headers: apiVersionHeaders,
               });
               await github.rest.issues.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
                 state: "closed",
-                headers: apiVersionHeaders,
               });
             }

--- a/api/app/Console/Commands/CheckExternalLinks.php
+++ b/api/app/Console/Commands/CheckExternalLinks.php
@@ -5,23 +5,25 @@ namespace App\Console\Commands;
 use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\Pool;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Symfony\Component\Finder\Finder;
+use Throwable;
 
-#[Signature('app:check-external-links {--list-only : Only build the list of external links; do not check them (checking is not yet implemented)}')]
+#[Signature('app:check-external-links {--list-only : Only build the list of external links; do not check them}')]
 #[Description('Scan apps/web/src for external links and check them for broken responses.')]
 class CheckExternalLinks extends Command
 {
+    private const USER_AGENT = 'Mozilla/5.0 (compatible; LinkChecker/1.0; +https://github.com/GCTC-NTGC/gc-digital-talent)';
+
     /**
      * Execute the console command.
      */
     public function handle()
     {
-        if (! $this->option('list-only')) {
-            $this->warn('Link checking is not yet implemented; only building the list of external links.');
-        }
-
         $webSrcPath = config('linkchecker.web_src_path');
 
         $finder = new Finder();
@@ -55,7 +57,52 @@ class CheckExternalLinks extends Command
 
         $this->info("Scanned {$fileCount} files, found ".count($links).' unique external links.');
 
-        return Command::SUCCESS;
+        if ($this->option('list-only')) {
+            return Command::SUCCESS;
+        }
+
+        $brokenLinks = $this->checkLinks($links);
+
+        Storage::disk('local')->put('external-broken-links.json', json_encode($brokenLinks, JSON_PRETTY_PRINT));
+
+        $this->info(count($links).' links checked, '.count($brokenLinks).' broken.');
+
+        return count($brokenLinks) > 0 ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    /**
+     * Check each link and return the ones that did not respond successfully.
+     *
+     * @param  array<int, array{file: string, url: string}>  $links
+     * @return array<int, array{file: string, url: string, status: int|string}>
+     */
+    private function checkLinks(array $links): array
+    {
+        $responses = Http::pool(fn (Pool $pool) => collect($links)->mapWithKeys(
+            fn ($link) => [$link['url'] => $pool->as($link['url'])
+                ->timeout(config('linkchecker.timeout'))
+                ->withUserAgent(self::USER_AGENT)
+                ->retry(2, 500, fn ($e) => $e instanceof ConnectionException, throw: false)
+                ->get($link['url'])]
+        )->all(), config('linkchecker.concurrency'));
+
+        $brokenLinks = [];
+
+        foreach ($links as $link) {
+            $response = $responses[$link['url']];
+
+            if ($response instanceof Throwable) {
+                $brokenLinks[] = ['file' => $link['file'], 'url' => $link['url'], 'status' => $response->getMessage()];
+
+                continue;
+            }
+
+            if (! $response->successful()) {
+                $brokenLinks[] = ['file' => $link['file'], 'url' => $link['url'], 'status' => $response->status()];
+            }
+        }
+
+        return $brokenLinks;
     }
 
     /**
@@ -75,7 +122,7 @@ class CheckExternalLinks extends Command
     }
 
     /**
-     * Mirrors the whitelisting logic from the original Node script.
+     * A link is worth checking if it's external and not blocklisted.
      */
     private function isValidExternalLink(string $url): bool
     {

--- a/api/app/Console/Commands/CheckExternalLinks.php
+++ b/api/app/Console/Commands/CheckExternalLinks.php
@@ -17,8 +17,6 @@ use Throwable;
 #[Description('Scan apps/web/src for external links and check them for broken responses.')]
 class CheckExternalLinks extends Command
 {
-    private const USER_AGENT = 'Mozilla/5.0 (compatible; LinkChecker/1.0; +https://github.com/GCTC-NTGC/gc-digital-talent)';
-
     /**
      * Execute the console command.
      */
@@ -81,7 +79,7 @@ class CheckExternalLinks extends Command
         $responses = Http::pool(fn (Pool $pool) => collect($links)->mapWithKeys(
             fn ($link) => [$link['url'] => $pool->as($link['url'])
                 ->timeout(config('linkchecker.timeout'))
-                ->withUserAgent(self::USER_AGENT)
+                ->withUserAgent($this->userAgentFor($link['url']))
                 ->retry(2, 500, fn ($e) => $e instanceof ConnectionException, throw: false)
                 ->get($link['url'])]
         )->all(), config('linkchecker.concurrency'));
@@ -103,6 +101,19 @@ class CheckExternalLinks extends Command
         }
 
         return $brokenLinks;
+    }
+
+    /**
+     * Most requests use an identifying User-Agent, but a handful of hosts
+     * only respond correctly to a realistic browser one.
+     */
+    private function userAgentFor(string $url): string
+    {
+        $host = strtolower(parse_url($url, PHP_URL_HOST) ?? '');
+
+        return in_array($host, config('linkchecker.browser_user_agent_hosts'), true)
+            ? config('linkchecker.browser_user_agent')
+            : config('linkchecker.user_agent');
     }
 
     /**

--- a/api/app/Console/Commands/CheckExternalLinks.php
+++ b/api/app/Console/Commands/CheckExternalLinks.php
@@ -5,7 +5,6 @@ namespace App\Console\Commands;
 use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
-use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\Pool;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
@@ -61,6 +60,12 @@ class CheckExternalLinks extends Command
 
         $brokenLinks = $this->checkLinks($links);
 
+        // one extra attempt
+        if (! empty($brokenLinks)) {
+            usleep(500_000);
+            $brokenLinks = $this->checkLinks($brokenLinks);
+        }
+
         Storage::disk('local')->put('external-broken-links.json', json_encode($brokenLinks, JSON_PRETTY_PRINT));
 
         $this->info(count($links).' links checked, '.count($brokenLinks).' broken.');
@@ -71,6 +76,12 @@ class CheckExternalLinks extends Command
     /**
      * Check each link and return the ones that did not respond successfully.
      *
+     * Retries (see handle()) are done by calling this method again with the
+     * remaining broken links, rather than via ->retry() inside the pool,
+     * because Guzzle's retry middleware blocks on the shared curl_multi
+     * handle the pool is already ticking, which can throw "Invoking the
+     * wait callback did not resolve the promise".
+     *
      * @param  array<int, array{file: string, url: string}>  $links
      * @return array<int, array{file: string, url: string, status: int|string}>
      */
@@ -80,7 +91,6 @@ class CheckExternalLinks extends Command
             fn ($link) => [$link['url'] => $pool->as($link['url'])
                 ->timeout(config('linkchecker.timeout'))
                 ->withUserAgent($this->userAgentFor($link['url']))
-                ->retry(2, 500, fn ($e) => $e instanceof ConnectionException, throw: false)
                 ->get($link['url'])]
         )->all(), config('linkchecker.concurrency'));
 

--- a/api/app/Console/Commands/CheckExternalLinks.php
+++ b/api/app/Console/Commands/CheckExternalLinks.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Symfony\Component\Finder\Finder;
+
+#[Signature('app:check-external-links {--list-only : Only build the list of external links; do not check them (checking is not yet implemented)}')]
+#[Description('Scan apps/web/src for external links and check them for broken responses.')]
+class CheckExternalLinks extends Command
+{
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        if (! $this->option('list-only')) {
+            $this->warn('Link checking is not yet implemented; only building the list of external links.');
+        }
+
+        $webSrcPath = config('linkchecker.web_src_path');
+
+        $finder = new Finder();
+        $finder->files()
+            ->in($webSrcPath)
+            ->name(['*.ts', '*.tsx', '*.js', '*.jsx', '*.html'])
+            ->exclude(['node_modules', 'dist', '.git', 'svg', 'Svg', 'icon', 'icons'])
+            ->notName('*.stories.*')
+            ->sortByName();
+
+        $repoRoot = dirname(base_path());
+        $seenUrls = [];
+        $links = [];
+        $fileCount = 0;
+
+        foreach ($finder as $file) {
+            $fileCount++;
+            $relativePath = Str::after($file->getRealPath(), $repoRoot.DIRECTORY_SEPARATOR);
+            $urls = $this->extractExternalLinks($file->getContents(), $file->getExtension());
+
+            foreach ($urls as $url) {
+                if (isset($seenUrls[$url])) {
+                    continue;
+                }
+                $seenUrls[$url] = true;
+                $links[] = ['file' => $relativePath, 'url' => $url];
+            }
+        }
+
+        Storage::disk('local')->put('external-links.json', json_encode($links, JSON_PRETTY_PRINT));
+
+        $this->info("Scanned {$fileCount} files, found ".count($links).' unique external links.');
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Extract external links from a file's contents.
+     *
+     * @return string[]
+     */
+    private function extractExternalLinks(string $content, string $extension): array
+    {
+        $pattern = $extension === 'html'
+            ? '/href=[\'"]([^\'"]+)[\'"]/'
+            : '/[\'"](https?:\/\/[^\'"]+)[\'"]/';
+
+        preg_match_all($pattern, $content, $matches);
+
+        return array_values(array_filter($matches[1], [$this, 'isValidExternalLink']));
+    }
+
+    /**
+     * Mirrors the whitelisting logic from the original Node script.
+     */
+    private function isValidExternalLink(string $url): bool
+    {
+        if (! str_starts_with($url, 'http')) {
+            return false;
+        }
+
+        $blocklistedDomains = config('linkchecker.blocklisted_domains');
+        $lowerUrl = strtolower($url);
+
+        foreach ($blocklistedDomains as $domain) {
+            if (str_starts_with($lowerUrl, strtolower($domain))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/api/app/Console/Commands/CheckExternalLinks.php
+++ b/api/app/Console/Commands/CheckExternalLinks.php
@@ -70,7 +70,7 @@ class CheckExternalLinks extends Command
 
         $this->info(count($links).' links checked, '.count($brokenLinks).' broken.');
 
-        return count($brokenLinks) > 0 ? Command::FAILURE : Command::SUCCESS;
+        return Command::SUCCESS;
     }
 
     /**

--- a/api/app/Console/Commands/CheckExternalLinks.php
+++ b/api/app/Console/Commands/CheckExternalLinks.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\Pool;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
@@ -60,12 +61,6 @@ class CheckExternalLinks extends Command
 
         $brokenLinks = $this->checkLinks($links);
 
-        // one extra attempt
-        if (! empty($brokenLinks)) {
-            usleep(500_000);
-            $brokenLinks = $this->checkLinks($brokenLinks);
-        }
-
         Storage::disk('local')->put('external-broken-links.json', json_encode($brokenLinks, JSON_PRETTY_PRINT));
 
         $this->info(count($links).' links checked, '.count($brokenLinks).' broken.');
@@ -76,12 +71,6 @@ class CheckExternalLinks extends Command
     /**
      * Check each link and return the ones that did not respond successfully.
      *
-     * Retries (see handle()) are done by calling this method again with the
-     * remaining broken links, rather than via ->retry() inside the pool,
-     * because Guzzle's retry middleware blocks on the shared curl_multi
-     * handle the pool is already ticking, which can throw "Invoking the
-     * wait callback did not resolve the promise".
-     *
      * @param  array<int, array{file: string, url: string}>  $links
      * @return array<int, array{file: string, url: string, status: int|string}>
      */
@@ -91,6 +80,7 @@ class CheckExternalLinks extends Command
             fn ($link) => [$link['url'] => $pool->as($link['url'])
                 ->timeout(config('linkchecker.timeout'))
                 ->withUserAgent($this->userAgentFor($link['url']))
+                ->retry(2, 500, fn ($e) => $e instanceof ConnectionException, throw: false)
                 ->get($link['url'])]
         )->all(), config('linkchecker.concurrency'));
 

--- a/api/app/Console/Commands/CheckExternalLinks.php
+++ b/api/app/Console/Commands/CheckExternalLinks.php
@@ -141,11 +141,12 @@ class CheckExternalLinks extends Command
             return false;
         }
 
+        $host = strtolower(parse_url($url, PHP_URL_HOST) ?? '');
         $blocklistedDomains = config('linkchecker.blocklisted_domains');
-        $lowerUrl = strtolower($url);
 
         foreach ($blocklistedDomains as $domain) {
-            if (str_starts_with($lowerUrl, strtolower($domain))) {
+            $domain = strtolower($domain);
+            if ($host === $domain || str_ends_with($host, '.'.$domain)) {
                 return false;
             }
         }

--- a/api/config/linkchecker.php
+++ b/api/config/linkchecker.php
@@ -71,6 +71,7 @@ return [
     'browser_user_agent_hosts' => [
         'connexion.canada.ca',
         'login.canada.ca',
+        'laws-lois.justice.gc.ca',
     ],
 
     /*

--- a/api/config/linkchecker.php
+++ b/api/config/linkchecker.php
@@ -1,0 +1,32 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Web source path
+    |--------------------------------------------------------------------------
+    |
+    | The directory scanned for external links (apps/web/src, a sibling of
+    | this Laravel app rather than a path within it).
+    |
+    */
+
+    'web_src_path' => env('LINK_CHECKER_WEB_SRC_PATH', base_path('../apps/web/src')),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Blocklisted domains
+    |--------------------------------------------------------------------------
+    |
+    | Domains that should not be checked. Links starting with any of these
+    | are excluded from the collected list.
+    |
+    */
+
+    'blocklisted_domains' => [
+        'https://fonts.googleapis.com',
+        'https://fonts.gstatic.com',
+        'https://gcxgce.sharepoint.com',
+        'http://localhost',
+    ],
+];

--- a/api/config/linkchecker.php
+++ b/api/config/linkchecker.php
@@ -18,21 +18,21 @@ return [
     | Blocklisted domains
     |--------------------------------------------------------------------------
     |
-    | Domains that should not be checked. Links starting with any of these
-    | are excluded from the collected list.
+    | Hosts that should not be checked. Links whose host matches (or is a
+    | subdomain of) any of these are excluded from the collected list.
     |
     */
 
     'blocklisted_domains' => [
-        'https://fonts.googleapis.com',
-        'https://fonts.gstatic.com',
-        'https://gcxgce.sharepoint.com',
-        'http://localhost',
+        'fonts.googleapis.com',
+        'fonts.gstatic.com',
+        'gcxgce.sharepoint.com',
+        'localhost',
 
         // Sits behind Cloudflare + Kasada bot-detection (JS/TLS-fingerprint
         // challenge), so it always 403s a plain HTTP client even though the
         // page is live for real visitors. Confirmed 2026-07-30.
-        'https://srvcanadavrs.ca',
+        'srvcanadavrs.ca',
 
         // Sign-in hosts that block automated traffic (e.g. requests from cloud/CI
         // IP ranges) with a 403 by design, regardless of User-Agent.

--- a/api/config/linkchecker.php
+++ b/api/config/linkchecker.php
@@ -28,6 +28,10 @@ return [
         'https://fonts.gstatic.com',
         'https://gcxgce.sharepoint.com',
         'http://localhost',
+        // Sits behind Cloudflare + Kasada bot-detection (JS/TLS-fingerprint
+        // challenge), so it always 403s a plain HTTP client even though the
+        // page is live for real visitors. Confirmed 2026-07-30.
+        'https://srvcanadavrs.ca',
     ],
 
     /*
@@ -51,4 +55,35 @@ return [
     */
 
     'concurrency' => env('LINK_CHECKER_CONCURRENCY', 10),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Browser User-Agent hosts
+    |--------------------------------------------------------------------------
+    |
+    | These hosts return 404 to any request without a realistic browser
+    | User-Agent string (confirmed via curl testing 2026-07-30 — no other
+    | header makes a difference). Requests to these hosts use the browser
+    | user agent below instead of the identifying default one.
+    |
+    */
+
+    'browser_user_agent_hosts' => [
+        'connexion.canada.ca',
+        'login.canada.ca',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | User agents
+    |--------------------------------------------------------------------------
+    |
+    | The default identifies this tool. The browser one is only used for
+    | the hosts listed in browser_user_agent_hosts above.
+    |
+    */
+
+    'user_agent' => 'Mozilla/5.0 (compatible; LinkChecker/1.0; +https://github.com/GCTC-NTGC/gc-digital-talent)',
+
+    'browser_user_agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36',
 ];

--- a/api/config/linkchecker.php
+++ b/api/config/linkchecker.php
@@ -28,10 +28,17 @@ return [
         'https://fonts.gstatic.com',
         'https://gcxgce.sharepoint.com',
         'http://localhost',
+
         // Sits behind Cloudflare + Kasada bot-detection (JS/TLS-fingerprint
         // challenge), so it always 403s a plain HTTP client even though the
         // page is live for real visitors. Confirmed 2026-07-30.
         'https://srvcanadavrs.ca',
+
+        // Sign-in hosts that block automated traffic (e.g. requests from cloud/CI
+        // IP ranges) with a 403 by design, regardless of User-Agent.
+        'connexion.canada.ca',
+        'login.canada.ca',
+
     ],
 
     /*
@@ -69,8 +76,6 @@ return [
     */
 
     'browser_user_agent_hosts' => [
-        'connexion.canada.ca',
-        'login.canada.ca',
         'laws-lois.justice.gc.ca',
     ],
 

--- a/api/config/linkchecker.php
+++ b/api/config/linkchecker.php
@@ -29,4 +29,26 @@ return [
         'https://gcxgce.sharepoint.com',
         'http://localhost',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Timeout
+    |--------------------------------------------------------------------------
+    |
+    | Seconds to wait for a response before considering a link unreachable.
+    |
+    */
+
+    'timeout' => env('LINK_CHECKER_TIMEOUT', 30),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Concurrency
+    |--------------------------------------------------------------------------
+    |
+    | Number of links to check at the same time.
+    |
+    */
+
+    'concurrency' => env('LINK_CHECKER_CONCURRENCY', 10),
 ];

--- a/api/config/linkchecker.php
+++ b/api/config/linkchecker.php
@@ -58,6 +58,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | Number of links to check at the same time.
+    | As of 2026-08-24 concurrency throttling doesn't seem to work reliably on
+    | PHP in Docker on MacOS.  Use "1" for no concurrency.
     |
     */
 


### PR DESCRIPTION
🤖 Resolves #16559 

## 👋 Introduction

I know we've been having some trouble with our link checker.  Almost more of a spike but I worked with Claude to reimagine it as an Artisan command to take advantage of all the nice Laravel tooling.  I'm pretty happy with how it turned out.

## 🕵️ Details

- The main script goes from 402 lines of code down to 155.
- No separate respawning.  Laravel's HTTP client (built on curl) handles TLS and has builtin retry functionality.
- Laravel's HTTP client also has built-in concurrency. The script time goes from 20 seconds down to 4.8 seconds.
- The two links that require a browser UA are on a list to trigger that.  
- The two links that are protected by Cloudflare and the two that refuse connections from Github are moved to the block list.

## 🧪 Testing

1. `php artisan app:check-external-links`
2. Check for the two files in api/storage/app

I tried running this on my own fork of the repo.  You're welcome to do the same.  My fork doesn't have issues enabled to test that part, though.

https://github.com/petertgiles/gc-digital-talent/actions/workflows/external-link-checker-php.yml

## 📸 Screenshot

<img width="844" height="121" alt="image" src="https://github.com/user-attachments/assets/7585c744-4176-4924-9192-8e1b0600a199" />
