### PR TITLE
[Fix] `SignInPage` font color

### DIFF
--- a/apps/web/src/pages/Auth/SignInPage/SignInPage.tsx
+++ b/apps/web/src/pages/Auth/SignInPage/SignInPage.tsx
@@ -385,7 +385,7 @@ export const Component = () => {
               </p>
 
               <div className="mt-2 mb-6.75">
-                <span className="text-sm font-normal text-gray-500 dark:text-gray-100">
+                <span className="text-sm font-normal text-gray-600 dark:text-gray-100">
                   {intl.formatMessage({
                     defaultMessage:
                       "Using a personal phone number will help ensure you don't lose access if you change jobs.",


### PR DESCRIPTION
🤖 Resolves #17678.

## 👋 Introduction

This PR fixes the `SignInPage` component insufficient color contrast on some of its text.

## 🧪 Testing

1. `pnpm storybook`
2. Navigate to http://localhost:6006/?path=/story/pages-auth-signinpage--default
3. Verify no a11y violations