### PR TITLE
[Fix] Candidates table filter count

### DIFF
--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateFilterDialog.tsx
@@ -236,8 +236,9 @@ const PoolCandidateFilterDialog = ({
     <FilterDialog<FormValues>
       options={{ defaultValues: initialValues }}
       // Remove hidden pools filters from count
+      // Default hard-coded filters: expiryStatus, suspendedStatus and poolId
       {...(hidePoolFilter && {
-        modifyFilterCount: -5,
+        modifyFilterCount: -3,
       })}
       {...{ resetValues, onSubmit }}
     >


### PR DESCRIPTION
🤖 Resolves #17483 

## 👋 Introduction

Fixes an issue with the filter count not appearing on the trigger for the filter dialog on the candidate table.

## 🕵️ Details

We have a magic number that decrements the count by the hard-coded present filters. The issue was, we had this set to `-5` whish is then number of hidden filters, not the number being applied.

so, the filter count started as `-2` meaning you would need to apply 3 filters to get it to appear as `1`.

This updates it to be `-3` to fix this. Ideally, we would not need a magiv number here but that can be sovled if we eventually split these tables up.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to any process in the admin area
4. Navigate to the candidates tab
5. Apply a number of filters
6. Confirm the value matches the number of filters you changed/applied