### PR TITLE
[Refactor] Remove full graphql object types 3

### DIFF
--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentDetailsDialog.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentDetailsDialog.tsx
@@ -23,11 +23,7 @@ import {
   localizedEnumToOptions,
 } from "@gc-digital-talent/forms";
 import { toast } from "@gc-digital-talent/toast";
-import type {
-  PoolSkill,
-  ScreeningQuestion,
-  FragmentType,
-} from "@gc-digital-talent/graphql";
+import type { FragmentType } from "@gc-digital-talent/graphql";
 import {
   graphql,
   AssessmentStepType,
@@ -113,8 +109,7 @@ const AssessmentDetailsDialogPoolSkill_Fragment = graphql(/* GraphQL */ `
       }
       key
       name {
-        en
-        fr
+        localized
       }
     }
     assessmentSteps {
@@ -170,40 +165,9 @@ interface FormValues {
   assessedSkillsScreeningQuestions?: string[] | null;
 }
 
-interface InitialValues extends Omit<
-  FormValues,
-  "poolId" | "screeningQuestionFieldArray"
-> {
+interface InitialValues extends Omit<FormValues, "poolId"> {
   poolId: NonNullable<FormValues["poolId"]>;
-  screeningQuestions?: ScreeningQuestion[];
 }
-
-const getDefaultValues = (initialValues: InitialValues): FormValues => {
-  const { screeningQuestions, ...restInitial } = initialValues;
-  if (screeningQuestions) {
-    screeningQuestions.sort((a, b) =>
-      (a.sortOrder ?? Number.MAX_SAFE_INTEGER) >
-      (b.sortOrder ?? Number.MAX_SAFE_INTEGER)
-        ? 1
-        : -1,
-    );
-  }
-
-  return {
-    ...restInitial,
-    screeningQuestionFieldArray: screeningQuestions?.map(
-      (initialScreeningQuestion) => ({
-        id: null, // filled by react-hook-form
-        screeningQuestion: {
-          id: initialScreeningQuestion.id,
-          sortOrder: initialScreeningQuestion.sortOrder,
-          en: initialScreeningQuestion.question?.en,
-          fr: initialScreeningQuestion.question?.fr,
-        },
-      }),
-    ),
-  };
-};
 
 interface AssessmentDetailsDialogProps {
   initialValues: InitialValues;
@@ -247,7 +211,7 @@ const AssessmentDetailsDialog = ({
   ] = useMutation(AssessmentDetailsDialog_ScreeningQuestionMutation);
 
   const methods = useForm<FormValues>({
-    defaultValues: getDefaultValues(initialValues),
+    defaultValues: initialValues,
   });
   const {
     handleSubmit,
@@ -314,7 +278,7 @@ const AssessmentDetailsDialog = ({
 
   // NOTE: Required to update form when initial values change
   useEffect(() => {
-    reset(getDefaultValues(initialValues));
+    reset(initialValues);
   }, [reset, initialValues]);
 
   const submitCreateAssessmentStepMutation = (
@@ -447,13 +411,17 @@ const AssessmentDetailsDialog = ({
   const canAddScreeningQuestions =
     fields.length < SCREENING_QUESTIONS_MAX_QUESTIONS;
 
-  const assessedSkillsItems: AssessedSkillsItems = allPoolSkills.reduce(
-    (assessedSkills: AssessedSkillsItems, poolSkill: PoolSkill) => {
+  const assessedSkillsItems = allPoolSkills.reduce<AssessedSkillsItems>(
+    (assessedSkills, poolSkill) => {
       if (poolSkill.type?.value === PoolSkillType.Essential) {
         return {
           essentialSkillItems: [
             ...assessedSkills.essentialSkillItems,
-            poolSkillToOption(poolSkill.id, poolSkill.skill?.name, intl),
+            poolSkillToOption(
+              poolSkill.id,
+              poolSkill.skill?.name?.localized,
+              intl,
+            ),
           ],
           assetSkills: assessedSkills.assetSkills,
         };
@@ -463,7 +431,11 @@ const AssessmentDetailsDialog = ({
         return {
           assetSkills: [
             ...assessedSkills.assetSkills,
-            poolSkillToOption(poolSkill.id, poolSkill.skill?.name, intl),
+            poolSkillToOption(
+              poolSkill.id,
+              poolSkill.skill?.name?.localized,
+              intl,
+            ),
           ],
           essentialSkillItems: assessedSkills.essentialSkillItems,
         };

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentDetailsDialog.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentDetailsDialog.tsx
@@ -453,10 +453,7 @@ const AssessmentDetailsDialog = ({
         return {
           essentialSkillItems: [
             ...assessedSkills.essentialSkillItems,
-            poolSkillToOption(
-              { id: poolSkill.id, skill: poolSkill.skill },
-              intl,
-            ),
+            poolSkillToOption(poolSkill.id, poolSkill.skill?.name, intl),
           ],
           assetSkills: assessedSkills.assetSkills,
         };
@@ -466,10 +463,7 @@ const AssessmentDetailsDialog = ({
         return {
           assetSkills: [
             ...assessedSkills.assetSkills,
-            poolSkillToOption(
-              { id: poolSkill.id, skill: poolSkill.skill },
-              intl,
-            ),
+            poolSkillToOption(poolSkill.id, poolSkill.skill?.name, intl),
           ],
           essentialSkillItems: assessedSkills.essentialSkillItems,
         };

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentStepCard.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentStepCard.tsx
@@ -1,13 +1,11 @@
 import { Fragment } from "react";
 import { useIntl } from "react-intl";
-import sortBy from "lodash/sortBy";
 
-import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
 import {
   appendLanguageName,
   commonMessages,
   formMessages,
-  getLocalizedName,
 } from "@gc-digital-talent/i18n";
 import {
   Accordion,
@@ -17,7 +15,7 @@ import {
   Notice,
   useCardRepeaterContext,
 } from "@gc-digital-talent/ui";
-import type { AssessmentStep, FragmentType } from "@gc-digital-talent/graphql";
+import type { FragmentType } from "@gc-digital-talent/graphql";
 import {
   AssessmentStepType,
   getFragment,
@@ -47,9 +45,34 @@ const AssessmentStepCardPool_Fragment = graphql(/* GraphQL */ `
   }
 `);
 
+const AssessmentStepCardStep_Fragment = graphql(/* GraphQL */ `
+  fragment AssessmentStepCardStep on AssessmentStep {
+    id
+    title {
+      en
+      fr
+      localized
+    }
+    type {
+      value
+      label {
+        localized
+      }
+    }
+    poolSkills {
+      id
+      skill {
+        name {
+          localized
+        }
+      }
+    }
+  }
+`);
+
 interface AssessmentStepCardProps {
   index: number;
-  assessmentStep: Pick<AssessmentStep, "id" | "type" | "title" | "poolSkills">;
+  assessmentStepQuery: FragmentType<typeof AssessmentStepCardStep_Fragment>;
   poolQuery: FragmentType<typeof AssessmentStepCardPool_Fragment>;
   onRemove: (index: number) => Promise<void>;
   onMove: (fromIndex: number, toIndex: number) => void;
@@ -57,7 +80,7 @@ interface AssessmentStepCardProps {
 
 const AssessmentStepCard = ({
   index,
-  assessmentStep,
+  assessmentStepQuery,
   poolQuery,
   onRemove,
   onMove,
@@ -65,13 +88,18 @@ const AssessmentStepCard = ({
   const intl = useIntl();
   const { move, remove } = useCardRepeaterContext();
   const pool = getFragment(AssessmentStepCardPool_Fragment, poolQuery);
-  const skillNames = unpackMaybes(assessmentStep.poolSkills).map((poolSkill) =>
-    getLocalizedName(poolSkill?.skill?.name, intl),
+  const assessmentStep = getFragment(
+    AssessmentStepCardStep_Fragment,
+    assessmentStepQuery,
+  );
+  const skillNames = unpackMaybes(assessmentStep.poolSkills).map(
+    (poolSkill) =>
+      poolSkill?.skill?.name?.localized ??
+      intl.formatMessage(commonMessages.notAvailable),
   );
   skillNames.sort();
-  const screeningQuestions = sortBy(
-    unpackMaybes(pool.screeningQuestions),
-    (question) => question.sortOrder,
+  const screeningQuestions = unpackMaybes(pool.screeningQuestions).sort(
+    (a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0),
   );
   const isApplicationScreening =
     assessmentStep.type?.value === AssessmentStepType.ApplicationScreening;
@@ -92,18 +120,25 @@ const AssessmentStepCard = ({
       onMove={handleMove} // immediately fire event
       edit={
         <AssessmentDetailsDialog
-          poolSkillsQuery={pool.poolSkills?.filter(notEmpty) ?? []}
+          poolSkillsQuery={unpackMaybes(pool.poolSkills)}
           initialValues={{
             id: assessmentStep.id,
             poolId: pool.id,
             typeOfAssessment: assessmentStep.type?.value,
             assessmentTitleEn: assessmentStep?.title?.en,
             assessmentTitleFr: assessmentStep?.title?.fr,
-            assessedSkills:
-              assessmentStep?.poolSkills
-                ?.map((poolSkill) => poolSkill?.id)
-                ?.filter(notEmpty) ?? [],
-            screeningQuestions: pool.screeningQuestions?.filter(notEmpty) ?? [],
+            assessedSkills: unpackMaybes(assessmentStep.poolSkills).map(
+              (poolSkill) => poolSkill.id,
+            ),
+            screeningQuestionFieldArray: screeningQuestions.map((question) => ({
+              id: null,
+              screeningQuestion: {
+                id: question.id,
+                sortOrder: question.sortOrder,
+                en: question.question?.en,
+                fr: question.question?.fr,
+              },
+            })),
           }}
           trigger={
             <CardRepeater.Edit
@@ -117,8 +152,8 @@ const AssessmentStepCard = ({
       remove={
         <ConfirmationDialog
           assessmentTitle={assessmentStepDisplayName(
-            assessmentStep.title,
-            assessmentStep.type?.label,
+            assessmentStep.title?.localized,
+            assessmentStep.type?.label?.localized,
             intl,
           )}
           onRemove={() => handleRemove(index)}
@@ -127,8 +162,8 @@ const AssessmentStepCard = ({
     >
       <Heading level="h4" size="h6" className="mt-0">
         {assessmentStepDisplayName(
-          assessmentStep.title,
-          assessmentStep.type?.label,
+          assessmentStep.title?.localized,
+          assessmentStep.type?.label?.localized,
           intl,
         )}
       </Heading>

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentStepCard.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentStepCard.tsx
@@ -117,7 +117,8 @@ const AssessmentStepCard = ({
       remove={
         <ConfirmationDialog
           assessmentTitle={assessmentStepDisplayName(
-            { type: assessmentStep.type, title: assessmentStep.title },
+            assessmentStep.title,
+            assessmentStep.type?.label,
             intl,
           )}
           onRemove={() => handleRemove(index)}
@@ -126,7 +127,8 @@ const AssessmentStepCard = ({
     >
       <Heading level="h4" size="h6" className="mt-0">
         {assessmentStepDisplayName(
-          { type: assessmentStep.type, title: assessmentStep.title },
+          assessmentStep.title,
+          assessmentStep.type?.label,
           intl,
         )}
       </Heading>

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/OrganizeSection.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/OrganizeSection.tsx
@@ -11,7 +11,7 @@ import {
   Notice,
 } from "@gc-digital-talent/ui";
 import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
-import type { AssessmentStep, FragmentType } from "@gc-digital-talent/graphql";
+import type { FragmentType } from "@gc-digital-talent/graphql";
 import {
   graphql,
   AssessmentStepType,
@@ -65,42 +65,14 @@ const OrganizeSectionPool_Fragment = graphql(/* GraphQL */ `
     }
     assessmentSteps {
       id
-      title {
-        en
-        fr
-        localized
-      }
+      sortOrder
       type {
         value
-        label {
-          en
-          fr
-        }
       }
-      sortOrder
-      poolSkills {
-        id
-        skill {
-          id
-          key
-          category {
-            value
-            label {
-              en
-              fr
-            }
-          }
-          name {
-            en
-            fr
-          }
-        }
-      }
+      ...AssessmentStepCardStep
     }
   }
 `);
-
-type StepState = Pick<AssessmentStep, "id" | "type" | "title" | "poolSkills">[];
 
 interface OrganizeSectionProps {
   poolQuery: FragmentType<typeof OrganizeSectionPool_Fragment>;
@@ -117,9 +89,8 @@ const OrganizeSection = ({
     () => sortBy(unpackMaybes(pool.assessmentSteps), (step) => step.sortOrder),
     [pool.assessmentSteps],
   );
-  const [steps, setSteps] = useState<StepState>(initialSteps);
-  const [prevInitialSteps, setPrevInitialSteps] =
-    useState<StepState>(initialSteps);
+  const [steps, setSteps] = useState(initialSteps);
+  const [prevInitialSteps, setPrevInitialSteps] = useState(initialSteps);
 
   if (initialSteps !== prevInitialSteps) {
     setSteps(initialSteps);
@@ -326,9 +297,7 @@ const OrganizeSection = ({
         </Accordion.Item>
       </Accordion.Root>
       <div className="my-6">
-        <CardRepeater.Root<
-          Pick<AssessmentStep, "id" | "type" | "title" | "poolSkills">
-        >
+        <CardRepeater.Root
           items={steps}
           disabled={formDisabled}
           max={ASSESSMENT_STEPS_MAX_STEPS}
@@ -368,7 +337,7 @@ const OrganizeSection = ({
               index={index}
               onMove={move}
               onRemove={remove}
-              assessmentStep={assessmentStep}
+              assessmentStepQuery={assessmentStep}
               poolQuery={pool}
             />
           ))}

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/SkillSummaryTable.stories.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/SkillSummaryTable.stories.tsx
@@ -7,7 +7,6 @@ import {
   fakeSkills,
   toLocalizedEnum,
 } from "@gc-digital-talent/fake-data";
-import type { AssessmentStep, PoolSkill } from "@gc-digital-talent/graphql";
 import {
   AssessmentStepType,
   PoolSkillType,
@@ -51,7 +50,7 @@ const behaviouralSkill4 = fakeSkills(
   fakeSkillFamilies(1),
   SkillCategory.Behavioural,
 )[3];
-const poolSkillsArray: PoolSkill[] = [
+const poolSkillsArray = [
   {
     id: "poolSkill1",
     skill: technicalSkill1,
@@ -93,7 +92,7 @@ const poolSkillsArray: PoolSkill[] = [
   },
 ];
 
-const assessmentStepsArray: AssessmentStep[] = [
+const assessmentStepsArray = [
   {
     id: "assessmentStep1",
     pool: fakePool,
@@ -108,7 +107,11 @@ const assessmentStepsArray: AssessmentStep[] = [
       },
     ],
     sortOrder: 1,
-    title: { en: "Application Screening EN", fr: "Application Screening FR" },
+    title: {
+      en: "Application Screening EN",
+      fr: "Application Screening FR",
+      localized: "Application Screening LOCALIZED",
+    },
     type: toLocalizedEnum(AssessmentStepType.ApplicationScreening),
   },
   {
@@ -121,7 +124,11 @@ const assessmentStepsArray: AssessmentStep[] = [
       },
     ],
     sortOrder: 2,
-    title: { en: "Reference EN", fr: "Reference FR" },
+    title: {
+      en: "Reference EN",
+      fr: "Reference FR",
+      localized: "Reference LOCALIZED",
+    },
     type: toLocalizedEnum(AssessmentStepType.ReferenceCheck),
   },
 ];

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/SkillSummaryTable.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/SkillSummaryTable.tsx
@@ -5,11 +5,9 @@ import type { IntlShape } from "react-intl";
 import { useIntl } from "react-intl";
 import CheckIcon from "@heroicons/react/20/solid/CheckIcon";
 
-import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
+import { commonMessages } from "@gc-digital-talent/i18n";
 import type {
   FragmentType,
-  LocalizedAssessmentStepType,
-  Skill,
   SkillSummaryPoolSkillFragment as SkillSummaryPoolSkillFragmentType,
   SkillSummaryTableAssessmentStepFragment as SkillSummaryAssessmentStepFragmentType,
 } from "@gc-digital-talent/graphql";
@@ -33,8 +31,7 @@ export const SkillSummaryTablePoolSkill_Fragment = graphql(/* GraphQL */ `
     type {
       value
       label {
-        en
-        fr
+        localized
       }
     }
     skill {
@@ -43,13 +40,11 @@ export const SkillSummaryTablePoolSkill_Fragment = graphql(/* GraphQL */ `
       category {
         value
         label {
-          en
-          fr
+          localized
         }
       }
       name {
-        en
-        fr
+        localized
       }
     }
   }
@@ -61,14 +56,12 @@ export const SkillSummaryTableAssessmentStep_Fragment = graphql(/* GraphQL */ `
     type {
       value
       label {
-        en
-        fr
+        localized
       }
     }
     sortOrder
     title {
-      en
-      fr
+      localized
     }
     poolSkills {
       id
@@ -87,19 +80,13 @@ interface SkillSummaryTableProps {
 }
 
 const CheckIconElement = (
-  skill: Skill | null | undefined,
-  assessmentStepType: LocalizedAssessmentStepType | null | undefined,
+  localizedName: string | null | undefined,
+  assessmentStepTypeLocalized: string | null | undefined,
 ): JSX.Element | null => {
   const intl = useIntl();
-  if (!skill) {
+  if (!localizedName) {
     return null;
   }
-  const { name } = skill;
-  const localizedName = getLocalizedName(name, intl);
-  const assessmentStepTypeLocalized = getLocalizedName(
-    assessmentStepType?.label,
-    intl,
-  );
 
   return (
     <CheckIcon
@@ -174,19 +161,25 @@ const assessmentStepCell = (
       (assessmentStepPoolSkill) => assessmentStepPoolSkill?.id === poolSkill.id,
     )
   ) {
-    return CheckIconElement(poolSkill.skill, assessmentStep.type);
+    return CheckIconElement(
+      poolSkill.skill?.name?.localized,
+      assessmentStep.type?.label?.localized,
+    );
   }
   return null;
 };
 
 const requirementTypeCell = ({ poolSkill, intl }: RequirementTypeCellProps) => {
   if (!poolSkill.type) return null;
+  const label =
+    poolSkill.type.label?.localized ??
+    intl.formatMessage(commonMessages.notAvailable);
   return poolSkill.type.value === PoolSkillType.Essential ? (
     <span className="font-bold text-secondary-600 dark:text-secondary-200">
-      {getLocalizedName(poolSkill.type.label, intl)}
+      {label}
     </span>
   ) : (
-    <span>{getLocalizedName(poolSkill.type.label, intl)}</span>
+    <span>{label}</span>
   );
 };
 
@@ -206,15 +199,20 @@ const SkillSummaryTable = ({
   );
 
   const initialColumns = [
-    columnHelper.accessor((row) => getLocalizedName(row.skill?.name, intl), {
-      id: "skillName",
-      header: intl.formatMessage({
-        defaultMessage: "Skill name",
-        id: "hjxxaQ",
-        description: "Skill name column header for the skill library table",
-      }),
-      enableHiding: false,
-    }),
+    columnHelper.accessor(
+      (row) =>
+        row.skill?.name?.localized ??
+        intl.formatMessage(commonMessages.notAvailable),
+      {
+        id: "skillName",
+        header: intl.formatMessage({
+          defaultMessage: "Skill name",
+          id: "hjxxaQ",
+          description: "Skill name column header for the skill library table",
+        }),
+        enableHiding: false,
+      },
+    ),
     columnHelper.display({
       id: "plannedAssessment",
       header: intl.formatMessage({
@@ -242,7 +240,9 @@ const SkillSummaryTable = ({
         cells.jsx(requirementTypeCell({ poolSkill, intl })),
     }),
     columnHelper.accessor(
-      ({ skill }) => getLocalizedName(skill?.category.label, intl),
+      ({ skill }) =>
+        skill?.category.label?.localized ??
+        intl.formatMessage(commonMessages.notAvailable),
       {
         id: "skillCategory",
         header: intl.formatMessage({
@@ -264,8 +264,8 @@ const SkillSummaryTable = ({
   });
   sortedAssessmentSteps.forEach((assessmentStep) => {
     const headerName = assessmentStepDisplayName(
-      assessmentStep.title,
-      assessmentStep.type?.label,
+      assessmentStep.title?.localized,
+      assessmentStep.type?.label?.localized,
       intl,
     );
     const newColumn = columnHelper.display({

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/SkillSummaryTable.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/SkillSummaryTable.tsx
@@ -82,11 +82,9 @@ interface SkillSummaryTableProps {
 const CheckIconElement = (
   localizedName: string | null | undefined,
   assessmentStepTypeLocalized: string | null | undefined,
-): JSX.Element | null => {
+): JSX.Element => {
   const intl = useIntl();
-  if (!localizedName) {
-    return null;
-  }
+  const notAvailable = intl.formatMessage(commonMessages.notAvailable);
 
   return (
     <CheckIcon
@@ -99,7 +97,11 @@ const CheckIconElement = (
             "Aria text for icon indicating a skill to assessment step connection.",
           id: "4LVc9T",
         },
-        { localizedName, assessmentStepTypeLocalized },
+        {
+          localizedName: localizedName ?? notAvailable,
+          assessmentStepTypeLocalized:
+            assessmentStepTypeLocalized ?? notAvailable,
+        },
       )}
     />
   );

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/SkillSummaryTable.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/SkillSummaryTable.tsx
@@ -264,7 +264,8 @@ const SkillSummaryTable = ({
   });
   sortedAssessmentSteps.forEach((assessmentStep) => {
     const headerName = assessmentStepDisplayName(
-      { type: assessmentStep.type, title: assessmentStep.title },
+      assessmentStep.title,
+      assessmentStep.type?.label,
       intl,
     );
     const newColumn = columnHelper.display({

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/utils.ts
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/utils.ts
@@ -1,25 +1,22 @@
 import type { IntlShape } from "react-intl";
 
-import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
-import type { LocalizedString } from "@gc-digital-talent/graphql";
+import { commonMessages } from "@gc-digital-talent/i18n";
 
 export const assessmentStepDisplayName = (
-  title: LocalizedString | null | undefined,
-  typeLabel: LocalizedString | null | undefined,
+  title: string | null | undefined,
+  typeLabel: string | null | undefined,
   intl: IntlShape,
 ): string => {
-  const localizedTitle = getLocalizedName(title, intl, true);
-  const localizedType = getLocalizedName(typeLabel, intl, true);
-  if (localizedTitle && localizedType) {
-    return `${localizedTitle} (${localizedType})`;
+  if (title && typeLabel) {
+    return `${title} (${typeLabel})`;
   }
 
-  if (!localizedTitle && localizedType) {
-    return localizedType;
+  if (!title && typeLabel) {
+    return typeLabel;
   }
 
-  if (localizedTitle && !localizedType) {
-    return localizedTitle;
+  if (title && !typeLabel) {
+    return title;
   }
 
   return intl.formatMessage(commonMessages.notAvailable);
@@ -27,11 +24,9 @@ export const assessmentStepDisplayName = (
 
 export const poolSkillToOption = (
   id: string,
-  skillName: LocalizedString | null | undefined,
+  skillName: string | null | undefined,
   intl: IntlShape,
 ) => ({
   value: id,
-  label: skillName
-    ? getLocalizedName(skillName, intl)
-    : intl.formatMessage(commonMessages.nameNotLoaded),
+  label: skillName ?? intl.formatMessage(commonMessages.nameNotLoaded),
 });

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/utils.ts
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/utils.ts
@@ -1,18 +1,15 @@
 import type { IntlShape } from "react-intl";
 
 import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
-import type { AssessmentStep, PoolSkill } from "@gc-digital-talent/graphql";
+import type { LocalizedString } from "@gc-digital-talent/graphql";
 
 export const assessmentStepDisplayName = (
-  assessmentStep: Pick<AssessmentStep, "type" | "title">,
+  title: LocalizedString | null | undefined,
+  typeLabel: LocalizedString | null | undefined,
   intl: IntlShape,
 ): string => {
-  const localizedTitle = getLocalizedName(assessmentStep?.title, intl, true);
-  const localizedType = getLocalizedName(
-    assessmentStep.type?.label,
-    intl,
-    true,
-  );
+  const localizedTitle = getLocalizedName(title, intl, true);
+  const localizedType = getLocalizedName(typeLabel, intl, true);
   if (localizedTitle && localizedType) {
     return `${localizedTitle} (${localizedType})`;
   }
@@ -29,11 +26,12 @@ export const assessmentStepDisplayName = (
 };
 
 export const poolSkillToOption = (
-  poolSkill: Pick<PoolSkill, "id" | "skill">,
+  id: string,
+  skillName: LocalizedString | null | undefined,
   intl: IntlShape,
 ) => ({
-  value: poolSkill.id,
-  label: poolSkill?.skill?.name
-    ? getLocalizedName(poolSkill.skill.name, intl)
+  value: id,
+  label: skillName
+    ? getLocalizedName(skillName, intl)
     : intl.formatMessage(commonMessages.nameNotLoaded),
 });

--- a/apps/web/src/pages/Pools/BrowseJobsPage/ClosedJobsPage.test.tsx
+++ b/apps/web/src/pages/Pools/BrowseJobsPage/ClosedJobsPage.test.tsx
@@ -8,8 +8,18 @@ import {
 } from "@gc-digital-talent/vitest-helpers";
 import { PoolStatus, PublishingGroup } from "@gc-digital-talent/graphql";
 import { toLocalizedEnum } from "@gc-digital-talent/fake-data";
+import type { GenericLocalizedEnum } from "@gc-digital-talent/i18n";
 
 import ClosedJobs from "./ClosedJobsPage";
+
+interface MockPool {
+  id: string;
+  publishingGroup: GenericLocalizedEnum<PublishingGroup>;
+  status: GenericLocalizedEnum<PoolStatus>;
+  publishedAt: string;
+  closingDate: string;
+  archivedAt: string | null;
+}
 
 const closedItJobsPool = {
   id: "closedItJobsPool",
@@ -60,7 +70,7 @@ describe("ClosedJobsPage", () => {
   function renderPage({
     pools,
   }: {
-    pools: (typeof closedItJobsPool)[];
+    pools: MockPool[];
   }) {
     // Source: https://formidable.com/open-source/urql/docs/advanced/testing/
     const mockClient = {

--- a/apps/web/src/pages/Pools/BrowseJobsPage/ClosedJobsPage.test.tsx
+++ b/apps/web/src/pages/Pools/BrowseJobsPage/ClosedJobsPage.test.tsx
@@ -6,7 +6,6 @@ import {
   expectNoAccessibilityErrors,
   renderWithProviders,
 } from "@gc-digital-talent/vitest-helpers";
-import type { Pool } from "@gc-digital-talent/graphql";
 import { PoolStatus, PublishingGroup } from "@gc-digital-talent/graphql";
 import { toLocalizedEnum } from "@gc-digital-talent/fake-data";
 
@@ -61,7 +60,7 @@ describe("ClosedJobsPage", () => {
   function renderPage({
     pools,
   }: {
-    pools: Omit<Pool, "activities" | "teamId" | "wasClosedEarly">[];
+    pools: (typeof closedItJobsPool)[];
   }) {
     // Source: https://formidable.com/open-source/urql/docs/advanced/testing/
     const mockClient = {

--- a/apps/web/src/pages/Pools/BrowseJobsPage/ClosedJobsPage.test.tsx
+++ b/apps/web/src/pages/Pools/BrowseJobsPage/ClosedJobsPage.test.tsx
@@ -67,11 +67,7 @@ const closedIAPJobsPool = {
 };
 
 describe("ClosedJobsPage", () => {
-  function renderPage({
-    pools,
-  }: {
-    pools: MockPool[];
-  }) {
+  function renderPage({ pools }: { pools: MockPool[] }) {
     // Source: https://formidable.com/open-source/urql/docs/advanced/testing/
     const mockClient = {
       executeQuery: () =>

--- a/apps/web/src/pages/Pools/BrowseJobsPage/ClosedJobsPage.tsx
+++ b/apps/web/src/pages/Pools/BrowseJobsPage/ClosedJobsPage.tsx
@@ -92,7 +92,7 @@ export const Component = () => {
   const closedPools = pools.filter(
     (p) =>
       p.status?.value === PoolStatus.Closed && // list jobs which have the PUBLISHED PoolStatus
-      canShowOnBrowseJobs(p),
+      canShowOnBrowseJobs(p.publishingGroup?.value),
   );
   // a different footer message is displayed if there are opportunities showing, otherwise a null state message is used
   const areOpportunitiesShowing = !!closedPools.length;

--- a/apps/web/src/pages/Pools/BrowseJobsPage/OpenJobsPage.test.tsx
+++ b/apps/web/src/pages/Pools/BrowseJobsPage/OpenJobsPage.test.tsx
@@ -6,7 +6,6 @@ import {
   expectNoAccessibilityErrors,
   renderWithProviders,
 } from "@gc-digital-talent/vitest-helpers";
-import type { Pool } from "@gc-digital-talent/graphql";
 import { PoolStatus, PublishingGroup } from "@gc-digital-talent/graphql";
 import { toLocalizedEnum } from "@gc-digital-talent/fake-data";
 
@@ -46,7 +45,7 @@ describe("OpenJobsPage", () => {
   function renderOpenJobsPage({
     pools,
   }: {
-    pools: Omit<Pool, "activities" | "teamId" | "wasClosedEarly">[];
+    pools: (typeof publishedItJobsPool)[];
   }) {
     // Source: https://formidable.com/open-source/urql/docs/advanced/testing/
     const mockClient = {

--- a/apps/web/src/pages/Pools/BrowseJobsPage/OpenJobsPage.test.tsx
+++ b/apps/web/src/pages/Pools/BrowseJobsPage/OpenJobsPage.test.tsx
@@ -49,11 +49,7 @@ const publishedIAPJobsPool = {
 };
 
 describe("OpenJobsPage", () => {
-  function renderOpenJobsPage({
-    pools,
-  }: {
-    pools: MockPool[];
-  }) {
+  function renderOpenJobsPage({ pools }: { pools: MockPool[] }) {
     // Source: https://formidable.com/open-source/urql/docs/advanced/testing/
     const mockClient = {
       executeQuery: () =>

--- a/apps/web/src/pages/Pools/BrowseJobsPage/OpenJobsPage.test.tsx
+++ b/apps/web/src/pages/Pools/BrowseJobsPage/OpenJobsPage.test.tsx
@@ -8,8 +8,15 @@ import {
 } from "@gc-digital-talent/vitest-helpers";
 import { PoolStatus, PublishingGroup } from "@gc-digital-talent/graphql";
 import { toLocalizedEnum } from "@gc-digital-talent/fake-data";
+import type { GenericLocalizedEnum } from "@gc-digital-talent/i18n";
 
 import OpenJobs from "./OpenJobsPage";
+
+interface MockPool {
+  id: string;
+  publishingGroup: GenericLocalizedEnum<PublishingGroup>;
+  status: GenericLocalizedEnum<PoolStatus>;
+}
 
 const publishedItJobsPool = {
   id: "publishedItJobsPool",
@@ -45,7 +52,7 @@ describe("OpenJobsPage", () => {
   function renderOpenJobsPage({
     pools,
   }: {
-    pools: (typeof publishedItJobsPool)[];
+    pools: MockPool[];
   }) {
     // Source: https://formidable.com/open-source/urql/docs/advanced/testing/
     const mockClient = {

--- a/apps/web/src/pages/Pools/BrowseJobsPage/OpenJobsPage.tsx
+++ b/apps/web/src/pages/Pools/BrowseJobsPage/OpenJobsPage.tsx
@@ -93,7 +93,7 @@ export const Component = () => {
   const activeRecruitmentPools = pools.filter(
     (p) =>
       p.status?.value === PoolStatus.Published && // list jobs which have the PUBLISHED PoolStatus
-      canShowOnBrowseJobs(p),
+      canShowOnBrowseJobs(p.publishingGroup?.value),
   );
 
   // a different footer message is displayed if there are opportunities showing, otherwise a null state message is used

--- a/apps/web/src/pages/Pools/BrowseJobsPage/utils.ts
+++ b/apps/web/src/pages/Pools/BrowseJobsPage/utils.ts
@@ -1,13 +1,11 @@
-import { PublishingGroup, type Pool } from "@gc-digital-talent/graphql";
-
-interface PartialPool {
-  publishingGroup?: Pool["publishingGroup"];
-}
+import { PublishingGroup } from "@gc-digital-talent/graphql";
 
 // the pool is OK to show on the browse jobs pages
-export function canShowOnBrowseJobs(p: PartialPool): boolean {
+export function canShowOnBrowseJobs(
+  publishingGroup: PublishingGroup | null | undefined,
+): boolean {
   return (
-    p.publishingGroup?.value === PublishingGroup.ItJobs ||
-    p.publishingGroup?.value === PublishingGroup.ExecutiveJobs
+    publishingGroup === PublishingGroup.ItJobs ||
+    publishingGroup === PublishingGroup.ExecutiveJobs
   );
 }

--- a/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/EditPoolPage.tsx
@@ -23,7 +23,6 @@ import {
   unpackMaybes,
 } from "@gc-digital-talent/helpers";
 import type {
-  Skill,
   FragmentType,
   UpdatePublishedPoolInput,
 } from "@gc-digital-talent/graphql";
@@ -75,6 +74,7 @@ import CoreRequirementsSection, {
 } from "./components/CoreRequirementsSection/CoreRequirementsSection";
 import EssentialSkillsSection from "./components/EssentialSkillsSection";
 import AssetSkillsSection from "./components/AssetSkillsSection";
+import type { SkillTableSkill_Fragment } from "./components/SkillTable";
 import EducationRequirementsSection from "./components/EducationRequirementsSection";
 import GeneralQuestionsSection, {
   type GeneralQuestionsSubmitData,
@@ -256,7 +256,7 @@ export type PoolSubmitData =
 export interface EditPoolFormProps {
   poolQuery: FragmentType<typeof EditPool_Fragment>;
   classifications: FragmentType<typeof PoolClassification_Fragment>[];
-  skills: Skill[];
+  skills: FragmentType<typeof SkillTableSkill_Fragment>[];
   onSave: (submitData: PoolSubmitData) => Promise<void>;
   onUpdatePublished: (submitData: UpdatePublishedPoolInput) => Promise<void>;
   poolSkillMutations: PoolSkillMutationsType;
@@ -637,13 +637,13 @@ export const EditPoolForm = ({
                   </div>
                   <EssentialSkillsSection
                     poolQuery={pool}
-                    skills={skills}
+                    skillsQuery={skills}
                     sectionMetadata={sectionMetadata.essentialSkills}
                     poolSkillMutations={poolSkillMutations}
                   />
                   <AssetSkillsSection
                     poolQuery={pool}
-                    skills={skills}
+                    skillsQuery={skills}
                     sectionMetadata={sectionMetadata.assetSkills}
                     poolSkillMutations={poolSkillMutations}
                   />
@@ -759,39 +759,7 @@ const EditPoolPage_Query = graphql(/* GraphQL */ `
 
     # all skills to populate skill pickers
     skills {
-      id
-      key
-      name {
-        en
-        fr
-      }
-      description {
-        en
-        fr
-      }
-      keywords {
-        en
-        fr
-      }
-      category {
-        value
-        label {
-          en
-          fr
-        }
-      }
-      families {
-        id
-        key
-        name {
-          en
-          fr
-        }
-        description {
-          en
-          fr
-        }
-      }
+      ...SkillTableSkill
     }
   }
 `);

--- a/apps/web/src/pages/Pools/EditPoolPage/components/AboutUsSection/AboutUsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/AboutUsSection/AboutUsSection.tsx
@@ -8,7 +8,6 @@ import { RichTextInput, Submit } from "@gc-digital-talent/forms";
 import { commonMessages, formMessages } from "@gc-digital-talent/i18n";
 import type {
   LocalizedString,
-  Pool,
   UpdatePoolInput,
   FragmentType,
 } from "@gc-digital-talent/graphql";
@@ -86,14 +85,14 @@ const AboutUsSection = ({
   });
 
   const dataToFormValues = (
-    initialData: Pick<Pool, "aboutUs">,
+    aboutUs: LocalizedString | null | undefined,
   ): FormValues => ({
-    aboutUsEn: initialData.aboutUs?.en ?? "",
-    aboutUsFr: initialData.aboutUs?.fr ?? "",
+    aboutUsEn: aboutUs?.en ?? "",
+    aboutUsFr: aboutUs?.fr ?? "",
   });
 
   const methods = useForm<FormValues>({
-    defaultValues: dataToFormValues(pool),
+    defaultValues: dataToFormValues(pool.aboutUs),
   });
   const { handleSubmit, watch } = methods;
   const values = watch();

--- a/apps/web/src/pages/Pools/EditPoolPage/components/AssetSkillsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/AssetSkillsSection.tsx
@@ -3,15 +3,10 @@ import { useIntl } from "react-intl";
 import AcademicCapIcon from "@heroicons/react/24/outline/AcademicCapIcon";
 
 import { ToggleSection } from "@gc-digital-talent/ui";
-import { notEmpty } from "@gc-digital-talent/helpers";
-import type {
-  SkillLevel,
-  Skill,
-  FragmentType,
-} from "@gc-digital-talent/graphql";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
+import type { SkillLevel, FragmentType } from "@gc-digital-talent/graphql";
 import {
   PoolSkillType,
-  SkillCategory,
   PoolStatus,
   getFragment,
 } from "@gc-digital-talent/graphql";
@@ -20,20 +15,20 @@ import useToggleSectionInfo from "~/hooks/useToggleSectionInfo";
 import type { EditPoolSectionMetadata } from "~/types/pool";
 import { hasEmptyRequiredFields } from "~/validators/process/nonEssentialSkills";
 
-import SkillTable from "./SkillTable";
+import SkillTable, { type SkillTableSkill_Fragment } from "./SkillTable";
 import type { PoolSkillMutationsType } from "../types";
 import { EditPoolSkills_Fragment } from "../fragments";
 
 interface AssetSkillsSectionProps {
   poolQuery: FragmentType<typeof EditPoolSkills_Fragment>;
   sectionMetadata: EditPoolSectionMetadata;
-  skills: Skill[];
+  skillsQuery: FragmentType<typeof SkillTableSkill_Fragment>[];
   poolSkillMutations: PoolSkillMutationsType;
 }
 
 const AssetSkillsSection = ({
   poolQuery,
-  skills,
+  skillsQuery,
   sectionMetadata,
   poolSkillMutations,
 }: AssetSkillsSectionProps): JSX.Element => {
@@ -46,32 +41,9 @@ const AssetSkillsSection = ({
     fallbackIcon: AcademicCapIcon,
   });
 
-  const poolSkills = pool.poolSkills ?? [];
-  const nonessentialPoolSkills = poolSkills
-    .filter(notEmpty)
-    .filter(
-      (poolSkill) =>
-        poolSkill.type?.value === PoolSkillType.Nonessential && poolSkill.skill,
-    );
-
-  const nonessentialSkills: (Skill & {
-    poolSkillId: string;
-    requiredLevel?: SkillLevel;
-  })[] = nonessentialPoolSkills.map((poolSkill) => {
-    return {
-      // Note: We need to clean these types up
-      category: poolSkill.skill?.category ?? {
-        value: SkillCategory.Technical,
-        label: { en: "", fr: "" },
-      },
-      description: poolSkill.skill?.description,
-      id: poolSkill.skill?.id ?? poolSkill.id,
-      key: poolSkill.skill?.key ?? "",
-      name: poolSkill.skill?.name ?? {},
-      poolSkillId: poolSkill.id,
-      requiredLevel: poolSkill.requiredLevel ?? undefined,
-    };
-  });
+  const nonessentialPoolSkills = unpackMaybes(pool.poolSkills).filter(
+    (poolSkill) => poolSkill.type?.value === PoolSkillType.Nonessential,
+  );
 
   const handleCreate = async (
     skillSelected: string,
@@ -122,8 +94,8 @@ const AssetSkillsSection = ({
       <p className="my-6">{subtitle}</p>
       <SkillTable
         caption={sectionMetadata.title}
-        data={nonessentialSkills}
-        allSkills={skills}
+        poolSkillsQuery={nonessentialPoolSkills}
+        allSkillsQuery={skillsQuery}
         onCreate={handleCreate}
         onUpdate={handleUpdate}
         onRemove={handleRemove}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/ClosingDateSection/ClosingDateSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/ClosingDateSection/ClosingDateSection.tsx
@@ -12,10 +12,7 @@ import {
   formatDate,
 } from "@gc-digital-talent/date-helpers";
 import { commonMessages, formMessages } from "@gc-digital-talent/i18n";
-import type {
-  UpdatePoolInput,
-  FragmentType,
-} from "@gc-digital-talent/graphql";
+import type { UpdatePoolInput, FragmentType } from "@gc-digital-talent/graphql";
 import { PoolStatus, graphql, getFragment } from "@gc-digital-talent/graphql";
 
 import useDeepCompareEffect from "~/hooks/useDeepCompareEffect";

--- a/apps/web/src/pages/Pools/EditPoolPage/components/ClosingDateSection/ClosingDateSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/ClosingDateSection/ClosingDateSection.tsx
@@ -13,7 +13,6 @@ import {
 } from "@gc-digital-talent/date-helpers";
 import { commonMessages, formMessages } from "@gc-digital-talent/i18n";
 import type {
-  Pool,
   UpdatePoolInput,
   FragmentType,
 } from "@gc-digital-talent/graphql";
@@ -51,7 +50,7 @@ const EditPoolClosingDate_Fragment = graphql(/* GraphQL */ `
 `);
 
 interface FormValues {
-  endDate?: Pool["closingDate"];
+  endDate?: string | null;
 }
 
 export type ClosingDateSubmitData = Pick<UpdatePoolInput, "closingDate">;
@@ -77,20 +76,16 @@ const ClosingDateSection = ({
   });
 
   const dataToFormValues = (
-    initialData: Pick<Pool, "closingDate">,
-  ): FormValues => {
-    const closingDateInPacific = initialData.closingDate
+    closingDate: string | null | undefined,
+  ): FormValues => ({
+    endDate: closingDate
       ? convertDateTimeToDate(
-          convertDateTimeZone(initialData.closingDate, "UTC", "Canada/Pacific"),
+          convertDateTimeZone(closingDate, "UTC", "Canada/Pacific"),
         )
-      : null;
+      : null,
+  });
 
-    return {
-      endDate: closingDateInPacific,
-    };
-  };
-
-  const suppliedValues = dataToFormValues(pool);
+  const suppliedValues = dataToFormValues(pool.closingDate);
   const methods = useForm<FormValues>({
     defaultValues: suppliedValues,
   });

--- a/apps/web/src/pages/Pools/EditPoolPage/components/ContactEmailSection/ContactEmailSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/ContactEmailSection/ContactEmailSection.tsx
@@ -2,10 +2,7 @@ import InboxIcon from "@heroicons/react/24/outline/InboxIcon";
 import { FormProvider, useForm } from "react-hook-form";
 import { useIntl } from "react-intl";
 
-import type {
-  FragmentType,
-  UpdatePoolInput,
-} from "@gc-digital-talent/graphql";
+import type { FragmentType, UpdatePoolInput } from "@gc-digital-talent/graphql";
 import { getFragment, graphql, PoolStatus } from "@gc-digital-talent/graphql";
 import { Button, ToggleSection } from "@gc-digital-talent/ui";
 import { Input, Submit } from "@gc-digital-talent/forms";

--- a/apps/web/src/pages/Pools/EditPoolPage/components/ContactEmailSection/ContactEmailSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/ContactEmailSection/ContactEmailSection.tsx
@@ -4,7 +4,6 @@ import { useIntl } from "react-intl";
 
 import type {
   FragmentType,
-  Pool,
   UpdatePoolInput,
 } from "@gc-digital-talent/graphql";
 import { getFragment, graphql, PoolStatus } from "@gc-digital-talent/graphql";
@@ -70,13 +69,13 @@ const ContactEmailSection = ({
   });
 
   const dataToFormValues = (
-    initialData: Pick<Pool, "contactEmail">,
+    contactEmail: string | null | undefined,
   ): FormValues => ({
-    contactEmail: initialData.contactEmail ?? "",
+    contactEmail: contactEmail ?? "",
   });
 
   const methods = useForm<FormValues>({
-    defaultValues: dataToFormValues(pool),
+    defaultValues: dataToFormValues(pool.contactEmail),
   });
   const { handleSubmit, watch } = methods;
   const values = watch();

--- a/apps/web/src/pages/Pools/EditPoolPage/components/CoreRequirementsSection/CoreRequirementsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/CoreRequirementsSection/CoreRequirementsSection.tsx
@@ -114,7 +114,12 @@ const CoreRequirementsSection = ({
   });
 
   const methods = useForm<FormValues>({
-    defaultValues: dataToFormValues(pool),
+    defaultValues: dataToFormValues(
+      pool.language?.value,
+      pool.securityClearance?.value,
+      pool.isRemote,
+      pool.location,
+    ),
   });
   const { handleSubmit, control, watch } = methods;
   const locationOption = useWatch<FormValues>({

--- a/apps/web/src/pages/Pools/EditPoolPage/components/CoreRequirementsSection/utils.ts
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/CoreRequirementsSection/utils.ts
@@ -1,7 +1,6 @@
 import { empty } from "@gc-digital-talent/helpers";
 import type {
   LocalizedString,
-  Pool,
   PoolLanguage,
   SecurityStatus,
   UpdatePoolInput,
@@ -29,16 +28,16 @@ export interface FormValues {
 }
 
 export const dataToFormValues = (
-  initialData: Pick<
-    Pool,
-    "language" | "securityClearance" | "isRemote" | "location"
-  >,
+  language: PoolLanguage | null | undefined,
+  securityClearance: SecurityStatus | null | undefined,
+  isRemote: boolean | null | undefined,
+  location: LocalizedString | null | undefined,
 ): FormValues => ({
-  languageRequirement: initialData.language?.value,
-  securityRequirement: initialData.securityClearance?.value,
-  locationOption: getLocationOption(initialData.isRemote),
-  specificLocationEn: initialData.location?.en,
-  specificLocationFr: initialData.location?.fr,
+  languageRequirement: language ?? undefined,
+  securityRequirement: securityClearance ?? undefined,
+  locationOption: getLocationOption(isRemote),
+  specificLocationEn: location?.en,
+  specificLocationFr: location?.fr,
 });
 
 export type CoreRequirementsSubmitData = Pick<

--- a/apps/web/src/pages/Pools/EditPoolPage/components/EssentialSkillsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/EssentialSkillsSection.tsx
@@ -3,37 +3,32 @@ import { useIntl } from "react-intl";
 import AcademicCapIcon from "@heroicons/react/24/outline/AcademicCapIcon";
 
 import { ToggleSection } from "@gc-digital-talent/ui";
-import type {
-  SkillLevel,
-  Skill,
-  FragmentType,
-} from "@gc-digital-talent/graphql";
+import type { SkillLevel, FragmentType } from "@gc-digital-talent/graphql";
 import {
   PoolSkillType,
-  SkillCategory,
   PoolStatus,
   getFragment,
 } from "@gc-digital-talent/graphql";
-import { notEmpty } from "@gc-digital-talent/helpers";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
 
 import { hasEmptyRequiredFields } from "~/validators/process/essentialSkills";
 import useToggleSectionInfo from "~/hooks/useToggleSectionInfo";
 import type { EditPoolSectionMetadata } from "~/types/pool";
 
-import SkillTable from "./SkillTable";
+import SkillTable, { type SkillTableSkill_Fragment } from "./SkillTable";
 import type { PoolSkillMutationsType } from "../types";
 import { EditPoolSkills_Fragment } from "../fragments";
 
 interface EssentialSkillsSectionProps {
   poolQuery: FragmentType<typeof EditPoolSkills_Fragment>;
   sectionMetadata: EditPoolSectionMetadata;
-  skills: Skill[];
+  skillsQuery: FragmentType<typeof SkillTableSkill_Fragment>[];
   poolSkillMutations: PoolSkillMutationsType;
 }
 
 const EssentialSkillsSection = ({
   poolQuery,
-  skills,
+  skillsQuery,
   sectionMetadata,
   poolSkillMutations,
 }: EssentialSkillsSectionProps): JSX.Element => {
@@ -46,32 +41,9 @@ const EssentialSkillsSection = ({
     fallbackIcon: AcademicCapIcon,
   });
 
-  const poolSkills = pool.poolSkills ?? [];
-  const essentialPoolSkills = poolSkills
-    .filter(notEmpty)
-    .filter(
-      (poolSkill) =>
-        poolSkill.type?.value === PoolSkillType.Essential && poolSkill.skill,
-    );
-
-  const essentialSkills: (Skill & {
-    poolSkillId: string;
-    requiredLevel?: SkillLevel;
-  })[] = essentialPoolSkills.map((poolSkill) => {
-    return {
-      // Note: This is ugly and should be cleaned up
-      category: poolSkill.skill?.category ?? {
-        value: SkillCategory.Technical,
-        label: { en: "", fr: "" },
-      },
-      description: poolSkill.skill?.description,
-      id: poolSkill.skill?.id ?? poolSkill.id,
-      key: poolSkill.skill?.key ?? "",
-      name: poolSkill.skill?.name ?? {},
-      poolSkillId: poolSkill.id,
-      requiredLevel: poolSkill.requiredLevel ?? undefined,
-    };
-  });
+  const essentialPoolSkills = unpackMaybes(pool.poolSkills).filter(
+    (poolSkill) => poolSkill.type?.value === PoolSkillType.Essential,
+  );
 
   const handleCreate = async (
     skillSelected: string,
@@ -122,8 +94,8 @@ const EssentialSkillsSection = ({
       <p className="my-6">{subtitle}</p>
       <SkillTable
         caption={sectionMetadata.title}
-        data={essentialSkills}
-        allSkills={skills}
+        poolSkillsQuery={essentialPoolSkills}
+        allSkillsQuery={skillsQuery}
         onCreate={handleCreate}
         onUpdate={handleUpdate}
         onRemove={handleRemove}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/GeneralQuestionsSection/GeneralQuestionDialog.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/GeneralQuestionsSection/GeneralQuestionDialog.tsx
@@ -49,7 +49,7 @@ const GeneralQuestionDialog = ({
   const question = getFragment(GeneralQuestionDialog_Fragment, questionQuery);
   const isUpdate = !!question;
   const methods = useForm<FormValues>({
-    defaultValues: dataToFormValues(question),
+    defaultValues: dataToFormValues(question?.id, question?.question),
   });
   const { setValue, register, reset } = methods;
   const actionProps = register("action");

--- a/apps/web/src/pages/Pools/EditPoolPage/components/GeneralQuestionsSection/GeneralQuestionsSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/GeneralQuestionsSection/GeneralQuestionsSection.tsx
@@ -1,11 +1,10 @@
 import { useState, useMemo } from "react";
 import { useIntl } from "react-intl";
 import QuestionMarkCircleIcon from "@heroicons/react/24/outline/QuestionMarkCircleIcon";
-import sortBy from "lodash/sortBy";
 
 import { TableOfContents, CardRepeater, Notice } from "@gc-digital-talent/ui";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
-import type { FragmentType, GeneralQuestion } from "@gc-digital-talent/graphql";
+import type { FragmentType } from "@gc-digital-talent/graphql";
 import { PoolStatus, getFragment, graphql } from "@gc-digital-talent/graphql";
 
 import type { EditPoolSectionMetadata } from "~/types/pool";
@@ -15,7 +14,7 @@ import type {
   GeneralQuestionsSubmit,
   GeneralQuestionsSubmitData,
 } from "./utils";
-import { repeaterQuestionsToSubmitData } from "./utils";
+import { questionToSubmitData } from "./utils";
 import GeneralQuestionCard from "./GeneralQuestionCard";
 import GeneralQuestionDialog from "./GeneralQuestionDialog";
 
@@ -30,6 +29,10 @@ const EditPoolGeneralQuestions_Fragment = graphql(/* GraphQL */ `
     generalQuestions {
       id
       sortOrder
+      question {
+        en
+        fr
+      }
       ...GeneralQuestionCard
     }
   }
@@ -53,20 +56,42 @@ const GeneralQuestionsSection = ({
   const pool = getFragment(EditPoolGeneralQuestions_Fragment, poolQuery);
   const questions = useMemo(
     () =>
-      sortBy(
-        unpackMaybes(pool.generalQuestions),
-        (question) => question.sortOrder,
+      unpackMaybes(pool.generalQuestions).sort(
+        (a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0),
       ),
     [pool.generalQuestions],
   );
   const { isSubmitting } = useEditPoolContext();
 
-  const handleUpdate = async (newQuestions: GeneralQuestion[]) => {
+  const handleUpdate = async (newQuestions: typeof questions) => {
     setIsUpdating(true);
-    const generalQuestions = repeaterQuestionsToSubmitData(
-      newQuestions,
-      questions,
-    );
+    const deleteItems = questions
+      .filter(
+        (question) =>
+          !newQuestions.some((newQuestion) => newQuestion.id === question.id),
+      )
+      .map((question) => question.id);
+    const addItem = newQuestions.find((question) => question.id === "new");
+    const updateItems = newQuestions
+      .filter((question) => question.id !== "new")
+      .map((question, index) => ({
+        id: question.id,
+        question: questionToSubmitData(question.question),
+        sortOrder: index + 1,
+      }));
+
+    const generalQuestions: GeneralQuestionsSubmitData["generalQuestions"] =
+      addItem
+        ? {
+            create: [
+              {
+                sortOrder: updateItems.length + 1,
+                question: questionToSubmitData(addItem.question),
+              },
+            ],
+          }
+        : { update: updateItems, delete: deleteItems };
+
     await onSave({ generalQuestions }).then(() => {
       setIsUpdating(false);
     });
@@ -91,7 +116,7 @@ const GeneralQuestionsSection = ({
         })}
       </p>
       <div className="my-6">
-        <CardRepeater.Root<GeneralQuestion>
+        <CardRepeater.Root
           items={questions}
           disabled={formDisabled}
           max={MAX_GENERAL_QUESTIONS}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/GeneralQuestionsSection/utils.ts
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/GeneralQuestionsSection/utils.ts
@@ -1,7 +1,7 @@
 import { defineMessages } from "react-intl";
 
 import type {
-  GeneralQuestion,
+  LocalizedString,
   UpdatePoolInput,
 } from "@gc-digital-talent/graphql";
 
@@ -15,11 +15,12 @@ export interface FormValues {
 }
 
 export const dataToFormValues = (
-  initialData?: GeneralQuestion | null,
+  id?: string,
+  question?: LocalizedString | null,
 ): FormValues => ({
-  id: initialData?.id ?? "new",
-  questionEn: initialData?.question?.en ?? "",
-  questionFr: initialData?.question?.fr ?? "",
+  id: id ?? "new",
+  questionEn: question?.en ?? "",
+  questionFr: question?.fr ?? "",
 });
 
 export type GeneralQuestionsSubmitData = Pick<
@@ -31,49 +32,12 @@ export type GeneralQuestionsSubmit = (
   submitData: GeneralQuestionsSubmitData,
 ) => Promise<void>;
 
-const questionToSubmitData = (question: GeneralQuestion["question"]) => ({
+export const questionToSubmitData = (
+  question: LocalizedString | null | undefined,
+) => ({
   en: question?.en ?? "",
   fr: question?.fr ?? "",
 });
-
-export const repeaterQuestionsToSubmitData = (
-  newQuestions: GeneralQuestion[],
-  questions: GeneralQuestion[],
-) => {
-  // Find missing items (to be deleted)
-  const deleteItems = questions
-    .filter(
-      (question) =>
-        !newQuestions.some((newQuestion) => newQuestion.id === question.id),
-    )
-    .map((question) => question.id);
-  const addItem = newQuestions.find((question) => question.id === "new");
-  const updateItems = newQuestions
-    .filter((question) => question.id !== "new")
-    .map((generalQuestion, index) => ({
-      id: generalQuestion.id,
-      question: questionToSubmitData(generalQuestion.question),
-      sortOrder: index + 1,
-    }));
-
-  let generalQuestions: GeneralQuestionsSubmitData["generalQuestions"] = {
-    update: updateItems,
-    delete: deleteItems,
-  };
-
-  if (addItem) {
-    generalQuestions = {
-      create: [
-        {
-          sortOrder: updateItems.length + 1, // Set new items sort order to the end
-          question: questionToSubmitData(addItem.question),
-        },
-      ],
-    };
-  }
-
-  return generalQuestions;
-};
 
 export const labels = defineMessages({
   question: {

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/PoolNameSection.tsx
@@ -44,7 +44,7 @@ import processMessages from "~/messages/processMessages";
 import { useEditPoolContext } from "../EditPoolContext";
 import Display from "./Display";
 import type { FormValues, PoolNameSubmitData } from "./utils";
-import { dataToFormValues, formValuesToSubmitData } from "./utils";
+import { formValuesToSubmitData } from "./utils";
 import type { SectionProps } from "../../types";
 import ActionWrapper from "../ActionWrapper";
 import CitizensNote from "./CitizensNote";
@@ -260,7 +260,17 @@ const PoolNameSection = ({
     : workStreams;
 
   const methods = useForm<FormValues>({
-    defaultValues: dataToFormValues(pool),
+    defaultValues: {
+      areaOfSelection: pool.areaOfSelection?.value ?? undefined,
+      selectionLimitations: pool.selectionLimitations?.map((l) => l.value),
+      classification: pool.classification?.id ?? "",
+      department: pool.department?.id ?? "",
+      stream: pool.workStream?.id ?? undefined,
+      specificTitleEn: pool.name?.en ?? "",
+      specificTitleFr: pool.name?.fr ?? "",
+      publishingGroup: pool.publishingGroup?.value,
+      opportunityLength: pool.opportunityLength?.value,
+    },
   });
   const { handleSubmit, watch, resetField } = methods;
 

--- a/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/utils.ts
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/PoolNameSection/utils.ts
@@ -1,51 +1,23 @@
 import type {
   PoolOpportunityLength,
-  Classification,
   LocalizedString,
-  Pool,
   PublishingGroup,
   UpdatePoolInput,
-  Department,
   PoolAreaOfSelection,
   PoolSelectionLimitation,
-  WorkStream,
 } from "@gc-digital-talent/graphql";
 
 export interface FormValues {
   areaOfSelection?: PoolAreaOfSelection | null;
   selectionLimitations?: PoolSelectionLimitation[] | null;
-  classification?: Classification["id"];
-  department?: Department["id"];
-  stream?: WorkStream["id"];
+  classification?: string;
+  department?: string;
+  stream?: string;
   specificTitleEn?: LocalizedString["en"];
   specificTitleFr?: LocalizedString["fr"];
   publishingGroup?: PublishingGroup | null;
   opportunityLength?: PoolOpportunityLength | null;
 }
-
-export const dataToFormValues = (
-  initialData: Pick<
-    Pool,
-    | "areaOfSelection"
-    | "selectionLimitations"
-    | "classification"
-    | "department"
-    | "workStream"
-    | "name"
-    | "publishingGroup"
-    | "opportunityLength"
-  >,
-): FormValues => ({
-  areaOfSelection: initialData.areaOfSelection?.value ?? undefined,
-  selectionLimitations: initialData.selectionLimitations?.map((l) => l.value),
-  classification: initialData.classification?.id ?? "",
-  department: initialData.department?.id ?? "",
-  stream: initialData.workStream?.id ?? undefined,
-  specificTitleEn: initialData.name?.en ?? "",
-  specificTitleFr: initialData.name?.fr ?? "",
-  publishingGroup: initialData.publishingGroup?.value,
-  opportunityLength: initialData.opportunityLength?.value,
-});
 
 export type PoolNameSubmitData = Pick<
   UpdatePoolInput,

--- a/apps/web/src/pages/Pools/EditPoolPage/components/SkillTable.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/SkillTable.tsx
@@ -43,6 +43,10 @@ export const SkillTableSkill_Fragment = graphql(/* GraphQL */ `
     families {
       id
       key
+      name {
+        en
+        fr
+      }
     }
   }
 `);
@@ -73,6 +77,10 @@ export const SkillTablePoolSkill_Fragment = graphql(/* GraphQL */ `
       families {
         id
         key
+        name {
+          en
+          fr
+        }
       }
     }
   }

--- a/apps/web/src/pages/Pools/EditPoolPage/components/SkillTable.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/SkillTable.tsx
@@ -11,7 +11,12 @@ import {
   getSkillLevelName,
 } from "@gc-digital-talent/i18n";
 import { Button } from "@gc-digital-talent/ui";
-import type { SkillLevel, Skill } from "@gc-digital-talent/graphql";
+import type {
+  SkillLevel,
+  FragmentType,
+  SkillTablePoolSkillFragment,
+} from "@gc-digital-talent/graphql";
+import { getFragment, graphql } from "@gc-digital-talent/graphql";
 
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import SkillBrowserDialog from "~/components/SkillBrowser/SkillBrowserDialog";
@@ -19,25 +24,76 @@ import { normalizedText } from "~/components/Table/sortingFns";
 import type { NullMessageProps } from "~/components/Table/ResponsiveTable/NullMessage";
 import tableMessages from "~/components/Table/tableMessages";
 
-const columnHelper = createColumnHelper<
-  Skill & {
-    poolSkillId: string;
-    requiredLevel?: SkillLevel;
+export const SkillTableSkill_Fragment = graphql(/* GraphQL */ `
+  fragment SkillTableSkill on Skill {
+    id
+    key
+    name {
+      en
+      fr
+      localized
+    }
+    description {
+      en
+      fr
+    }
+    category {
+      value
+      label {
+        en
+        fr
+      }
+    }
+    families {
+      id
+      key
+    }
   }
->();
+`);
+
+export const SkillTablePoolSkill_Fragment = graphql(/* GraphQL */ `
+  fragment SkillTablePoolSkill on PoolSkill {
+    id
+    requiredLevel
+    skill {
+      id
+      key
+      name {
+        en
+        fr
+        localized
+      }
+      description {
+        en
+        fr
+      }
+      category {
+        value
+        label {
+          en
+          fr
+        }
+      }
+      families {
+        id
+        key
+      }
+    }
+  }
+`);
+
+const columnHelper = createColumnHelper<SkillTablePoolSkillFragment>();
 
 const ActionCell = (
-  skill: Skill & {
-    poolSkillId: string;
-    requiredLevel?: SkillLevel;
-  },
+  poolSkill: SkillTablePoolSkillFragment,
   onUpdate: (id: string, skillLevel: SkillLevel) => Promise<void>,
   onRemove: (poolSkillSelected: string) => Promise<void>,
 ) => {
   const intl = useIntl();
   const [isOpen] = useState<boolean>(false);
-  const { id, poolSkillId, requiredLevel, name } = skill;
-  const localizedName = getLocalizedName(name, intl);
+  const { id: poolSkillId, requiredLevel, skill } = poolSkill;
+  const localizedName =
+    skill?.name?.localized ?? intl.formatMessage(commonMessages.notAvailable);
 
   return (
     <div className="flex flex-wrap gap-1.5">
@@ -61,10 +117,10 @@ const ActionCell = (
             )}
           />
         }
-        skills={[skill]}
+        skills={skill ? [skill] : []}
         initialState={{
           family: "all",
-          skill: id,
+          skill: skill?.id,
           skillLevel: requiredLevel ?? undefined,
         }}
         onSave={async (value) => {
@@ -95,11 +151,8 @@ const ActionCell = (
 
 interface SkillTableProps {
   caption: string;
-  data: (Skill & {
-    poolSkillId: string;
-    requiredLevel?: SkillLevel;
-  })[];
-  allSkills: Skill[];
+  poolSkillsQuery: FragmentType<typeof SkillTablePoolSkill_Fragment>[];
+  allSkillsQuery: FragmentType<typeof SkillTableSkill_Fragment>[];
   disableAdd?: boolean;
   nullMessage?: NullMessageProps;
   onCreate: (skillSelected: string, skillLevel: SkillLevel) => Promise<void>;
@@ -112,8 +165,8 @@ interface SkillTableProps {
 
 const SkillTable = ({
   caption,
-  data,
-  allSkills,
+  poolSkillsQuery,
+  allSkillsQuery,
   disableAdd,
   nullMessage,
   onCreate,
@@ -121,30 +174,40 @@ const SkillTable = ({
   onRemove,
 }: SkillTableProps) => {
   const intl = useIntl();
+  const data = getFragment(SkillTablePoolSkill_Fragment, poolSkillsQuery);
+  const allSkills = getFragment(SkillTableSkill_Fragment, allSkillsQuery);
   const availableSkills = allSkills.filter(
-    (skill) => !data.find((value) => value.id === skill.id),
+    (skill) => !data.find((poolSkill) => poolSkill.skill?.id === skill.id),
   );
 
   let columns = [
-    columnHelper.accessor((skill) => getLocalizedName(skill.name, intl), {
-      id: "name",
-      header: intl.formatMessage({
-        defaultMessage: "Skill name",
-        id: "hjxxaQ",
-        description: "Skill name column header for the skill library table",
-      }),
-      enableHiding: false,
-      enableColumnFilter: false,
-      sortingFn: normalizedText,
-      meta: {
-        isRowTitle: true,
-      },
-    }),
     columnHelper.accessor(
-      (skill) =>
-        skill.requiredLevel
+      (poolSkill) =>
+        poolSkill.skill?.name?.localized ??
+        intl.formatMessage(commonMessages.notAvailable),
+      {
+        id: "name",
+        header: intl.formatMessage({
+          defaultMessage: "Skill name",
+          id: "hjxxaQ",
+          description: "Skill name column header for the skill library table",
+        }),
+        enableHiding: false,
+        enableColumnFilter: false,
+        sortingFn: normalizedText,
+        meta: {
+          isRowTitle: true,
+        },
+      },
+    ),
+    columnHelper.accessor(
+      (poolSkill) =>
+        poolSkill.requiredLevel && poolSkill.skill
           ? intl.formatMessage(
-              getSkillLevelName(skill.requiredLevel, skill.category.value),
+              getSkillLevelName(
+                poolSkill.requiredLevel,
+                poolSkill.skill.category.value,
+              ),
             )
           : intl.formatMessage(commonMessages.notFound),
       {
@@ -162,32 +225,22 @@ const SkillTable = ({
         },
       },
     ),
-  ] as ColumnDef<
-    Skill & {
-      poolSkillId: string;
-      requiredLevel?: SkillLevel;
-    }
-  >[];
+  ] as ColumnDef<SkillTablePoolSkillFragment>[];
 
   if (!disableAdd) {
     columns = [
       columnHelper.display({
         id: "actions",
         header: intl.formatMessage(tableMessages.actions),
-        cell: ({ row: { original: skill } }) =>
-          ActionCell(skill, onUpdate, onRemove),
+        cell: ({ row: { original: poolSkill } }) =>
+          ActionCell(poolSkill, onUpdate, onRemove),
       }),
       ...columns,
     ];
   }
 
   return (
-    <Table<
-      Skill & {
-        poolSkillId: string;
-        requiredLevel?: SkillLevel;
-      }
-    >
+    <Table<SkillTablePoolSkillFragment>
       caption={caption}
       data={data}
       columns={columns}

--- a/apps/web/src/pages/Pools/EditPoolPage/components/SkillTable.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/SkillTable.tsx
@@ -5,11 +5,7 @@ import { createColumnHelper } from "@tanstack/react-table";
 import TrashIcon from "@heroicons/react/20/solid/TrashIcon";
 import PencilSquareIcon from "@heroicons/react/20/solid/PencilSquareIcon";
 
-import {
-  commonMessages,
-  getLocalizedName,
-  getSkillLevelName,
-} from "@gc-digital-talent/i18n";
+import { commonMessages, getSkillLevelName } from "@gc-digital-talent/i18n";
 import { Button } from "@gc-digital-talent/ui";
 import type {
   SkillLevel,

--- a/apps/web/src/pages/Pools/EditPoolPage/components/SpecialNoteSection/SpecialNoteSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/SpecialNoteSection/SpecialNoteSection.tsx
@@ -7,7 +7,6 @@ import { Checkbox, RichTextInput, Submit } from "@gc-digital-talent/forms";
 import { commonMessages, formMessages } from "@gc-digital-talent/i18n";
 import type {
   LocalizedString,
-  Pool,
   UpdatePoolInput,
   FragmentType,
 } from "@gc-digital-talent/graphql";
@@ -82,16 +81,15 @@ const SpecialNoteSection = ({
   });
 
   const dataToFormValues = (
-    initialData: Pick<Pool, "specialNote">,
+    specialNote: LocalizedString | null | undefined,
   ): FormValues => ({
-    hasSpecialNote:
-      !!initialData.specialNote?.en || !!initialData.specialNote?.fr,
-    specialNoteEn: initialData.specialNote?.en ?? "",
-    specialNoteFr: initialData.specialNote?.fr ?? "",
+    hasSpecialNote: !!specialNote?.en || !!specialNote?.fr,
+    specialNoteEn: specialNote?.en ?? "",
+    specialNoteFr: specialNote?.fr ?? "",
   });
 
   const methods = useForm<FormValues>({
-    defaultValues: dataToFormValues(pool),
+    defaultValues: dataToFormValues(pool.specialNote),
   });
   const { handleSubmit, watch } = methods;
   const [watchHasSpecialNote, specialNoteEn, specialNoteFr] = watch([

--- a/apps/web/src/pages/Pools/EditPoolPage/components/WhatToExpectAdmissionSection/WhatToExpectAdmissionSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/WhatToExpectAdmissionSection/WhatToExpectAdmissionSection.tsx
@@ -7,7 +7,6 @@ import { RichTextInput, Submit } from "@gc-digital-talent/forms";
 import { commonMessages, formMessages } from "@gc-digital-talent/i18n";
 import type {
   LocalizedString,
-  Pool,
   UpdatePoolInput,
   FragmentType,
 } from "@gc-digital-talent/graphql";
@@ -87,14 +86,14 @@ const WhatToExpectAdmissionSection = ({
   });
 
   const dataToFormValues = (
-    initialData: Pick<Pool, "whatToExpectAdmission">,
+    whatToExpectAdmission: LocalizedString | null | undefined,
   ): FormValues => ({
-    whatToExpectAdmissionEn: initialData.whatToExpectAdmission?.en ?? "",
-    whatToExpectAdmissionFr: initialData.whatToExpectAdmission?.fr ?? "",
+    whatToExpectAdmissionEn: whatToExpectAdmission?.en ?? "",
+    whatToExpectAdmissionFr: whatToExpectAdmission?.fr ?? "",
   });
 
   const methods = useForm<FormValues>({
-    defaultValues: dataToFormValues(pool),
+    defaultValues: dataToFormValues(pool.whatToExpectAdmission),
   });
   const { handleSubmit, watch } = methods;
   const values = watch();

--- a/apps/web/src/pages/Pools/EditPoolPage/components/WhatToExpectSection/WhatToExpectSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/WhatToExpectSection/WhatToExpectSection.tsx
@@ -7,7 +7,6 @@ import { RichTextInput, Submit } from "@gc-digital-talent/forms";
 import { commonMessages, formMessages } from "@gc-digital-talent/i18n";
 import type {
   LocalizedString,
-  Pool,
   UpdatePoolInput,
   FragmentType,
 } from "@gc-digital-talent/graphql";
@@ -81,14 +80,14 @@ const WhatToExpectSection = ({
   });
 
   const dataToFormValues = (
-    initialData: Pick<Pool, "whatToExpect">,
+    whatToExpect: LocalizedString | null | undefined,
   ): FormValues => ({
-    whatToExpectEn: initialData.whatToExpect?.en ?? "",
-    whatToExpectFr: initialData.whatToExpect?.fr ?? "",
+    whatToExpectEn: whatToExpect?.en ?? "",
+    whatToExpectFr: whatToExpect?.fr ?? "",
   });
 
   const methods = useForm<FormValues>({
-    defaultValues: dataToFormValues(pool),
+    defaultValues: dataToFormValues(pool.whatToExpect),
   });
   const { handleSubmit, watch } = methods;
   const values = watch();

--- a/apps/web/src/pages/Pools/EditPoolPage/components/WorkTasksSection/WorkTasksSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/WorkTasksSection/WorkTasksSection.tsx
@@ -7,7 +7,6 @@ import { RichTextInput, Submit } from "@gc-digital-talent/forms";
 import { commonMessages, formMessages } from "@gc-digital-talent/i18n";
 import type {
   LocalizedString,
-  Pool,
   UpdatePoolInput,
   FragmentType,
 } from "@gc-digital-talent/graphql";
@@ -85,14 +84,14 @@ const WorkTasksSection = ({
   });
 
   const dataToFormValues = (
-    initialData: Pick<Pool, "keyTasks">,
+    keyTasks: LocalizedString | null | undefined,
   ): FormValues => ({
-    YourWorkEn: initialData.keyTasks?.en ?? "",
-    YourWorkFr: initialData.keyTasks?.fr ?? "",
+    YourWorkEn: keyTasks?.en ?? "",
+    YourWorkFr: keyTasks?.fr ?? "",
   });
 
   const methods = useForm<FormValues>({
-    defaultValues: dataToFormValues(pool),
+    defaultValues: dataToFormValues(pool.keyTasks),
   });
   const { handleSubmit, watch } = methods;
   const values = watch();

--- a/apps/web/src/pages/Pools/EditPoolPage/components/YourImpactSection/YourImpactSection.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/YourImpactSection/YourImpactSection.tsx
@@ -7,7 +7,6 @@ import { RichTextInput, Submit } from "@gc-digital-talent/forms";
 import { commonMessages, formMessages } from "@gc-digital-talent/i18n";
 import type {
   LocalizedString,
-  Pool,
   UpdatePoolInput,
   FragmentType,
 } from "@gc-digital-talent/graphql";
@@ -85,14 +84,14 @@ const YourImpactSection = ({
   });
 
   const dataToFormValues = (
-    initialData: Pick<Pool, "yourImpact">,
+    yourImpact: LocalizedString | null | undefined,
   ): FormValues => ({
-    yourImpactEn: initialData.yourImpact?.en ?? "",
-    yourImpactFr: initialData.yourImpact?.fr ?? "",
+    yourImpactEn: yourImpact?.en ?? "",
+    yourImpactFr: yourImpact?.fr ?? "",
   });
 
   const methods = useForm<FormValues>({
-    defaultValues: dataToFormValues(pool),
+    defaultValues: dataToFormValues(pool.yourImpact),
   });
   const { handleSubmit, watch } = methods;
   const values = watch();

--- a/apps/web/src/pages/Pools/EditPoolPage/fragments.ts
+++ b/apps/web/src/pages/Pools/EditPoolPage/fragments.ts
@@ -20,25 +20,7 @@ export const EditPoolSkills_Fragment = graphql(/* GraphQL */ `
         }
       }
       requiredLevel
-      skill {
-        id
-        key
-        category {
-          value
-          label {
-            en
-            fr
-          }
-        }
-        name {
-          en
-          fr
-        }
-        description {
-          en
-          fr
-        }
-      }
+      ...SkillTablePoolSkill
     }
   }
 `);

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -283,7 +283,7 @@ const PoolTable = ({ title, initialFilterInput }: PoolTableProps) => {
     }),
     columnHelper.accessor(
       (row) =>
-        poolNameAccessor({ name: row.name, workStream: row.workStream }, intl),
+        poolNameAccessor(row.name, row.workStream?.name, intl),
       {
         id: "name",
         header: intl.formatMessage(commonMessages.name),
@@ -291,7 +291,7 @@ const PoolTable = ({ title, initialFilterInput }: PoolTableProps) => {
           isRowTitle: true,
         },
         cell: ({ row: { original: pool } }) =>
-          viewCell(paths.poolView(pool.id), { name: pool.name }, intl),
+          viewCell(paths.poolView(pool.id), pool.name, intl),
       },
     ),
     columnHelper.accessor(
@@ -306,7 +306,7 @@ const PoolTable = ({ title, initialFilterInput }: PoolTableProps) => {
         }),
         enableColumnFilter: false,
         cell: ({ row: { original: pool } }) =>
-          classificationCell(pool.classification),
+          classificationCell(pool.classification?.groupAndLevel),
       },
     ),
     columnHelper.accessor(

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolTable.tsx
@@ -282,8 +282,7 @@ const PoolTable = ({ title, initialFilterInput }: PoolTableProps) => {
       },
     }),
     columnHelper.accessor(
-      (row) =>
-        poolNameAccessor(row.name, row.workStream?.name, intl),
+      (row) => poolNameAccessor(row.name, row.workStream?.name, intl),
       {
         id: "name",
         header: intl.formatMessage(commonMessages.name),

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/helpers.tsx
@@ -6,11 +6,9 @@ import type { Locales } from "@gc-digital-talent/i18n";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
 import { Link, Chip } from "@gc-digital-talent/ui";
 import type {
-  Classification,
   FragmentType,
   LocalizedString,
   OrderByColumnInput,
-  Pool,
   PoolBookmarksOrderByInput,
   PoolFilterInput,
   PoolWorkStreamNameOrderByInput,
@@ -32,31 +30,30 @@ import type { PoolBookmark_Fragment } from "./PoolBookmark";
 import PoolBookmark from "./PoolBookmark";
 
 export function poolNameAccessor(
-  pool: Pick<Pool, "name" | "workStream">,
+  name: LocalizedString | null | undefined,
+  workStreamName: LocalizedString | null | undefined,
   intl: IntlShape,
 ) {
-  const name = getLocalizedName(pool.name, intl);
-  return `${name.toLowerCase()} ${getLocalizedName(pool?.workStream?.name, intl, true)}`;
+  const localizedName = getLocalizedName(name, intl);
+  return `${localizedName.toLowerCase()} ${getLocalizedName(workStreamName, intl, true)}`;
 }
 
 export function viewCell(
   url: string,
-  pool: Pick<Pool, "name">,
+  name: LocalizedString | null | undefined,
   intl: IntlShape,
 ) {
   return (
     <Link color="black" href={url}>
-      {getLocalizedName(pool.name, intl)}
+      {getLocalizedName(name, intl)}
     </Link>
   );
 }
 
-export function classificationCell(
-  classification: Pick<Classification, "groupAndLevel"> | null | undefined,
-) {
-  if (!classification) return null;
+export function classificationCell(groupAndLevel: string | undefined) {
+  if (!groupAndLevel) return null;
 
-  return <Chip color="primary">{classification.groupAndLevel}</Chip>;
+  return <Chip color="primary">{groupAndLevel}</Chip>;
 }
 
 interface TransformPoolInputArgs {

--- a/apps/web/src/pages/Pools/ManageAccessPage/components/types.ts
+++ b/apps/web/src/pages/Pools/ManageAccessPage/components/types.ts
@@ -1,6 +1,5 @@
 import type {
   FragmentType,
-  Role,
   ManageAccessPagePoolFragment as ManageAccessPagePoolFragmentType,
 } from "@gc-digital-talent/graphql";
 
@@ -21,10 +20,10 @@ type ManageAccessPagePoolFragmentUserType = NonNullable<
   ManageAccessPagePoolFragmentType["roleAssignments"]
 >[number]["user"];
 
-export type PoolTeamMember = {
-  roles: Role[];
-} & ManageAccessPagePoolFragmentUserType;
-
 export type ManageAccessPagePoolFragmentRoleType = NonNullable<
   ManageAccessPagePoolFragmentType["roleAssignments"]
 >[number]["role"];
+
+export type PoolTeamMember = {
+  roles: NonNullable<ManageAccessPagePoolFragmentRoleType>[];
+} & ManageAccessPagePoolFragmentUserType;

--- a/apps/web/src/pages/Pools/ManageAccessPage/components/useAvailableRoles.ts
+++ b/apps/web/src/pages/Pools/ManageAccessPage/components/useAvailableRoles.ts
@@ -1,9 +1,8 @@
 import { useQuery } from "urql";
 import { useMemo } from "react";
 
-import type { Role } from "@gc-digital-talent/graphql";
 import { graphql } from "@gc-digital-talent/graphql";
-import { notEmpty } from "@gc-digital-talent/helpers";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
 
 const ManageAccessPool_AvailableRolesQuery = graphql(/* GraphQL */ `
   query ManageAccessPoolAvailableRolesQuery {
@@ -19,12 +18,7 @@ const ManageAccessPool_AvailableRolesQuery = graphql(/* GraphQL */ `
   }
 `);
 
-interface UseAvailableRolesReturn {
-  roles: Role[];
-  fetching: boolean;
-}
-
-const useAvailableRoles = (): UseAvailableRolesReturn => {
+const useAvailableRoles = () => {
   const [{ data, fetching }] = useQuery({
     query: ManageAccessPool_AvailableRolesQuery,
   });
@@ -34,14 +28,11 @@ const useAvailableRoles = (): UseAvailableRolesReturn => {
     return roles;
   }, []);
 
-  const roles: Role[] = useMemo(
+  const roles = useMemo(
     () =>
-      data?.roles
-        ? data.roles
-            .filter(notEmpty)
-            .filter((role) => role.isTeamBased)
-            .filter((role) => poolRolesArray.includes(role.name))
-        : [],
+      unpackMaybes(data?.roles)
+        .filter((role) => role.isTeamBased)
+        .filter((role) => poolRolesArray.includes(role.name)),
     [data?.roles, poolRolesArray],
   );
 

--- a/apps/web/src/pages/Pools/ManageAccessPage/components/useAvailableUsers.ts
+++ b/apps/web/src/pages/Pools/ManageAccessPage/components/useAvailableUsers.ts
@@ -1,6 +1,5 @@
 import { useQuery } from "urql";
 
-import type { UserWorkEmail } from "@gc-digital-talent/graphql";
 import { graphql } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 
@@ -13,12 +12,7 @@ const ManageAccessPool_WorkEmailsQuery = graphql(/* GraphQL */ `
   }
 `);
 
-interface UseAvailableUsersReturn {
-  users: UserWorkEmail[];
-  fetching: boolean;
-}
-
-const useAvailableUsers = (search: string): UseAvailableUsersReturn => {
+const useAvailableUsers = (search: string) => {
   const [{ data, fetching }] = useQuery({
     query: ManageAccessPool_WorkEmailsQuery,
     variables: {

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.stories.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.stories.tsx
@@ -1,7 +1,6 @@
 import type { StoryFn, Meta } from "@storybook/react-vite";
 
 import { fakePools } from "@gc-digital-talent/fake-data";
-import type { Pool } from "@gc-digital-talent/graphql";
 import { makeFragmentData, PoolStatus } from "@gc-digital-talent/graphql";
 import {
   FAR_FUTURE_DATE,
@@ -13,7 +12,7 @@ import {
   PoolPoster,
 } from "./PoolAdvertisementPage";
 
-const fakePool: Pool = fakePools(1)[0];
+const fakePool = fakePools(1)[0];
 const openPool = {
   ...fakePool,
   status: { value: PoolStatus.Published, label: {} },

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -195,11 +195,7 @@ export const PoolAdvertisement_Fragment = graphql(/* GraphQL */ `
       maxSalary
       genericJobTitles {
         id
-        key
-        name {
-          en
-          fr
-        }
+        ...GenericJobTitleAccordion
       }
     }
     yourImpact {
@@ -326,8 +322,7 @@ export const PoolPoster = ({
   const featureFlags = useFeatureFlags();
 
   const { classification } = pool;
-  const genericJobTitles =
-    classification?.genericJobTitles?.filter(notEmpty) ?? [];
+  const genericJobTitles = unpackMaybes(classification?.genericJobTitles);
   let classificationString = ""; // type wrangling the complex type into a string
   if (classification) {
     classificationString = classification.groupAndLevel;
@@ -1019,7 +1014,7 @@ export const PoolPoster = ({
                       <GenericJobTitleAccordion
                         key={genericJobTitle.id}
                         classification={classificationString}
-                        genericJobTitle={genericJobTitle}
+                        genericJobTitleQuery={genericJobTitle}
                       />
                     ))}
                   </>

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/GenericJobTitleAccordion.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/GenericJobTitleAccordion.tsx
@@ -1,24 +1,39 @@
 import { useIntl } from "react-intl";
 
 import { Accordion } from "@gc-digital-talent/ui";
-import { getLocalizedName } from "@gc-digital-talent/i18n";
-import type { GenericJobTitle } from "@gc-digital-talent/graphql";
+import { commonMessages } from "@gc-digital-talent/i18n";
+import type { FragmentType } from "@gc-digital-talent/graphql";
+import { getFragment, graphql } from "@gc-digital-talent/graphql";
 
 import ClassificationDefinition from "./ClassificationDefinition";
 
+export const GenericJobTitleAccordion_Fragment = graphql(/* GraphQL */ `
+  fragment GenericJobTitleAccordion on GenericJobTitle {
+    id
+    key
+    name {
+      localized
+    }
+  }
+`);
+
 interface GenericJobTitleAccordionProps {
-  genericJobTitle: GenericJobTitle;
+  genericJobTitleQuery: FragmentType<typeof GenericJobTitleAccordion_Fragment>;
   classification: string;
 }
 
 const GenericJobTitleAccordion = ({
-  genericJobTitle,
+  genericJobTitleQuery,
   classification,
 }: GenericJobTitleAccordionProps) => {
   const intl = useIntl();
+  const genericJobTitle = getFragment(
+    GenericJobTitleAccordion_Fragment,
+    genericJobTitleQuery,
+  );
 
   return (
-    <Accordion.Item value={genericJobTitle?.id}>
+    <Accordion.Item value={genericJobTitle.id}>
       <Accordion.Trigger as="h3">
         {intl.formatMessage(
           {
@@ -29,7 +44,9 @@ const GenericJobTitleAccordion = ({
           },
           {
             classification,
-            genericTitle: getLocalizedName(genericJobTitle.name, intl),
+            genericTitle:
+              genericJobTitle.name?.localized ??
+              intl.formatMessage(commonMessages.notAvailable),
           },
         )}
       </Accordion.Trigger>

--- a/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/ViewPoolPage.tsx
@@ -16,8 +16,9 @@ import {
   formatDate,
   parseDateTimeUtc,
 } from "@gc-digital-talent/date-helpers";
+import type { AuthRoleAssignment } from "@gc-digital-talent/auth";
 import { ROLE_NAME } from "@gc-digital-talent/auth";
-import type { FragmentType, RoleAssignment } from "@gc-digital-talent/graphql";
+import type { FragmentType } from "@gc-digital-talent/graphql";
 import { getFragment, graphql, PoolStatus } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 
@@ -91,7 +92,7 @@ export const ViewPool_Fragment = graphql(/* GraphQL */ `
 export interface ViewPoolProps {
   poolQuery: FragmentType<typeof ViewPool_Fragment>;
   departmentsQuery: FragmentType<typeof DuplicatePoolDepartment_Fragment>[];
-  roleAssignments: RoleAssignment[];
+  roleAssignments: AuthRoleAssignment[];
   isFetching: boolean;
   onPublish: () => Promise<void>;
   onDelete: () => Promise<void>;

--- a/apps/web/src/pages/Pools/ViewPoolPage/components/ChangeDateDialog.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/components/ChangeDateDialog.tsx
@@ -14,7 +14,6 @@ import {
   errorMessages,
   formMessages,
 } from "@gc-digital-talent/i18n";
-import type { Pool } from "@gc-digital-talent/graphql";
 import { ErrorCode } from "@gc-digital-talent/graphql";
 
 import processMessages from "~/messages/processMessages";
@@ -23,12 +22,12 @@ import type { ProcessDialogProps } from "./types";
 
 interface FormValues {
   type?: "extend" | "close";
-  expiryEndDate?: Pool["closingDate"];
+  expiryEndDate?: string | null;
   reason?: string;
 }
 
 interface ChangeDateDialogProps extends ProcessDialogProps {
-  closingDate?: Pool["closingDate"];
+  closingDate?: string | null;
   onExtend: (closingDate: string) => Promise<void>;
   onClose: (reason: string) => Promise<void>;
 }

--- a/apps/web/src/pages/Pools/ViewPoolPage/components/DuplicateProcessDialog.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/components/DuplicateProcessDialog.tsx
@@ -11,9 +11,9 @@ import {
 } from "@gc-digital-talent/i18n";
 import type { Option } from "@gc-digital-talent/forms";
 import { Select } from "@gc-digital-talent/forms";
-import type { FragmentType, RoleAssignment } from "@gc-digital-talent/graphql";
+import type { FragmentType } from "@gc-digital-talent/graphql";
 import { getFragment, graphql } from "@gc-digital-talent/graphql";
-import type { RoleName } from "@gc-digital-talent/auth";
+import type { AuthRoleAssignment, RoleName } from "@gc-digital-talent/auth";
 import { hasRequiredRoles, ROLE_NAME } from "@gc-digital-talent/auth";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 
@@ -37,7 +37,7 @@ interface FormValues {
 interface DuplicateProcessDialogProps extends ProcessDialogProps {
   departmentsQuery: FragmentType<typeof DuplicatePoolDepartment_Fragment>[];
   onDuplicate: (opts: { department: string | undefined }) => Promise<void>;
-  roleAssignments: RoleAssignment[];
+  roleAssignments: AuthRoleAssignment[];
 }
 
 const DuplicateProcessDialog = ({
@@ -59,9 +59,7 @@ const DuplicateProcessDialog = ({
     ROLE_NAME.DepartmentAdmin,
     ROLE_NAME.DepartmentHRAdvisor,
   ];
-  function isAuthorizedDepartment(
-    assignment: RoleAssignment,
-  ): assignment is RoleAssignment {
+  function isAuthorizedDepartment(assignment: AuthRoleAssignment): boolean {
     return (
       !!assignment.role &&
       departmentRoles.includes(assignment.role.name as RoleName)

--- a/apps/web/src/pages/Pools/ViewPoolPage/components/PublishProcessDialog.tsx
+++ b/apps/web/src/pages/Pools/ViewPoolPage/components/PublishProcessDialog.tsx
@@ -7,12 +7,11 @@ import {
   relativeClosingDate,
 } from "@gc-digital-talent/date-helpers";
 import { commonMessages, formMessages } from "@gc-digital-talent/i18n";
-import type { Pool } from "@gc-digital-talent/graphql";
 
 import type { ProcessDialogProps } from "./types";
 
 interface PublishProcessDialogProps extends ProcessDialogProps {
-  closingDate: Pool["closingDate"];
+  closingDate: string | null | undefined;
   onPublish: () => Promise<void>;
   isReadyToPublish: boolean;
 }

--- a/packages/auth/src/index.tsx
+++ b/packages/auth/src/index.tsx
@@ -34,7 +34,7 @@ import {
 } from "./const";
 import type { LogoutReason, RoleName } from "./const";
 import getAuthenticationState from "./utils/authenticationState";
-import type { AuthenticationState } from "./types";
+import type { AuthenticationState, AuthRoleAssignment } from "./types";
 import { setTokensFromLocation } from "./utils/setTokensFromLocation";
 
 export {
@@ -74,6 +74,7 @@ export type {
   RoleName,
   LogoutReason,
   AuthenticationState,
+  AuthRoleAssignment,
   RoleRequirement,
   PermissionRequirement,
   HasRequiredRolesArgs,

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -23,6 +23,7 @@ export interface AuthRoleAssignment {
   id: string;
   role?: AuthRole | null;
   team?: AuthTeam | null;
+  teamable?: { id: string } | null;
 }
 
 export interface AuthUserInfo {


### PR DESCRIPTION
Related: https://github.com/GCTC-NTGC/gc-digital-talent/pull/17552

## 👋 Introduction

Removes full object types from `apps/web/src/pages/Pools`

## 🕵️ Details

I really hope this is the largest one :sweat_smile: This turned out being muhc larger than I anticipated so I apologize in advanced. I guess this goes to show how heavily we leaned on these large types instead of writing simpler ones by hand :sweat: 

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Test the different pools pages
3. Confirm no errors