### PR TITLE
[Feature] Tooltip component

### DIFF
--- a/packages/ui/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/ui/src/components/DropdownMenu/DropdownMenu.tsx
@@ -21,25 +21,6 @@ const Trigger = ({ btnProps, render, ...triggerProps }: TriggerProps) => (
   />
 );
 
-function ArrowSvg(props: React.ComponentProps<"svg">) {
-  return (
-    <svg width="20" height="10" viewBox="0 0 20 10" fill="none" {...props}>
-      <path
-        d="M9.66437 2.60207L4.80758 6.97318C4.07308 7.63423 3.11989 8 2.13172 8H0V10H20V8H18.5349C17.5468 8 16.5936 7.63423 15.8591 6.97318L11.0023 2.60207C10.622 2.2598 10.0447 2.25979 9.66437 2.60207Z"
-        className="fill-white dark:fill-gray-600"
-      />
-      <path
-        d="M8.99542 1.85876C9.75604 1.17425 10.9106 1.17422 11.6713 1.85878L16.5281 6.22989C17.0789 6.72568 17.7938 7.00001 18.5349 7.00001L15.89 7L11.0023 2.60207C10.622 2.2598 10.0447 2.2598 9.66436 2.60207L4.77734 7L2.13171 7.00001C2.87284 7.00001 3.58774 6.72568 4.13861 6.22989L8.99542 1.85876Z"
-        className="fill-gray-200 dark:fill-none"
-      />
-      <path
-        d="M10.3333 3.34539L5.47654 7.71648C4.55842 8.54279 3.36693 9 2.13172 9H0V8H2.13172C3.11989 8 4.07308 7.63423 4.80758 6.97318L9.66437 2.60207C10.0447 2.25979 10.622 2.2598 11.0023 2.60207L15.8591 6.97318C16.5936 7.63423 17.5468 8 18.5349 8H20V9H18.5349C17.2998 9 16.1083 8.54278 15.1901 7.71648L10.3333 3.34539Z"
-        className="dark:fill-gray-300"
-      />
-    </svg>
-  );
-}
-
 const popup = tv({
   base: `max-h-[var(--available-height)] max-w-screen overflow-y-auto rounded-md bg-white py-3 font-sans text-black shadow-md outline-1 outline-gray-200 dark:bg-gray-600 dark:text-white dark:-outline-offset-1 dark:outline-gray-300`,
 });
@@ -70,7 +51,20 @@ const Popup = ({
         {...popupProps}
       >
         <Menu.Arrow className="data-[side=bottom]:-top-2 data-[side=left]:-right-3.25 data-[side=left]:rotate-90 data-[side=right]:-left-3.25 data-[side=right]:-rotate-90 data-[side=top]:-bottom-1.75 data-[side=top]:rotate-180 md:data-[side=bottom]:-top-1.75">
-          <ArrowSvg />
+          <svg width="20" height="10" viewBox="0 0 20 10" fill="none">
+            <path
+              d="M9.66437 2.60207L4.80758 6.97318C4.07308 7.63423 3.11989 8 2.13172 8H0V10H20V8H18.5349C17.5468 8 16.5936 7.63423 15.8591 6.97318L11.0023 2.60207C10.622 2.2598 10.0447 2.25979 9.66437 2.60207Z"
+              className="fill-white dark:fill-gray-600"
+            />
+            <path
+              d="M8.99542 1.85876C9.75604 1.17425 10.9106 1.17422 11.6713 1.85878L16.5281 6.22989C17.0789 6.72568 17.7938 7.00001 18.5349 7.00001L15.89 7L11.0023 2.60207C10.622 2.2598 10.0447 2.2598 9.66436 2.60207L4.77734 7L2.13171 7.00001C2.87284 7.00001 3.58774 6.72568 4.13861 6.22989L8.99542 1.85876Z"
+              className="fill-gray-200 dark:fill-none"
+            />
+            <path
+              d="M10.3333 3.34539L5.47654 7.71648C4.55842 8.54279 3.36693 9 2.13172 9H0V8H2.13172C3.11989 8 4.07308 7.63423 4.80758 6.97318L9.66437 2.60207C10.0447 2.25979 10.622 2.2598 11.0023 2.60207L15.8591 6.97318C16.5936 7.63423 17.5468 8 18.5349 8H20V9H18.5349C17.2998 9 16.1083 8.54278 15.1901 7.71648L10.3333 3.34539Z"
+              className="dark:fill-gray-300"
+            />
+          </svg>
         </Menu.Arrow>
         {children}
       </Menu.Popup>

--- a/packages/ui/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.stories.tsx
@@ -36,7 +36,7 @@ export default {
 
 const Template: StoryFn<typeof Tooltip.Root> = () => (
   <Tooltip.Provider>
-    <Tooltip.Root>
+    <Tooltip.Root defaultOpen>
       <Tooltip.Trigger aria-label="Administrative Services">
         CS-02
       </Tooltip.Trigger>

--- a/packages/ui/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,114 @@
+import InformationCircleIcon from "@heroicons/react/20/solid/InformationCircleIcon";
+import type { StoryFn, Meta } from "@storybook/react-vite";
+
+import {
+  GLOBAL_A11Y_EXCLUDES,
+  allModes,
+} from "@gc-digital-talent/storybook-helpers";
+
+import Button from "../Button";
+import IconButton from "../Button/IconButton";
+import Tooltip from "./Tooltip";
+
+export default {
+  component: Tooltip.Root,
+  decorators: [
+    (Story) => (
+      <div className="flex justify-center p-16">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    chromatic: {
+      modes: {
+        light: allModes.light,
+        dark: allModes.dark,
+      },
+    },
+    a11y: {
+      context: {
+        exclude: [...GLOBAL_A11Y_EXCLUDES],
+      },
+    },
+  },
+} as Meta;
+
+const Template: StoryFn<typeof Tooltip.Root> = () => (
+  <Tooltip.Provider>
+    <Tooltip.Root>
+      <Tooltip.Trigger aria-label="Administrative Services">
+        CS-02
+      </Tooltip.Trigger>
+      <Tooltip.Popup>Administrative Services</Tooltip.Popup>
+    </Tooltip.Root>
+  </Tooltip.Provider>
+);
+
+export const Default = Template.bind({});
+
+export const OpeningFromTop: StoryFn<typeof Tooltip.Root> = () => (
+  <Tooltip.Provider>
+    <Tooltip.Root defaultOpen>
+      <Tooltip.Trigger aria-label="Administrative Services">
+        CS-02
+      </Tooltip.Trigger>
+      <Tooltip.Popup positionerProps={{ side: "top" }}>
+        Administrative Services
+      </Tooltip.Popup>
+    </Tooltip.Root>
+  </Tooltip.Provider>
+);
+
+export const OpeningFromBottom: StoryFn<typeof Tooltip.Root> = () => (
+  <Tooltip.Provider>
+    <Tooltip.Root defaultOpen>
+      <Tooltip.Trigger aria-label="Administrative Services">
+        CS-02
+      </Tooltip.Trigger>
+      <Tooltip.Popup positionerProps={{ side: "bottom" }}>
+        Administrative Services
+      </Tooltip.Popup>
+    </Tooltip.Root>
+  </Tooltip.Provider>
+);
+
+export const OnIcon: StoryFn<typeof Tooltip.Root> = () => (
+  <Tooltip.Provider>
+    <Tooltip.Root defaultOpen>
+      <Tooltip.Trigger
+        render={
+          <IconButton
+            color="black"
+            icon={InformationCircleIcon}
+            label="More information"
+          />
+        }
+      />
+      <Tooltip.Popup>More information</Tooltip.Popup>
+    </Tooltip.Root>
+  </Tooltip.Provider>
+);
+
+export const OnButton: StoryFn<typeof Tooltip.Root> = () => (
+  <Tooltip.Provider>
+    <Tooltip.Root defaultOpen>
+      <Tooltip.Trigger render={<Button color="primary">Submit</Button>} />
+      <Tooltip.Popup>Submit the application</Tooltip.Popup>
+    </Tooltip.Root>
+  </Tooltip.Provider>
+);
+
+export const OnText: StoryFn<typeof Tooltip.Root> = () => (
+  <Tooltip.Provider>
+    <Tooltip.Root defaultOpen>
+      <Tooltip.Trigger
+        aria-label="Roob, Fisher and Associates"
+        className="cursor-default border-0 bg-transparent p-0 underline decoration-dotted underline-offset-4"
+      >
+        CS-02: Roob
+      </Tooltip.Trigger>
+      <Tooltip.Popup>Roob, Fisher and Associates</Tooltip.Popup>
+    </Tooltip.Root>
+  </Tooltip.Provider>
+);

--- a/packages/ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.tsx
@@ -4,13 +4,28 @@
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
 import { tv } from "tailwind-variants";
 
+const popupColor = "bg-white text-black dark:bg-gray-600 dark:text-white";
+const popupShape = "rounded-md px-2 py-1 font-sans text-sm shadow-md";
+const popupMotion =
+  "origin-(--transform-origin) transition duration-100 ease-out data-starting-style:scale-95 data-starting-style:opacity-0 data-ending-style:scale-95 data-ending-style:opacity-0 data-instant:transition-none";
+
 const popup = tv({
-  base: `origin-(--transform-origin) rounded-md bg-gray-100 px-2 py-1 font-sans text-sm text-black shadow-md transition-[transform,opacity] duration-100 ease-out data-ending-style:scale-[0.98] data-ending-style:opacity-0 data-instant:transition-none data-starting-style:scale-[0.98] data-starting-style:opacity-0 dark:bg-gray-700 dark:text-white`,
+  base: [popupShape, popupColor, popupMotion],
 });
 
-const arrow = tv({
-  base: "relative block h-1.5 w-3 overflow-clip before:absolute before:bottom-0 before:left-1/2 before:h-[calc(6px*sqrt(2))] before:w-[calc(6px*sqrt(2))] before:origin-center before:-translate-x-1/2 before:translate-y-1/2 before:rotate-45 before:bg-gray-100 before:content-[''] data-[side=bottom]:-top-1.5 data-[side=left]:-right-2.25 data-[side=left]:rotate-90 data-[side=right]:-left-2.25 data-[side=right]:-rotate-90 data-[side=top]:-bottom-1.5 data-[side=top]:rotate-180 dark:before:bg-gray-700",
-});
+function ArrowSvg(props: React.ComponentProps<"svg">) {
+  return (
+    <svg width="20" height="10" viewBox="0 0 20 10" fill="none" {...props}>
+      <path
+        d="M9.66437 2.60207L4.80758 6.97318C4.07308 7.63423 3.11989 8 2.13172 8H0V10H20V8H18.5349C17.5468 8 16.5936 7.63423 15.8591 6.97318L11.0023 2.60207C10.622 2.2598 10.0447 2.25979 9.66437 2.60207Z"
+        className="fill-white dark:fill-gray-600"
+      />
+    </svg>
+  );
+}
+
+const arrowPosition =
+  "data-[side=bottom]:-top-2 data-[side=left]:-right-3.25 data-[side=left]:rotate-90 data-[side=right]:-left-3.25 data-[side=right]:-rotate-90 data-[side=top]:-bottom-1.75 data-[side=top]:rotate-180";
 
 interface PopupProps extends Omit<TooltipPrimitive.Popup.Props, "className"> {
   portalProps?: TooltipPrimitive.Portal.Props;
@@ -33,7 +48,9 @@ const Popup = ({
         className={popup({ class: className })}
         {...popupProps}
       >
-        <TooltipPrimitive.Arrow className={arrow()} />
+        <TooltipPrimitive.Arrow className={arrowPosition}>
+          <ArrowSvg />
+        </TooltipPrimitive.Arrow>
         {children}
       </TooltipPrimitive.Popup>
     </TooltipPrimitive.Positioner>

--- a/packages/ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,48 @@
+/**
+ * Documentation: https://base-ui.com/react/components/tooltip
+ */
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
+import { tv } from "tailwind-variants";
+
+const popup = tv({
+  base: `origin-(--transform-origin) rounded-md bg-gray-100 px-2 py-1 font-sans text-sm text-black shadow-md transition-[transform,opacity] duration-100 ease-out data-ending-style:scale-[0.98] data-ending-style:opacity-0 data-instant:transition-none data-starting-style:scale-[0.98] data-starting-style:opacity-0 dark:bg-gray-700 dark:text-white`,
+});
+
+const arrow = tv({
+  base: "relative block h-1.5 w-3 overflow-clip before:absolute before:bottom-0 before:left-1/2 before:h-[calc(6px*sqrt(2))] before:w-[calc(6px*sqrt(2))] before:origin-center before:-translate-x-1/2 before:translate-y-1/2 before:rotate-45 before:bg-gray-100 before:content-[''] data-[side=bottom]:-top-1.5 data-[side=left]:-right-2.25 data-[side=left]:rotate-90 data-[side=right]:-left-2.25 data-[side=right]:-rotate-90 data-[side=top]:-bottom-1.5 data-[side=top]:rotate-180 dark:before:bg-gray-700",
+});
+
+interface PopupProps extends Omit<TooltipPrimitive.Popup.Props, "className"> {
+  portalProps?: TooltipPrimitive.Portal.Props;
+  positionerProps?: TooltipPrimitive.Positioner.Props;
+  className?: string;
+}
+
+const Popup = ({
+  portalProps,
+  positionerProps,
+  children,
+  className,
+  ref,
+  ...popupProps
+}: PopupProps) => (
+  <TooltipPrimitive.Portal {...portalProps}>
+    <TooltipPrimitive.Positioner sideOffset={8} {...positionerProps}>
+      <TooltipPrimitive.Popup
+        ref={ref}
+        className={popup({ class: className })}
+        {...popupProps}
+      >
+        <TooltipPrimitive.Arrow className={arrow()} />
+        {children}
+      </TooltipPrimitive.Popup>
+    </TooltipPrimitive.Positioner>
+  </TooltipPrimitive.Portal>
+);
+
+export default {
+  Provider: TooltipPrimitive.Provider,
+  Root: TooltipPrimitive.Root,
+  Trigger: TooltipPrimitive.Trigger,
+  Popup,
+};

--- a/packages/ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.tsx
@@ -4,13 +4,12 @@
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
 import { tv } from "tailwind-variants";
 
-const popupColor = "bg-white text-black dark:bg-gray-600 dark:text-white";
-const popupShape = "rounded-md px-2 py-1 font-sans text-sm shadow-md";
-const popupMotion =
-  "origin-(--transform-origin) transition duration-100 ease-out data-starting-style:scale-95 data-starting-style:opacity-0 data-ending-style:scale-95 data-ending-style:opacity-0 data-instant:transition-none";
-
 const popup = tv({
-  base: [popupShape, popupColor, popupMotion],
+  base: [
+    "rounded-md px-2 py-1 font-sans text-sm shadow-md", // popup shape
+    "bg-white text-black dark:bg-gray-600 dark:text-white", // popup color
+    "origin-(--transform-origin) transition duration-100 ease-out data-ending-style:scale-95 data-ending-style:opacity-0 data-instant:transition-none data-starting-style:scale-95 data-starting-style:opacity-0", // popup motion
+  ],
 });
 
 function ArrowSvg(props: React.ComponentProps<"svg">) {

--- a/packages/ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.tsx
@@ -12,20 +12,6 @@ const popup = tv({
   ],
 });
 
-function ArrowSvg(props: React.ComponentProps<"svg">) {
-  return (
-    <svg width="20" height="10" viewBox="0 0 20 10" fill="none" {...props}>
-      <path
-        d="M9.66437 2.60207L4.80758 6.97318C4.07308 7.63423 3.11989 8 2.13172 8H0V10H20V8H18.5349C17.5468 8 16.5936 7.63423 15.8591 6.97318L11.0023 2.60207C10.622 2.2598 10.0447 2.25979 9.66437 2.60207Z"
-        className="fill-white dark:fill-gray-600"
-      />
-    </svg>
-  );
-}
-
-const arrowPosition =
-  "data-[side=bottom]:-top-2 data-[side=left]:-right-3.25 data-[side=left]:rotate-90 data-[side=right]:-left-3.25 data-[side=right]:-rotate-90 data-[side=top]:-bottom-1.75 data-[side=top]:rotate-180";
-
 interface PopupProps extends Omit<TooltipPrimitive.Popup.Props, "className"> {
   portalProps?: TooltipPrimitive.Portal.Props;
   positionerProps?: TooltipPrimitive.Positioner.Props;
@@ -47,8 +33,13 @@ const Popup = ({
         className={popup({ class: className })}
         {...popupProps}
       >
-        <TooltipPrimitive.Arrow className={arrowPosition}>
-          <ArrowSvg />
+        <TooltipPrimitive.Arrow className="data-[side=bottom]:-top-2 data-[side=left]:-right-3.25 data-[side=left]:rotate-90 data-[side=right]:-left-3.25 data-[side=right]:-rotate-90 data-[side=top]:-bottom-1.75 data-[side=top]:rotate-180">
+          <svg width="20" height="10" viewBox="0 0 20 10" fill="none">
+            <path
+              d="M9.66437 2.60207L4.80758 6.97318C4.07308 7.63423 3.11989 8 2.13172 8H0V10H20V8H18.5349C17.5468 8 16.5936 7.63423 15.8591 6.97318L11.0023 2.60207C10.622 2.2598 10.0447 2.25979 9.66437 2.60207Z"
+              className="fill-white dark:fill-gray-600"
+            />
+          </svg>
         </TooltipPrimitive.Arrow>
         {children}
       </TooltipPrimitive.Popup>

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -97,6 +97,7 @@ import type {
 } from "./components/TableOfContents";
 import TableOfContents from "./components/TableOfContents";
 import Tabs from "./components/Tabs/Tabs";
+import Tooltip from "./components/Tooltip/Tooltip";
 import ToggleGroup from "./components/ToggleGroup/ToggleGroup";
 import ToggleSection from "./components/ToggleSection/ToggleSection";
 import TreeView from "./components/TreeView/TreeView";
@@ -213,6 +214,7 @@ export {
   TableOfContents,
   Tabs,
   TaskCard,
+  Tooltip,
   ToggleGroup,
   ToggleSection,
   TreeView,


### PR DESCRIPTION
🤖 Resolves #17631

## 👋 Introduction

Adds a `Tooltip` component built on Base UI's unstyled primitive.

## 🕵️ Details

- New `Tooltip` in `packages/ui`, using the Base UI component library `@base-ui/react/tooltip`.
- Styled for light/dark mode, matching the design.
- 6 Storybook stories: default, opening from top/bottom, on icon, on button, on plain text.

## 🧪 Testing

1. Run Storybook.
2. Open the `Tooltip` stories.
3. Hover/focus each trigger and check both light and dark modes.