### PR TITLE
[Refactor] Move matching candidates to details tab

### DIFF
--- a/apps/playwright/tests/admin/talent-requests-validation.spec.ts
+++ b/apps/playwright/tests/admin/talent-requests-validation.spec.ts
@@ -191,15 +191,20 @@ test.describe("Talent search", () => {
         level: 2,
       }),
     ).toBeVisible();
+    await expect(
+      appPage.page.getByRole("heading", {
+        name: /Find matching candidates/i,
+        level: 2,
+      }),
+    ).toBeVisible();
     await appPage.page.goto(`/en/admin/talent-requests/${requestId}/tracking`);
     const trackingPageHeadings = appPage.page.getByRole("heading", {
       level: 2,
     });
-    await expect(trackingPageHeadings).toHaveCount(3);
+    await expect(trackingPageHeadings).toHaveCount(2);
     await expect(trackingPageHeadings).toHaveText([
       /Test user/i,
       /Candidate tracking/i,
-      /Find matching candidates/i,
     ]);
   });
 
@@ -293,9 +298,6 @@ test.describe("Talent search", () => {
     });
 
     await test.step("Verify no candidates are displayed in the talent requests", async () => {
-      await appPage.page.goto(
-        `/en/admin/talent-requests/${requestId}/tracking`,
-      );
       await tableValidation.noCandidatesFound();
     });
   });

--- a/apps/web/src/pages/TalentRequests/Details.tsx
+++ b/apps/web/src/pages/TalentRequests/Details.tsx
@@ -1,4 +1,6 @@
 import { useQuery } from "urql";
+import MagnifyingGlassPlusIcon from "@heroicons/react/24/outline/MagnifyingGlassPlusIcon";
+import { useIntl } from "react-intl";
 
 import { Pending, ThrowNotFound } from "@gc-digital-talent/ui";
 import { ROLE_NAME } from "@gc-digital-talent/auth";
@@ -19,6 +21,9 @@ import TalentRequestDetailsCard from "./components/TalentRequestDetailsCard";
 import TalentRequestSourcesCard from "./components/TalentRequestSourcesCard";
 import TalentRequestCriteriaCard from "./components/TalentRequestCriteriaCard";
 import TalentRequestEmptyNotice from "./components/TalentRequestEmptyNotice";
+import TalentRequestSectionCard from "./components/TalentRequestSectionCard";
+import TalentRequestMatchesTable from "./components/TalentRequestMatchesTable/TalentRequestMatchesTable";
+import type { TalentRequestReferralDialogOptions } from "./components/TalentRequestReferralDialogs/ReferralFormFields";
 
 const TalentRequestDetails_Fragment = graphql(/** GraphQL */ `
   fragment TalentRequestDetails on TalentRequest {
@@ -26,15 +31,28 @@ const TalentRequestDetails_Fragment = graphql(/** GraphQL */ `
     ...TalentRequestDetailsCard
     ...TalentRequestSourcesCard
     ...TalentRequestCriteriaCard
+    ...TalentRequestMatchesTableTalentRequest
+
+    applicantFilter {
+      skills {
+        ...TalentRequestUserSkillMatch
+      }
+    }
   }
 `);
 
 interface DetailsProps {
   query: FragmentType<typeof TalentRequestDetails_Fragment>;
   optionsQuery?: FragmentType<typeof TalentRequestSourceOptions_Fragment>;
+  referralOptionsQuery?: TalentRequestReferralDialogOptions;
 }
 
-const Details = ({ query, optionsQuery }: DetailsProps) => {
+const Details = ({
+  query,
+  optionsQuery,
+  referralOptionsQuery,
+}: DetailsProps) => {
+  const intl = useIntl();
   const talentRequest = getFragment(TalentRequestDetails_Fragment, query);
   const talentSourceOptions = narrowEnumType(
     unpackMaybes(
@@ -53,6 +71,29 @@ const Details = ({ query, optionsQuery }: DetailsProps) => {
         talentSourceOptions={talentSourceOptions}
       />
       <TalentRequestCriteriaCard query={talentRequest} />
+      <TalentRequestSectionCard
+        color="warning"
+        icon={MagnifyingGlassPlusIcon}
+        title={intl.formatMessage({
+          defaultMessage: "Find matching candidates",
+          id: "CtcCZj",
+          description:
+            "Heading for the table that contains users who match talent request criteria",
+        })}
+        subtitle={intl.formatMessage({
+          defaultMessage:
+            "This list is always up-to-date, find new candidates that match to this talent request.",
+          id: "JT8Azd",
+          description:
+            "Description of the table showing users who match talent request criteria",
+        })}
+      >
+        <TalentRequestMatchesTable
+          query={talentRequest}
+          skillsQuery={unpackMaybes(talentRequest?.applicantFilter?.skills)}
+          optionsQuery={referralOptionsQuery}
+        />
+      </TalentRequestSectionCard>
     </div>
   );
 };
@@ -63,6 +104,7 @@ const TalentRequestDetails_Query = graphql(/** GraphQL */ `
       ...TalentRequestDetails
     }
     ...TalentRequestSourceOptionsFragment
+    ...TalentRequestReferralDialogOptions
   }
 `);
 

--- a/apps/web/src/pages/TalentRequests/Tracking.tsx
+++ b/apps/web/src/pages/TalentRequests/Tracking.tsx
@@ -1,26 +1,21 @@
 import { useIntl } from "react-intl";
 import MapPinIcon from "@heroicons/react/24/outline/MapPinIcon";
-import MagnifyingGlassPlusIcon from "@heroicons/react/24/outline/MagnifyingGlassPlusIcon";
 import { useQuery, type OperationContext } from "urql";
 
-import { Pending, ThrowNotFound } from "@gc-digital-talent/ui";
 import { ROLE_NAME } from "@gc-digital-talent/auth";
 import { graphql } from "@gc-digital-talent/graphql";
-import { unpackMaybes } from "@gc-digital-talent/helpers";
 
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import talentRequestMessages from "~/messages/talentRequestMessages";
 import useRequiredParams from "~/hooks/useRequiredParams";
 
 import TalentRequestSectionCard from "./components/TalentRequestSectionCard";
-import TalentRequestMatchesTable from "./components/TalentRequestMatchesTable/TalentRequestMatchesTable";
 import TalentRequestTrackedUsersInbox from "./components/TalentRequestTrackedUsersInbox/TalentRequestTrackedUsersInbox";
 import type { RouteParams } from "./types";
 
 const TalentRequestTracking_Query = graphql(/** GraphQL */ `
   query TalentRequestTracking($id: UUID!) {
     talentRequest(id: $id) {
-      ...TalentRequestMatchesTableTalentRequest
       applicantFilter {
         skills {
           ...TalentRequestUserSkillMatch
@@ -41,7 +36,7 @@ const context: Partial<OperationContext> = {
 const Tracking = () => {
   const intl = useIntl();
   const { talentRequestId } = useRequiredParams<RouteParams>("talentRequestId");
-  const [{ data, fetching, error }] = useQuery({
+  const [{ data }] = useQuery({
     query: TalentRequestTracking_Query,
     variables: { id: talentRequestId },
     context,
@@ -68,38 +63,6 @@ const Tracking = () => {
             data?.talentRequest?.applicantFilter?.skills?.length ?? 0
           }
         />
-      </TalentRequestSectionCard>
-
-      <TalentRequestSectionCard
-        color="warning"
-        icon={MagnifyingGlassPlusIcon}
-        title={intl.formatMessage({
-          defaultMessage: "Find matching candidates",
-          id: "CtcCZj",
-          description:
-            "Heading for the table that contains users who match talent request criteria",
-        })}
-        subtitle={intl.formatMessage({
-          defaultMessage:
-            "This list is always up-to-date, find new candidates that match to this talent request.",
-          id: "JT8Azd",
-          description:
-            "Description of the table showing users who match talent request criteria",
-        })}
-      >
-        <Pending fetching={fetching} error={error}>
-          {data?.talentRequest ? (
-            <TalentRequestMatchesTable
-              query={data.talentRequest}
-              skillsQuery={unpackMaybes(
-                data?.talentRequest?.applicantFilter?.skills,
-              )}
-              optionsQuery={data}
-            />
-          ) : (
-            <ThrowNotFound />
-          )}
-        </Pending>
       </TalentRequestSectionCard>
     </div>
   );


### PR DESCRIPTION
🤖 Resolves #17633 

## 👋 Introduction

This moves the mathcing candidates table to the details tab on the talent request page where it is most useful to admins.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to `/admin/talent-requests`
4. Navigate to a few of the talent requests in the table
5. Confirm the matching candidates table appears on the details tab and functions as expected

## 📸 Screenshot

<img width="3413" height="3739" alt="localhost_8000_en_admin_talent-requests_500bcbe7-ff1c-42f2-8bff-f3f3f3757d12" src="https://github.com/user-attachments/assets/0e0bb4e8-0f94-49e3-9cdd-afac640f60d2" />
