### PR TITLE
[Refactor] Remove full graphql object types 5

### DIFF
--- a/apps/web/src/components/Profile/components/CitizenVeteranPriority/CitizenVeteranPriority.tsx
+++ b/apps/web/src/components/Profile/components/CitizenVeteranPriority/CitizenVeteranPriority.tsx
@@ -6,7 +6,7 @@ import { ToggleSection, Notice } from "@gc-digital-talent/ui";
 import { BasicForm } from "@gc-digital-talent/forms";
 import { toast } from "@gc-digital-talent/toast";
 import { commonMessages } from "@gc-digital-talent/i18n";
-import type { FragmentType, Pool } from "@gc-digital-talent/graphql";
+import type { FragmentType } from "@gc-digital-talent/graphql";
 import { getFragment, graphql } from "@gc-digital-talent/graphql";
 
 import profileMessages from "~/messages/profileMessages";
@@ -16,7 +16,7 @@ import {
 } from "~/validators/profile/citizenVeteranPriority";
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
 
-import type { SectionProps } from "../../types";
+import type { ProfileSectionPool, SectionProps } from "../../types";
 import FormActions from "../FormActions";
 import useSectionInfo from "../../hooks/useSectionInfo";
 import { dataToFormValues, formValuesToSubmitData } from "./utils";
@@ -46,7 +46,7 @@ const ProfileCitizenVeteranPriority_Fragment = graphql(/** GraphQL */ `
   }
 `);
 
-interface CitizenVeteranPriorityProps extends SectionProps<Pick<Pool, "id">> {
+interface CitizenVeteranPriorityProps extends SectionProps<ProfileSectionPool> {
   query: FragmentType<typeof ProfileCitizenVeteranPriority_Fragment>;
 }
 

--- a/apps/web/src/components/Profile/components/CitizenVeteranPriority/utils.ts
+++ b/apps/web/src/components/Profile/components/CitizenVeteranPriority/utils.ts
@@ -4,7 +4,6 @@ import { boolToYesNo } from "@gc-digital-talent/helpers";
 import type {
   ProfileCitizenVeteranPriorityFragment,
   UpdateUserAsUserInput,
-  User,
 } from "@gc-digital-talent/graphql";
 import {
   ArmedForcesStatus,
@@ -17,7 +16,7 @@ import type { FormValues } from "./types";
 
 export const formValuesToSubmitData = (
   values: FormValues,
-  userId: User["id"],
+  userId: string,
 ): UpdateUserAsUserInput => {
   return {
     id: userId,

--- a/apps/web/src/components/Profile/components/DiversityEquityInclusion/DiversityEquityInclusion.tsx
+++ b/apps/web/src/components/Profile/components/DiversityEquityInclusion/DiversityEquityInclusion.tsx
@@ -37,8 +37,7 @@ const ProfileDiversityEquityInclusion_Fragment = graphql(/** GraphQL */ `
   }
 `);
 
-interface DiversityEquityInclusionProps
-  extends SectionProps<ProfileSectionPool> {
+interface DiversityEquityInclusionProps extends SectionProps<ProfileSectionPool> {
   query: FragmentType<typeof ProfileDiversityEquityInclusion_Fragment>;
 }
 

--- a/apps/web/src/components/Profile/components/DiversityEquityInclusion/DiversityEquityInclusion.tsx
+++ b/apps/web/src/components/Profile/components/DiversityEquityInclusion/DiversityEquityInclusion.tsx
@@ -5,7 +5,6 @@ import { useIntl } from "react-intl";
 import { Accordion, Heading, Ul, Notice } from "@gc-digital-talent/ui";
 import type {
   FragmentType,
-  Pool,
   UpdateUserAsUserInput,
 } from "@gc-digital-talent/graphql";
 import { getFragment, graphql } from "@gc-digital-talent/graphql";
@@ -15,7 +14,7 @@ import type { EquityKeys } from "~/components/EmploymentEquity/types";
 import { hasEmptyRequiredFields } from "~/validators/profile/diversityEquityInclusion";
 import applicationMessages from "~/messages/applicationMessages";
 
-import type { SectionProps } from "../../types";
+import type { ProfileSectionPool, SectionProps } from "../../types";
 import { getSectionTitle } from "../../utils";
 
 type AccordionItems = "information" | "";
@@ -38,9 +37,8 @@ const ProfileDiversityEquityInclusion_Fragment = graphql(/** GraphQL */ `
   }
 `);
 
-interface DiversityEquityInclusionProps extends SectionProps<
-  Pick<Pool, "publishingGroup">
-> {
+interface DiversityEquityInclusionProps
+  extends SectionProps<ProfileSectionPool> {
   query: FragmentType<typeof ProfileDiversityEquityInclusion_Fragment>;
 }
 

--- a/apps/web/src/components/Profile/components/LanguageProfile/LanguageProfile.tsx
+++ b/apps/web/src/components/Profile/components/LanguageProfile/LanguageProfile.tsx
@@ -7,7 +7,7 @@ import { Loading, ToggleSection, Notice } from "@gc-digital-talent/ui";
 import { BasicForm } from "@gc-digital-talent/forms";
 import { toast } from "@gc-digital-talent/toast";
 import { commonMessages } from "@gc-digital-talent/i18n";
-import type { FragmentType, Pool } from "@gc-digital-talent/graphql";
+import type { FragmentType } from "@gc-digital-talent/graphql";
 import { getFragment, graphql } from "@gc-digital-talent/graphql";
 
 import MissingLanguageRequirements from "~/components/MissingLanguageRequirements";
@@ -19,7 +19,7 @@ import {
 import { getMissingLanguageRequirements } from "~/utils/languageUtils";
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
 
-import type { SectionProps } from "../../types";
+import type { ProfileSectionPool, SectionProps } from "../../types";
 import FormActions from "../FormActions";
 import useSectionInfo from "../../hooks/useSectionInfo";
 import { dataToFormValues, formValuesToSubmitData } from "./utils";
@@ -73,7 +73,7 @@ const ProfileLanguageProfile_Fragment = graphql(/** GraphQL */ `
   }
 `);
 
-interface LanguageProfileProps extends SectionProps<Pick<Pool, "id">> {
+interface LanguageProfileProps extends SectionProps<ProfileSectionPool> {
   query: FragmentType<typeof ProfileLanguageProfile_Fragment>;
   languagePresetNoticeIsVisible: boolean;
   setLanguagePresetNoticeIsVisible: (isVisible: boolean) => void;

--- a/apps/web/src/components/Profile/components/PersonalInformation/PersonalInformation.tsx
+++ b/apps/web/src/components/Profile/components/PersonalInformation/PersonalInformation.tsx
@@ -8,7 +8,7 @@ import { Link, Loading, ToggleSection, Notice } from "@gc-digital-talent/ui";
 import { toast } from "@gc-digital-talent/toast";
 import { BasicForm } from "@gc-digital-talent/forms";
 import { commonMessages } from "@gc-digital-talent/i18n";
-import type { FragmentType, Pool } from "@gc-digital-talent/graphql";
+import type { FragmentType } from "@gc-digital-talent/graphql";
 import { getFragment, graphql } from "@gc-digital-talent/graphql";
 import { useLocalStorage } from "@gc-digital-talent/storage";
 
@@ -20,7 +20,7 @@ import {
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
 import useRoutes from "~/hooks/useRoutes";
 
-import type { SectionProps } from "../../types";
+import type { ProfileSectionPool, SectionProps } from "../../types";
 import FormActions from "../FormActions";
 import useSectionInfo from "../../hooks/useSectionInfo";
 import { formValuesToSubmitData, dataToFormValues } from "./utils";
@@ -60,7 +60,7 @@ const ProfilePersonalInformation_Fragment = graphql(/** GraphQL */ `
   }
 `);
 
-interface PersonalInformationProps extends SectionProps<Pick<Pool, "id">> {
+interface PersonalInformationProps extends SectionProps<ProfileSectionPool> {
   query: FragmentType<typeof ProfilePersonalInformation_Fragment>;
 }
 
@@ -93,7 +93,7 @@ const PersonalInformation = ({
   });
 
   const handleSubmit: SubmitHandler<FormValues> = async (formValues) => {
-    return onUpdate(user.id, formValuesToSubmitData(formValues, user))
+    return onUpdate(user.id, formValuesToSubmitData(formValues, user.id))
       .then((response) => {
         if (response) {
           toast.success(

--- a/apps/web/src/components/Profile/components/PersonalInformation/utils.ts
+++ b/apps/web/src/components/Profile/components/PersonalInformation/utils.ts
@@ -3,7 +3,6 @@ import type { IntlShape } from "react-intl";
 import { commonMessages } from "@gc-digital-talent/i18n";
 import type {
   UpdateUserAsUserInput,
-  User,
   ProfilePersonalInformationFragment as UserProfileFragmentType,
 } from "@gc-digital-talent/graphql";
 import {
@@ -66,11 +65,11 @@ export const dataToFormValues = (
 
 export const formValuesToSubmitData = (
   data: FormValues,
-  initialUser: Pick<User, "id">,
+  userId: string,
 ): UpdateUserAsUserInput => {
   return {
     ...data,
-    id: initialUser.id,
+    id: userId,
   };
 };
 

--- a/apps/web/src/components/Profile/components/WorkPreferences/WorkPreferences.tsx
+++ b/apps/web/src/components/Profile/components/WorkPreferences/WorkPreferences.tsx
@@ -7,7 +7,7 @@ import { Loading, ToggleSection, Notice } from "@gc-digital-talent/ui";
 import { BasicForm } from "@gc-digital-talent/forms";
 import { toast } from "@gc-digital-talent/toast";
 import { commonMessages } from "@gc-digital-talent/i18n";
-import type { FragmentType, Pool } from "@gc-digital-talent/graphql";
+import type { FragmentType } from "@gc-digital-talent/graphql";
 import { getFragment, graphql } from "@gc-digital-talent/graphql";
 
 import profileMessages from "~/messages/profileMessages";
@@ -17,7 +17,7 @@ import {
 } from "~/validators/profile/workPreferences";
 import ToggleForm from "~/components/ToggleForm/ToggleForm";
 
-import type { SectionProps } from "../../types";
+import type { ProfileSectionPool, SectionProps } from "../../types";
 import FormActions from "../FormActions";
 import useSectionInfo from "../../hooks/useSectionInfo";
 import { dataToFormValues, formValuesToSubmitData } from "./utils";
@@ -52,7 +52,7 @@ const ProfileWorkPreferences_Fragment = graphql(/** GraphQL */ `
   }
 `);
 
-interface WorkPreferencesProps extends SectionProps<Pick<Pool, "id">> {
+interface WorkPreferencesProps extends SectionProps<ProfileSectionPool> {
   query: FragmentType<typeof ProfileWorkPreferences_Fragment>;
 }
 

--- a/apps/web/src/components/Profile/types.ts
+++ b/apps/web/src/components/Profile/types.ts
@@ -1,9 +1,11 @@
 import type { FieldLabels } from "@gc-digital-talent/forms";
 import type {
   Application_PoolCandidateFragment,
+  PublishingGroup,
   UpdateUserAsUserInput,
   UpdateUserAsUserMutation,
 } from "@gc-digital-talent/graphql";
+import type { GenericLocalizedEnum } from "@gc-digital-talent/i18n";
 
 export type SectionKey =
   | "personal"
@@ -13,6 +15,11 @@ export type SectionKey =
   | "government"
   | "language"
   | "account";
+
+export interface ProfileSectionPool {
+  id: string;
+  publishingGroup?: GenericLocalizedEnum<PublishingGroup> | null;
+}
 
 export interface SectionProps<P = void> {
   isUpdating?: boolean;

--- a/apps/web/src/pages/Users/AdminUserAdvancedToolsPage/components/IndividualRoleTable.tsx
+++ b/apps/web/src/pages/Users/AdminUserAdvancedToolsPage/components/IndividualRoleTable.tsx
@@ -5,7 +5,7 @@ import { useIntl } from "react-intl";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 import { Heading } from "@gc-digital-talent/ui";
 import { commonMessages } from "@gc-digital-talent/i18n";
-import type { RoleAssignment } from "@gc-digital-talent/graphql";
+import type { AuthRoleAssignment } from "@gc-digital-talent/auth";
 
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import { normalizedText } from "~/components/Table/sortingFns";
@@ -16,7 +16,7 @@ import { getRoleTableFragments, roleCell } from "../utils";
 import RemoveIndividualRoleDialog from "./RemoveIndividualRoleDialog";
 import AddIndividualRoleDialog from "./AddIndividualRoleDialog";
 
-const columnHelper = createColumnHelper<RoleAssignment>();
+const columnHelper = createColumnHelper<AuthRoleAssignment>();
 
 const IndividualRoleTable = ({ query, optionsQuery }: RoleTableProps) => {
   const intl = useIntl();
@@ -41,7 +41,7 @@ const IndividualRoleTable = ({ query, optionsQuery }: RoleTableProps) => {
       header: intl.formatMessage(commonMessages.role),
       cell: ({ getValue }) => roleCell(getValue()),
     }),
-  ] as ColumnDef<RoleAssignment>[];
+  ] as ColumnDef<AuthRoleAssignment>[];
 
   const data = unpackMaybes(user.authInfo?.roleAssignments).filter(
     (assignment) => !assignment.role?.isTeamBased,
@@ -58,7 +58,7 @@ const IndividualRoleTable = ({ query, optionsQuery }: RoleTableProps) => {
       <Heading level="h3" size="h4" className="font-bold">
         {pageTitle}
       </Heading>
-      <Table<RoleAssignment>
+      <Table<AuthRoleAssignment>
         caption={pageTitle}
         data={data}
         columns={columns}

--- a/apps/web/src/pages/Users/AdminUserAdvancedToolsPage/components/RemoveCommunityRoleDialog.tsx
+++ b/apps/web/src/pages/Users/AdminUserAdvancedToolsPage/components/RemoveCommunityRoleDialog.tsx
@@ -16,11 +16,12 @@ import {
   formMessages,
   uiMessages,
 } from "@gc-digital-talent/i18n";
-import type { Role, RoleInput } from "@gc-digital-talent/graphql";
+import type { AuthCommunityTeamable, AuthRole } from "@gc-digital-talent/auth";
+import type { RoleInput } from "@gc-digital-talent/graphql";
 
 import { getFullNameHtml } from "~/utils/nameUtils";
 
-import type { CommunityTeamable, UserRoleDialogBaseProps } from "../utils";
+import type { UserRoleDialogBaseProps } from "../utils";
 import { getUserRoleDialogFragment, useUpdateRolesMutation } from "../utils";
 
 interface FormValues {
@@ -30,8 +31,8 @@ interface FormValues {
 }
 
 interface RemoveCommunityRoleDialogProps extends UserRoleDialogBaseProps {
-  community: CommunityTeamable;
-  roles: Role[];
+  community: AuthCommunityTeamable;
+  roles: AuthRole[];
 }
 
 const RemoveCommunityRoleDialog = ({

--- a/apps/web/src/pages/Users/AdminUserAdvancedToolsPage/components/RemoveDepartmentRoleDialog.tsx
+++ b/apps/web/src/pages/Users/AdminUserAdvancedToolsPage/components/RemoveDepartmentRoleDialog.tsx
@@ -16,11 +16,12 @@ import {
   formMessages,
   uiMessages,
 } from "@gc-digital-talent/i18n";
-import type { Role, RoleInput } from "@gc-digital-talent/graphql";
+import type { AuthDepartmentTeamable, AuthRole } from "@gc-digital-talent/auth";
+import type { RoleInput } from "@gc-digital-talent/graphql";
 
 import { getFullNameHtml } from "~/utils/nameUtils";
 
-import type { DepartmentTeamable, UserRoleDialogBaseProps } from "../utils";
+import type { UserRoleDialogBaseProps } from "../utils";
 import { getUserRoleDialogFragment, useUpdateRolesMutation } from "../utils";
 
 interface FormValues {
@@ -30,8 +31,8 @@ interface FormValues {
 }
 
 interface RemoveDepartmentRoleDialogProps extends UserRoleDialogBaseProps {
-  department: DepartmentTeamable;
-  roles: Role[];
+  department: AuthDepartmentTeamable;
+  roles: AuthRole[];
 }
 
 const RemoveDepartmentRoleDialog = ({

--- a/apps/web/src/pages/Users/AdminUserAdvancedToolsPage/components/RemoveIndividualRoleDialog.tsx
+++ b/apps/web/src/pages/Users/AdminUserAdvancedToolsPage/components/RemoveIndividualRoleDialog.tsx
@@ -9,7 +9,7 @@ import {
   formMessages,
   uiMessages,
 } from "@gc-digital-talent/i18n";
-import type { Role } from "@gc-digital-talent/graphql";
+import type { AuthRole } from "@gc-digital-talent/auth";
 
 import { getFullNameHtml } from "~/utils/nameUtils";
 
@@ -22,7 +22,7 @@ interface FormValues {
 }
 
 interface RemoveIndividualRoleDialogProps extends UserRoleDialogBaseProps {
-  role: Role;
+  role: AuthRole;
 }
 
 const RemoveIndividualRoleDialog = ({

--- a/apps/web/src/pages/Users/AdminUserAdvancedToolsPage/components/RemoveProcessRoleDialog.tsx
+++ b/apps/web/src/pages/Users/AdminUserAdvancedToolsPage/components/RemoveProcessRoleDialog.tsx
@@ -16,11 +16,12 @@ import {
   formMessages,
   uiMessages,
 } from "@gc-digital-talent/i18n";
-import type { Role, RoleInput } from "@gc-digital-talent/graphql";
+import type { AuthPoolTeamable, AuthRole } from "@gc-digital-talent/auth";
+import type { RoleInput } from "@gc-digital-talent/graphql";
 
 import { getFullNameHtml } from "~/utils/nameUtils";
 
-import type { PoolTeamable, UserRoleDialogBaseProps } from "../utils";
+import type { UserRoleDialogBaseProps } from "../utils";
 import { getUserRoleDialogFragment, useUpdateRolesMutation } from "../utils";
 
 interface FormValues {
@@ -30,8 +31,8 @@ interface FormValues {
 }
 
 interface RemoveProcessRoleDialogProps extends UserRoleDialogBaseProps {
-  pool: PoolTeamable;
-  roles: Role[];
+  pool: AuthPoolTeamable;
+  roles: AuthRole[];
 }
 
 const RemoveProcessRoleDialog = ({

--- a/apps/web/src/pages/Users/AdminUserAdvancedToolsPage/useAvailablePools.ts
+++ b/apps/web/src/pages/Users/AdminUserAdvancedToolsPage/useAvailablePools.ts
@@ -1,8 +1,22 @@
 import { useQuery } from "urql";
 
-import type { Pool, PoolFilterInput } from "@gc-digital-talent/graphql";
-import { graphql } from "@gc-digital-talent/graphql";
+import type {
+  AvailablePoolFragment,
+  PoolFilterInput,
+} from "@gc-digital-talent/graphql";
+import { getFragment, graphql } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
+
+const AvailablePool_Fragment = graphql(/* GraphQL */ `
+  fragment AvailablePool on Pool {
+    id
+    name {
+      en
+      fr
+    }
+    teamIdForRoleAssignment
+  }
+`);
 
 const EditUserPage_AvailablePoolsQuery = graphql(/* GraphQL */ `
   query EditUserPage_AvailablePools(
@@ -24,12 +38,7 @@ const EditUserPage_AvailablePoolsQuery = graphql(/* GraphQL */ `
       orderBy: $orderBy
     ) {
       data {
-        id
-        name {
-          en
-          fr
-        }
-        teamIdForRoleAssignment
+        ...AvailablePool
       }
       paginatorInfo {
         total
@@ -39,7 +48,7 @@ const EditUserPage_AvailablePoolsQuery = graphql(/* GraphQL */ `
 `);
 
 interface UseAvailablePoolsReturn {
-  pools: Omit<Pool, "activities" | "teamId" | "wasClosedEarly">[];
+  pools: AvailablePoolFragment[];
   total: number;
   fetching: boolean;
 }
@@ -57,7 +66,10 @@ const useAvailablePools = (
     },
   });
 
-  const pools = unpackMaybes(data?.poolsPaginated?.data);
+  const pools = getFragment(
+    AvailablePool_Fragment,
+    unpackMaybes(data?.poolsPaginated?.data),
+  );
   const total = data?.poolsPaginated.paginatorInfo?.total ?? pools.length;
 
   return {

--- a/apps/web/src/pages/Users/AdminUserAdvancedToolsPage/utils.tsx
+++ b/apps/web/src/pages/Users/AdminUserAdvancedToolsPage/utils.tsx
@@ -4,12 +4,14 @@ import type { DefaultValues, FieldValues } from "react-hook-form";
 import { useForm } from "react-hook-form";
 
 import type {
-  Community,
-  Department,
+  AuthCommunityTeamable,
+  AuthDepartmentTeamable,
+  AuthPoolTeamable,
+  AuthRole,
+  AuthTeamable,
+} from "@gc-digital-talent/auth";
+import type {
   FragmentType,
-  Pool,
-  Role,
-  Team,
   UpdateUserRolesInput,
 } from "@gc-digital-talent/graphql";
 import { getFragment, graphql } from "@gc-digital-talent/graphql";
@@ -174,48 +176,23 @@ export const useUpdateRolesMutation = <TFormValues extends FieldValues>(
   return { fetching, updateRoles, methods };
 };
 
-export type PoolTeamable = Pick<
-  Pool,
-  "id" | "__typename" | "name" | "teamIdForRoleAssignment"
->;
-
-export type CommunityTeamable = Pick<
-  Community,
-  "id" | "__typename" | "name" | "teamIdForRoleAssignment"
->;
-
-export type DepartmentTeamable = Pick<
-  Department,
-  "id" | "__typename" | "teamIdForRoleAssignment"
-> & {
-  departmentName: {
-    __typename?: "LocalizedString" | undefined;
-    localized?: string | null | undefined;
-  };
-};
-
-type TeamTeamable = Pick<Team, "id" | "__typename">;
-
-type Teamable =
-  PoolTeamable | CommunityTeamable | TeamTeamable | DepartmentTeamable;
-
 export interface PoolAssignment {
-  pool: PoolTeamable;
-  roles: Role[];
+  pool: AuthPoolTeamable;
+  roles: AuthRole[];
 }
 export interface CommunityAssignment {
-  community: CommunityTeamable;
-  roles: Role[];
+  community: AuthCommunityTeamable;
+  roles: AuthRole[];
 }
 
 export interface DepartmentAssignment {
-  department: DepartmentTeamable;
-  roles: Role[];
+  department: AuthDepartmentTeamable;
+  roles: AuthRole[];
 }
 
 export const isCommunityTeamable = (
-  teamable: Teamable | undefined | null,
-): teamable is CommunityTeamable => {
+  teamable: AuthTeamable | undefined | null,
+): teamable is AuthCommunityTeamable => {
   if (teamable?.__typename === "Community") {
     return true;
   }
@@ -223,8 +200,8 @@ export const isCommunityTeamable = (
 };
 
 export const isPoolTeamable = (
-  teamable: Teamable | undefined | null,
-): teamable is PoolTeamable => {
+  teamable: AuthTeamable | undefined | null,
+): teamable is AuthPoolTeamable => {
   if (teamable?.__typename === "Pool") {
     return true;
   }
@@ -232,8 +209,8 @@ export const isPoolTeamable = (
 };
 
 export const isDepartmentTeamable = (
-  teamable: Teamable | undefined | null,
-): teamable is DepartmentTeamable => {
+  teamable: AuthTeamable | undefined | null,
+): teamable is AuthDepartmentTeamable => {
   if (teamable?.__typename === "Department") {
     return true;
   }

--- a/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/UserTable.tsx
@@ -11,14 +11,13 @@ import { useQuery } from "urql";
 import { useState, useMemo, useRef } from "react";
 
 import { Link } from "@gc-digital-talent/ui";
-import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
-import {
-  commonMessages,
-  getLocalizedName,
-  navigationMessages,
-} from "@gc-digital-talent/i18n";
-import type { User, UserFilterInput } from "@gc-digital-talent/graphql";
-import { graphql } from "@gc-digital-talent/graphql";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
+import { commonMessages, navigationMessages } from "@gc-digital-talent/i18n";
+import type {
+  UserFilterInput,
+  UserTableRowFragment as UserTableRowFragmentType,
+} from "@gc-digital-talent/graphql";
+import { getFragment, graphql } from "@gc-digital-talent/graphql";
 
 import Table, {
   getTableStateFromSearchParams,
@@ -48,7 +47,7 @@ import {
 import type { FormValues } from "./UserFilterDialog";
 import UserFilterDialog from "./UserFilterDialog";
 
-const columnHelper = createColumnHelper<User>();
+const columnHelper = createColumnHelper<UserTableRowFragmentType>();
 
 const defaultState = {
   ...INITIAL_STATE,
@@ -70,6 +69,43 @@ const defaultState = {
   },
 };
 
+const UserTableRow_Fragment = graphql(/* GraphQL */ `
+  fragment UserTableRow on User {
+    id
+    email
+    isGovEmployee
+    workEmail
+    firstName
+    lastName
+    telephone
+    preferredLang {
+      label {
+        localized
+      }
+    }
+    flexibleWorkLocations {
+      label {
+        localized
+      }
+    }
+    lookingForEnglish
+    lookingForFrench
+    lookingForBilingual
+    createdDate
+    updatedDate
+    authInfo {
+      roleAssignments {
+        role {
+          name
+          displayName {
+            localized
+          }
+        }
+      }
+    }
+  }
+`);
+
 const UsersPaginated_Query = graphql(/* GraphQL */ `
   query UsersPaginated(
     $where: UserFilterInput
@@ -84,58 +120,7 @@ const UsersPaginated_Query = graphql(/* GraphQL */ `
       orderBy: $orderBy
     ) {
       data {
-        id
-        email
-        isGovEmployee
-        workEmail
-        firstName
-        lastName
-        telephone
-        preferredLang {
-          value
-          label {
-            en
-            fr
-          }
-        }
-        preferredLanguageForInterview {
-          value
-          label {
-            en
-            fr
-          }
-        }
-        preferredLanguageForExam {
-          value
-          label {
-            en
-            fr
-          }
-        }
-        flexibleWorkLocations {
-          value
-          label {
-            localized
-          }
-        }
-        lookingForEnglish
-        lookingForFrench
-        lookingForBilingual
-        createdDate
-        updatedDate
-        authInfo {
-          id
-          roleAssignments {
-            id
-            role {
-              id
-              name
-              displayName {
-                localized
-              }
-            }
-          }
-        }
+        ...UserTableRow
       }
       paginatorInfo {
         count
@@ -303,7 +288,12 @@ const UserTable = ({ title }: UserTableProps) => {
     }),
     columnHelper.accessor(
       (user) =>
-        rolesAccessor(unpackMaybes(user?.authInfo?.roleAssignments), intl),
+        rolesAccessor(
+          unpackMaybes(user?.authInfo?.roleAssignments).map(
+            (assignment) => assignment.role,
+          ),
+          intl,
+        ),
       {
         id: "rolesAndPermissions",
         header: intl.formatMessage(adminMessages.rolesAndPermissions),
@@ -317,7 +307,9 @@ const UserTable = ({ title }: UserTableProps) => {
       cell: ({ getValue }) => cells.phone(getValue()),
     }),
     columnHelper.accessor(
-      ({ preferredLang }) => getLocalizedName(preferredLang?.label, intl),
+      ({ preferredLang }) =>
+        preferredLang?.label?.localized ??
+        intl.formatMessage(commonMessages.notAvailable),
       {
         id: "preferredLang",
         enableColumnFilter: false,
@@ -382,7 +374,7 @@ const UserTable = ({ title }: UserTableProps) => {
         },
       }) => cells.date(updatedDate, intl),
     }),
-  ] as ColumnDef<User>[];
+  ] as ColumnDef<UserTableRowFragmentType>[];
 
   const [{ data, fetching }] = useQuery({
     query: UsersPaginated_Query,
@@ -400,15 +392,14 @@ const UserTable = ({ title }: UserTableProps) => {
     },
   });
 
-  const filteredData: User[] = useMemo(() => {
-    const users = data?.usersPaginated?.data ?? [];
-    return users.filter(notEmpty);
-  }, [data?.usersPaginated?.data]);
+  const filteredData = unpackMaybes(
+    getFragment(UserTableRow_Fragment, data?.usersPaginated?.data),
+  );
 
   const hasSelectedRows = selectedRows.length > 0;
 
   return (
-    <Table<User, UserFilterInput>
+    <Table<UserTableRowFragmentType, UserFilterInput>
       data={filteredData}
       caption={title}
       columns={columns}

--- a/apps/web/src/pages/Users/IndexUserPage/components/utils.tsx
+++ b/apps/web/src/pages/Users/IndexUserPage/components/utils.tsx
@@ -8,8 +8,8 @@ import {
 } from "@gc-digital-talent/helpers";
 import { commonMessages, EmploymentDuration } from "@gc-digital-talent/i18n";
 import type {
+  LocalizedString,
   OrderByClause,
-  RoleAssignment,
   UserFilterInput,
 } from "@gc-digital-talent/graphql";
 import {
@@ -24,13 +24,15 @@ import type { FormValues, OtherFilter } from "./UserFilterDialog";
 import { OTHER_FILTER } from "./UserFilterDialog";
 import ROLES_TO_HIDE_USERS_TABLE from "./constants";
 
+interface DisplayRole {
+  name: string;
+  displayName?: LocalizedString | null;
+}
+
 export function rolesAccessor(
-  roleAssignments: RoleAssignment[],
+  roles: (DisplayRole | null | undefined)[],
   intl: IntlShape,
 ): string | null {
-  if (!roleAssignments) return null;
-
-  const roles = roleAssignments.map((roleAssignment) => roleAssignment.role);
   const rolesToDisplay = unpackMaybes(roles)
     .filter((role) => !ROLES_TO_HIDE_USERS_TABLE.includes(role.name))
     .map(

--- a/packages/auth/src/index.tsx
+++ b/packages/auth/src/index.tsx
@@ -34,7 +34,16 @@ import {
 } from "./const";
 import type { LogoutReason, RoleName } from "./const";
 import getAuthenticationState from "./utils/authenticationState";
-import type { AuthenticationState, AuthRoleAssignment } from "./types";
+import type {
+  AuthCommunityTeamable,
+  AuthDepartmentTeamable,
+  AuthenticationState,
+  AuthPoolTeamable,
+  AuthRole,
+  AuthRoleAssignment,
+  AuthTeamable,
+  AuthTeamTeamable,
+} from "./types";
 import { setTokensFromLocation } from "./utils/setTokensFromLocation";
 
 export {
@@ -74,7 +83,13 @@ export type {
   RoleName,
   LogoutReason,
   AuthenticationState,
+  AuthCommunityTeamable,
+  AuthDepartmentTeamable,
+  AuthPoolTeamable,
+  AuthRole,
   AuthRoleAssignment,
+  AuthTeamable,
+  AuthTeamTeamable,
   RoleRequirement,
   PermissionRequirement,
   HasRequiredRolesArgs,

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -6,7 +6,7 @@ export interface AuthenticationState {
   refreshTokenSet: () => Promise<void>;
 }
 
-interface AuthRole {
+export interface AuthRole {
   id: string;
   name: string;
   isTeamBased?: boolean | null;
@@ -18,6 +18,38 @@ interface AuthTeam {
   id: string;
   name: string;
 }
+
+export interface AuthPoolTeamable {
+  __typename: "Pool";
+  id: string;
+  name?: LocalizedString | null;
+  teamIdForRoleAssignment?: string | null;
+}
+
+export interface AuthCommunityTeamable {
+  __typename: "Community";
+  id: string;
+  name?: LocalizedString | null;
+  teamIdForRoleAssignment?: string | null;
+}
+
+export interface AuthDepartmentTeamable {
+  __typename: "Department";
+  id: string;
+  departmentName: LocalizedString;
+  teamIdForRoleAssignment?: string | null;
+}
+
+export interface AuthTeamTeamable {
+  __typename: "Team";
+  id: string;
+}
+
+export type AuthTeamable =
+  | AuthPoolTeamable
+  | AuthCommunityTeamable
+  | AuthDepartmentTeamable
+  | AuthTeamTeamable;
 
 export interface AuthRoleAssignment {
   id: string;


### PR DESCRIPTION
Related: #17227 

## 👋 Introduction

Removes the full graphql object types from the users section.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to `/admin/users`
4. Confirm the index page still functions and all information is present
5. BNavigate to a few users in the table
6. Confirm the display of each tab is accurate, no errors and has all informaiton rendered