### PR TITLE
[Feature] Add 9box to review page and details tab

### DIFF
--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/ReviewAndSubmit/NominationDetailsReview.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/ReviewAndSubmit/NominationDetailsReview.tsx
@@ -1,9 +1,11 @@
 import { useIntl } from "react-intl";
+import type { MessageDescriptor } from "react-intl";
 
 import type { FragmentType } from "@gc-digital-talent/graphql";
 import {
   getFragment,
   graphql,
+  NineBoxRating,
   TalentNominationStep,
 } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
@@ -24,8 +26,33 @@ interface ListItem {
   name: string;
 }
 
+const performanceLabels: Record<NineBoxRating, MessageDescriptor> = {
+  [NineBoxRating.Low]: labels.lowPerformance,
+  [NineBoxRating.Moderate]: labels.moderatePerformance,
+  [NineBoxRating.High]: labels.highPerformance,
+};
+
+const leadershipPotentialLabels: Record<NineBoxRating, MessageDescriptor> = {
+  [NineBoxRating.Low]: labels.lowPotential,
+  [NineBoxRating.Moderate]: labels.moderatePotential,
+  [NineBoxRating.High]: labels.highPotential,
+};
+
 const NominationDetailsReview_Fragment = graphql(/* GraphQL */ `
   fragment NominationDetailsReview on TalentNomination {
+    talentNominationEvent {
+      id
+      includeNineBox
+    }
+
+    # Nine-box details
+    nineBoxPerformance {
+      value
+    }
+    nineBoxLeadershipPotential {
+      value
+    }
+
     # Nomination types
     nominateForAdvancement
     nominateForLateralMovement
@@ -153,6 +180,10 @@ const NominationDetailsReview = ({
     name: cdp.developmentProgram.name?.localized ?? "",
   }));
 
+  const performance = talentNomination?.nineBoxPerformance?.value;
+  const leadershipPotential =
+    talentNomination?.nineBoxLeadershipPotential?.value;
+
   return (
     <>
       <ReviewHeading
@@ -168,6 +199,22 @@ const NominationDetailsReview = ({
         {intl.formatMessage(messages.nominationDetails)}
       </ReviewHeading>
       <div className="grid grid-cols-2 gap-6">
+        {talentNomination?.talentNominationEvent?.includeNineBox && (
+          <>
+            <FieldDisplay label={intl.formatMessage(labels.nomineePerformance)}>
+              {performance
+                ? intl.formatMessage(performanceLabels[performance])
+                : notProvided}
+            </FieldDisplay>
+            <FieldDisplay
+              label={intl.formatMessage(labels.nomineeLeadershipPotential)}
+            >
+              {leadershipPotential
+                ? intl.formatMessage(leadershipPotentialLabels[leadershipPotential])
+                : notProvided}
+            </FieldDisplay>
+          </>
+        )}
         <FieldDisplay
           className="col-span-2"
           label={intl.formatMessage(labels.nominationOptions)}

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/ReviewAndSubmit/NominationDetailsReview.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/ReviewAndSubmit/NominationDetailsReview.tsx
@@ -201,12 +201,16 @@ const NominationDetailsReview = ({
       <div className="grid grid-cols-2 gap-6">
         {talentNomination?.talentNominationEvent?.includeNineBox && (
           <>
-            <FieldDisplay label={intl.formatMessage(labels.nomineePerformance)}>
+            <FieldDisplay
+              className="col-span-2"
+              label={intl.formatMessage(labels.nomineePerformance)}
+            >
               {performance
                 ? intl.formatMessage(performanceLabels[performance])
                 : notProvided}
             </FieldDisplay>
             <FieldDisplay
+              className="col-span-2"
               label={intl.formatMessage(labels.nomineeLeadershipPotential)}
             >
               {leadershipPotential

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/ReviewAndSubmit/NominationDetailsReview.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/ReviewAndSubmit/NominationDetailsReview.tsx
@@ -214,7 +214,9 @@ const NominationDetailsReview = ({
               label={intl.formatMessage(labels.nomineeLeadershipPotential)}
             >
               {leadershipPotential
-                ? intl.formatMessage(leadershipPotentialLabels[leadershipPotential])
+                ? intl.formatMessage(
+                    leadershipPotentialLabels[leadershipPotential],
+                  )
                 : notProvided}
             </FieldDisplay>
           </>

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/TalentNominationAccordionItem.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/TalentNominationAccordionItem.tsx
@@ -280,7 +280,8 @@ const TalentNominationAccordionItem = ({
   const notFound = intl.formatMessage(commonMessages.notFound);
 
   const performance = talentNomination.nineBoxPerformance?.value;
-  const leadershipPotential = talentNomination.nineBoxLeadershipPotential?.value;
+  const leadershipPotential =
+    talentNomination.nineBoxLeadershipPotential?.value;
 
   return (
     <Accordion.Item value={talentNomination.id} {...rest}>
@@ -526,7 +527,9 @@ const TalentNominationAccordionItem = ({
               )}
             >
               {leadershipPotential
-                ? intl.formatMessage(leadershipPotentialLabels[leadershipPotential])
+                ? intl.formatMessage(
+                    leadershipPotentialLabels[leadershipPotential],
+                  )
                 : notFound}
             </FieldDisplay>
           </>

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/TalentNominationAccordionItem.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/TalentNominationAccordionItem.tsx
@@ -1,9 +1,11 @@
 import { defineMessage, useIntl } from "react-intl";
+import type { MessageDescriptor } from "react-intl";
 
 import type { FragmentType } from "@gc-digital-talent/graphql";
 import {
   getFragment,
   graphql,
+  NineBoxRating,
   TalentNominationLateralMovementOption,
 } from "@gc-digital-talent/graphql";
 import { Accordion, Ul } from "@gc-digital-talent/ui";
@@ -18,6 +20,18 @@ import adminMessages from "~/messages/adminMessages";
 
 import { formMessages } from "../messages";
 import nominationLabels from "../../NominateTalent/labels";
+
+const performanceLabels: Record<NineBoxRating, MessageDescriptor> = {
+  [NineBoxRating.Low]: nominationLabels.lowPerformance,
+  [NineBoxRating.Moderate]: nominationLabels.moderatePerformance,
+  [NineBoxRating.High]: nominationLabels.highPerformance,
+};
+
+const leadershipPotentialLabels: Record<NineBoxRating, MessageDescriptor> = {
+  [NineBoxRating.Low]: nominationLabels.lowPotential,
+  [NineBoxRating.Moderate]: nominationLabels.moderatePotential,
+  [NineBoxRating.High]: nominationLabels.highPotential,
+};
 
 const TalentNominationAccordionItemOptions_Fragment = graphql(/* GraphQL */ `
   fragment TalentNominationAccordionItemOptions on Query {
@@ -46,6 +60,14 @@ const TalentNominationAccordionItem_Fragment = graphql(/* GraphQL */ `
         }
       }
       includeLeadershipCompetencies
+      includeNineBox
+    }
+
+    nineBoxPerformance {
+      value
+    }
+    nineBoxLeadershipPotential {
+      value
     }
 
     nominatorFallbackName
@@ -256,6 +278,9 @@ const TalentNominationAccordionItem = ({
   }
 
   const notFound = intl.formatMessage(commonMessages.notFound);
+
+  const performance = talentNomination.nineBoxPerformance?.value;
+  const leadershipPotential = talentNomination.nineBoxLeadershipPotential?.value;
 
   return (
     <Accordion.Item value={talentNomination.id} {...rest}>
@@ -481,6 +506,30 @@ const TalentNominationAccordionItem = ({
               </Accordion.Content>
             </Accordion.Item>
           </Accordion.Root>
+        ) : null}
+
+        {/* nine-box fields only displayed if enabled for the event */}
+        {talentNomination.talentNominationEvent.includeNineBox ? (
+          <>
+            <FieldDisplay
+              className="my-6"
+              label={intl.formatMessage(nominationLabels.nomineePerformance)}
+            >
+              {performance
+                ? intl.formatMessage(performanceLabels[performance])
+                : notFound}
+            </FieldDisplay>
+            <FieldDisplay
+              className="my-6"
+              label={intl.formatMessage(
+                nominationLabels.nomineeLeadershipPotential,
+              )}
+            >
+              {leadershipPotential
+                ? intl.formatMessage(leadershipPotentialLabels[leadershipPotential])
+                : notFound}
+            </FieldDisplay>
+          </>
         ) : null}
 
         <FieldDisplay


### PR DESCRIPTION
🤖 Resolves #17646 

## 👋 Introduction

Adds the 9box fields to the review page and details tab.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

1. Rebuild and log in as admin@test.com
2. Find or create an event with 9box enabled
3. Submit a talent nomination to the event
- [ ] 9box choices show on the Review and Submit step
4. Review the talent nomination from the admin interface
- [ ] 9box choices show on the Nomination Details tab
5. Find or create an event with 9box disabled
- [ ] 9box choices do not appear on the Review and Submit step or the Nomination Details tab

## 📸 Screenshot

<img width="1367" height="529" alt="image" src="https://github.com/user-attachments/assets/fde87b35-6502-4e79-b633-e8c9c97dd1d8" />

<img width="1316" height="768" alt="image" src="https://github.com/user-attachments/assets/9e2c8a9e-8d21-456a-9509-c307d6d3a333" />

