### PR TITLE
[Refactor] Remove full graphql object types 7

### DIFF
--- a/apps/web/src/components/SkillBrowser/SkillBrowser.stories.tsx
+++ b/apps/web/src/components/SkillBrowser/SkillBrowser.stories.tsx
@@ -4,16 +4,20 @@ import { action } from "storybook/actions";
 import { getStaticSkills } from "@gc-digital-talent/fake-data";
 import { BasicForm } from "@gc-digital-talent/forms";
 import { Button } from "@gc-digital-talent/ui";
+import { makeFragmentData } from "@gc-digital-talent/graphql";
 
 import SkillBrowser from "./SkillBrowser";
+import { SkillBrowserSkill_Fragment } from "./SkillSelection";
 import type { FormValues } from "./types";
 
-const mockSkills = getStaticSkills();
+const mockSkills = getStaticSkills().map((skill) =>
+  makeFragmentData(skill, SkillBrowserSkill_Fragment),
+);
 
 export default {
   component: SkillBrowser,
   args: {
-    skills: mockSkills,
+    query: mockSkills,
     name: "skills",
   },
 };

--- a/apps/web/src/components/SkillBrowser/SkillBrowser.tsx
+++ b/apps/web/src/components/SkillBrowser/SkillBrowser.tsx
@@ -1,14 +1,17 @@
-import { useId, useMemo, useEffect } from "react";
+import { useId, useEffect } from "react";
 import { useIntl } from "react-intl";
 import type { RegisterOptions } from "react-hook-form";
 import { useFormContext } from "react-hook-form";
 
-import { getLocalizedName } from "@gc-digital-talent/i18n";
+import { commonMessages } from "@gc-digital-talent/i18n";
 import { Combobox, Select } from "@gc-digital-talent/forms";
 import { normalizeString } from "@gc-digital-talent/helpers";
+import type { FragmentType } from "@gc-digital-talent/graphql";
+import { getFragment } from "@gc-digital-talent/graphql";
 
-import type { BaseSkillBrowserProps, FormValues } from "./types";
+import type { FormValues } from "./types";
 import skillBrowserMessages from "./messages";
+import { SkillBrowserSkill_Fragment } from "./SkillSelection";
 import {
   INPUT_NAME,
   getFamilyOptions,
@@ -16,19 +19,21 @@ import {
   getFilteredSkills,
 } from "./utils";
 
-interface SkillBrowserProps extends BaseSkillBrowserProps {
+interface SkillBrowserProps {
+  query: FragmentType<typeof SkillBrowserSkill_Fragment>[];
   name: string;
   isMulti?: boolean;
   rules?: RegisterOptions;
 }
 
 const SkillBrowser = ({
-  skills,
+  query,
   name,
   rules,
   isMulti = true,
 }: SkillBrowserProps) => {
   const intl = useIntl();
+  const skills = getFragment(SkillBrowserSkill_Fragment, query);
   const id = useId();
   const inputNames = {
     category: `${id}-${INPUT_NAME.CATEGORY}`,
@@ -40,27 +45,28 @@ const SkillBrowser = ({
   }>();
   const [family, skillValue] = watch([inputNames.family, name]);
 
-  const filteredFamilies = useMemo(() => {
-    return getFilteredFamilies({ skills }).sort((familyA, familyB) => {
-      const a = normalizeString(getLocalizedName(familyA.name, intl));
-      const b = normalizeString(getLocalizedName(familyB.name, intl));
+  const filteredFamilies = getFilteredFamilies({ skills: [...skills] }).sort(
+    (familyA, familyB) => {
+      const a = normalizeString(familyA.name?.localized ?? "");
+      const b = normalizeString(familyB.name?.localized ?? "");
 
       if (a === b) return 0;
 
       return a > b ? 1 : -1;
-    });
-  }, [skills, intl]);
+    },
+  );
 
-  const filteredSkills = useMemo(() => {
-    return getFilteredSkills({ skills, family }).sort((skillA, skillB) => {
-      const a = normalizeString(getLocalizedName(skillA.name, intl));
-      const b = normalizeString(getLocalizedName(skillB.name, intl));
+  const filteredSkills = getFilteredSkills({
+    skills: [...skills],
+    family,
+  }).sort((skillA, skillB) => {
+    const a = normalizeString(skillA.name?.localized ?? "");
+    const b = normalizeString(skillB.name?.localized ?? "");
 
-      if (a === b) return 0;
+    if (a === b) return 0;
 
-      return a > b ? 1 : -1;
-    });
-  }, [family, skills, intl]);
+    return a > b ? 1 : -1;
+  });
 
   useEffect(() => {
     resetField("skill");
@@ -76,7 +82,11 @@ const SkillBrowser = ({
     }
   }, [skillValue, family, setValue, inputNames.family]);
 
-  const familyOptions = getFamilyOptions(skills, intl);
+  const familyOptions = getFamilyOptions(
+    skills.map((currentSkill) => currentSkill.id),
+    intl,
+  );
+  const notAvailable = intl.formatMessage(commonMessages.notAvailable);
 
   return (
     <div className="mb-6 grid gap-6 sm:grid-cols-3">
@@ -93,7 +103,7 @@ const SkillBrowser = ({
           ...familyOptions,
           ...filteredFamilies.map((skillFamily) => ({
             value: skillFamily.id,
-            label: getLocalizedName(skillFamily.name, intl),
+            label: skillFamily.name?.localized ?? notAvailable,
           })),
         ]}
       />
@@ -108,7 +118,7 @@ const SkillBrowser = ({
           label={intl.formatMessage(skillBrowserMessages.skill)}
           options={filteredSkills.map((currentSkill) => ({
             value: currentSkill.id,
-            label: getLocalizedName(currentSkill.name, intl),
+            label: currentSkill.name?.localized ?? notAvailable,
           }))}
         />
       </div>

--- a/apps/web/src/components/SkillBrowser/SkillBrowserDialog.stories.tsx
+++ b/apps/web/src/components/SkillBrowser/SkillBrowserDialog.stories.tsx
@@ -4,18 +4,21 @@ import { faker } from "@faker-js/faker/locale/en";
 
 import { OverlayOrDialogDecorator } from "@gc-digital-talent/storybook-helpers";
 import { getStaticSkills } from "@gc-digital-talent/fake-data";
-import type { Skill } from "@gc-digital-talent/graphql";
+import { makeFragmentData } from "@gc-digital-talent/graphql";
 
 import SkillBrowserDialog from "./SkillBrowserDialog";
+import { SkillBrowserSkill_Fragment } from "./SkillSelection";
 import type { FormValues } from "./types";
 
-const mockSkills = getStaticSkills();
+const mockSkills = getStaticSkills().map((skill) =>
+  makeFragmentData(skill, SkillBrowserSkill_Fragment),
+);
 
 export default {
   component: SkillBrowserDialog,
   decorators: [OverlayOrDialogDecorator],
   args: {
-    skills: mockSkills,
+    query: mockSkills,
     defaultOpen: true,
   },
 };
@@ -51,5 +54,5 @@ ShowcaseContext.args = {
 export const ShowcaseShowMyLibraryContext = Template.bind({});
 ShowcaseShowMyLibraryContext.args = {
   context: "showcase",
-  inLibrary: faker.helpers.arrayElements<Skill>(mockSkills, 15),
+  inLibraryQuery: faker.helpers.arrayElements(mockSkills, 15),
 };

--- a/apps/web/src/components/SkillBrowser/SkillBrowserDialog.tsx
+++ b/apps/web/src/components/SkillBrowser/SkillBrowserDialog.tsx
@@ -6,29 +6,33 @@ import { useEffect, useState } from "react";
 
 import type { ButtonProps, IconType } from "@gc-digital-talent/ui";
 import { Button, Dialog, Link } from "@gc-digital-talent/ui";
-import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
+import { commonMessages } from "@gc-digital-talent/i18n";
 import { toast } from "@gc-digital-talent/toast";
-import type { Skill } from "@gc-digital-talent/graphql";
-import { SkillCategory } from "@gc-digital-talent/graphql";
+import type { FragmentType } from "@gc-digital-talent/graphql";
+import { getFragment, SkillCategory } from "@gc-digital-talent/graphql";
 
 import SkillDetails from "./SkillDetails";
-import SkillSelection from "./SkillSelection";
+import SkillSelection, { SkillBrowserSkill_Fragment } from "./SkillSelection";
 import {
   defaultFormValues,
   getSkillBrowserDialogMessages,
   showDetails,
 } from "./utils";
-import type { SkillBrowserDialogContext, FormValues } from "./types";
+import type {
+  SkillBrowserDialogContext,
+  FormValues,
+  SelectedSkill,
+} from "./types";
 import SkillDetailsPool from "./SkillDetailsPool";
 import useRoutes from "../../hooks/useRoutes";
 
 interface SkillBrowserDialogProps {
   // All available skills
-  skills: Skill[];
+  query: FragmentType<typeof SkillBrowserSkill_Fragment>[];
   // The context in which the dialog is being used
   context?: SkillBrowserDialogContext;
   // Currently selected skills (only needed if you want to display them in the selection)
-  inLibrary?: Skill[];
+  inLibraryQuery?: FragmentType<typeof SkillBrowserSkill_Fragment>[];
   // Should the dialog be open on page load?
   defaultOpen?: boolean;
   // Customize the trigger text and icon
@@ -50,11 +54,11 @@ interface SkillBrowserDialogProps {
 }
 
 const SkillBrowserDialog = ({
-  skills,
+  query,
   onSave,
   context,
   trigger,
-  inLibrary,
+  inLibraryQuery,
   initialState,
   defaultOpen = false,
   noToast = false,
@@ -65,7 +69,9 @@ const SkillBrowserDialog = ({
   const paths = useRoutes();
   const [isOpen, setIsOpen] = useState<boolean>(defaultOpen);
   const [adding, setAdding] = useState<boolean>(false);
-  const [selectedSkill, setSelectedSkill] = useState<Skill | null>(null);
+  const [selectedSkill, setSelectedSkill] = useState<SelectedSkill | null>(
+    null,
+  );
   const methods = useForm<FormValues>({
     defaultValues: initialState ?? defaultFormValues,
   });
@@ -101,7 +107,10 @@ const SkillBrowserDialog = ({
           reset();
           if (!noToast)
             toast.success(
-              selected(getLocalizedName(selectedSkill?.name, intl)),
+              selected(
+                selectedSkill?.name ??
+                  intl.formatMessage(commonMessages.notAvailable),
+              ),
             );
         })
         .finally(() => setAdding(false));
@@ -141,9 +150,10 @@ const SkillBrowserDialog = ({
     }
   }, [watchSkill, formTrigger]);
 
-  const skillInLibrary = !!inLibrary?.find(
-    (librarySkill) => selectedSkill?.id === librarySkill.id,
-  );
+  const skillInLibrary = !!getFragment(
+    SkillBrowserSkill_Fragment,
+    inLibraryQuery,
+  )?.find((librarySkill) => selectedSkill?.id === librarySkill.id);
   const shouldShowDetails = showDetails(skillInLibrary, context);
   const shouldShowDetailsPool =
     context === "pool" || context === "skill-proficiency-list-with-level";
@@ -168,21 +178,17 @@ const SkillBrowserDialog = ({
               }}
             >
               <SkillSelection
-                {...{ skills, inLibrary }}
+                {...{ query, inLibraryQuery }}
                 onSelectSkill={setSelectedSkill}
               />
               {selectedSkill && shouldShowDetails && (
                 <SkillDetails
-                  category={
-                    selectedSkill.category.value ?? SkillCategory.Technical
-                  }
+                  category={selectedSkill.category ?? SkillCategory.Technical}
                 />
               )}
               {selectedSkill && shouldShowDetailsPool && (
                 <SkillDetailsPool
-                  category={
-                    selectedSkill.category.value ?? SkillCategory.Technical
-                  }
+                  category={selectedSkill.category ?? SkillCategory.Technical}
                 />
               )}
               <Dialog.Footer>

--- a/apps/web/src/components/SkillBrowser/SkillDescription.tsx
+++ b/apps/web/src/components/SkillBrowser/SkillDescription.tsx
@@ -1,18 +1,17 @@
 import { useIntl } from "react-intl";
 
 import { Notice } from "@gc-digital-talent/ui";
-import { getLocalizedName } from "@gc-digital-talent/i18n";
-import type { Skill } from "@gc-digital-talent/graphql";
+import { commonMessages } from "@gc-digital-talent/i18n";
 
 interface SkillDescriptionProps {
-  skill?: Skill | null;
+  name?: string | null;
+  description?: string | null;
 }
 
-const SkillDescription = ({ skill }: SkillDescriptionProps) => {
+const SkillDescription = ({ name, description }: SkillDescriptionProps) => {
   const intl = useIntl();
-  const description = getLocalizedName(skill?.description, intl);
 
-  if (!skill || !description) {
+  if (!description) {
     return null;
   }
 
@@ -26,7 +25,7 @@ const SkillDescription = ({ skill }: SkillDescriptionProps) => {
             description: "Heading for a specific skills definition",
           },
           {
-            skill: getLocalizedName(skill.name, intl),
+            skill: name ?? intl.formatMessage(commonMessages.notAvailable),
           },
         )}
       </Notice.Title>

--- a/apps/web/src/components/SkillBrowser/SkillSelection.tsx
+++ b/apps/web/src/components/SkillBrowser/SkillSelection.tsx
@@ -4,9 +4,10 @@ import { useIntl } from "react-intl";
 
 import { Notice } from "@gc-digital-talent/ui";
 import { Combobox, Select } from "@gc-digital-talent/forms";
-import { errorMessages, getLocalizedName } from "@gc-digital-talent/i18n";
+import { commonMessages, errorMessages } from "@gc-digital-talent/i18n";
 import { normalizeString } from "@gc-digital-talent/helpers";
-import type { Skill } from "@gc-digital-talent/graphql";
+import type { FragmentType } from "@gc-digital-talent/graphql";
+import { getFragment, graphql } from "@gc-digital-talent/graphql";
 
 import skillBrowserMessages from "./messages";
 import SkillDescription from "./SkillDescription";
@@ -15,47 +16,71 @@ import {
   getFilteredFamilies,
   getFilteredSkills,
 } from "./utils";
-import type { FormValues } from "./types";
+import type { FormValues, SelectedSkill } from "./types";
+
+export const SkillBrowserSkill_Fragment = graphql(/* GraphQL */ `
+  fragment SkillBrowserSkill on Skill {
+    id
+    name {
+      localized
+    }
+    description {
+      localized
+    }
+    category {
+      value
+    }
+    families {
+      id
+      name {
+        localized
+      }
+    }
+  }
+`);
 
 interface SkillSelectionProps {
-  skills: Skill[];
-  inLibrary?: Skill[];
-  onSelectSkill?: (skill: Skill | null) => void;
+  query: FragmentType<typeof SkillBrowserSkill_Fragment>[];
+  inLibraryQuery?: FragmentType<typeof SkillBrowserSkill_Fragment>[];
+  onSelectSkill?: (skill: SelectedSkill | null) => void;
 }
 
 const SkillSelection = ({
-  skills,
+  query,
   onSelectSkill,
-  inLibrary,
+  inLibraryQuery,
 }: SkillSelectionProps) => {
   const intl = useIntl();
   const { watch, resetField } = useFormContext<FormValues>();
 
+  const skills = getFragment(SkillBrowserSkill_Fragment, query);
+  const inLibrary = getFragment(SkillBrowserSkill_Fragment, inLibraryQuery);
+
   const [family, skill] = watch(["family", "skill"]);
 
-  const filteredFamilies = useMemo(() => {
-    return getFilteredFamilies({ skills }).sort((familyA, familyB) => {
-      const a = normalizeString(getLocalizedName(familyA.name, intl));
-      const b = normalizeString(getLocalizedName(familyB.name, intl));
+  const filteredFamilies = getFilteredFamilies({ skills: [...skills] }).sort(
+    (familyA, familyB) => {
+      const a = normalizeString(familyA.name?.localized ?? "");
+      const b = normalizeString(familyB.name?.localized ?? "");
 
       if (a === b) return 0;
 
       return a > b ? 1 : -1;
-    });
-  }, [skills, intl]);
+    },
+  );
 
-  const filteredSkills = useMemo(() => {
-    return getFilteredSkills({ skills, family, inLibrary }).sort(
-      (skillA, skillB) => {
-        const a = normalizeString(getLocalizedName(skillA.name, intl));
-        const b = normalizeString(getLocalizedName(skillB.name, intl));
+  const filteredSkills = getFilteredSkills({
+    skills: [...skills],
+    family,
+    inLibrary: inLibrary ? [...inLibrary] : undefined,
+  }).sort((skillA, skillB) => {
+    const a = normalizeString(skillA.name?.localized ?? "");
+    const b = normalizeString(skillB.name?.localized ?? "");
 
-        if (a === b) return 0;
+    if (a === b) return 0;
 
-        return a > b ? 1 : -1;
-      },
-    );
-  }, [family, inLibrary, skills, intl]);
+    return a > b ? 1 : -1;
+  });
 
   const selectedSkill = useMemo(() => {
     return skill
@@ -65,7 +90,15 @@ const SkillSelection = ({
 
   useEffect(() => {
     if (onSelectSkill) {
-      onSelectSkill(selectedSkill ?? null);
+      onSelectSkill(
+        selectedSkill
+          ? {
+              id: selectedSkill.id,
+              name: selectedSkill.name?.localized ?? null,
+              category: selectedSkill.category.value,
+            }
+          : null,
+      );
     }
   }, [onSelectSkill, selectedSkill]);
 
@@ -77,7 +110,12 @@ const SkillSelection = ({
     resetField("family");
   }, [resetField]);
 
-  const familyOptions = getFamilyOptions(skills, intl, inLibrary);
+  const familyOptions = getFamilyOptions(
+    skills.map((currentSkill) => currentSkill.id),
+    intl,
+    inLibrary?.map((librarySkill) => librarySkill.id),
+  );
+  const notAvailable = intl.formatMessage(commonMessages.notAvailable);
 
   return (
     <>
@@ -95,7 +133,7 @@ const SkillSelection = ({
             ...familyOptions,
             ...filteredFamilies.map((skillFamily) => ({
               value: skillFamily.id,
-              label: getLocalizedName(skillFamily.name, intl),
+              label: skillFamily.name?.localized ?? notAvailable,
             })),
           ]}
         />
@@ -109,7 +147,7 @@ const SkillSelection = ({
             label={intl.formatMessage(skillBrowserMessages.skill)}
             options={filteredSkills.map((currentSkill) => ({
               value: currentSkill.id,
-              label: getLocalizedName(currentSkill.name, intl),
+              label: currentSkill.name?.localized ?? notAvailable,
             }))}
           />
         </div>
@@ -123,7 +161,12 @@ const SkillSelection = ({
           </Notice.Content>
         </Notice.Root>
       )}
-      {selectedSkill && <SkillDescription skill={selectedSkill} />}
+      {selectedSkill && (
+        <SkillDescription
+          name={selectedSkill.name?.localized}
+          description={selectedSkill.description?.localized}
+        />
+      )}
     </>
   );
 };

--- a/apps/web/src/components/SkillBrowser/types.ts
+++ b/apps/web/src/components/SkillBrowser/types.ts
@@ -1,5 +1,4 @@
 import type {
-  Skill,
   SkillCategory,
   SkillLevel,
   WhenSkillUsed,
@@ -13,6 +12,12 @@ export type SkillBrowserDialogContext =
   | "skill-proficiency-list-with-level"
   | "skill-proficiency-list-without-level";
 
+export interface SelectedSkill {
+  id: string;
+  name: string | null;
+  category: SkillCategory | null;
+}
+
 export interface FormValues {
   category?: SkillCategory | "all" | "";
   family?: string;
@@ -20,8 +25,4 @@ export interface FormValues {
   details?: string;
   skillLevel?: SkillLevel;
   whenSkillUsed?: WhenSkillUsed;
-}
-
-export interface BaseSkillBrowserProps {
-  skills: Skill[];
 }

--- a/apps/web/src/components/SkillBrowser/utils.ts
+++ b/apps/web/src/components/SkillBrowser/utils.ts
@@ -3,9 +3,8 @@ import type { ReactNode } from "react";
 
 import type { Option } from "@gc-digital-talent/forms";
 import type {
-  Skill,
+  SkillBrowserSkillFragment,
   SkillCategory,
-  SkillFamily,
 } from "@gc-digital-talent/graphql";
 
 import { invertSkillSkillFamilyTree } from "~/utils/skillUtils";
@@ -202,32 +201,28 @@ export const showDetails = (
 };
 
 interface GetFilteredFamiliesArgs {
-  skills: Skill[];
+  skills: SkillBrowserSkillFragment[];
 }
 
-type GetFilteredFamilies = (args: GetFilteredFamiliesArgs) => SkillFamily[];
-
-export const getFilteredFamilies: GetFilteredFamilies = ({ skills }) => {
+export const getFilteredFamilies = ({ skills }: GetFilteredFamiliesArgs) => {
   const invertedTree = invertSkillSkillFamilyTree(skills);
 
   return invertedTree;
 };
 
 interface GetFilteredSkillsArgs {
-  skills: Skill[];
+  skills: SkillBrowserSkillFragment[];
   family?: string;
   category?: SkillCategory | "all" | "";
-  inLibrary?: Skill[];
+  inLibrary?: SkillBrowserSkillFragment[];
 }
 
-type GetFilteredSkills = (args: GetFilteredSkillsArgs) => Skill[];
-
-export const getFilteredSkills: GetFilteredSkills = ({
+export const getFilteredSkills = ({
   skills,
   family,
   category,
   inLibrary,
-}) => {
+}: GetFilteredSkillsArgs): SkillBrowserSkillFragment[] => {
   if (inLibrary && family && family === "library") {
     // If `inLibrary` was passed and selected, filter by those instead of family
     return skills.filter((currentSkill) =>
@@ -255,12 +250,12 @@ export const getFilteredSkills: GetFilteredSkills = ({
 };
 
 export const getFamilyOptions = (
-  skills: Skill[],
+  skillIds: string[],
   intl: IntlShape,
-  inLibrary?: Skill[],
+  inLibraryIds?: string[],
 ): Option[] => {
-  const filteredLibrary = inLibrary?.filter((librarySkill) =>
-    skills.some((skill) => skill.id === librarySkill.id),
+  const filteredLibrary = inLibraryIds?.filter((librarySkillId) =>
+    skillIds.includes(librarySkillId),
   );
 
   let familyOptions = [

--- a/apps/web/src/components/SkillProficiencyList/SkillProficiencyAccordionItem.tsx
+++ b/apps/web/src/components/SkillProficiencyList/SkillProficiencyAccordionItem.tsx
@@ -89,7 +89,7 @@ const SkillProficiencyAccordionItem = ({
       type: "button-component",
       component: (
         <SkillBrowserDialog
-          skills={availableSkills}
+          query={availableSkills}
           initialState={
             {
               skill: skillId,

--- a/apps/web/src/components/SkillProficiencyList/SkillProficiencyList.tsx
+++ b/apps/web/src/components/SkillProficiencyList/SkillProficiencyList.tsx
@@ -16,6 +16,7 @@ import SkillBrowserDialog from "../SkillBrowser/SkillBrowserDialog";
 export const Options_Fragment = graphql(/* GraphQL */ `
   fragment SkillProficiencyListOptions on Query {
     skills {
+      ...SkillBrowserSkill
       id
       key
       name {
@@ -154,7 +155,7 @@ const SkillProficiencyList = ({
             ? "skill-proficiency-list-with-level"
             : "skill-proficiency-list-without-level"
         }
-        skills={availableSkills}
+        query={availableSkills}
         onSave={async (value) => {
           await onAdd({
             skillId: value.skill ?? null,

--- a/apps/web/src/components/SkillsPortfolioTable/SkillPortfolioTable.tsx
+++ b/apps/web/src/components/SkillsPortfolioTable/SkillPortfolioTable.tsx
@@ -83,6 +83,7 @@ export const SkillPortfolioTable_UserSkillFragment = graphql(/* GraphQL */ `
 
 export const SkillPortfolioTable_SkillFragment = graphql(/* GraphQL */ `
   fragment SkillPortfolioTable_Skill on Skill {
+    ...SkillBrowserSkill
     id
     key
     category {
@@ -263,7 +264,7 @@ const SkillPortfolioTable = ({
               component: (
                 <SkillBrowserDialog
                   context="library"
-                  skills={unclaimedSkills}
+                  query={unclaimedSkills}
                   onSave={async (value) => {
                     await executeCreateMutation({
                       userId: userAuthInfo?.id ?? "",

--- a/apps/web/src/pages/Pools/EditPoolPage/components/SkillTable.tsx
+++ b/apps/web/src/pages/Pools/EditPoolPage/components/SkillTable.tsx
@@ -22,6 +22,7 @@ import tableMessages from "~/components/Table/tableMessages";
 
 export const SkillTableSkill_Fragment = graphql(/* GraphQL */ `
   fragment SkillTableSkill on Skill {
+    ...SkillBrowserSkill
     id
     key
     name {
@@ -56,6 +57,7 @@ export const SkillTablePoolSkill_Fragment = graphql(/* GraphQL */ `
     id
     requiredLevel
     skill {
+      ...SkillBrowserSkill
       id
       key
       name {
@@ -121,7 +123,7 @@ const ActionCell = (
             )}
           />
         }
-        skills={skill ? [skill] : []}
+        query={skill ? [skill] : []}
         initialState={{
           family: "all",
           skill: skill?.id,
@@ -255,7 +257,7 @@ const SkillTable = ({
               component: (
                 <SkillBrowserDialog
                   context="pool"
-                  skills={availableSkills}
+                  query={availableSkills}
                   onSave={async (value) => {
                     if (value.skill && value.skillLevel) {
                       await onCreate(value.skill, value.skillLevel);

--- a/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/ExperienceFormPage.tsx
@@ -90,6 +90,7 @@ interface FormValues extends ExperienceFormValues<AllExperienceFormValues> {
 
 export const ExperienceFormSkill_Fragment = graphql(/* GraphQL */ `
   fragment ExperienceFormSkill on Skill {
+    ...SkillBrowserSkill
     id
     key
     name {

--- a/apps/web/src/pages/Profile/ExperienceFormPage/components/ExperienceSkills.tsx
+++ b/apps/web/src/pages/Profile/ExperienceFormPage/components/ExperienceSkills.tsx
@@ -4,7 +4,8 @@ import { useClient } from "urql";
 import { useFieldArray, useFormContext } from "react-hook-form";
 
 import { Accordion, Heading, Ul, Notice } from "@gc-digital-talent/ui";
-import { graphql, type Skill } from "@gc-digital-talent/graphql";
+import type { ExperienceFormSkillFragment } from "@gc-digital-talent/graphql";
+import { graphql } from "@gc-digital-talent/graphql";
 
 import SkillsInDetail from "~/components/SkillsInDetail/SkillsInDetail";
 import type { ExperienceType, FormSkill, FormSkills } from "~/types/experience";
@@ -28,7 +29,7 @@ interface ExperienceSkillValues {
 type AccordionStates = "learn-more" | "";
 
 interface ExperienceSkillsProps {
-  skills: Skill[];
+  skills: ExperienceFormSkillFragment[];
   experienceType?: ExperienceType;
   experienceId?: string;
 }
@@ -203,7 +204,7 @@ const ExperienceSkills = ({
                 }),
               }}
               context="experience"
-              skills={unclaimedSkills}
+              query={unclaimedSkills}
               onSave={handleAddSkill}
             />
           </div>

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/FormFields.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/FormFields.tsx
@@ -21,7 +21,7 @@ import {
 } from "@gc-digital-talent/i18n";
 import type {
   Classification,
-  Skill,
+  FragmentType,
   WorkStream,
 } from "@gc-digital-talent/graphql";
 import {
@@ -34,6 +34,7 @@ import { Link } from "@gc-digital-talent/ui";
 
 import { NullSelection } from "~/types/talentRequestForm";
 import SkillBrowser from "~/components/SkillBrowser/SkillBrowser";
+import type { SkillBrowserSkill_Fragment } from "~/components/SkillBrowser/SkillSelection";
 import processMessages from "~/messages/processMessages";
 import messages from "~/messages/profileMessages";
 import talentRequestMessages from "~/messages/talentRequestMessages";
@@ -80,7 +81,7 @@ const SearchRequestOptions_Query = graphql(/* GraphQL */ `
 
 interface FormFieldsProps {
   classifications: Classification[];
-  skills: Skill[];
+  skills: FragmentType<typeof SkillBrowserSkill_Fragment>[];
   workStreams: WorkStream[];
 }
 
@@ -236,7 +237,7 @@ const FormFields = ({
           },
         )}
       >
-        <SkillBrowser skills={skills || []} name="skills" />
+        <SkillBrowser query={skills} name="skills" />
         <Field.Context className="mt-1.5">
           {intl.formatMessage({
             defaultMessage:

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -15,7 +15,7 @@ import { unpackMaybes } from "@gc-digital-talent/helpers";
 import type {
   Classification,
   ApplicantFilterInput,
-  Skill,
+  FragmentType,
   WorkStream,
 } from "@gc-digital-talent/graphql";
 import {
@@ -27,6 +27,7 @@ import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 
 import type { FormValues } from "~/types/talentRequestForm";
 import useRoutes from "~/hooks/useRoutes";
+import type { SkillBrowserSkill_Fragment } from "~/components/SkillBrowser/SkillSelection";
 
 import { formValuesToData } from "../utils";
 import {
@@ -48,7 +49,7 @@ const defaultRequestState = {
 
 interface SearchFormProps {
   classifications: Classification[];
-  skills: Skill[];
+  skills: FragmentType<typeof SkillBrowserSkill_Fragment>[];
   workStreams: WorkStream[];
 }
 
@@ -301,6 +302,7 @@ const SearchForm_Query = graphql(/* GraphQL */ `
       }
     }
     skills {
+      ...SkillBrowserSkill
       id
       key
       name {
@@ -337,7 +339,7 @@ const SearchForm_Query = graphql(/* GraphQL */ `
 const SearchFormAPI = () => {
   const [{ data, fetching, error }] = useQuery({ query: SearchForm_Query });
 
-  const skills = unpackMaybes<Skill>(data?.skills);
+  const skills = unpackMaybes(data?.skills);
   const classifications = unpackMaybes(data?.classifications);
   const workStreams = unpackMaybes(data?.workStreams);
 

--- a/apps/web/src/pages/SkillFamilies/CreateSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/CreateSkillFamilyPage.tsx
@@ -2,19 +2,13 @@ import { useNavigate } from "react-router";
 import { useIntl } from "react-intl";
 import type { SubmitHandler } from "react-hook-form";
 import { FormProvider, useForm } from "react-hook-form";
-import sortBy from "lodash/sortBy";
 import { useMutation, useQuery } from "urql";
 import IdentificationIcon from "@heroicons/react/24/outline/IdentificationIcon";
 
 import { toast } from "@gc-digital-talent/toast";
 import { Input, TextArea, Submit, Combobox } from "@gc-digital-talent/forms";
-import {
-  getLocale,
-  errorMessages,
-  getLocalizedName,
-  commonMessages,
-} from "@gc-digital-talent/i18n";
-import { unpackMaybes } from "@gc-digital-talent/helpers";
+import { errorMessages, commonMessages } from "@gc-digital-talent/i18n";
+import { sortAlphaBy, unpackMaybes } from "@gc-digital-talent/helpers";
 import {
   Pending,
   Heading,
@@ -22,8 +16,11 @@ import {
   Link,
   CardSeparator,
 } from "@gc-digital-talent/ui";
-import type { Skill, CreateSkillFamilyInput } from "@gc-digital-talent/graphql";
-import { graphql } from "@gc-digital-talent/graphql";
+import type {
+  CreateSkillFamilyInput,
+  FragmentType,
+} from "@gc-digital-talent/graphql";
+import { getFragment, graphql } from "@gc-digital-talent/graphql";
 import { ROLE_NAME } from "@gc-digital-talent/auth";
 
 import SEO from "~/components/SEO/SEO";
@@ -48,11 +45,6 @@ const CreateSkillFamily_Mutation = graphql(/* GraphQL */ `
   }
 `);
 
-interface Option<V> {
-  value: V;
-  label: string;
-}
-
 interface FormValues {
   key: string;
   name: {
@@ -66,20 +58,26 @@ interface FormValues {
   skills: string[] | undefined;
 }
 
+export const CreateSkillFamilySkill_Fragment = graphql(/* GraphQL */ `
+  fragment CreateSkillFamilySkill on Skill {
+    id
+    name {
+      localized
+    }
+  }
+`);
+
 interface CreateSkillFamilyProps {
-  skills: Skill[];
+  query: FragmentType<typeof CreateSkillFamilySkill_Fragment>[];
 }
 
-export const CreateSkillFamily = ({ skills }: CreateSkillFamilyProps) => {
+export const CreateSkillFamily = ({ query }: CreateSkillFamilyProps) => {
   const intl = useIntl();
-  const locale = getLocale(intl);
   const navigate = useNavigate();
   const paths = useRoutes();
   const methods = useForm<FormValues>();
   const { handleSubmit } = methods;
-  const sortedSkills = sortBy(skills, (skill) => {
-    return skill.name?.[locale]?.toLocaleUpperCase();
-  });
+  const skills = getFragment(CreateSkillFamilySkill_Fragment, query);
   const [, executeMutation] = useMutation(CreateSkillFamily_Mutation);
 
   const formValuesToSubmitData = (
@@ -148,10 +146,12 @@ export const CreateSkillFamily = ({ skills }: CreateSkillFamilyProps) => {
       .catch(handleError);
   };
 
-  const skillOptions: Option<string>[] = sortedSkills.map(({ id, name }) => ({
-    value: id,
-    label: getLocalizedName(name, intl),
-  }));
+  const skillOptions = [...skills]
+    .sort(sortAlphaBy((skill) => skill.name?.localized))
+    .map(({ id, name }) => ({
+      value: id,
+      label: name?.localized ?? intl.formatMessage(commonMessages.notAvailable),
+    }));
 
   return (
     <>
@@ -287,19 +287,7 @@ export const CreateSkillFamily = ({ skills }: CreateSkillFamilyProps) => {
 const SkillFamilySkills_Query = graphql(/* GraphQL */ `
   query SkillFamilySkills {
     skills {
-      id
-      key
-      name {
-        en
-        fr
-      }
-      category {
-        value
-        label {
-          en
-          fr
-        }
-      }
+      ...CreateSkillFamilySkill
     }
   }
 `);
@@ -312,7 +300,7 @@ const CreateSkillFamilyPage = () => {
   return (
     <>
       <Pending fetching={fetching} error={error}>
-        <CreateSkillFamily skills={unpackMaybes(lookupData?.skills)} />
+        <CreateSkillFamily query={unpackMaybes(lookupData?.skills)} />
       </Pending>
     </>
   );

--- a/apps/web/src/pages/SkillFamilies/UpdateSkillFamilyPage.tsx
+++ b/apps/web/src/pages/SkillFamilies/UpdateSkillFamilyPage.tsx
@@ -2,7 +2,6 @@ import { useNavigate } from "react-router";
 import { useIntl } from "react-intl";
 import type { SubmitHandler } from "react-hook-form";
 import { FormProvider, useForm } from "react-hook-form";
-import sortBy from "lodash/sortBy";
 import { useMutation, useQuery } from "urql";
 import IdentificationIcon from "@heroicons/react/24/outline/IdentificationIcon";
 
@@ -14,9 +13,8 @@ import {
   TextArea,
   unpackIds,
 } from "@gc-digital-talent/forms";
-import { unpackMaybes } from "@gc-digital-talent/helpers";
+import { sortAlphaBy, unpackMaybes } from "@gc-digital-talent/helpers";
 import {
-  getLocale,
   errorMessages,
   commonMessages,
   getLocalizedName,
@@ -31,7 +29,8 @@ import {
   CardSeparator,
 } from "@gc-digital-talent/ui";
 import type {
-  SkillFamily,
+  LocalizedString,
+  UpdateSkillFamilyFragment,
   UpdateSkillFamilyInput,
   FragmentType,
 } from "@gc-digital-talent/graphql";
@@ -49,29 +48,17 @@ import FieldDisplay from "~/components/FieldDisplay/FieldDisplay";
 
 import messages from "./messages";
 
-interface Option<V> {
-  value: V;
-  label: string;
-}
-
-interface FormValues extends Pick<SkillFamily, "name" | "description"> {
+interface FormValues {
+  name?: LocalizedString | null;
+  description?: LocalizedString | null;
   skills: string[];
 }
 
 export const UpdateSkillFamilySkill_Fragment = graphql(/* GraphQL */ `
   fragment UpdateSkillFamilySkill on Skill {
     id
-    key
     name {
-      en
-      fr
-    }
-    category {
-      value
-      label {
-        en
-        fr
-      }
+      localized
     }
   }
 `);
@@ -129,16 +116,12 @@ export const UpdateSkillFamily = ({
   skillsQuery,
 }: UpdateSkillFamilyProps) => {
   const intl = useIntl();
-  const locale = getLocale(intl);
   const navigate = useNavigate();
   const paths = useRoutes();
   const skillFamily = getFragment(UpdateSkillFamily_Fragment, skillFamilyQuery);
   const skills = getFragment(UpdateSkillFamilySkill_Fragment, skillsQuery);
-  const sortedSkills = sortBy([...skills], (skill) => {
-    return skill.name?.[locale]?.toLocaleUpperCase();
-  });
 
-  const dataToFormValues = (data: SkillFamily): FormValues => ({
+  const dataToFormValues = (data: UpdateSkillFamilyFragment): FormValues => ({
     ...data,
     skills: unpackIds(data?.skills),
   });
@@ -235,10 +218,12 @@ export const UpdateSkillFamily = ({
       .catch(handleError);
   };
 
-  const skillOptions: Option<string>[] = sortedSkills.map(({ id, name }) => ({
-    value: id,
-    label: getLocalizedName(name, intl),
-  }));
+  const skillOptions = [...skills]
+    .sort(sortAlphaBy((skill) => skill.name?.localized))
+    .map(({ id, name }) => ({
+      value: id,
+      label: name?.localized ?? intl.formatMessage(commonMessages.notAvailable),
+    }));
 
   return (
     <>

--- a/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.stories.tsx
+++ b/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.stories.tsx
@@ -1,22 +1,28 @@
 import type { Meta, StoryFn } from "@storybook/react-vite";
 
 import { fakeSkillFamilies } from "@gc-digital-talent/fake-data";
+import { makeFragmentData } from "@gc-digital-talent/graphql";
 
-import { SkillFamilyTable } from "./SkillFamilyTable";
+import {
+  SkillFamilyTable,
+  SkillFamilyTableRow_Fragment,
+} from "./SkillFamilyTable";
 
-const mockSkillFamilies = fakeSkillFamilies();
+const mockSkillFamilies = fakeSkillFamilies().map((skillFamily) =>
+  makeFragmentData(skillFamily, SkillFamilyTableRow_Fragment),
+);
 
 export default {
   component: SkillFamilyTable,
 } as Meta<typeof SkillFamilyTable>;
 
 const Template: StoryFn<typeof SkillFamilyTable> = (args) => {
-  const { skillFamilies, title } = args;
-  return <SkillFamilyTable skillFamilies={skillFamilies} title={title} />;
+  const { query, title } = args;
+  return <SkillFamilyTable query={query} title={title} />;
 };
 
 export const Default = Template.bind({});
 Default.args = {
-  skillFamilies: mockSkillFamilies,
+  query: mockSkillFamilies,
   title: "Skill families",
 };

--- a/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
+++ b/apps/web/src/pages/SkillFamilies/components/SkillFamilyTable.tsx
@@ -4,30 +4,43 @@ import { useIntl } from "react-intl";
 import { useLocation } from "react-router";
 import { useQuery } from "urql";
 
-import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
-import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
+import { commonMessages } from "@gc-digital-talent/i18n";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
 import { Link, Pending } from "@gc-digital-talent/ui";
-import type { SkillFamily } from "@gc-digital-talent/graphql";
-import { graphql } from "@gc-digital-talent/graphql";
+import type {
+  FragmentType,
+  SkillFamilyTableRowFragment,
+} from "@gc-digital-talent/graphql";
+import { getFragment, graphql } from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
 import adminMessages from "~/messages/adminMessages";
 import { normalizedText } from "~/components/Table/sortingFns";
 
-const columnHelper = createColumnHelper<SkillFamily>();
+const columnHelper = createColumnHelper<SkillFamilyTableRowFragment>();
+
+export const SkillFamilyTableRow_Fragment = graphql(/* GraphQL */ `
+  fragment SkillFamilyTableRow on SkillFamily {
+    id
+    name {
+      localized
+    }
+    description {
+      localized
+    }
+  }
+`);
 
 interface SkillFamilyTableProps {
-  skillFamilies: SkillFamily[];
+  query: FragmentType<typeof SkillFamilyTableRow_Fragment>[];
   title: string;
 }
 
-export const SkillFamilyTable = ({
-  skillFamilies,
-  title,
-}: SkillFamilyTableProps) => {
+export const SkillFamilyTable = ({ query, title }: SkillFamilyTableProps) => {
   const intl = useIntl();
   const paths = useRoutes();
+  const data = getFragment(SkillFamilyTableRow_Fragment, query);
   const columns = [
     columnHelper.accessor("id", {
       id: "id",
@@ -35,7 +48,9 @@ export const SkillFamilyTable = ({
       header: intl.formatMessage(adminMessages.id),
     }),
     columnHelper.accessor(
-      (skillFamily) => getLocalizedName(skillFamily.name, intl),
+      (skillFamily) =>
+        skillFamily.name?.localized ??
+        intl.formatMessage(commonMessages.notAvailable),
       {
         id: "name",
         sortingFn: normalizedText,
@@ -56,22 +71,20 @@ export const SkillFamilyTable = ({
       },
     ),
     columnHelper.accessor(
-      (skillFamily) => getLocalizedName(skillFamily.description, intl, true),
+      (skillFamily) => skillFamily.description?.localized ?? "",
       {
         id: "description",
         sortingFn: normalizedText,
         header: intl.formatMessage(commonMessages.description),
       },
     ),
-  ] as ColumnDef<SkillFamily>[];
-
-  const data = skillFamilies.filter(notEmpty);
+  ] as ColumnDef<SkillFamilyTableRowFragment>[];
 
   const { pathname, search, hash } = useLocation();
   const currentUrl = `${pathname}${search}${hash}`;
 
   return (
-    <Table<SkillFamily>
+    <Table<SkillFamilyTableRowFragment>
       caption={title}
       data={data}
       columns={columns}
@@ -116,31 +129,7 @@ export const SkillFamilyTable = ({
 const SkillFamilies_Query = graphql(/* GraphQL */ `
   query SkillFamilies {
     skillFamilies {
-      id
-      key
-      name {
-        en
-        fr
-      }
-      description {
-        en
-        fr
-      }
-      skills {
-        id
-        key
-        name {
-          en
-          fr
-        }
-        category {
-          value
-          label {
-            en
-            fr
-          }
-        }
-      }
+      ...SkillFamilyTableRow
     }
   }
 `);
@@ -153,7 +142,7 @@ const SkillFamilyTableApi = ({ title }: { title: string }) => {
   return (
     <Pending fetching={fetching} error={error}>
       <SkillFamilyTable
-        skillFamilies={unpackMaybes(data?.skillFamilies)}
+        query={unpackMaybes(data?.skillFamilies)}
         title={title}
       />
     </Pending>

--- a/apps/web/src/pages/Skills/CreateSkillPage.tsx
+++ b/apps/web/src/pages/Skills/CreateSkillPage.tsx
@@ -2,7 +2,6 @@ import { useNavigate } from "react-router";
 import { useIntl } from "react-intl";
 import type { SubmitHandler } from "react-hook-form";
 import { FormProvider, useForm } from "react-hook-form";
-import sortBy from "lodash/sortBy";
 import { useMutation, useQuery } from "urql";
 import IdentificationIcon from "@heroicons/react/24/outline/IdentificationIcon";
 
@@ -15,13 +14,12 @@ import {
   Select,
   localizedEnumToOptions,
 } from "@gc-digital-talent/forms";
+import { errorMessages, commonMessages } from "@gc-digital-talent/i18n";
 import {
-  getLocale,
-  errorMessages,
-  getLocalizedName,
-  commonMessages,
-} from "@gc-digital-talent/i18n";
-import { keyStringRegex, unpackMaybes } from "@gc-digital-talent/helpers";
+  keyStringRegex,
+  sortAlphaBy,
+  unpackMaybes,
+} from "@gc-digital-talent/helpers";
 import {
   Card,
   CardSeparator,
@@ -30,8 +28,6 @@ import {
   Pending,
 } from "@gc-digital-talent/ui";
 import type {
-  Skill,
-  SkillFamily,
   CreateSkillInput,
   SkillCategory,
   FragmentType,
@@ -50,12 +46,7 @@ import pageTitles from "~/messages/pageTitles";
 
 import { SkillFormOptions_Fragment } from "./operations";
 
-interface Option<V> {
-  value: V;
-  label: string;
-}
-
-interface FormValues extends Pick<Skill, "description"> {
+interface FormValues {
   key: string;
   name: {
     en: string;
@@ -73,27 +64,33 @@ interface FormValues extends Pick<Skill, "description"> {
   families: string[] | undefined;
 }
 
+export const CreateSkillFamily_Fragment = graphql(/* GraphQL */ `
+  fragment CreateSkillFamily on SkillFamily {
+    id
+    name {
+      localized
+    }
+  }
+`);
+
 interface CreateSkillFormProps {
-  families: SkillFamily[];
+  query: FragmentType<typeof CreateSkillFamily_Fragment>[];
   optionsQuery?: FragmentType<typeof SkillFormOptions_Fragment>;
   handleCreateSkill: (data: CreateSkillInput) => Promise<string>;
 }
 
 export const CreateSkillForm = ({
-  families,
+  query,
   optionsQuery,
   handleCreateSkill,
 }: CreateSkillFormProps) => {
   const intl = useIntl();
-  const locale = getLocale(intl);
   const navigate = useNavigate();
   const paths = useRoutes();
   const data = getFragment(SkillFormOptions_Fragment, optionsQuery);
+  const families = getFragment(CreateSkillFamily_Fragment, query);
   const methods = useForm<FormValues>();
   const { handleSubmit } = methods;
-  const sortedFamilies = sortBy(families, (family) => {
-    return family.name?.[locale]?.toLocaleUpperCase();
-  });
 
   const formValuesToSubmitData = (values: FormValues): CreateSkillInput => ({
     ...values,
@@ -131,12 +128,12 @@ export const CreateSkillForm = ({
       });
   };
 
-  const skillFamilyOptions: Option<string>[] = sortedFamilies.map(
-    ({ id, name }) => ({
+  const skillFamilyOptions = [...families]
+    .sort(sortAlphaBy((family) => family.name?.localized))
+    .map(({ id, name }) => ({
       value: id,
-      label: getLocalizedName(name, intl),
-    }),
-  );
+      label: name?.localized ?? intl.formatMessage(commonMessages.notAvailable),
+    }));
 
   return (
     <FormProvider {...methods}>
@@ -321,31 +318,7 @@ const CreateSkillSkillFamilies_Query = graphql(/* GraphQL */ `
     ...SkillFormOptions
 
     skillFamilies {
-      id
-      key
-      name {
-        en
-        fr
-      }
-      description {
-        en
-        fr
-      }
-      skills {
-        id
-        key
-        name {
-          en
-          fr
-        }
-        category {
-          value
-          label {
-            en
-            fr
-          }
-        }
-      }
+      ...CreateSkillFamily
     }
   }
 `);
@@ -418,7 +391,7 @@ const CreateSkillPage = () => {
           <CreateSkillForm
             optionsQuery={data}
             handleCreateSkill={handleCreateSkill}
-            families={unpackMaybes(data?.skillFamilies)}
+            query={unpackMaybes(data?.skillFamilies)}
           />
         </Pending>
       </Hero>

--- a/apps/web/src/pages/Skills/ImproveBehaviouralSkillsPage.tsx
+++ b/apps/web/src/pages/Skills/ImproveBehaviouralSkillsPage.tsx
@@ -8,8 +8,8 @@ import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 import { ROLE_NAME, useAuthorization } from "@gc-digital-talent/auth";
 import { navigationMessages } from "@gc-digital-talent/i18n";
 import type {
-  Skill,
-  UpdateSkillShowcase_UserSkillFragment as UpdateSkillShowcaseUserSkillFragmentType,
+  UpdateSkillShowcaseSkillFragment,
+  UpdateSkillShowcaseUserSkillFragment,
 } from "@gc-digital-talent/graphql";
 import {
   getFragment,
@@ -23,8 +23,8 @@ import RequireAuth from "~/components/RequireAuth/RequireAuth";
 
 import type { FormValues } from "./components/UpdateSkillShowcase";
 import UpdateSkillShowcase, {
-  UpdateSkillShowcase_SkillFragment,
-  UpdateSkillShowcase_UserSkillFragment,
+  UpdateSkillShowcaseSkill_Fragment,
+  UpdateSkillShowcaseUserSkill_Fragment,
 } from "./components/UpdateSkillShowcase";
 import { UpdateUserSkillRankings_Mutation } from "./operations";
 
@@ -35,18 +35,18 @@ const ImproveBehaviouralSkillsPage_Query = graphql(/* GraphQL */ `
     me {
       id
       userSkills {
-        ...UpdateSkillShowcase_UserSkill
+        ...UpdateSkillShowcaseUserSkill
       }
     }
     skills {
-      ...UpdateSkillShowcase_Skill
+      ...UpdateSkillShowcaseSkill
     }
   }
 `);
 
 interface ImproveBehaviouralSkillsProps {
-  skills: Skill[];
-  userSkills: UpdateSkillShowcaseUserSkillFragmentType[];
+  skills: UpdateSkillShowcaseSkillFragment[];
+  userSkills: UpdateSkillShowcaseUserSkillFragment[];
   initialSkills: FormValues;
   stale: boolean;
 }
@@ -180,13 +180,13 @@ const ImproveBehaviouralSkillsPage = () => {
 
   const userSkillsQuery = data?.me?.userSkills?.filter(notEmpty);
   const userSkills = getFragment(
-    UpdateSkillShowcase_UserSkillFragment,
+    UpdateSkillShowcaseUserSkill_Fragment,
     userSkillsQuery,
   );
 
   const skillsQuery = data?.skills.filter(notEmpty);
   const skills = getFragment(
-    UpdateSkillShowcase_SkillFragment,
+    UpdateSkillShowcaseSkill_Fragment,
     skillsQuery,
   )?.filter(notEmpty);
   const behaviouralSkills = skills

--- a/apps/web/src/pages/Skills/ImproveTechnicalSkillsPage.tsx
+++ b/apps/web/src/pages/Skills/ImproveTechnicalSkillsPage.tsx
@@ -8,8 +8,8 @@ import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 import { ROLE_NAME, useAuthorization } from "@gc-digital-talent/auth";
 import { navigationMessages } from "@gc-digital-talent/i18n";
 import type {
-  Skill,
-  UpdateSkillShowcase_UserSkillFragment as UpdateSkillShowcaseUserSkillFragmentType,
+  UpdateSkillShowcaseSkillFragment,
+  UpdateSkillShowcaseUserSkillFragment,
 } from "@gc-digital-talent/graphql";
 import {
   graphql,
@@ -23,8 +23,8 @@ import RequireAuth from "~/components/RequireAuth/RequireAuth";
 
 import type { FormValues } from "./components/UpdateSkillShowcase";
 import UpdateSkillShowcase, {
-  UpdateSkillShowcase_SkillFragment,
-  UpdateSkillShowcase_UserSkillFragment,
+  UpdateSkillShowcaseSkill_Fragment,
+  UpdateSkillShowcaseUserSkill_Fragment,
 } from "./components/UpdateSkillShowcase";
 import { UpdateUserSkillRankings_Mutation } from "./operations";
 
@@ -35,18 +35,18 @@ const ImproveTechnicalSkillsPage_Query = graphql(/* GraphQL */ `
     me {
       id
       userSkills {
-        ...UpdateSkillShowcase_UserSkill
+        ...UpdateSkillShowcaseUserSkill
       }
     }
     skills {
-      ...UpdateSkillShowcase_Skill
+      ...UpdateSkillShowcaseSkill
     }
   }
 `);
 
 interface ImproveTechnicalSkillsProps {
-  skills: Skill[];
-  userSkills: UpdateSkillShowcaseUserSkillFragmentType[];
+  skills: UpdateSkillShowcaseSkillFragment[];
+  userSkills: UpdateSkillShowcaseUserSkillFragment[];
   initialSkills: FormValues;
   stale: boolean;
 }
@@ -178,13 +178,13 @@ const ImproveTechnicalSkillsPage = () => {
 
   const userSkillsQuery = data?.me?.userSkills?.filter(notEmpty);
   const userSkills = getFragment(
-    UpdateSkillShowcase_UserSkillFragment,
+    UpdateSkillShowcaseUserSkill_Fragment,
     userSkillsQuery,
   );
 
   const skillsQuery = data?.skills.filter(notEmpty);
   const skills = getFragment(
-    UpdateSkillShowcase_SkillFragment,
+    UpdateSkillShowcaseSkill_Fragment,
     skillsQuery,
   )?.filter(notEmpty);
   const technicalSkills = skills

--- a/apps/web/src/pages/Skills/TopBehaviouralSkillsPage.tsx
+++ b/apps/web/src/pages/Skills/TopBehaviouralSkillsPage.tsx
@@ -8,8 +8,8 @@ import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 import { ROLE_NAME, useAuthorization } from "@gc-digital-talent/auth";
 import { navigationMessages } from "@gc-digital-talent/i18n";
 import type {
-  Skill,
-  UpdateSkillShowcase_UserSkillFragment as UpdateSkillShowcaseUserSkillFragmentType,
+  UpdateSkillShowcaseSkillFragment,
+  UpdateSkillShowcaseUserSkillFragment,
 } from "@gc-digital-talent/graphql";
 import {
   graphql,
@@ -23,8 +23,8 @@ import RequireAuth from "~/components/RequireAuth/RequireAuth";
 
 import type { FormValues } from "./components/UpdateSkillShowcase";
 import UpdateSkillShowcase, {
-  UpdateSkillShowcase_SkillFragment,
-  UpdateSkillShowcase_UserSkillFragment,
+  UpdateSkillShowcaseSkill_Fragment,
+  UpdateSkillShowcaseUserSkill_Fragment,
 } from "./components/UpdateSkillShowcase";
 import { UpdateUserSkillRankings_Mutation } from "./operations";
 
@@ -35,18 +35,18 @@ const TopBehaviouralSkillsPage_Query = graphql(/* GraphQL */ `
     me {
       id
       userSkills {
-        ...UpdateSkillShowcase_UserSkill
+        ...UpdateSkillShowcaseUserSkill
       }
     }
     skills {
-      ...UpdateSkillShowcase_Skill
+      ...UpdateSkillShowcaseSkill
     }
   }
 `);
 
 interface TopBehaviouralSkillsProps {
-  skills: Skill[];
-  userSkills: UpdateSkillShowcaseUserSkillFragmentType[];
+  skills: UpdateSkillShowcaseSkillFragment[];
+  userSkills: UpdateSkillShowcaseUserSkillFragment[];
   initialSkills: FormValues;
   stale: boolean;
 }
@@ -178,13 +178,13 @@ const TopBehaviouralSkillsPage = () => {
 
   const userSkillsQuery = data?.me?.userSkills?.filter(notEmpty);
   const userSkills = getFragment(
-    UpdateSkillShowcase_UserSkillFragment,
+    UpdateSkillShowcaseUserSkill_Fragment,
     userSkillsQuery,
   );
 
   const skillsQuery = data?.skills.filter(notEmpty);
   const skills = getFragment(
-    UpdateSkillShowcase_SkillFragment,
+    UpdateSkillShowcaseSkill_Fragment,
     skillsQuery,
   )?.filter(notEmpty);
   const behaviouralSkills = skills

--- a/apps/web/src/pages/Skills/TopTechnicalSkillsPage.tsx
+++ b/apps/web/src/pages/Skills/TopTechnicalSkillsPage.tsx
@@ -8,8 +8,8 @@ import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 import { ROLE_NAME, useAuthorization } from "@gc-digital-talent/auth";
 import { navigationMessages } from "@gc-digital-talent/i18n";
 import type {
-  Skill,
-  UpdateSkillShowcase_UserSkillFragment as UpdateSkillShowcaseUserSkillFragmentType,
+  UpdateSkillShowcaseSkillFragment,
+  UpdateSkillShowcaseUserSkillFragment,
 } from "@gc-digital-talent/graphql";
 import {
   graphql,
@@ -23,8 +23,8 @@ import RequireAuth from "~/components/RequireAuth/RequireAuth";
 
 import type { FormValues } from "./components/UpdateSkillShowcase";
 import UpdateSkillShowcase, {
-  UpdateSkillShowcase_SkillFragment,
-  UpdateSkillShowcase_UserSkillFragment,
+  UpdateSkillShowcaseSkill_Fragment,
+  UpdateSkillShowcaseUserSkill_Fragment,
 } from "./components/UpdateSkillShowcase";
 import { UpdateUserSkillRankings_Mutation } from "./operations";
 
@@ -35,18 +35,18 @@ const TopTechnicalSkillsPage_Query = graphql(/* GraphQL */ `
     me {
       id
       userSkills {
-        ...UpdateSkillShowcase_UserSkill
+        ...UpdateSkillShowcaseUserSkill
       }
     }
     skills {
-      ...UpdateSkillShowcase_Skill
+      ...UpdateSkillShowcaseSkill
     }
   }
 `);
 
 interface TopTechnicalSkillsProps {
-  skills: Skill[];
-  userSkills: UpdateSkillShowcaseUserSkillFragmentType[];
+  skills: UpdateSkillShowcaseSkillFragment[];
+  userSkills: UpdateSkillShowcaseUserSkillFragment[];
   initialSkills: FormValues;
   stale: boolean;
 }
@@ -182,13 +182,13 @@ const TopTechnicalSkillsPage = () => {
 
   const userSkillsQuery = data?.me?.userSkills?.filter(notEmpty);
   const userSkills = getFragment(
-    UpdateSkillShowcase_UserSkillFragment,
+    UpdateSkillShowcaseUserSkill_Fragment,
     userSkillsQuery,
   );
 
   const skillsQuery = data?.skills.filter(notEmpty);
   const skills = getFragment(
-    UpdateSkillShowcase_SkillFragment,
+    UpdateSkillShowcaseSkill_Fragment,
     skillsQuery,
   )?.filter(notEmpty);
   const technicalSkills = skills

--- a/apps/web/src/pages/Skills/UpdateSkillPage.tsx
+++ b/apps/web/src/pages/Skills/UpdateSkillPage.tsx
@@ -3,7 +3,6 @@ import { useIntl } from "react-intl";
 import type { SubmitHandler } from "react-hook-form";
 import { FormProvider, useForm } from "react-hook-form";
 import pick from "lodash/pick";
-import sortBy from "lodash/sortBy";
 import { useMutation, useQuery } from "urql";
 import IdentificationIcon from "@heroicons/react/24/outline/IdentificationIcon";
 
@@ -17,9 +16,8 @@ import {
   Select,
   localizedEnumToOptions,
 } from "@gc-digital-talent/forms";
-import { unpackMaybes } from "@gc-digital-talent/helpers";
+import { sortAlphaBy, unpackMaybes } from "@gc-digital-talent/helpers";
 import {
-  getLocale,
   errorMessages,
   commonMessages,
   getLocalizedName,
@@ -34,7 +32,8 @@ import {
   Card,
 } from "@gc-digital-talent/ui";
 import type {
-  Skill,
+  LocalizedString,
+  UpdateSkillFragment,
   UpdateSkillInput,
   UpdateSkillMutation,
   SkillCategory,
@@ -56,12 +55,9 @@ import pageTitles from "~/messages/pageTitles";
 
 import { SkillFormOptions_Fragment } from "./operations";
 
-interface Option<V> {
-  value: V;
-  label: string;
-}
-
-interface FormValues extends Pick<Skill, "name" | "description"> {
+interface FormValues {
+  name: LocalizedString;
+  description?: LocalizedString | null;
   category?: SkillCategory;
   families: string[];
   keywords: {
@@ -73,10 +69,8 @@ interface FormValues extends Pick<Skill, "name" | "description"> {
 export const UpdateSkillSkillFamily_Fragment = graphql(/* GraphQL */ `
   fragment UpdateSkillSkillFamily on SkillFamily {
     id
-    key
     name {
-      en
-      fr
+      localized
     }
   }
 `);
@@ -128,7 +122,6 @@ export const UpdateSkillForm = ({
   handleUpdateSkill,
 }: UpdateSkillFormProps) => {
   const intl = useIntl();
-  const locale = getLocale(intl);
   const navigate = useNavigate();
   const paths = useRoutes();
   const data = getFragment(SkillFormOptions_Fragment, optionsQuery);
@@ -137,11 +130,7 @@ export const UpdateSkillForm = ({
     UpdateSkillSkillFamily_Fragment,
     familiesQuery,
   );
-  const sortedFamilies = sortBy([...skillFamilies], (family) => {
-    return family.name?.[locale]?.toLocaleUpperCase();
-  });
-
-  const dataToFormValues = (values: Skill): FormValues => ({
+  const dataToFormValues = (values: UpdateSkillFragment): FormValues => ({
     ...values,
     category: values.category.value ?? undefined,
     keywords: {
@@ -202,12 +191,12 @@ export const UpdateSkillForm = ({
       });
   };
 
-  const skillFamilyOptions: Option<string>[] = sortedFamilies.map(
-    ({ id, name }) => ({
+  const skillFamilyOptions = [...skillFamilies]
+    .sort(sortAlphaBy((family) => family.name?.localized))
+    .map(({ id, name }) => ({
       value: id,
-      label: getLocalizedName(name, intl),
-    }),
-  );
+      label: name?.localized ?? intl.formatMessage(commonMessages.notAvailable),
+    }));
 
   return (
     <FormProvider {...methods}>

--- a/apps/web/src/pages/Skills/components/SkillFilterDialog.tsx
+++ b/apps/web/src/pages/Skills/components/SkillFilterDialog.tsx
@@ -2,13 +2,22 @@ import { useIntl } from "react-intl";
 import { useQuery } from "urql";
 
 import { Combobox, localizedEnumToOptions } from "@gc-digital-talent/forms";
-import { getLocalizedName } from "@gc-digital-talent/i18n";
-import type { SkillCategory, SkillFamily } from "@gc-digital-talent/graphql";
-import { graphql } from "@gc-digital-talent/graphql";
+import { commonMessages } from "@gc-digital-talent/i18n";
+import type { FragmentType, SkillCategory } from "@gc-digital-talent/graphql";
+import { getFragment, graphql } from "@gc-digital-talent/graphql";
 
 import adminMessages from "~/messages/adminMessages";
 import type { CommonFilterDialogProps } from "~/components/FilterDialog/FilterDialog";
 import FilterDialog from "~/components/FilterDialog/FilterDialog";
+
+export const SkillFilterFamily_Fragment = graphql(/* GraphQL */ `
+  fragment SkillFilterFamily on SkillFamily {
+    key
+    name {
+      localized
+    }
+  }
+`);
 
 const SkillFilterOptions_Query = graphql(/* GraphQL */ `
   query SkillFilterOptions {
@@ -28,18 +37,19 @@ export interface FormValues {
 }
 
 interface SkillFilterDialogProps extends CommonFilterDialogProps<FormValues> {
-  skillFamilies: SkillFamily[];
+  query: FragmentType<typeof SkillFilterFamily_Fragment>[];
   fetching?: boolean;
 }
 
 const SkillFilterDialog = ({
-  skillFamilies,
+  query,
   fetching,
   initialValues,
   resetValues,
   onSubmit,
 }: SkillFilterDialogProps) => {
   const intl = useIntl();
+  const skillFamilies = getFragment(SkillFilterFamily_Fragment, query);
   const [{ data, fetching: optionsFetching }] = useQuery({
     query: SkillFilterOptions_Query,
   });
@@ -59,7 +69,9 @@ const SkillFilterDialog = ({
           doNotSort
           options={skillFamilies.map(({ key, name }) => ({
             value: key,
-            label: getLocalizedName(name, intl),
+            label:
+              name?.localized ??
+              intl.formatMessage(commonMessages.notAvailable),
           }))}
         />
         <Combobox

--- a/apps/web/src/pages/Skills/components/SkillShowcaseCard.tsx
+++ b/apps/web/src/pages/Skills/components/SkillShowcaseCard.tsx
@@ -1,14 +1,17 @@
 import { useIntl } from "react-intl";
 import { useMutation } from "urql";
 
-import { getLocalizedName, getSkillLevelName } from "@gc-digital-talent/i18n";
+import { commonMessages, getSkillLevelName } from "@gc-digital-talent/i18n";
 import { CardRepeater, useCardRepeaterContext } from "@gc-digital-talent/ui";
 import type {
+  FragmentType,
   UpdateUserSkillRankingsInput,
-  Skill,
-  UserSkill,
 } from "@gc-digital-talent/graphql";
-import { SkillCategory } from "@gc-digital-talent/graphql";
+import {
+  getFragment,
+  graphql,
+  SkillCategory,
+} from "@gc-digital-talent/graphql";
 import { useAuthorization } from "@gc-digital-talent/auth";
 
 import type { FormValues as SkillBrowserDialogFormValues } from "~/components/SkillBrowser/types";
@@ -16,10 +19,22 @@ import type { FormValues as SkillBrowserDialogFormValues } from "~/components/Sk
 import RemoveDialog from "./RemoveDialog";
 import { UpdateUserSkillRankings_Mutation } from "../operations";
 
+export const SkillShowcaseCardSkill_Fragment = graphql(/* GraphQL */ `
+  fragment SkillShowcaseCardSkill on Skill {
+    id
+    name {
+      localized
+    }
+    description {
+      localized
+    }
+  }
+`);
+
 interface SkillShowcaseCardProps {
   index: number;
   item: SkillBrowserDialogFormValues;
-  skills: Skill[];
+  query: FragmentType<typeof SkillShowcaseCardSkill_Fragment>[];
   // which user-skill ranking are we updating with this card
   userSkillRanking: keyof UpdateUserSkillRankingsInput;
 }
@@ -27,7 +42,7 @@ interface SkillShowcaseCardProps {
 const SkillShowcaseCard = ({
   index,
   item,
-  skills,
+  query,
   userSkillRanking,
 }: SkillShowcaseCardProps) => {
   const intl = useIntl();
@@ -36,19 +51,20 @@ const SkillShowcaseCard = ({
     UpdateUserSkillRankings_Mutation,
   );
   const { items } = useCardRepeaterContext();
-
-  const getSkill = (skillId: string | undefined) =>
-    skills.find((skill) => skill.id === skillId);
+  const notAvailable = intl.formatMessage(commonMessages.notAvailable);
+  const skill = getFragment(SkillShowcaseCardSkill_Fragment, query).find(
+    (currentSkill) => currentSkill.id === item.skill,
+  );
 
   // the mutation has be done at the card level.  If done in the parent the card is unmounted and dialog is lost if there is an error.
   const handleRemove = async (): Promise<void> => {
-    const copyOfItems = [...(items ?? [])] as UserSkill[];
+    const copyOfItems = [...(items ?? [])] as SkillBrowserDialogFormValues[];
     copyOfItems.splice(index, 1);
     const res = await updateUserSkillRankingsMutation({
       userId: userAuthInfo?.id ?? "",
       userSkillRanking: {
         [userSkillRanking]: [
-          ...copyOfItems.map((userSkill: UserSkill) => userSkill.skill),
+          ...copyOfItems.map((userSkill) => userSkill.skill),
         ],
       },
     });
@@ -66,7 +82,7 @@ const SkillShowcaseCard = ({
       <div className="mt-3 flex flex-col gap-3">
         <span className="flex justify-between" role="presentation">
           <span className="font-bold">
-            {getLocalizedName(getSkill(item.skill)?.name ?? undefined, intl)}
+            {skill?.name?.localized ?? notAvailable}
           </span>
           <span className="text-gray-600 dark:text-gray-200">
             {item.skillLevel
@@ -78,17 +94,12 @@ const SkillShowcaseCard = ({
                       : SkillCategory.Technical,
                   ),
                 )
-              : getLocalizedName(null, intl)}
+              : notAvailable}
           </span>
         </span>
 
         <div>
-          <p>
-            {getLocalizedName(
-              getSkill(item.skill)?.description ?? undefined,
-              intl,
-            )}
-          </p>
+          <p>{skill?.description?.localized ?? notAvailable}</p>
         </div>
       </div>
     </CardRepeater.Card>

--- a/apps/web/src/pages/Skills/components/SkillTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillTable.tsx
@@ -16,8 +16,12 @@ import {
 } from "@gc-digital-talent/i18n";
 import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 import { Link, LoadingErrorMessage } from "@gc-digital-talent/ui";
-import type { Skill } from "@gc-digital-talent/graphql";
-import { SkillCategory, graphql } from "@gc-digital-talent/graphql";
+import type { SkillTableRowFragment } from "@gc-digital-talent/graphql";
+import {
+  SkillCategory,
+  getFragment,
+  graphql,
+} from "@gc-digital-talent/graphql";
 
 import useRoutes from "~/hooks/useRoutes";
 import Table from "~/components/Table/ResponsiveTable/ResponsiveTable";
@@ -69,53 +73,42 @@ function transformSkillFilterInputToFormValues(
   };
 }
 
-const columnHelper = createColumnHelper<Skill>();
+const columnHelper = createColumnHelper<SkillTableRowFragment>();
+
+const SkillTableRow_Fragment = graphql(/* GraphQL */ `
+  fragment SkillTableRow on Skill {
+    ...SkillCsv
+    id
+    category {
+      value
+      label {
+        localized
+      }
+    }
+    name {
+      en
+      fr
+    }
+    description {
+      en
+      fr
+    }
+    families {
+      key
+      name {
+        localized
+      }
+    }
+  }
+`);
 
 const SkillTableSkills_Query = graphql(/* GraphQL */ `
   query SkillTableSkills {
     skills {
-      ...SkillCsv
-      id
-      key
-      category {
-        value
-        label {
-          en
-          fr
-        }
-      }
-      name {
-        en
-        fr
-      }
-      description {
-        en
-        fr
-      }
-      keywords {
-        en
-        fr
-      }
-      families {
-        id
-        key
-        name {
-          en
-          fr
-        }
-        description {
-          en
-          fr
-        }
-      }
+      ...SkillTableRow
     }
     skillFamilies {
-      id
-      key
-      name {
-        en
-        fr
-      }
+      ...SkillFilterFamily
     }
   }
 `);
@@ -150,7 +143,10 @@ const SkillTable = ({
     context,
   });
 
-  const skills = useMemo(() => unpackMaybes(data?.skills), [data?.skills]);
+  const skills = getFragment(
+    SkillTableRow_Fragment,
+    unpackMaybes(data?.skills),
+  );
   const skillFamilies = unpackMaybes(data?.skillFamilies);
 
   const paths = useRoutes();
@@ -291,19 +287,30 @@ const SkillTable = ({
       header: intl.formatMessage(adminMessages.id),
     }),
     ...columnsOrderedByLocale,
-    columnHelper.accessor((skill) => familiesAccessor(skill, intl), {
-      id: "skillFamilies",
-      sortingFn: normalizedText,
-      header: intl.formatMessage(adminMessages.skillFamilies),
-      cell: ({ row: { original: skill } }) =>
-        skillFamiliesCell(skill.families, intl),
-    }),
-    columnHelper.accessor(({ category }) => categoryAccessor(category, intl), {
-      id: "category",
-      sortingFn: normalizedText,
-      header: intl.formatMessage(adminMessages.category),
-    }),
-  ] as ColumnDef<Skill>[];
+    columnHelper.accessor(
+      (skill) =>
+        familiesAccessor(
+          skill.families?.map((family) => family.name?.localized),
+        ),
+      {
+        id: "skillFamilies",
+        sortingFn: normalizedText,
+        header: intl.formatMessage(adminMessages.skillFamilies),
+        cell: ({ row: { original: skill } }) =>
+          skillFamiliesCell(
+            skill.families?.map((family) => family.name?.localized),
+          ),
+      },
+    ),
+    columnHelper.accessor(
+      ({ category }) => categoryAccessor(category.label?.localized),
+      {
+        id: "category",
+        sortingFn: normalizedText,
+        header: intl.formatMessage(adminMessages.category),
+      },
+    ),
+  ] as ColumnDef<SkillTableRowFragment>[];
 
   const { pathname, search, hash } = useLocation();
   const currentUrl = `${pathname}${search}${hash}`;
@@ -313,7 +320,7 @@ const SkillTable = ({
   }
 
   return (
-    <Table<Skill>
+    <Table<SkillTableRowFragment>
       caption={title}
       isLoading={fetching}
       data={filteredSkills}
@@ -361,7 +368,7 @@ const SkillTable = ({
         state: filterState,
         component: (
           <SkillFilterDialog
-            skillFamilies={skillFamilies}
+            query={skillFamilies}
             fetching={fetching}
             onSubmit={handleFilterSubmit}
             resetValues={transformSkillFilterInputToFormValues({})}

--- a/apps/web/src/pages/Skills/components/SkillTable.tsx
+++ b/apps/web/src/pages/Skills/components/SkillTable.tsx
@@ -74,6 +74,7 @@ const columnHelper = createColumnHelper<Skill>();
 const SkillTableSkills_Query = graphql(/* GraphQL */ `
   query SkillTableSkills {
     skills {
+      ...SkillCsv
       id
       key
       category {
@@ -377,7 +378,7 @@ const SkillTable = ({
                 csv: {
                   headers: getSkillCsvHeaders(intl),
                   data: () => {
-                    return getSkillCsvData(skills, intlEn, intlFr);
+                    return getSkillCsvData(skills);
                   },
                   fileName: intl.formatMessage({
                     defaultMessage: "GC Digital Talent - All skills.csv",

--- a/apps/web/src/pages/Skills/components/UpdateSkillShowcase.tsx
+++ b/apps/web/src/pages/Skills/components/UpdateSkillShowcase.tsx
@@ -20,8 +20,8 @@ import { commonMessages } from "@gc-digital-talent/i18n";
 import { toast } from "@gc-digital-talent/toast";
 import type {
   UpdateUserSkillRankingsInput,
-  UpdateSkillShowcase_UserSkillFragment as UpdateSkillShowcaseUserSkillFragmentType,
-  UpdateSkillShowcase_SkillFragment as UpdateSkillShowcaseSkillFragmentType,
+  UpdateSkillShowcaseUserSkillFragment,
+  UpdateSkillShowcaseSkillFragment,
 } from "@gc-digital-talent/graphql";
 import { graphql } from "@gc-digital-talent/graphql";
 
@@ -36,8 +36,8 @@ import {
 } from "../operations";
 import SkillShowcaseCard from "./SkillShowcaseCard";
 
-export const UpdateSkillShowcase_UserSkillFragment = graphql(/* GraphQL */ `
-  fragment UpdateSkillShowcase_UserSkill on UserSkill {
+export const UpdateSkillShowcaseUserSkill_Fragment = graphql(/* GraphQL */ `
+  fragment UpdateSkillShowcaseUserSkill on UserSkill {
     id
     whenSkillUsed
     skillLevel
@@ -62,9 +62,10 @@ export const UpdateSkillShowcase_UserSkillFragment = graphql(/* GraphQL */ `
   }
 `);
 
-export const UpdateSkillShowcase_SkillFragment = graphql(/* GraphQL */ `
-  fragment UpdateSkillShowcase_Skill on Skill {
+export const UpdateSkillShowcaseSkill_Fragment = graphql(/* GraphQL */ `
+  fragment UpdateSkillShowcaseSkill on Skill {
     ...SkillBrowserSkill
+    ...SkillShowcaseCardSkill
     id
     key
     category {
@@ -105,10 +106,14 @@ export interface FormValues {
   userSkills: SkillBrowserDialogFormValues[];
 }
 
+interface RankedSkill extends SkillBrowserDialogFormValues {
+  skill: string;
+}
+
 interface UpdateSkillShowcaseProps {
   userId: string;
-  allUserSkills: UpdateSkillShowcaseUserSkillFragmentType[];
-  allSkills: UpdateSkillShowcaseSkillFragmentType[];
+  allUserSkills: UpdateSkillShowcaseUserSkillFragment[];
+  allSkills: UpdateSkillShowcaseSkillFragment[];
   initialData: FormValues;
   maxItems: number;
   crumbs: BreadcrumbsProps["crumbs"];
@@ -302,6 +307,10 @@ const UpdateSkillShowcase = ({
     return submitPromise;
   };
 
+  const rankedSkills = initialData.userSkills.filter(
+    (userSkill): userSkill is RankedSkill => !!userSkill.skill,
+  );
+
   return (
     <>
       <SEO title={pageInfo.title} description={pageInfo.description} />
@@ -335,8 +344,8 @@ const UpdateSkillShowcase = ({
                 <div className="mb-6">
                   <CardRepeater.Root<SkillBrowserDialogFormValues>
                     disabled={isBusy || disabled}
-                    items={initialData.userSkills.map((userSkill) => ({
-                      id: userSkill.skill ?? "unknown",
+                    items={rankedSkills.map((userSkill) => ({
+                      id: userSkill.skill,
                       ...userSkill,
                     }))}
                     max={maxItems}
@@ -362,12 +371,12 @@ const UpdateSkillShowcase = ({
                       handleUpdate({ userSkills: items })
                     }
                   >
-                    {initialData.userSkills.map((item, index) => (
+                    {rankedSkills.map((item, index) => (
                       <SkillShowcaseCard
                         key={item.skill}
                         item={item}
                         index={index}
-                        skills={allSkills}
+                        query={allSkills}
                         userSkillRanking={userSkillRanking}
                       />
                     ))}

--- a/apps/web/src/pages/Skills/components/UpdateSkillShowcase.tsx
+++ b/apps/web/src/pages/Skills/components/UpdateSkillShowcase.tsx
@@ -44,6 +44,7 @@ export const UpdateSkillShowcase_UserSkillFragment = graphql(/* GraphQL */ `
     topSkillsRank
     improveSkillsRank
     skill {
+      ...SkillBrowserSkill
       id
       key
       name {
@@ -63,6 +64,7 @@ export const UpdateSkillShowcase_UserSkillFragment = graphql(/* GraphQL */ `
 
 export const UpdateSkillShowcase_SkillFragment = graphql(/* GraphQL */ `
   fragment UpdateSkillShowcase_Skill on Skill {
+    ...SkillBrowserSkill
     id
     key
     category {
@@ -340,7 +342,7 @@ const UpdateSkillShowcase = ({
                     max={maxItems}
                     add={
                       <SkillBrowserDialog
-                        inLibrary={allUserSkills
+                        inLibraryQuery={allUserSkills
                           .map((userSkill) => userSkill.skill)
                           .filter(
                             (skill) =>
@@ -348,7 +350,7 @@ const UpdateSkillShowcase = ({
                           )}
                         trigger={triggerProps}
                         context="showcase"
-                        skills={allSkills.filter(
+                        query={allSkills.filter(
                           (skill) =>
                             !existingSkillsRankingFiltered.includes(skill.id),
                         )}

--- a/apps/web/src/pages/Skills/components/skillCsv.tsx
+++ b/apps/web/src/pages/Skills/components/skillCsv.tsx
@@ -1,29 +1,59 @@
 import type { IntlShape } from "react-intl";
 
 import type { DownloadCsvProps } from "@gc-digital-talent/ui";
-import type { Skill } from "@gc-digital-talent/graphql";
+import type { FragmentType } from "@gc-digital-talent/graphql";
+import { getFragment, graphql } from "@gc-digital-talent/graphql";
 import { appendLanguageName, commonMessages } from "@gc-digital-talent/i18n";
 import { nodeToString } from "@gc-digital-talent/helpers";
 
 import { getSkillFamilies } from "~/utils/csvUtils";
 import adminMessages from "~/messages/adminMessages";
 
+export const SkillCsv_Fragment = graphql(/* GraphQL */ `
+  fragment SkillCsv on Skill {
+    id
+    name {
+      en
+      fr
+    }
+    description {
+      en
+      fr
+    }
+    category {
+      label {
+        en
+        fr
+      }
+    }
+    families {
+      name {
+        en
+        fr
+      }
+    }
+  }
+`);
+
 export const getSkillCsvData = (
-  skills: Skill[],
-  intlEn: IntlShape,
-  intlFr: IntlShape,
+  query: FragmentType<typeof SkillCsv_Fragment>[],
 ) => {
+  const skills = getFragment(SkillCsv_Fragment, query);
   const data: DownloadCsvProps["data"] = skills.map(
     ({ id, name, description, category, families }) => {
       return {
         id,
         nameEn: name.en,
         categoryEn: category.label?.en,
-        skillFamiliesEn: getSkillFamilies(families, intlEn),
+        skillFamiliesEn: getSkillFamilies(
+          families?.map((family) => family.name?.en),
+        ),
         descriptionEn: description?.en ?? "",
         nameFr: name.fr,
         categoryFr: category.label?.fr,
-        skillFamiliesFr: getSkillFamilies(families, intlFr),
+        skillFamiliesFr: getSkillFamilies(
+          families?.map((family) => family.name?.fr),
+        ),
         descriptionFr: description?.fr ?? "",
       };
     },

--- a/apps/web/src/pages/Skills/components/tableHelpers.tsx
+++ b/apps/web/src/pages/Skills/components/tableHelpers.tsx
@@ -1,42 +1,25 @@
-import type { IntlShape } from "react-intl";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
 
-import { getLocalizedName } from "@gc-digital-talent/i18n";
-import { notEmpty } from "@gc-digital-talent/helpers";
-import type {
-  LocalizedSkillCategory,
-  Skill,
-  SkillFamily,
-} from "@gc-digital-talent/graphql";
-
-export function categoryAccessor(
-  category: LocalizedSkillCategory | null,
-  intl: IntlShape,
-) {
-  return category?.label ? getLocalizedName(category.label, intl) : "";
+export function categoryAccessor(categoryLabel: string | null | undefined) {
+  return categoryLabel ?? "";
 }
 
 export function skillFamiliesCell(
-  skillFamilies: (SkillFamily | null)[] | null | undefined,
-  intl: IntlShape,
+  familyNames: (string | null | undefined)[] | null | undefined,
 ) {
-  const familyNames = skillFamilies
-    ?.filter(notEmpty)
-    .sort()
-    .map((family) => getLocalizedName(family.name, intl));
+  const sortedNames = unpackMaybes(familyNames).sort((a, b) =>
+    a.localeCompare(b),
+  );
 
-  familyNames?.sort((a, b) => a.localeCompare(b));
-
-  const familyItems = familyNames?.map((familyName) => (
+  const familyItems = sortedNames.map((familyName) => (
     <li key={familyName}>{familyName}</li>
   ));
 
-  return familyItems ? <ul>{familyItems}</ul> : null;
+  return familyItems.length ? <ul>{familyItems}</ul> : null;
 }
 
-export function familiesAccessor(skill: Skill, intl: IntlShape) {
-  return skill.families
-    ?.map((family) => getLocalizedName(family.name, intl, true))
-    .filter(notEmpty)
-    .sort()
-    .join(", ");
+export function familiesAccessor(
+  familyNames: (string | null | undefined)[] | null | undefined,
+) {
+  return unpackMaybes(familyNames).sort().join(", ");
 }

--- a/apps/web/src/utils/csvUtils.tsx
+++ b/apps/web/src/utils/csvUtils.tsx
@@ -1,8 +1,4 @@
-import type { IntlShape } from "react-intl";
-
-import { getLocalizedName } from "@gc-digital-talent/i18n";
-import { insertBetween, notEmpty } from "@gc-digital-talent/helpers";
-import type { Skill } from "@gc-digital-talent/graphql";
+import { insertBetween, unpackMaybes } from "@gc-digital-talent/helpers";
 
 /**
  * Converts a possible array to
@@ -16,20 +12,14 @@ const listOrEmptyString = (value: string[] | undefined) => {
 };
 
 /**
- * Converts possible array of skill families
+ * Converts possible array of skill family names
  * to a comma separated list or empty string
  *
- * @param families  Skill["families"]
- * @param intl react-intl object
+ * @param familyNames Localized skill family names
  * @returns string
  */
 export const getSkillFamilies = (
-  families: Skill["families"],
-  intl: IntlShape,
+  familyNames: (string | null | undefined)[] | null | undefined,
 ) => {
-  const familyNames = families
-    ?.filter(notEmpty)
-    .map((family) => getLocalizedName(family.name, intl));
-
-  return listOrEmptyString(familyNames);
+  return listOrEmptyString(unpackMaybes(familyNames));
 };

--- a/apps/web/src/utils/skillUtils.ts
+++ b/apps/web/src/utils/skillUtils.ts
@@ -4,7 +4,6 @@ import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 import type {
   Experience,
   Skill,
-  SkillFamily,
   PoolSkill,
   PoolSkillType,
 } from "@gc-digital-talent/graphql";
@@ -12,40 +11,49 @@ import { SkillLevel, SkillCategory } from "@gc-digital-talent/graphql";
 
 import type { SimpleAnyExperience } from "./experienceUtils";
 
+export interface SkillFamilyIdentifier {
+  id: string;
+}
+
+export interface SkillWithFamilies<F extends SkillFamilyIdentifier> {
+  id: string;
+  families?: F[] | null;
+}
+
 /**
  * Transforms an array of skills with child skill families into a tree of skill families with child skills.
- * @param { Skill[] } skills - The collection of skills with child skill families to invert
- * @returns { SkillFamily[] } - The new collection of skill families with child skills
+ * @param skills - The collection of skills with child skill families to invert
+ * @returns The new collection of skill families with child skills
  */
-export function invertSkillSkillFamilyTree(skills: Skill[]): SkillFamily[] {
+export function invertSkillSkillFamilyTree<F extends SkillFamilyIdentifier>(
+  skills: SkillWithFamilies<F>[],
+) {
   const allChildSkillFamilies = skills
     .flatMap((s) => s.families)
     .filter(notEmpty);
   const uniqueSkillFamilies = uniqBy(allChildSkillFamilies, "id");
-  const skillFamiliesWithSkills = uniqueSkillFamilies.map(
-    (family: SkillFamily) => {
-      // step 1 - find the skills that belong to this family
-      const skillsInThisFamily = skills.filter((skill) =>
-        skill.families?.some(
-          (childSkillFamilies) => family.id === childSkillFamilies?.id,
-        ),
-      );
+  const skillFamiliesWithSkills = uniqueSkillFamilies.map((family) => {
+    // step 1 - find the skills that belong to this family
+    const skillsInThisFamily = skills.filter((skill) =>
+      skill.families?.some(
+        (childSkillFamilies) => family.id === childSkillFamilies?.id,
+      ),
+    );
 
-      // step 2 - clone the skills and strip off the child skillFamilies to prevent circular references
-      const skillWithChildrenRemoved = skillsInThisFamily.map((skill) => {
-        return {
-          ...skill,
-          families: [],
-        };
-      });
-
-      // step 3 - clone the skill family and attach the skill collection
+    // step 2 - clone the skills and strip off the child skillFamilies to prevent circular references
+    const skillWithChildrenRemoved = skillsInThisFamily.map((skill) => {
       return {
-        ...family,
-        skills: skillWithChildrenRemoved,
+        ...skill,
+        families: [],
       };
-    },
-  );
+    });
+
+    // step 3 - clone the skill family and attach the skill collection
+    return {
+      ...family,
+      skills: skillWithChildrenRemoved,
+    };
+  });
   return skillFamiliesWithSkills;
 }
 

--- a/apps/web/src/utils/skillUtils.ts
+++ b/apps/web/src/utils/skillUtils.ts
@@ -3,6 +3,7 @@ import uniqBy from "lodash/uniqBy";
 import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 import type {
   Experience,
+  LocalizedString,
   Skill,
   PoolSkill,
   PoolSkillType,
@@ -11,23 +12,22 @@ import { SkillLevel, SkillCategory } from "@gc-digital-talent/graphql";
 
 import type { SimpleAnyExperience } from "./experienceUtils";
 
-export interface SkillFamilyIdentifier {
+export interface SkillFamilyOption {
   id: string;
+  name?: LocalizedString | null;
 }
 
-export interface SkillWithFamilies<F extends SkillFamilyIdentifier> {
+export interface SkillWithFamilies {
   id: string;
-  families?: F[] | null;
+  families?: SkillFamilyOption[] | null;
 }
 
 /**
  * Transforms an array of skills with child skill families into a tree of skill families with child skills.
- * @param skills - The collection of skills with child skill families to invert
- * @returns The new collection of skill families with child skills
+ * @param { SkillWithFamilies[] } skills - The collection of skills with child skill families to invert
+ * @returns { SkillFamilyOption[] } - The new collection of skill families with child skills
  */
-export function invertSkillSkillFamilyTree<F extends SkillFamilyIdentifier>(
-  skills: SkillWithFamilies<F>[],
-) {
+export function invertSkillSkillFamilyTree(skills: SkillWithFamilies[]) {
   const allChildSkillFamilies = skills
     .flatMap((s) => s.families)
     .filter(notEmpty);

--- a/packages/fake-data/src/skills.json
+++ b/packages/fake-data/src/skills.json
@@ -6,11 +6,13 @@
         "key": "ability_to_learn_quickly",
         "name": {
           "en": "Ability to Learn Quickly",
-          "fr": "Capacité d’apprendre rapidement"
+          "fr": "Capacité d’apprendre rapidement",
+          "localized": "Ability to Learn Quickly"
         },
         "description": {
           "en": "Demonstrated ability to rapidly pick up new skills and competencies, and apply them in a work situation.",
-          "fr": "Capacité démontrée à acquérir rapidement de nouvelles aptitudes et compétences et à les appliquer dans une situation de travail."
+          "fr": "Capacité démontrée à acquérir rapidement de nouvelles aptitudes et compétences et à les appliquer dans une situation de travail.",
+          "localized": "Demonstrated ability to rapidly pick up new skills and competencies, and apply them in a work situation."
         },
         "keywords": {
           "en": ["Fast Learner", "Quick Learner"],
@@ -25,11 +27,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -39,11 +43,13 @@
         "key": "accessibility_testing",
         "name": {
           "en": "Accessibility testing",
-          "fr": "Tests d’accessibilité"
+          "fr": "Tests d’accessibilité",
+          "localized": "Accessibility testing"
         },
         "description": {
           "en": "Demonstrated the ability to create, facilitate, and interpret data from manual and/or automated tests that are designed to highlight accessibility concerns. These tests include but are not limited to the product's interface design, the use of assistive technologies, written content, and cognitive usability.",
-          "fr": "Capacité démontrée à créer, de simplifier et d’interpréter des données provenant de tests manuels ou automatisés conçus pour mettre en évidence les problèmes d’accessibilité. Ces tests portent notamment sur la conception de l’interface du produit, l’utilisation des technologies d’assistance, le contenu écrit et la facilité d’utilisation cognitive."
+          "fr": "Capacité démontrée à créer, de simplifier et d’interpréter des données provenant de tests manuels ou automatisés conçus pour mettre en évidence les problèmes d’accessibilité. Ces tests portent notamment sur la conception de l’interface du produit, l’utilisation des technologies d’assistance, le contenu écrit et la facilité d’utilisation cognitive.",
+          "localized": "Demonstrated the ability to create, facilitate, and interpret data from manual and/or automated tests that are designed to highlight accessibility concerns. These tests include but are not limited to the product's interface design, the use of assistive technologies, written content, and cognitive usability."
         },
         "keywords": {
           "en": ["Accessibility", "testing"],
@@ -58,11 +64,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           }
         ]
@@ -72,11 +80,13 @@
         "key": "accountability",
         "name": {
           "en": "Accountability",
-          "fr": "Responsabilité"
+          "fr": "Responsabilité",
+          "localized": "Accountability"
         },
         "description": {
           "en": "Demonstrated ability to be transparent about, and take responsibility for, decisions and actions.",
-          "fr": "Capacité démontrée à faire preuve de transparence et assumer la responsabilité des décisions et actions."
+          "fr": "Capacité démontrée à faire preuve de transparence et assumer la responsabilité des décisions et actions.",
+          "localized": "Demonstrated ability to be transparent about, and take responsibility for, decisions and actions."
         },
         "keywords": {
           "en": ["Responsibility", "Ownership", "Transparency"],
@@ -91,11 +101,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -105,11 +117,13 @@
         "key": "accreditation_procedures__policies__and_practices",
         "name": {
           "en": "Accreditation Procedures, Policies, and Practices",
-          "fr": "Procédures, politiques et pratiques d’accréditation"
+          "fr": "Procédures, politiques et pratiques d’accréditation",
+          "localized": "Accreditation Procedures, Policies, and Practices"
         },
         "description": {
           "en": "",
-          "fr": ""
+          "fr": "",
+          "localized": ""
         },
         "keywords": {
           "en": [],
@@ -124,11 +138,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -138,11 +154,13 @@
         "key": "adaptability",
         "name": {
           "en": "Adaptability",
-          "fr": "Adaptabilité"
+          "fr": "Adaptabilité",
+          "localized": "Adaptability"
         },
         "description": {
           "en": "Demonstrated ability to adjust actions and mindset to changing circumstances, including demonstrated openness to new thinking and information.",
-          "fr": "Capacité démontrée d’adapter ses actions et son état d’esprit à l’évolution des circonstances, y compris une ouverture démontrée à de nouvelles idées et informations."
+          "fr": "Capacité démontrée d’adapter ses actions et son état d’esprit à l’évolution des circonstances, y compris une ouverture démontrée à de nouvelles idées et informations.",
+          "localized": "Demonstrated ability to adjust actions and mindset to changing circumstances, including demonstrated openness to new thinking and information."
         },
         "keywords": {
           "en": ["Flexibility", "Resilience", "Versatility"],
@@ -157,11 +175,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -171,11 +191,13 @@
         "key": "adobe_xd",
         "name": {
           "en": "Adobe XD",
-          "fr": "Adobe XD"
+          "fr": "Adobe XD",
+          "localized": "Adobe XD"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this product to develop a variety of projects.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce produit pour développer une variété de projets."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce produit pour développer une variété de projets.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this product to develop a variety of projects."
         },
         "keywords": {
           "en": null,
@@ -190,11 +212,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -204,11 +228,13 @@
         "key": "advice_senior_management",
         "name": {
           "en": "Advice to Senior Management",
-          "fr": "Conseils à la haute direction"
+          "fr": "Conseils à la haute direction",
+          "localized": "Advice to Senior Management"
         },
         "description": {
           "en": "Demonstrated ability to provide oral and written briefings and strategic advice to senior management on complex and significant topics, as well as presentations to senior management committees. Senior management is defined as those in the top two layers of an organization (e.g. Deputy Minister, Assistant Deputy Minister, Chief Information Officer, Chief Executive Officer, President, Vice-President).",
-          "fr": "Capacité démontrée à fournir des exposés oraux et écrits et des conseils stratégiques à la haute direction sur des sujets complexes et importants, ainsi que des présentations aux comités de haute direction. La haute direction est définie comme étant celle des deux niveaux supérieurs d'une organisation (par exemple, sous-ministre, sous-ministre adjoint, dirigeant principal de l'information, directeur général, président, vice-président)."
+          "fr": "Capacité démontrée à fournir des exposés oraux et écrits et des conseils stratégiques à la haute direction sur des sujets complexes et importants, ainsi que des présentations aux comités de haute direction. La haute direction est définie comme étant celle des deux niveaux supérieurs d'une organisation (par exemple, sous-ministre, sous-ministre adjoint, dirigeant principal de l'information, directeur général, président, vice-président).",
+          "localized": "Demonstrated ability to provide oral and written briefings and strategic advice to senior management on complex and significant topics, as well as presentations to senior management committees. Senior management is defined as those in the top two layers of an organization (e.g. Deputy Minister, Assistant Deputy Minister, Chief Information Officer, Chief Executive Officer, President, Vice-President)."
         },
         "keywords": {
           "en": null,
@@ -223,11 +249,13 @@
             "key": "executive_leadership",
             "name": {
               "en": "Leadership - Executive Technical Skills",
-              "fr": "Leadership - Compétences techniques des cadres"
+              "fr": "Leadership - Compétences techniques des cadres",
+              "localized": "Leadership - Executive Technical Skills"
             },
             "description": {
               "en": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation",
-              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX"
+              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX",
+              "localized": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation"
             }
           }
         ]
@@ -237,11 +265,13 @@
         "key": "advice_to_senior_management",
         "name": {
           "en": "Advice to Management",
-          "fr": "Conseils à la direction"
+          "fr": "Conseils à la direction",
+          "localized": "Advice to Management"
         },
         "description": {
           "en": "Demonstrated ability to develop evidence-based analysis and recommendations. Demonstrated ability to communicate this work to management, verbally and in writing, in a clear and meaningful way.",
-          "fr": "Capacité démontrée d’élaborer des analyses et des recommandations fondées sur des données probantes. Capacité démontrée de communiquer ce travail à la direction, verbalement et par écrit, de manière claire et significative."
+          "fr": "Capacité démontrée d’élaborer des analyses et des recommandations fondées sur des données probantes. Capacité démontrée de communiquer ce travail à la direction, verbalement et par écrit, de manière claire et significative.",
+          "localized": "Demonstrated ability to develop evidence-based analysis and recommendations. Demonstrated ability to communicate this work to management, verbally and in writing, in a clear and meaningful way."
         },
         "keywords": {
           "en": ["Advising", "Counselling", "Guiding"],
@@ -256,11 +286,13 @@
             "key": "management_competencies",
             "name": {
               "en": "Leadership - General Technical Skills",
-              "fr": "Leadership - Compétences techniques générales"
+              "fr": "Leadership - Compétences techniques générales",
+              "localized": "Leadership - General Technical Skills"
             },
             "description": {
               "en": "Management skills at the non-executive level for oversight of finances, human resources, initiatives, and accountabilities",
-              "fr": "Compétences en gestion au niveau non exécutif pour la surveillance des finances, des ressources humaines, des initiatives et des responsabilités"
+              "fr": "Compétences en gestion au niveau non exécutif pour la surveillance des finances, des ressources humaines, des initiatives et des responsabilités",
+              "localized": "Management skills at the non-executive level for oversight of finances, human resources, initiatives, and accountabilities"
             }
           }
         ]
@@ -270,11 +302,13 @@
         "key": "advise_and_negotiate",
         "name": {
           "en": "Advise and Negotiate",
-          "fr": "Conseiller et négocier"
+          "fr": "Conseiller et négocier",
+          "localized": "Advise and Negotiate"
         },
         "description": {
           "en": "Ability to negotiate with or provide advice to internal or external stakeholders.\n\n*Internal is defined as within the candidate’s organization; external is defined as any institution outside of the candidate’s organization.",
-          "fr": "Négociation ou de fourniture des conseils à des parties prenantes internes ou externes.\n\n*Interne est défini comme étant au sein de l’organisation du candidat ; externe est défini comme toute institution extérieure à l’organisation du candidat."
+          "fr": "Négociation ou de fourniture des conseils à des parties prenantes internes ou externes.\n\n*Interne est défini comme étant au sein de l’organisation du candidat ; externe est défini comme toute institution extérieure à l’organisation du candidat.",
+          "localized": "Ability to negotiate with or provide advice to internal or external stakeholders.\n\n*Internal is defined as within the candidate’s organization; external is defined as any institution outside of the candidate’s organization."
         },
         "keywords": {
           "en": ["Advise", "negotiate."],
@@ -289,11 +323,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           },
           {
@@ -301,11 +337,13 @@
             "key": "interpersonal",
             "name": {
               "en": "Interpersonal Behaviours",
-              "fr": "Comportements interpersonnels"
+              "fr": "Comportements interpersonnels",
+              "localized": "Interpersonal Behaviours"
             },
             "description": {
               "en": "Behavioural - Interpersonal",
-              "fr": "Comportemental - Interpersonnel"
+              "fr": "Comportemental - Interpersonnel",
+              "localized": "Behavioural - Interpersonal"
             }
           }
         ]
@@ -315,11 +353,13 @@
         "key": "agile_methodologies",
         "name": {
           "en": "Agile Methodologies",
-          "fr": "Méthodologies agiles"
+          "fr": "Méthodologies agiles",
+          "localized": "Agile Methodologies"
         },
         "description": {
           "en": "Demonstrated ability to break projects up into short, structured cycles so work can be routinely assessed and improved upon.",
-          "fr": "Capacité avérée à diviser les projets en cycles courts et structurés afin que le travail puisse être régulièrement évalué et amélioré."
+          "fr": "Capacité avérée à diviser les projets en cycles courts et structurés afin que le travail puisse être régulièrement évalué et amélioré.",
+          "localized": "Demonstrated ability to break projects up into short, structured cycles so work can be routinely assessed and improved upon."
         },
         "keywords": {
           "en": null,
@@ -334,11 +374,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           },
           {
@@ -346,11 +388,13 @@
             "key": "infrastructure_operations",
             "name": {
               "en": "IT Infrastructure Operations",
-              "fr": "Opérations d'infrastructure informatique"
+              "fr": "Opérations d'infrastructure informatique",
+              "localized": "IT Infrastructure Operations"
             },
             "description": {
               "en": "IT generic work stream - Infrastructure Operations",
-              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique"
+              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique",
+              "localized": "IT generic work stream - Infrastructure Operations"
             }
           },
           {
@@ -358,11 +402,13 @@
             "key": "it_project_management",
             "name": {
               "en": "Digital Business Line Advisory Services",
-              "fr": "Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Services consultatifs auprès des secteurs de la numérique",
+              "localized": "Digital Business Line Advisory Services"
             },
             "description": {
               "en": "IT generic work stream - Business Line Advisory Services",
-              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique",
+              "localized": "IT generic work stream - Business Line Advisory Services"
             }
           },
           {
@@ -370,11 +416,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           },
           {
@@ -382,11 +430,13 @@
             "key": "user_experience_and_interface_design",
             "name": {
               "en": "Software Solutions - Product Design",
-              "fr": "Solutions logicielles - Conception de produits"
+              "fr": "Solutions logicielles - Conception de produits",
+              "localized": "Software Solutions - Product Design"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur",
+              "localized": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design"
             }
           },
           {
@@ -394,11 +444,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -408,11 +460,13 @@
         "key": "analysis",
         "name": {
           "en": "Analysis",
-          "fr": "Analyse"
+          "fr": "Analyse",
+          "localized": "Analysis"
         },
         "description": {
           "en": "Demonstrated ability to collect and utilize qualitative and quantitative data to make decisions.",
-          "fr": "Capacité démontrée à recueillir et à utiliser des données qualitatives et quantitatives pour prendre des décisions."
+          "fr": "Capacité démontrée à recueillir et à utiliser des données qualitatives et quantitatives pour prendre des décisions.",
+          "localized": "Demonstrated ability to collect and utilize qualitative and quantitative data to make decisions."
         },
         "keywords": {
           "en": [
@@ -439,11 +493,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -453,11 +509,13 @@
         "key": "analytical_thinking",
         "name": {
           "en": "Analytical Thinking",
-          "fr": "Pensée analytique"
+          "fr": "Pensée analytique",
+          "localized": "Analytical Thinking"
         },
         "description": {
           "en": "Demonstrated ability to interpret, link and analyze information in order to understand issues.",
-          "fr": "Capacité démontrée d’interpréter, de relier et d’analyser l’information afin de comprendre les enjeux."
+          "fr": "Capacité démontrée d’interpréter, de relier et d’analyser l’information afin de comprendre les enjeux.",
+          "localized": "Demonstrated ability to interpret, link and analyze information in order to understand issues."
         },
         "keywords": {
           "en": ["Critical Thinking", "Logical Thinking", "Analysis of Facts"],
@@ -472,11 +530,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -486,11 +546,13 @@
         "key": "angular",
         "name": {
           "en": "Angular",
-          "fr": "Angular"
+          "fr": "Angular",
+          "localized": "Angular"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this framework to develop a variety of web applications.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce cadre pour développer une variété d’applications Web."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce cadre pour développer une variété d’applications Web.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this framework to develop a variety of web applications."
         },
         "keywords": {
           "en": null,
@@ -505,11 +567,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -519,11 +583,13 @@
         "key": "apache",
         "name": {
           "en": "Apache",
-          "fr": "Apache"
+          "fr": "Apache",
+          "localized": "Apache"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this server to support a variety of projects and needs.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce serveur pour soutenir une variété de projets et de besoins."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce serveur pour soutenir une variété de projets et de besoins.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this server to support a variety of projects and needs."
         },
         "keywords": {
           "en": null,
@@ -538,11 +604,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -552,11 +620,13 @@
         "key": "api_design",
         "name": {
           "en": "API Design",
-          "fr": "API Design"
+          "fr": "API Design",
+          "localized": "API Design"
         },
         "description": {
           "en": "Demonstrated ability to plan and build interfaces for connections between systems to expose data to users and developers.",
-          "fr": "Capacité démontrée à planifier et construire des interfaces pour les connexions entre les systèmes afin d’exposer les données aux utilisateurs et aux développeurs."
+          "fr": "Capacité démontrée à planifier et construire des interfaces pour les connexions entre les systèmes afin d’exposer les données aux utilisateurs et aux développeurs.",
+          "localized": "Demonstrated ability to plan and build interfaces for connections between systems to expose data to users and developers."
         },
         "keywords": {
           "en": null,
@@ -571,11 +641,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           },
           {
@@ -583,11 +655,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -597,11 +671,13 @@
         "key": "application_access_management",
         "name": {
           "en": "Application Access Management",
-          "fr": "Gestion de l’accès aux applications"
+          "fr": "Gestion de l’accès aux applications",
+          "localized": "Application Access Management"
         },
         "description": {
           "en": "Demonstrated ability to effectively control user access to applications and systems by implementing practices that ensure authorized users can interact with specific software, while preventing unauthorized access.",
-          "fr": "Capacité démontrée de contrôler efficacement l’accès des utilisateurs aux applications et aux systèmes en mettant en œuvre des pratiques qui garantissent que les utilisateurs autorisés peuvent interagir avec des logiciels particuliers, tout en empêchant les accès non autorisés."
+          "fr": "Capacité démontrée de contrôler efficacement l’accès des utilisateurs aux applications et aux systèmes en mettant en œuvre des pratiques qui garantissent que les utilisateurs autorisés peuvent interagir avec des logiciels particuliers, tout en empêchant les accès non autorisés.",
+          "localized": "Demonstrated ability to effectively control user access to applications and systems by implementing practices that ensure authorized users can interact with specific software, while preventing unauthorized access."
         },
         "keywords": {
           "en": ["Application", "Access", "Management"],
@@ -616,11 +692,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -630,11 +708,13 @@
         "key": "application_architecture",
         "name": {
           "en": "Application Architecture",
-          "fr": "Architecture d’application"
+          "fr": "Architecture d’application",
+          "localized": "Application Architecture"
         },
         "description": {
           "en": "Demonstrated ability to use, architect with or operate technologies in an enterprise such as identity services, programming languages, operating systems or enterprise resource planning applications.",
-          "fr": "Capacité avérée d’utiliser, d’utiliser ou d’exploiter des technologies dans une entreprise, telles que des services d’identité, des langages de programmation, des systèmes d’exploitation ou des applications de planification des ressources de l’entreprise."
+          "fr": "Capacité avérée d’utiliser, d’utiliser ou d’exploiter des technologies dans une entreprise, telles que des services d’identité, des langages de programmation, des systèmes d’exploitation ou des applications de planification des ressources de l’entreprise.",
+          "localized": "Demonstrated ability to use, architect with or operate technologies in an enterprise such as identity services, programming languages, operating systems or enterprise resource planning applications."
         },
         "keywords": {
           "en": null,
@@ -649,11 +729,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           }
         ]
@@ -663,11 +745,13 @@
         "key": "application_content_development",
         "name": {
           "en": "Application Content Development",
-          "fr": "Développement de contenu pour les applications"
+          "fr": "Développement de contenu pour les applications",
+          "localized": "Application Content Development"
         },
         "description": {
           "en": "Demonstrated ability to develop content for applications, including copy, visuals, and feature elements.",
-          "fr": "Capacité démontrée à développer du contenu pour des applications, y compris des textes, des visuels et des éléments de fonctionnalité."
+          "fr": "Capacité démontrée à développer du contenu pour des applications, y compris des textes, des visuels et des éléments de fonctionnalité.",
+          "localized": "Demonstrated ability to develop content for applications, including copy, visuals, and feature elements."
         },
         "keywords": {
           "en": null,
@@ -682,11 +766,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           }
         ]
@@ -696,11 +782,13 @@
         "key": "application_development",
         "name": {
           "en": "Application Development",
-          "fr": "Développement d’application"
+          "fr": "Développement d’application",
+          "localized": "Application Development"
         },
         "description": {
           "en": "Demonstrated ability to design, build, and deploy application software using programming languages and tools.",
-          "fr": "Capacité démontrée à concevoir, construire et déployer des logiciels d’application à l’aide de langages et d’outils de programmation."
+          "fr": "Capacité démontrée à concevoir, construire et déployer des logiciels d’application à l’aide de langages et d’outils de programmation.",
+          "localized": "Demonstrated ability to design, build, and deploy application software using programming languages and tools."
         },
         "keywords": {
           "en": null,
@@ -715,11 +803,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           }
         ]
@@ -729,11 +819,13 @@
         "key": "application_development_languages",
         "name": {
           "en": "Application Development Languages and Tools",
-          "fr": "Langages et outils de développement d'applications"
+          "fr": "Langages et outils de développement d'applications",
+          "localized": "Application Development Languages and Tools"
         },
         "description": {
           "en": "Demonstrated ability to comfortably use common application development languages (such as Java, JavaScript, Python, C++, C#, SQL)  and have familiarity with additional frameworks and database languages, as needed.",
-          "fr": "Capacité démontrée à utiliser confortablement les langages de développement d'applications courants (tels que Java, JavaScript, Python, C++, C#, SQL) et à être familiarisé avec des frameworks et des langages de bases de données supplémentaires, si nécessaire."
+          "fr": "Capacité démontrée à utiliser confortablement les langages de développement d'applications courants (tels que Java, JavaScript, Python, C++, C#, SQL) et à être familiarisé avec des frameworks et des langages de bases de données supplémentaires, si nécessaire.",
+          "localized": "Demonstrated ability to comfortably use common application development languages (such as Java, JavaScript, Python, C++, C#, SQL)  and have familiarity with additional frameworks and database languages, as needed."
         },
         "keywords": {
           "en": null,
@@ -748,11 +840,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           },
           {
@@ -760,11 +854,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -774,11 +870,13 @@
         "key": "application_of_legislation",
         "name": {
           "en": "Interpretation and Application of Legislation",
-          "fr": "Interprétation et application des lois"
+          "fr": "Interprétation et application des lois",
+          "localized": "Interpretation and Application of Legislation"
         },
         "description": {
           "en": "Demonstrated ability to interpret and apply federal, territorial, provincial, or municipal legislation in a professional or academic context.",
-          "fr": "Capacité manifeste à interpréter et à appliquer les lois fédérales, territoriales, provinciales ou municipales dans un contexte professionnel ou d’enseignement."
+          "fr": "Capacité manifeste à interpréter et à appliquer les lois fédérales, territoriales, provinciales ou municipales dans un contexte professionnel ou d’enseignement.",
+          "localized": "Demonstrated ability to interpret and apply federal, territorial, provincial, or municipal legislation in a professional or academic context."
         },
         "keywords": {
           "en": null,
@@ -793,11 +891,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           }
         ]
@@ -807,11 +907,13 @@
         "key": "application_of_nist_controls",
         "name": {
           "en": "Application of NIST controls",
-          "fr": "Application des contrôles NIST"
+          "fr": "Application des contrôles NIST",
+          "localized": "Application of NIST controls"
         },
         "description": {
           "en": "Demonstrated ability to implement and manage security measures to protect information systems by effectively applying the recommended security measures outlined by the National Institute of Standards and Technology (NIST).",
-          "fr": "Capacité démontrée de mettre en œuvre et de gérer des mesures de sécurité de manière à protéger l’information en appliquant efficacement les mesures de sécurité recommandées par le National Institute of Standards and Technology (NIST)."
+          "fr": "Capacité démontrée de mettre en œuvre et de gérer des mesures de sécurité de manière à protéger l’information en appliquant efficacement les mesures de sécurité recommandées par le National Institute of Standards and Technology (NIST).",
+          "localized": "Demonstrated ability to implement and manage security measures to protect information systems by effectively applying the recommended security measures outlined by the National Institute of Standards and Technology (NIST)."
         },
         "keywords": {
           "en": ["NIST", "controls"],
@@ -826,11 +928,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           }
         ]
@@ -840,11 +944,13 @@
         "key": "applied_mathematics_and_statistics",
         "name": {
           "en": "Applied Mathematics and Statistics",
-          "fr": "Mathématiques appliquées et statistiques"
+          "fr": "Mathématiques appliquées et statistiques",
+          "localized": "Applied Mathematics and Statistics"
         },
         "description": {
           "en": "Demonstrated ability to apply designated quantitative techniques such as time series analysis, optimization and simulation to create and embed appropriate models for analysis, prediction and machine learning.",
-          "fr": "Capacité démontrée à appliquer les techniques quantitatives désignées telles que l'analyse des séries chronologiques, l'optimisation et la simulation pour créer et intégrer des modèles appropriés pour l'analyse, la prédiction et l'apprentissage automatique."
+          "fr": "Capacité démontrée à appliquer les techniques quantitatives désignées telles que l'analyse des séries chronologiques, l'optimisation et la simulation pour créer et intégrer des modèles appropriés pour l'analyse, la prédiction et l'apprentissage automatique.",
+          "localized": "Demonstrated ability to apply designated quantitative techniques such as time series analysis, optimization and simulation to create and embed appropriate models for analysis, prediction and machine learning."
         },
         "keywords": {
           "en": ["Applied", "Mathematics", "Statistics."],
@@ -859,11 +965,13 @@
             "key": "data_services_data_science",
             "name": {
               "en": "Data Services - Data Science",
-              "fr": "Services de données - Science des données"
+              "fr": "Services de données - Science des données",
+              "localized": "Data Services - Data Science"
             },
             "description": {
               "en": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources.",
-              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses."
+              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses.",
+              "localized": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources."
             }
           }
         ]
@@ -873,11 +981,13 @@
         "key": "artificial_intelligence_programming_languages",
         "name": {
           "en": "Artificial Intelligence Programming Languages",
-          "fr": "Langages de programmation d’intelligence artificielle"
+          "fr": "Langages de programmation d’intelligence artificielle",
+          "localized": "Artificial Intelligence Programming Languages"
         },
         "description": {
           "en": "Demonstrated ability to design, write and iterate code and scripts in languages such as Python, R, Julia, C++, Java along the model lifecycle from concept, to development, to prototype, to production, through to deployment.",
-          "fr": "Capacité démontrée à concevoir, écrire et modifier du code et des scripts dans des langages tels que Python, R, Julia, C++, Java tout au long du cycle de vie du modèle, du concept au développement, au prototype, à la production, jusqu'au déploiement."
+          "fr": "Capacité démontrée à concevoir, écrire et modifier du code et des scripts dans des langages tels que Python, R, Julia, C++, Java tout au long du cycle de vie du modèle, du concept au développement, au prototype, à la production, jusqu'au déploiement.",
+          "localized": "Demonstrated ability to design, write and iterate code and scripts in languages such as Python, R, Julia, C++, Java along the model lifecycle from concept, to development, to prototype, to production, through to deployment."
         },
         "keywords": {
           "en": ["Artificial", "Intelligence", "Programming", "Languages."],
@@ -892,11 +1002,13 @@
             "key": "data_services_data_science",
             "name": {
               "en": "Data Services - Data Science",
-              "fr": "Services de données - Science des données"
+              "fr": "Services de données - Science des données",
+              "localized": "Data Services - Data Science"
             },
             "description": {
               "en": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources.",
-              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses."
+              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses.",
+              "localized": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources."
             }
           },
           {
@@ -904,11 +1016,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -918,11 +1032,13 @@
         "key": "artificial_intelligence_system_monitoring_and_governance",
         "name": {
           "en": "Artificial Intelligence System Monitoring and Governance",
-          "fr": "Surveillance et gouvernance des systèmes d’intelligence artificielle"
+          "fr": "Surveillance et gouvernance des systèmes d’intelligence artificielle",
+          "localized": "Artificial Intelligence System Monitoring and Governance"
         },
         "description": {
           "en": "Demonstrated ability to develop and maintain monitoring systems for AI systems, addressing health, bias, and data drift to ensure ethical and reliable performance.",
-          "fr": "Capacité démontrée à développer et à maintenir des systèmes de surveillance pour les systèmes d'IA, en tenant compte de la santé, de la partialité et de la dérive des données afin d'assurer des performances éthiques et fiables."
+          "fr": "Capacité démontrée à développer et à maintenir des systèmes de surveillance pour les systèmes d'IA, en tenant compte de la santé, de la partialité et de la dérive des données afin d'assurer des performances éthiques et fiables.",
+          "localized": "Demonstrated ability to develop and maintain monitoring systems for AI systems, addressing health, bias, and data drift to ensure ethical and reliable performance."
         },
         "keywords": {
           "en": [
@@ -949,11 +1065,13 @@
             "key": "data_services_data_science",
             "name": {
               "en": "Data Services - Data Science",
-              "fr": "Services de données - Science des données"
+              "fr": "Services de données - Science des données",
+              "localized": "Data Services - Data Science"
             },
             "description": {
               "en": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources.",
-              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses."
+              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses.",
+              "localized": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources."
             }
           }
         ]
@@ -963,11 +1081,13 @@
         "key": "artificial_intelligence_system_operations",
         "name": {
           "en": "Artificial Intelligence System Operations",
-          "fr": "Opérations du système d’intelligence artificielle"
+          "fr": "Opérations du système d’intelligence artificielle",
+          "localized": "Artificial Intelligence System Operations"
         },
         "description": {
           "en": "Demonstrated ability to manage the operational aspects of AI systems, including automation software development, system availability, and effective deployment processes.",
-          "fr": "Capacité démontrée à gérer les aspects opérationnels des systèmes d'intelligence artificielle, y compris le développement de logiciels d'automatisation, la disponibilité des systèmes et des processus de déploiement efficaces."
+          "fr": "Capacité démontrée à gérer les aspects opérationnels des systèmes d'intelligence artificielle, y compris le développement de logiciels d'automatisation, la disponibilité des systèmes et des processus de déploiement efficaces.",
+          "localized": "Demonstrated ability to manage the operational aspects of AI systems, including automation software development, system availability, and effective deployment processes."
         },
         "keywords": {
           "en": ["Artificial", "Intelligence", "System", "Operations."],
@@ -982,11 +1102,13 @@
             "key": "data_services_data_science",
             "name": {
               "en": "Data Services - Data Science",
-              "fr": "Services de données - Science des données"
+              "fr": "Services de données - Science des données",
+              "localized": "Data Services - Data Science"
             },
             "description": {
               "en": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources.",
-              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses."
+              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses.",
+              "localized": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources."
             }
           }
         ]
@@ -996,11 +1118,13 @@
         "key": "aspdotnet",
         "name": {
           "en": "asp.net",
-          "fr": "asp.net"
+          "fr": "asp.net",
+          "localized": "asp.net"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this framework to develop a variety of applications.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce cadre pour développer une variété d’applications."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce cadre pour développer une variété d’applications.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this framework to develop a variety of applications."
         },
         "keywords": {
           "en": null,
@@ -1015,11 +1139,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -1029,11 +1155,13 @@
         "key": "atip_software",
         "name": {
           "en": "Access to Information and Privacy Software",
-          "fr": "Logiciels d’accès à l’information et de protection de la vie privée"
+          "fr": "Logiciels d’accès à l’information et de protection de la vie privée",
+          "localized": "Access to Information and Privacy Software"
         },
         "description": {
           "en": "Demonstrated ability to use Access to Information and Privacy software (portals, databases, query programs)",
-          "fr": "Capacité manifeste à utiliser des logiciels d’accès à l’information et de protection de la vie privée (portails, bases de données, programmes de requêtes)."
+          "fr": "Capacité manifeste à utiliser des logiciels d’accès à l’information et de protection de la vie privée (portails, bases de données, programmes de requêtes).",
+          "localized": "Demonstrated ability to use Access to Information and Privacy software (portals, databases, query programs)"
         },
         "keywords": {
           "en": null,
@@ -1048,11 +1176,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           }
         ]
@@ -1062,11 +1192,13 @@
         "key": "attention_to_detail",
         "name": {
           "en": "Attention to Detail",
-          "fr": "Souci du détail"
+          "fr": "Souci du détail",
+          "localized": "Attention to Detail"
         },
         "description": {
           "en": "Demonstrated ability to pay close attention to all elements of an activity or product, identify any gaps or incomplete components, find inaccuracies and inconsistencies, and ensure that the task is completed in full according to the requirements.",
-          "fr": "Capacité démontrée à porter une attention particulière à tous les éléments d’une activité ou d’un produit, à identifier les lacunes ou les composants incomplets, à trouver des inexactitudes et des incohérences, et à s’assurer que la tâche est entièrement accomplie conformément aux exigences."
+          "fr": "Capacité démontrée à porter une attention particulière à tous les éléments d’une activité ou d’un produit, à identifier les lacunes ou les composants incomplets, à trouver des inexactitudes et des incohérences, et à s’assurer que la tâche est entièrement accomplie conformément aux exigences.",
+          "localized": "Demonstrated ability to pay close attention to all elements of an activity or product, identify any gaps or incomplete components, find inaccuracies and inconsistencies, and ensure that the task is completed in full according to the requirements."
         },
         "keywords": {
           "en": [
@@ -1091,11 +1223,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -1105,11 +1239,13 @@
         "key": "automated_decision_making",
         "name": {
           "en": "Automated Decision-Making",
-          "fr": "Prise de décision automatisée"
+          "fr": "Prise de décision automatisée",
+          "localized": "Automated Decision-Making"
         },
         "description": {
           "en": "Demonstrated ability to apply the Directive on Automated Decision-Making, including completing an Algorithmic Impact Assessment, to identify, evaluate and mitigate risks associated with deploying an automated decision-making system.",
-          "fr": "Capacité démontrée à appliquer la directive sur la prise de décision automatisée, notamment en réalisant une évaluation de l'impact algorithmique, afin d'identifier, d'évaluer et d'atténuer les risques liés au déploiement d'un système de prise de décision automatisée."
+          "fr": "Capacité démontrée à appliquer la directive sur la prise de décision automatisée, notamment en réalisant une évaluation de l'impact algorithmique, afin d'identifier, d'évaluer et d'atténuer les risques liés au déploiement d'un système de prise de décision automatisée.",
+          "localized": "Demonstrated ability to apply the Directive on Automated Decision-Making, including completing an Algorithmic Impact Assessment, to identify, evaluate and mitigate risks associated with deploying an automated decision-making system."
         },
         "keywords": {
           "en": ["Automated", "Decision", "Making."],
@@ -1124,11 +1260,13 @@
             "key": "data_services_data_science",
             "name": {
               "en": "Data Services - Data Science",
-              "fr": "Services de données - Science des données"
+              "fr": "Services de données - Science des données",
+              "localized": "Data Services - Data Science"
             },
             "description": {
               "en": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources.",
-              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses."
+              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses.",
+              "localized": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources."
             }
           }
         ]
@@ -1138,11 +1276,13 @@
         "key": "automated_testing",
         "name": {
           "en": "Automated testing",
-          "fr": "Tests automatisés"
+          "fr": "Tests automatisés",
+          "localized": "Automated testing"
         },
         "description": {
           "en": "Demonstrated ability to run tests on products using automation tools to compare actual outcomes with intended results.",
-          "fr": "Capacité démontrée à effectuer des tests sur des produits à l’aide d’outils d’automatisation pour comparer les résultats réels aux résultats escomptés."
+          "fr": "Capacité démontrée à effectuer des tests sur des produits à l’aide d’outils d’automatisation pour comparer les résultats réels aux résultats escomptés.",
+          "localized": "Demonstrated ability to run tests on products using automation tools to compare actual outcomes with intended results."
         },
         "keywords": {
           "en": null,
@@ -1157,11 +1297,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           },
           {
@@ -1169,11 +1311,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           }
         ]
@@ -1183,11 +1327,13 @@
         "key": "awareness_of_science_organizations",
         "name": {
           "en": "Awareness of Science Organizations",
-          "fr": "Connaissance des organisations scientifiques"
+          "fr": "Connaissance des organisations scientifiques",
+          "localized": "Awareness of Science Organizations"
         },
         "description": {
           "en": "Demonstrated knowledge of Canada's various scientific organizations and their mandates, as well as a general understanding of operating considerations in a science-based organization.",
-          "fr": "Connaissance avérée des divers organismes scientifiques du Canada et de leurs mandats, ainsi qu’une compréhension générale des considérations opérationnelles d’un organisme à vocation scientifique."
+          "fr": "Connaissance avérée des divers organismes scientifiques du Canada et de leurs mandats, ainsi qu’une compréhension générale des considérations opérationnelles d’un organisme à vocation scientifique.",
+          "localized": "Demonstrated knowledge of Canada's various scientific organizations and their mandates, as well as a general understanding of operating considerations in a science-based organization."
         },
         "keywords": {
           "en": null,
@@ -1202,11 +1348,13 @@
             "key": "working_in_government",
             "name": {
               "en": "Working in Government",
-              "fr": "Travailler au sein du gouvernement"
+              "fr": "Travailler au sein du gouvernement",
+              "localized": "Working in Government"
             },
             "description": {
               "en": "Technical skills family - Working in Government",
-              "fr": "Groupe de compétences techniques - Travailler au sein du gouvernement"
+              "fr": "Groupe de compétences techniques - Travailler au sein du gouvernement",
+              "localized": "Technical skills family - Working in Government"
             }
           }
         ]
@@ -1216,11 +1364,13 @@
         "key": "aws_codebuild",
         "name": {
           "en": "AWS CodeBuild",
-          "fr": "AWS CodeBuild"
+          "fr": "AWS CodeBuild",
+          "localized": "AWS CodeBuild"
         },
         "description": {
           "en": "Demonstrated ability to  set up code builds in preconfigured build environments, including establishing encryption solutions for artifacts.",
-          "fr": "Capacité démontrée à configurer des builds de code dans des environnements de build préconfigurés, y compris la mise en place de solutions de chiffrement pour les artefacts."
+          "fr": "Capacité démontrée à configurer des builds de code dans des environnements de build préconfigurés, y compris la mise en place de solutions de chiffrement pour les artefacts.",
+          "localized": "Demonstrated ability to  set up code builds in preconfigured build environments, including establishing encryption solutions for artifacts."
         },
         "keywords": {
           "en": null,
@@ -1235,11 +1385,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -1249,11 +1401,13 @@
         "key": "aws_codepipeline",
         "name": {
           "en": "AWS CodePipeline",
-          "fr": "AWS CodePipeline"
+          "fr": "AWS CodePipeline",
+          "localized": "AWS CodePipeline"
         },
         "description": {
           "en": "Demonstrated apply to leverage this service to develop software modeling, visualization and automations.",
-          "fr": "Démontrer l’application pour tirer parti de ce service pour développer des logiciels de modélisation, de visualisation et d’automatisation."
+          "fr": "Démontrer l’application pour tirer parti de ce service pour développer des logiciels de modélisation, de visualisation et d’automatisation.",
+          "localized": "Demonstrated apply to leverage this service to develop software modeling, visualization and automations."
         },
         "keywords": {
           "en": null,
@@ -1268,11 +1422,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -1282,11 +1438,13 @@
         "key": "aws_ecr",
         "name": {
           "en": "AWS ECR",
-          "fr": "AWS ECR"
+          "fr": "AWS ECR",
+          "localized": "AWS ECR"
         },
         "description": {
           "en": "Demonstrated ability to leverage this Docker container registry to store, share, and deploy container images.",
-          "fr": "Capacité démontrée à exploiter ce registre de conteneurs Docker pour stocker, partager et déployer des images de conteneurs."
+          "fr": "Capacité démontrée à exploiter ce registre de conteneurs Docker pour stocker, partager et déployer des images de conteneurs.",
+          "localized": "Demonstrated ability to leverage this Docker container registry to store, share, and deploy container images."
         },
         "keywords": {
           "en": null,
@@ -1301,11 +1459,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -1315,11 +1475,13 @@
         "key": "aws_ectwo",
         "name": {
           "en": "AWS EC2",
-          "fr": "AWS EC2"
+          "fr": "AWS EC2",
+          "localized": "AWS EC2"
         },
         "description": {
           "en": "Demonstrated ability to leverage the AWS cloud computing service to launch and configure virtual servers, including setting up security, networking and storage management.",
-          "fr": "Capacité démontrée à tirer parti du service de cloud computing AWS pour lancer et configurer des serveurs virtuels, y compris la mise en place de la sécurité, de la mise en réseau et de la gestion du stockage."
+          "fr": "Capacité démontrée à tirer parti du service de cloud computing AWS pour lancer et configurer des serveurs virtuels, y compris la mise en place de la sécurité, de la mise en réseau et de la gestion du stockage.",
+          "localized": "Demonstrated ability to leverage the AWS cloud computing service to launch and configure virtual servers, including setting up security, networking and storage management."
         },
         "keywords": {
           "en": null,
@@ -1334,11 +1496,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -1348,11 +1512,13 @@
         "key": "aws_lambda",
         "name": {
           "en": "AWS Lambda",
-          "fr": "AWS Lambda"
+          "fr": "AWS Lambda",
+          "localized": "AWS Lambda"
         },
         "description": {
           "en": "Demonstrated ability to leverage this event-driven service to run code without servers.",
-          "fr": "Capacité démontrée à exploiter ce service basé sur les événements pour exécuter du code sans serveurs."
+          "fr": "Capacité démontrée à exploiter ce service basé sur les événements pour exécuter du code sans serveurs.",
+          "localized": "Demonstrated ability to leverage this event-driven service to run code without servers."
         },
         "keywords": {
           "en": null,
@@ -1367,11 +1533,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -1381,11 +1549,13 @@
         "key": "aws_rds",
         "name": {
           "en": "AWS RDS",
-          "fr": "AWS RDS"
+          "fr": "AWS RDS",
+          "localized": "AWS RDS"
         },
         "description": {
           "en": "Demonstrated ability to leverage this service to set up, operate, and scale relational databases in cloud-based environments.",
-          "fr": "Capacité démontrée à tirer parti de ce service pour configurer, exploiter et faire évoluer des bases de données relationnelles dans des environnements cloud."
+          "fr": "Capacité démontrée à tirer parti de ce service pour configurer, exploiter et faire évoluer des bases de données relationnelles dans des environnements cloud.",
+          "localized": "Demonstrated ability to leverage this service to set up, operate, and scale relational databases in cloud-based environments."
         },
         "keywords": {
           "en": null,
@@ -1400,11 +1570,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -1414,11 +1586,13 @@
         "key": "aws_sthree",
         "name": {
           "en": "AWS S3",
-          "fr": "AWS S3"
+          "fr": "AWS S3",
+          "localized": "AWS S3"
         },
         "description": {
           "en": "Demonstrated ability to leverage this cloud object storage service, including setting up storage management features and security permissions.",
-          "fr": "Capacité démontrée à exploiter ce service de stockage d'objets cloud, y compris la configuration des fonctionnalités de gestion du stockage et des autorisations de sécurité."
+          "fr": "Capacité démontrée à exploiter ce service de stockage d'objets cloud, y compris la configuration des fonctionnalités de gestion du stockage et des autorisations de sécurité.",
+          "localized": "Demonstrated ability to leverage this cloud object storage service, including setting up storage management features and security permissions."
         },
         "keywords": {
           "en": null,
@@ -1433,11 +1607,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -1447,11 +1623,13 @@
         "key": "azure_blob_storage",
         "name": {
           "en": "Azure Blob Storage",
-          "fr": "Azure Blob Storage"
+          "fr": "Azure Blob Storage",
+          "localized": "Azure Blob Storage"
         },
         "description": {
           "en": "Demonstrated ability to leverage this cloud computing platform to support a variety of projects.",
-          "fr": "Capacité démontrée à exploiter cette plate-forme de cloud computing pour prendre en charge une variété de projets."
+          "fr": "Capacité démontrée à exploiter cette plate-forme de cloud computing pour prendre en charge une variété de projets.",
+          "localized": "Demonstrated ability to leverage this cloud computing platform to support a variety of projects."
         },
         "keywords": {
           "en": null,
@@ -1466,11 +1644,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -1480,11 +1660,13 @@
         "key": "azure_container_registry",
         "name": {
           "en": "Azure Container Registry",
-          "fr": "Azure Container Registry"
+          "fr": "Azure Container Registry",
+          "localized": "Azure Container Registry"
         },
         "description": {
           "en": "Demonstrated ability to work with this container registry to scan, build, store, secure,  and manage container images and OCI artifacts.",
-          "fr": "Capacité démontrée à travailler avec ce registre de conteneurs pour analyser, créer, stocker, sécuriser et gérer des images de conteneurs et des artefacts OCI."
+          "fr": "Capacité démontrée à travailler avec ce registre de conteneurs pour analyser, créer, stocker, sécuriser et gérer des images de conteneurs et des artefacts OCI.",
+          "localized": "Demonstrated ability to work with this container registry to scan, build, store, secure,  and manage container images and OCI artifacts."
         },
         "keywords": {
           "en": null,
@@ -1499,11 +1681,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -1513,11 +1697,13 @@
         "key": "azure_data_lake",
         "name": {
           "en": "Azure Data Lake",
-          "fr": "Azure Data Lake"
+          "fr": "Azure Data Lake",
+          "localized": "Azure Data Lake"
         },
         "description": {
           "en": "Demonstrated ability to leverage this cloud-based solution to design, implement and manage scalable architectures for diverse data types and advanced analytics.",
-          "fr": "Capacité démontrée à exploiter cette solution basée sur le cloud pour concevoir, mettre en œuvre et gérer des architectures évolutives pour différents types de données et des analyses avancées."
+          "fr": "Capacité démontrée à exploiter cette solution basée sur le cloud pour concevoir, mettre en œuvre et gérer des architectures évolutives pour différents types de données et des analyses avancées.",
+          "localized": "Demonstrated ability to leverage this cloud-based solution to design, implement and manage scalable architectures for diverse data types and advanced analytics."
         },
         "keywords": {
           "en": ["Azure", "Data", "Lake"],
@@ -1532,11 +1718,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           }
         ]
@@ -1546,11 +1734,13 @@
         "key": "azure_devops",
         "name": {
           "en": "Azure DevOps",
-          "fr": "Azure DevOps"
+          "fr": "Azure DevOps",
+          "localized": "Azure DevOps"
         },
         "description": {
           "en": "Demonstrated ability to leverage this product suite for comprehensive software development lifecycle management to streamline development processes and enhance team collaboration and productivity. This may include source code management, project planning, build automation, testing, and release management.",
-          "fr": "Capacité démontrée à exploiter cet outil pour la gestion complète du cycle de vie du développement logiciel afin de rationaliser les processus de développement, d'améliorer la collaboration et la productivité de l'équipe. Cela peut inclure la gestion du code source, la planification de projet, l'automatisation des builds, les tests et la gestion des versions."
+          "fr": "Capacité démontrée à exploiter cet outil pour la gestion complète du cycle de vie du développement logiciel afin de rationaliser les processus de développement, d'améliorer la collaboration et la productivité de l'équipe. Cela peut inclure la gestion du code source, la planification de projet, l'automatisation des builds, les tests et la gestion des versions.",
+          "localized": "Demonstrated ability to leverage this product suite for comprehensive software development lifecycle management to streamline development processes and enhance team collaboration and productivity. This may include source code management, project planning, build automation, testing, and release management."
         },
         "keywords": {
           "en": ["Azure", "DevOps"],
@@ -1565,11 +1755,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -1579,11 +1771,13 @@
         "key": "azure_pipelines",
         "name": {
           "en": "Azure Pipelines",
-          "fr": "Azure Pipelines"
+          "fr": "Azure Pipelines",
+          "localized": "Azure Pipelines"
         },
         "description": {
           "en": "Demonstrated ability to leverage this cloud-hosted pipeline service to support content, containers or applications developed for Linux, Windows or MacOS.",
-          "fr": "Capacité démontrée à exploiter ce service de pipeline hébergé dans le cloud pour prendre en charge du contenu, des conteneurs ou des applications développés pour Linux, Windows ou MacOS."
+          "fr": "Capacité démontrée à exploiter ce service de pipeline hébergé dans le cloud pour prendre en charge du contenu, des conteneurs ou des applications développés pour Linux, Windows ou MacOS.",
+          "localized": "Demonstrated ability to leverage this cloud-hosted pipeline service to support content, containers or applications developed for Linux, Windows or MacOS."
         },
         "keywords": {
           "en": null,
@@ -1598,11 +1792,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -1612,11 +1808,13 @@
         "key": "azure_policy",
         "name": {
           "en": "Azure Policy",
-          "fr": "Politique Azure"
+          "fr": "Politique Azure",
+          "localized": "Azure Policy"
         },
         "description": {
           "en": "Demonstrated ability to use, create, and modify policies in Azure, with awareness of the impact of these changes on the broader Azure policy ecosystem.",
-          "fr": "Capacité démontrée à utiliser, créer et modifier des stratégies dans Azure, en étant conscient de l’impact de ces changements sur l’écosystème de stratégies Azure au sens large."
+          "fr": "Capacité démontrée à utiliser, créer et modifier des stratégies dans Azure, en étant conscient de l’impact de ces changements sur l’écosystème de stratégies Azure au sens large.",
+          "localized": "Demonstrated ability to use, create, and modify policies in Azure, with awareness of the impact of these changes on the broader Azure policy ecosystem."
         },
         "keywords": {
           "en": ["Azure", "policy", "ecosystem."],
@@ -1631,11 +1829,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           },
           {
@@ -1643,11 +1843,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -1657,11 +1859,13 @@
         "key": "azure_resources",
         "name": {
           "en": "Azure Resources",
-          "fr": "Ressources Azure"
+          "fr": "Ressources Azure",
+          "localized": "Azure Resources"
         },
         "description": {
           "en": "Demonstrated ability to manage Azure resources related to different Azure solutions, with awareness of the impact on the broader security and architecture of the organization.",
-          "fr": "Capacité démontrée à gérer les ressources Azure liées à différentes solutions Azure, en tenant compte de l’incidence sur la sécurité et l’architecture plus vaste de l’organisation."
+          "fr": "Capacité démontrée à gérer les ressources Azure liées à différentes solutions Azure, en tenant compte de l’incidence sur la sécurité et l’architecture plus vaste de l’organisation.",
+          "localized": "Demonstrated ability to manage Azure resources related to different Azure solutions, with awareness of the impact on the broader security and architecture of the organization."
         },
         "keywords": {
           "en": [
@@ -1688,11 +1892,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           },
           {
@@ -1700,11 +1906,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -1714,11 +1922,13 @@
         "key": "azure_sql_database",
         "name": {
           "en": "Azure SQL Database",
-          "fr": "Azure SQL Database"
+          "fr": "Azure SQL Database",
+          "localized": "Azure SQL Database"
         },
         "description": {
           "en": "Demonstrated ability to leverage this platform as a service (PaaS) database engine to optimize and support cloud applications on a variety of projects.",
-          "fr": "Capacité démontrée à tirer parti de ce moteur de base de données en tant que service (PaaS) pour optimiser et prendre en charge des applications cloud dans divers projets."
+          "fr": "Capacité démontrée à tirer parti de ce moteur de base de données en tant que service (PaaS) pour optimiser et prendre en charge des applications cloud dans divers projets.",
+          "localized": "Demonstrated ability to leverage this platform as a service (PaaS) database engine to optimize and support cloud applications on a variety of projects."
         },
         "keywords": {
           "en": ["Azure", "SQL", "Database"],
@@ -1733,11 +1943,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -1747,11 +1959,13 @@
         "key": "azure_sql_managed_instance",
         "name": {
           "en": "Azure SQL Managed Instance",
-          "fr": "Instance gérée de Azure SQL"
+          "fr": "Instance gérée de Azure SQL",
+          "localized": "Azure SQL Managed Instance"
         },
         "description": {
           "en": "Demonstrated the ability in managing and configuring environments to optimize secure, scalable, and high-performing database solutions. This includes the migration of on-premises SQL Server databases to Azure, implementation of high availability and disaster recovery solutions, and seamless integration with other Azure services.",
-          "fr": "Capacité démontrée à gérer et configurer des environnements pour optimiser des solutions de bases de données sécurisées, évolutives et performantes. Cela inclut la migration des bases de données SQL Server sur site vers Azure, l'implémentation de solutions de haute disponibilité et de reprise après sinistre, ainsi que l'intégration transparente avec d'autres services Azure."
+          "fr": "Capacité démontrée à gérer et configurer des environnements pour optimiser des solutions de bases de données sécurisées, évolutives et performantes. Cela inclut la migration des bases de données SQL Server sur site vers Azure, l'implémentation de solutions de haute disponibilité et de reprise après sinistre, ainsi que l'intégration transparente avec d'autres services Azure.",
+          "localized": "Demonstrated the ability in managing and configuring environments to optimize secure, scalable, and high-performing database solutions. This includes the migration of on-premises SQL Server databases to Azure, implementation of high availability and disaster recovery solutions, and seamless integration with other Azure services."
         },
         "keywords": {
           "en": ["Azure", "SQL", "Managed", "Instance"],
@@ -1766,11 +1980,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -1780,11 +1996,13 @@
         "key": "azure_synapse",
         "name": {
           "en": "Azure Synapse",
-          "fr": "Azure Synapse"
+          "fr": "Azure Synapse",
+          "localized": "Azure Synapse"
         },
         "description": {
           "en": "Demonstrated ability to leverage this enterprise analytics service for unified data integration, engineering, warehousing, data science, real-time analytics, or business intelligence.",
-          "fr": "Capacité démontrée à tirer parti de ce service d'analyse d'entreprise pour l'intégration unifiée des données, l'ingénierie, l'entreposage, la science des données, l'analyse en temps réel ou l'intelligence d'affaires."
+          "fr": "Capacité démontrée à tirer parti de ce service d'analyse d'entreprise pour l'intégration unifiée des données, l'ingénierie, l'entreposage, la science des données, l'analyse en temps réel ou l'intelligence d'affaires.",
+          "localized": "Demonstrated ability to leverage this enterprise analytics service for unified data integration, engineering, warehousing, data science, real-time analytics, or business intelligence."
         },
         "keywords": {
           "en": ["Azure", "Synapse"],
@@ -1799,11 +2017,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           }
         ]
@@ -1813,11 +2033,13 @@
         "key": "azure_synapse_pipelines",
         "name": {
           "en": "Azure Synapse Pipelines",
-          "fr": "Pipelines Azure Synapse"
+          "fr": "Pipelines Azure Synapse",
+          "localized": "Azure Synapse Pipelines"
         },
         "description": {
           "en": "Demonstrated ability to leverage this enterprise analytics service for data integration by creating data-driven workflows for orchestrating data movement and transforming data at scale.",
-          "fr": "Capacité démontrée à tirer parti de ce service d'analyse d'entreprise pour l'intégration des données en créant des flux de travail axés sur les données pour orchestrer le mouvement des données et les transformer à grande échelle."
+          "fr": "Capacité démontrée à tirer parti de ce service d'analyse d'entreprise pour l'intégration des données en créant des flux de travail axés sur les données pour orchestrer le mouvement des données et les transformer à grande échelle.",
+          "localized": "Demonstrated ability to leverage this enterprise analytics service for data integration by creating data-driven workflows for orchestrating data movement and transforming data at scale."
         },
         "keywords": {
           "en": ["Azure", "Synapse", "Pipelines"],
@@ -1832,11 +2054,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -1846,11 +2070,13 @@
         "key": "back_end_development",
         "name": {
           "en": "Back-end Development",
-          "fr": "Développement dorsal"
+          "fr": "Développement dorsal",
+          "localized": "Back-end Development"
         },
         "description": {
           "en": "Demonstrated ability to build server-side logic, modeling, and data services for applications. This includes using programing languages such as, but not limited to Python, Java, C#, PHP, or JavaScript (Node.js), along with frameworks such as but not limited to ASP.NET, Django, Spring or Express.js.",
-          "fr": "Capacité démontrée à créer des services de logique, de modélisation et de données côté serveur pour les applications. Cela inclut l’utilisation de langages de programmation tels que Python, Java, C#, PHP ou JavaScript (Node.js), ainsi que des cadres tels qu’ASP.NET, Django, Spring ou Express.js."
+          "fr": "Capacité démontrée à créer des services de logique, de modélisation et de données côté serveur pour les applications. Cela inclut l’utilisation de langages de programmation tels que Python, Java, C#, PHP ou JavaScript (Node.js), ainsi que des cadres tels qu’ASP.NET, Django, Spring ou Express.js.",
+          "localized": "Demonstrated ability to build server-side logic, modeling, and data services for applications. This includes using programing languages such as, but not limited to Python, Java, C#, PHP, or JavaScript (Node.js), along with frameworks such as but not limited to ASP.NET, Django, Spring or Express.js."
         },
         "keywords": {
           "en": ["Back", "end", "Development"],
@@ -1865,11 +2091,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           },
           {
@@ -1877,11 +2105,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -1891,11 +2121,13 @@
         "key": "big_data_analytics",
         "name": {
           "en": "Big Data Analytics",
-          "fr": "Analyse des données massives"
+          "fr": "Analyse des données massives",
+          "localized": "Big Data Analytics"
         },
         "description": {
           "en": "Demonstrated ability to use big data tools such as SparkSQL, Apache Flink, Cloud platforms, to query, manipulate and analyze large data sets, to extract meaningful insights.",
-          "fr": "Capacité démontrée à utiliser des outils de big data tels que SparkSQL, Apache Flink, des plateformes Cloud, pour interroger, manipuler et analyser de grands ensembles de données, afin d'en extraire des informations significatives."
+          "fr": "Capacité démontrée à utiliser des outils de big data tels que SparkSQL, Apache Flink, des plateformes Cloud, pour interroger, manipuler et analyser de grands ensembles de données, afin d'en extraire des informations significatives.",
+          "localized": "Demonstrated ability to use big data tools such as SparkSQL, Apache Flink, Cloud platforms, to query, manipulate and analyze large data sets, to extract meaningful insights."
         },
         "keywords": {
           "en": ["Big", "Data", "Analytics."],
@@ -1910,11 +2142,13 @@
             "key": "data_services_data_science",
             "name": {
               "en": "Data Services - Data Science",
-              "fr": "Services de données - Science des données"
+              "fr": "Services de données - Science des données",
+              "localized": "Data Services - Data Science"
             },
             "description": {
               "en": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources.",
-              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses."
+              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses.",
+              "localized": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources."
             }
           }
         ]
@@ -1924,11 +2158,13 @@
         "key": "briefing_management",
         "name": {
           "en": "Briefing Management",
-          "fr": "Breffage de la gestion"
+          "fr": "Breffage de la gestion",
+          "localized": "Briefing Management"
         },
         "description": {
           "en": "Demonstrated ability to manage taskings on topic and on time by preparing briefing material, and providing written or verbal briefings and advice to mid-level and immediate management levels.",
-          "fr": "Capacité démontrée à gérer les tâches en fonction du sujet et dans les délais impartis en préparant des documents d’information et en fournissant des exposés et des conseils écrits ou verbaux aux niveaux intermédiaires et immédiats de la direction."
+          "fr": "Capacité démontrée à gérer les tâches en fonction du sujet et dans les délais impartis en préparant des documents d’information et en fournissant des exposés et des conseils écrits ou verbaux aux niveaux intermédiaires et immédiats de la direction.",
+          "localized": "Demonstrated ability to manage taskings on topic and on time by preparing briefing material, and providing written or verbal briefings and advice to mid-level and immediate management levels."
         },
         "keywords": {
           "en": null,
@@ -1943,11 +2179,13 @@
             "key": "management_competencies",
             "name": {
               "en": "Leadership - General Technical Skills",
-              "fr": "Leadership - Compétences techniques générales"
+              "fr": "Leadership - Compétences techniques générales",
+              "localized": "Leadership - General Technical Skills"
             },
             "description": {
               "en": "Management skills at the non-executive level for oversight of finances, human resources, initiatives, and accountabilities",
-              "fr": "Compétences en gestion au niveau non exécutif pour la surveillance des finances, des ressources humaines, des initiatives et des responsabilités"
+              "fr": "Compétences en gestion au niveau non exécutif pour la surveillance des finances, des ressources humaines, des initiatives et des responsabilités",
+              "localized": "Management skills at the non-executive level for oversight of finances, human resources, initiatives, and accountabilities"
             }
           }
         ]
@@ -1957,11 +2195,13 @@
         "key": "budget_and_team_operations_management",
         "name": {
           "en": "Budget and team operations management",
-          "fr": "Gestion du budget et des opérations de l’équipe"
+          "fr": "Gestion du budget et des opérations de l’équipe",
+          "localized": "Budget and team operations management"
         },
         "description": {
           "en": "Demonstrated ability to effectively allocate resources, optimize team workflows, and adhere to budget funding levels while achieving operational goals.",
-          "fr": "Capacité démontrée d’affecter efficacement les ressources, d’optimiser les flux de travail de l’équipe et de respecter les niveaux de financement du budget tout en atteignant les objectifs opérationnels."
+          "fr": "Capacité démontrée d’affecter efficacement les ressources, d’optimiser les flux de travail de l’équipe et de respecter les niveaux de financement du budget tout en atteignant les objectifs opérationnels.",
+          "localized": "Demonstrated ability to effectively allocate resources, optimize team workflows, and adhere to budget funding levels while achieving operational goals."
         },
         "keywords": {
           "en": ["Budget", "and", "team", "operations", "management"],
@@ -1976,11 +2216,13 @@
             "key": "management_competencies",
             "name": {
               "en": "Leadership - General Technical Skills",
-              "fr": "Leadership - Compétences techniques générales"
+              "fr": "Leadership - Compétences techniques générales",
+              "localized": "Leadership - General Technical Skills"
             },
             "description": {
               "en": "Management skills at the non-executive level for oversight of finances, human resources, initiatives, and accountabilities",
-              "fr": "Compétences en gestion au niveau non exécutif pour la surveillance des finances, des ressources humaines, des initiatives et des responsabilités"
+              "fr": "Compétences en gestion au niveau non exécutif pour la surveillance des finances, des ressources humaines, des initiatives et des responsabilités",
+              "localized": "Management skills at the non-executive level for oversight of finances, human resources, initiatives, and accountabilities"
             }
           }
         ]
@@ -1990,11 +2232,13 @@
         "key": "bug_fixing",
         "name": {
           "en": "Bug Identification and Bug Fixing",
-          "fr": "Identification et correction des bogues"
+          "fr": "Identification et correction des bogues",
+          "localized": "Bug Identification and Bug Fixing"
         },
         "description": {
           "en": "Demonstrated ability to test for, accurately identify, and communicate technical problems or broken functionality in digital software, and the ability to implement corrective action, including further testing, ensuring that the bug is fixed and the problem and solution are documented.",
-          "fr": "Capacité démontrée à tester, identifier avec précision et communiquer les problèmes techniques ou les fonctionnalités défectueuses des logiciels numériques, et la capacité de mettre en œuvre des mesures correctives, y compris des tests supplémentaires, en veillant à ce que le bogue soit corrigé et que le problème et la solution soient documentés."
+          "fr": "Capacité démontrée à tester, identifier avec précision et communiquer les problèmes techniques ou les fonctionnalités défectueuses des logiciels numériques, et la capacité de mettre en œuvre des mesures correctives, y compris des tests supplémentaires, en veillant à ce que le bogue soit corrigé et que le problème et la solution soient documentés.",
+          "localized": "Demonstrated ability to test for, accurately identify, and communicate technical problems or broken functionality in digital software, and the ability to implement corrective action, including further testing, ensuring that the bug is fixed and the problem and solution are documented."
         },
         "keywords": {
           "en": null,
@@ -2009,11 +2253,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           },
           {
@@ -2021,11 +2267,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           },
           {
@@ -2033,11 +2281,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -2047,11 +2297,13 @@
         "key": "business_analysis",
         "name": {
           "en": "IT Business Analysis",
-          "fr": "Analyse d’affaires informatique"
+          "fr": "Analyse d’affaires informatique",
+          "localized": "IT Business Analysis"
         },
         "description": {
           "en": "Demonstrated ability to analyze business requirements and map them to the appropriate IT services required.",
-          "fr": "Capacité démontrée d’analyser les besoins opérationnels et de les mettre en correspondance avec les services informatiques appropriés."
+          "fr": "Capacité démontrée d’analyser les besoins opérationnels et de les mettre en correspondance avec les services informatiques appropriés.",
+          "localized": "Demonstrated ability to analyze business requirements and map them to the appropriate IT services required."
         },
         "keywords": {
           "en": null,
@@ -2066,11 +2318,13 @@
             "key": "it_project_management",
             "name": {
               "en": "Digital Business Line Advisory Services",
-              "fr": "Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Services consultatifs auprès des secteurs de la numérique",
+              "localized": "Digital Business Line Advisory Services"
             },
             "description": {
               "en": "IT generic work stream - Business Line Advisory Services",
-              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique",
+              "localized": "IT generic work stream - Business Line Advisory Services"
             }
           },
           {
@@ -2078,11 +2332,13 @@
             "key": "technical_advising",
             "name": {
               "en": "IT Planning and Reporting",
-              "fr": "Planification et établissement de rapports en matière de la numérique"
+              "fr": "Planification et établissement de rapports en matière de la numérique",
+              "localized": "IT Planning and Reporting"
             },
             "description": {
               "en": "IT generic work stream - IT Planning and Reporting",
-              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique"
+              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique",
+              "localized": "IT generic work stream - IT Planning and Reporting"
             }
           }
         ]
@@ -2092,11 +2348,13 @@
         "key": "business_analysis_general",
         "name": {
           "en": "Business Analysis",
-          "fr": "Analyse d’affarires"
+          "fr": "Analyse d’affarires",
+          "localized": "Business Analysis"
         },
         "description": {
           "en": "Demonstrated ability to apply the principles of business analysis in the planning, reengineering, and requirement gathering for business environments, operations, processes, and practices.",
-          "fr": "Capacité démontrée à appliquer les principes de l'analyse opérationnelle à la planification, à la réorganisation et à la collecte des besoins en matière d'environnements, d'opérations, de processus et de pratiques d'affaires."
+          "fr": "Capacité démontrée à appliquer les principes de l'analyse opérationnelle à la planification, à la réorganisation et à la collecte des besoins en matière d'environnements, d'opérations, de processus et de pratiques d'affaires.",
+          "localized": "Demonstrated ability to apply the principles of business analysis in the planning, reengineering, and requirement gathering for business environments, operations, processes, and practices."
         },
         "keywords": {
           "en": null,
@@ -2111,11 +2369,13 @@
             "key": "it_project_management",
             "name": {
               "en": "Digital Business Line Advisory Services",
-              "fr": "Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Services consultatifs auprès des secteurs de la numérique",
+              "localized": "Digital Business Line Advisory Services"
             },
             "description": {
               "en": "IT generic work stream - Business Line Advisory Services",
-              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique",
+              "localized": "IT generic work stream - Business Line Advisory Services"
             }
           }
         ]
@@ -2125,11 +2385,13 @@
         "key": "business_continuity_analysis_procedures_and_exercise_frameworks",
         "name": {
           "en": "Business Continuity Analysis Procedures and Exercise Frameworks",
-          "fr": "Procédures d’analyse de la continuité des activités et cadres d’exercices"
+          "fr": "Procédures d’analyse de la continuité des activités et cadres d’exercices",
+          "localized": "Business Continuity Analysis Procedures and Exercise Frameworks"
         },
         "description": {
           "en": "Demonstrated ability to identify threats to essential business functions and create prevention and recovery systems to deal with them.",
-          "fr": "Capacité démontrée à identifier les menaces qui pèsent sur les fonctions essentielles de l’entreprise et à créer des systèmes de prévention et de rétablissement pour y faire face."
+          "fr": "Capacité démontrée à identifier les menaces qui pèsent sur les fonctions essentielles de l’entreprise et à créer des systèmes de prévention et de rétablissement pour y faire face.",
+          "localized": "Demonstrated ability to identify threats to essential business functions and create prevention and recovery systems to deal with them."
         },
         "keywords": {
           "en": null,
@@ -2144,11 +2406,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -2158,11 +2422,13 @@
         "key": "business_intelligence_tools",
         "name": {
           "en": "Business intelligence tools",
-          "fr": "Outils d’informatique décisionnelle"
+          "fr": "Outils d’informatique décisionnelle",
+          "localized": "Business intelligence tools"
         },
         "description": {
           "en": "Demonstrated ability to comfortably use common Business Intelligence tools to create, develop, and deploy interactive dashboards, visualizations and reports, enabling data-driven decision-making. This may include products such as Tableau, Power BI, or Looker.",
-          "fr": "Capacité démontrée à utiliser aisément des outils d’informatique décisionnelle courants pour concevoir, élaborer et déployer des tableaux de bord, des représentations visuelles et des rapports interactifs permettant la prise de décisions fondées sur des données. Cela peut inclure des produits tels que Tableau, Power BI ou Looker."
+          "fr": "Capacité démontrée à utiliser aisément des outils d’informatique décisionnelle courants pour concevoir, élaborer et déployer des tableaux de bord, des représentations visuelles et des rapports interactifs permettant la prise de décisions fondées sur des données. Cela peut inclure des produits tels que Tableau, Power BI ou Looker.",
+          "localized": "Demonstrated ability to comfortably use common Business Intelligence tools to create, develop, and deploy interactive dashboards, visualizations and reports, enabling data-driven decision-making. This may include products such as Tableau, Power BI, or Looker."
         },
         "keywords": {
           "en": ["Business", "intelligence", "tools"],
@@ -2177,11 +2443,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           },
           {
@@ -2189,11 +2457,13 @@
             "key": "data_services_data_science",
             "name": {
               "en": "Data Services - Data Science",
-              "fr": "Services de données - Science des données"
+              "fr": "Services de données - Science des données",
+              "localized": "Data Services - Data Science"
             },
             "description": {
               "en": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources.",
-              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses."
+              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses.",
+              "localized": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources."
             }
           },
           {
@@ -2201,11 +2471,13 @@
             "key": "data_services_data_systems",
             "name": {
               "en": "Data Services - Data Systems Operations",
-              "fr": "Services de données - Opérations des systèmes de données"
+              "fr": "Services de données - Opérations des systèmes de données",
+              "localized": "Data Services - Data Systems Operations"
             },
             "description": {
               "en": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes.",
-              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux."
+              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux.",
+              "localized": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes."
             }
           }
         ]
@@ -2215,11 +2487,13 @@
         "key": "change_management",
         "name": {
           "en": "Change Management",
-          "fr": "Gestion du changement"
+          "fr": "Gestion du changement",
+          "localized": "Change Management"
         },
         "description": {
           "en": "Demonstrated ability to create a supported, sustained change in organizations, products or services. This includes developing approaches to communicate change and ensure the adoption of new behaviours, as well as planning and implementing new ways of operating.",
-          "fr": "Capacité démontrée à créer un changement soutenu et durable dans les organisations, les produits ou les services. Il s’agit notamment d’élaborer des approches pour communiquer le changement et assurer l’adoption de nouveaux comportements, ainsi que de planifier et de mettre en œuvre de nouvelles façons de fonctionner."
+          "fr": "Capacité démontrée à créer un changement soutenu et durable dans les organisations, les produits ou les services. Il s’agit notamment d’élaborer des approches pour communiquer le changement et assurer l’adoption de nouveaux comportements, ainsi que de planifier et de mettre en œuvre de nouvelles façons de fonctionner.",
+          "localized": "Demonstrated ability to create a supported, sustained change in organizations, products or services. This includes developing approaches to communicate change and ensure the adoption of new behaviours, as well as planning and implementing new ways of operating."
         },
         "keywords": {
           "en": [
@@ -2244,11 +2518,13 @@
             "key": "leadership",
             "name": {
               "en": "Leadership - General Behaviours",
-              "fr": "Leadership - Comportements généraux"
+              "fr": "Leadership - Comportements généraux",
+              "localized": "Leadership - General Behaviours"
             },
             "description": {
               "en": "Behavioural - Leadership",
-              "fr": "Comportemental - Leadership"
+              "fr": "Comportemental - Leadership",
+              "localized": "Behavioural - Leadership"
             }
           }
         ]
@@ -2258,11 +2534,13 @@
         "key": "character_leadership",
         "name": {
           "en": "Character Leadership",
-          "fr": "Leadership de caractère"
+          "fr": "Leadership de caractère",
+          "localized": "Character Leadership"
         },
         "description": {
           "en": "Demonstrated ability to use ones current and past experiences to make decisions that exercise judgement, develop strong leaders, support well-beings of employees, and enable organizational excellence.",
-          "fr": "Capacité démontrée à utiliser ses expériences actuelles et passées pour prendre des décisions qui permettent de faire preuve de discernement, de former des dirigeants forts, de soutenir le bien-être des employés et de favoriser l'excellence organisationnelle"
+          "fr": "Capacité démontrée à utiliser ses expériences actuelles et passées pour prendre des décisions qui permettent de faire preuve de discernement, de former des dirigeants forts, de soutenir le bien-être des employés et de favoriser l'excellence organisationnelle",
+          "localized": "Demonstrated ability to use ones current and past experiences to make decisions that exercise judgement, develop strong leaders, support well-beings of employees, and enable organizational excellence."
         },
         "keywords": {
           "en": ["Character"],
@@ -2277,11 +2555,13 @@
             "key": "klc",
             "name": {
               "en": "Leadership - Executive Behaviours",
-              "fr": "Leadership - Comportements des cadres"
+              "fr": "Leadership - Comportements des cadres",
+              "localized": "Leadership - Executive Behaviours"
             },
             "description": {
               "en": "Behavioural - Key Leadership Competencies",
-              "fr": "Comportemental – Compétences clés en leadership"
+              "fr": "Comportemental – Compétences clés en leadership",
+              "localized": "Behavioural - Key Leadership Competencies"
             }
           }
         ]
@@ -2291,11 +2571,13 @@
         "key": "client_focus",
         "name": {
           "en": "Client Focus",
-          "fr": "Axé sur le client"
+          "fr": "Axé sur le client",
+          "localized": "Client Focus"
         },
         "description": {
           "en": "Demonstrated ability to engage respectfully with service or product users, prioritize their needs, promote satisfaction, and resolve issues.",
-          "fr": "Capacité démontrée à s’engager avec respect avec les utilisateurs de services ou de produits, à hiérarchiser leurs besoins, à promouvoir la satisfaction et à résoudre les problèmes."
+          "fr": "Capacité démontrée à s’engager avec respect avec les utilisateurs de services ou de produits, à hiérarchiser leurs besoins, à promouvoir la satisfaction et à résoudre les problèmes.",
+          "localized": "Demonstrated ability to engage respectfully with service or product users, prioritize their needs, promote satisfaction, and resolve issues."
         },
         "keywords": {
           "en": [
@@ -2322,11 +2604,13 @@
             "key": "interpersonal",
             "name": {
               "en": "Interpersonal Behaviours",
-              "fr": "Comportements interpersonnels"
+              "fr": "Comportements interpersonnels",
+              "localized": "Interpersonal Behaviours"
             },
             "description": {
               "en": "Behavioural - Interpersonal",
-              "fr": "Comportemental - Interpersonnel"
+              "fr": "Comportemental - Interpersonnel",
+              "localized": "Behavioural - Interpersonal"
             }
           }
         ]
@@ -2336,11 +2620,13 @@
         "key": "client_services",
         "name": {
           "en": "Client Services",
-          "fr": "Services à la clientèle"
+          "fr": "Services à la clientèle",
+          "localized": "Client Services"
         },
         "description": {
           "en": "Demonstrated ability to interact respectfully with clients, adhere to established client services procedures, identify issues, and effectively resolve client concerns.",
-          "fr": "Capacité manifeste à interagir respectueusement avec les clients, à respecter les procédures établies en matière de services à la clientèle, à cerner les problèmes et à résoudre efficacement les préoccupations des clients."
+          "fr": "Capacité manifeste à interagir respectueusement avec les clients, à respecter les procédures établies en matière de services à la clientèle, à cerner les problèmes et à résoudre efficacement les préoccupations des clients.",
+          "localized": "Demonstrated ability to interact respectfully with clients, adhere to established client services procedures, identify issues, and effectively resolve client concerns."
         },
         "keywords": {
           "en": null,
@@ -2355,11 +2641,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           },
           {
@@ -2367,11 +2655,13 @@
             "key": "infrastructure_operations",
             "name": {
               "en": "IT Infrastructure Operations",
-              "fr": "Opérations d'infrastructure informatique"
+              "fr": "Opérations d'infrastructure informatique",
+              "localized": "IT Infrastructure Operations"
             },
             "description": {
               "en": "IT generic work stream - Infrastructure Operations",
-              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique"
+              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique",
+              "localized": "IT generic work stream - Infrastructure Operations"
             }
           },
           {
@@ -2379,11 +2669,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           },
           {
@@ -2391,11 +2683,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -2405,11 +2699,13 @@
         "key": "cloud_architecture",
         "name": {
           "en": "Cloud Architecture",
-          "fr": "Architecture infonuagique"
+          "fr": "Architecture infonuagique",
+          "localized": "Cloud Architecture"
         },
         "description": {
           "en": "Demonstrated ability to describe and document how different components and capabilities connect to build an online platform.",
-          "fr": "Capacité démontrée à décrire et à documenter la façon dont différents composants et capacités se connectent pour créer une plateforme en ligne."
+          "fr": "Capacité démontrée à décrire et à documenter la façon dont différents composants et capacités se connectent pour créer une plateforme en ligne.",
+          "localized": "Demonstrated ability to describe and document how different components and capabilities connect to build an online platform."
         },
         "keywords": {
           "en": null,
@@ -2424,11 +2720,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           }
         ]
@@ -2438,11 +2736,13 @@
         "key": "cloud_computing_platform_configuration",
         "name": {
           "en": "Cloud Computing Platform Configuration",
-          "fr": "Configuration de la plate-forme infonuagique"
+          "fr": "Configuration de la plate-forme infonuagique",
+          "localized": "Cloud Computing Platform Configuration"
         },
         "description": {
           "en": "Demonstrated ability to set hardware and software details for elements of a cloud environment to make sure they can interoperate and communicate.",
-          "fr": "Capacité démontrée à définir les détails matériels et logiciels des éléments d’un environnement infonuagique afin de s’assurer qu’ils peuvent interagir et communiquer."
+          "fr": "Capacité démontrée à définir les détails matériels et logiciels des éléments d’un environnement infonuagique afin de s’assurer qu’ils peuvent interagir et communiquer.",
+          "localized": "Demonstrated ability to set hardware and software details for elements of a cloud environment to make sure they can interoperate and communicate."
         },
         "keywords": {
           "en": null,
@@ -2457,11 +2757,13 @@
             "key": "infrastructure_operations",
             "name": {
               "en": "IT Infrastructure Operations",
-              "fr": "Opérations d'infrastructure informatique"
+              "fr": "Opérations d'infrastructure informatique",
+              "localized": "IT Infrastructure Operations"
             },
             "description": {
               "en": "IT generic work stream - Infrastructure Operations",
-              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique"
+              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique",
+              "localized": "IT generic work stream - Infrastructure Operations"
             }
           },
           {
@@ -2469,11 +2771,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           }
         ]
@@ -2483,11 +2787,13 @@
         "key": "cloud_migration",
         "name": {
           "en": "Cloud Migration",
-          "fr": "Migration vers le cloud"
+          "fr": "Migration vers le cloud",
+          "localized": "Cloud Migration"
         },
         "description": {
           "en": "Demonstrated ability to effectively transfer organizational data, applications, and processes from on-premises infrastructure to cloud environments.",
-          "fr": "Capacité démontrée à transférer efficacement les données organisationnelles, les applications et les processus de l'infrastructure sur site vers des environnements cloud."
+          "fr": "Capacité démontrée à transférer efficacement les données organisationnelles, les applications et les processus de l'infrastructure sur site vers des environnements cloud.",
+          "localized": "Demonstrated ability to effectively transfer organizational data, applications, and processes from on-premises infrastructure to cloud environments."
         },
         "keywords": {
           "en": ["Cloud", "Migration"],
@@ -2502,11 +2808,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           }
         ]
@@ -2516,11 +2824,13 @@
         "key": "cloud_security",
         "name": {
           "en": "Cloud Security",
-          "fr": "Sécurité de l'informatique en nuage"
+          "fr": "Sécurité de l'informatique en nuage",
+          "localized": "Cloud Security"
         },
         "description": {
           "en": "Demonstrated ability to utilize a collection of technologies, policies, services, and security controls to protect an organization’s sensitive data and applications in a cloud environment.",
-          "fr": "Capacité démontrée à utiliser un ensemble de technologies, de politiques, de services et de contrôles de sécurité pour protéger les données et les applications sensibles d'une organisation dans un environnement cloud."
+          "fr": "Capacité démontrée à utiliser un ensemble de technologies, de politiques, de services et de contrôles de sécurité pour protéger les données et les applications sensibles d'une organisation dans un environnement cloud.",
+          "localized": "Demonstrated ability to utilize a collection of technologies, policies, services, and security controls to protect an organization’s sensitive data and applications in a cloud environment."
         },
         "keywords": {
           "en": ["cloud", "security"],
@@ -2535,11 +2845,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           },
           {
@@ -2547,11 +2859,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -2561,11 +2875,13 @@
         "key": "cloud_security_architecture",
         "name": {
           "en": "Cloud Security Architecture",
-          "fr": "Architecture de sécurité infonuagique"
+          "fr": "Architecture de sécurité infonuagique",
+          "localized": "Cloud Security Architecture"
         },
         "description": {
           "en": "Demonstrated ability to describe and document how to integrate security controls throughout the deployment of information to cloud-based servers.",
-          "fr": "Capacité démontrée à décrire et à documenter la façon d’intégrer les contrôles de sécurité tout au long du déploiement de l’information sur des serveurs infonuagiques."
+          "fr": "Capacité démontrée à décrire et à documenter la façon d’intégrer les contrôles de sécurité tout au long du déploiement de l’information sur des serveurs infonuagiques.",
+          "localized": "Demonstrated ability to describe and document how to integrate security controls throughout the deployment of information to cloud-based servers."
         },
         "keywords": {
           "en": null,
@@ -2580,11 +2896,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           }
         ]
@@ -2594,11 +2912,13 @@
         "key": "cobol",
         "name": {
           "en": "COBOL",
-          "fr": "COBOL"
+          "fr": "COBOL",
+          "localized": "COBOL"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this language to develop a variety of projects.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de cette langue pour développer une variété de projets."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de cette langue pour développer une variété de projets.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this language to develop a variety of projects."
         },
         "keywords": {
           "en": null,
@@ -2613,11 +2933,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -2627,11 +2949,13 @@
         "key": "collaboration",
         "name": {
           "en": "Collaboration",
-          "fr": "Collaboration"
+          "fr": "Collaboration",
+          "localized": "Collaboration"
         },
         "description": {
           "en": "Demonstrated ability to work with others toward a common goal through the mutual sharing of ideas, information, and resources.",
-          "fr": "Capacité démontrée à travailler avec d’autres personnes vers un objectif commun grâce au partage mutuel d’idées, d’informations et de ressources."
+          "fr": "Capacité démontrée à travailler avec d’autres personnes vers un objectif commun grâce au partage mutuel d’idées, d’informations et de ressources.",
+          "localized": "Demonstrated ability to work with others toward a common goal through the mutual sharing of ideas, information, and resources."
         },
         "keywords": {
           "en": ["Cooperation", "Teamwork", "Working Together"],
@@ -2646,11 +2970,13 @@
             "key": "interpersonal",
             "name": {
               "en": "Interpersonal Behaviours",
-              "fr": "Comportements interpersonnels"
+              "fr": "Comportements interpersonnels",
+              "localized": "Interpersonal Behaviours"
             },
             "description": {
               "en": "Behavioural - Interpersonal",
-              "fr": "Comportemental - Interpersonnel"
+              "fr": "Comportemental - Interpersonnel",
+              "localized": "Behavioural - Interpersonal"
             }
           }
         ]
@@ -2660,11 +2986,13 @@
         "key": "communication_of_technical_information_to_non_technical_audiences",
         "name": {
           "en": "Communication of Technical Information to Non-Technical Audiences",
-          "fr": "Communication d’informations techniques à des publics non techniques"
+          "fr": "Communication d’informations techniques à des publics non techniques",
+          "localized": "Communication of Technical Information to Non-Technical Audiences"
         },
         "description": {
           "en": "Demonstrated ability to explain technical content using plain language and simple visual elements that are easy to understand.",
-          "fr": "Capacité avérée à expliquer un contenu technique en utilisant un langage et des éléments visuels simples et faciles à comprendre."
+          "fr": "Capacité avérée à expliquer un contenu technique en utilisant un langage et des éléments visuels simples et faciles à comprendre.",
+          "localized": "Demonstrated ability to explain technical content using plain language and simple visual elements that are easy to understand."
         },
         "keywords": {
           "en": null,
@@ -2679,11 +3007,13 @@
             "key": "technical_advising",
             "name": {
               "en": "IT Planning and Reporting",
-              "fr": "Planification et établissement de rapports en matière de la numérique"
+              "fr": "Planification et établissement de rapports en matière de la numérique",
+              "localized": "IT Planning and Reporting"
             },
             "description": {
               "en": "IT generic work stream - IT Planning and Reporting",
-              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique"
+              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique",
+              "localized": "IT generic work stream - IT Planning and Reporting"
             }
           }
         ]
@@ -2693,11 +3023,13 @@
         "key": "complex_problem_solving",
         "name": {
           "en": "Complex Problem Solving",
-          "fr": "Résolution de problèmes complexes"
+          "fr": "Résolution de problèmes complexes",
+          "localized": "Complex Problem Solving"
         },
         "description": {
           "en": "Demonstrated ability to use logical approaches and partnership building to solve unique, ill-defined, or intricate problems involving multiple layers and numerous unknowns.",
-          "fr": "Capacité démontrée d’utiliser des approches logiques et l’établissement de partenariats pour résoudre des problèmes uniques, mal définis ou complexes impliquant plusieurs niveaux et de nombreuses inconnues."
+          "fr": "Capacité démontrée d’utiliser des approches logiques et l’établissement de partenariats pour résoudre des problèmes uniques, mal définis ou complexes impliquant plusieurs niveaux et de nombreuses inconnues.",
+          "localized": "Demonstrated ability to use logical approaches and partnership building to solve unique, ill-defined, or intricate problems involving multiple layers and numerous unknowns."
         },
         "keywords": {
           "en": ["Problem Resolution", "Troubleshooting", "Problem Analysis"],
@@ -2712,11 +3044,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -2726,11 +3060,13 @@
         "key": "conflict_management",
         "name": {
           "en": "Conflict Management",
-          "fr": "Gestion des conflits"
+          "fr": "Gestion des conflits",
+          "localized": "Conflict Management"
         },
         "description": {
           "en": "Demonstrated ability to help others overcome difficulties stemming from differences of opinion or issues with communication.",
-          "fr": "Capacité démontrée d’aider les autres à surmonter les difficultés découlant de divergences d’opinions ou de problèmes de communication."
+          "fr": "Capacité démontrée d’aider les autres à surmonter les difficultés découlant de divergences d’opinions ou de problèmes de communication.",
+          "localized": "Demonstrated ability to help others overcome difficulties stemming from differences of opinion or issues with communication."
         },
         "keywords": {
           "en": [
@@ -2753,11 +3089,13 @@
             "key": "interpersonal",
             "name": {
               "en": "Interpersonal Behaviours",
-              "fr": "Comportements interpersonnels"
+              "fr": "Comportements interpersonnels",
+              "localized": "Interpersonal Behaviours"
             },
             "description": {
               "en": "Behavioural - Interpersonal",
-              "fr": "Comportemental - Interpersonnel"
+              "fr": "Comportemental - Interpersonnel",
+              "localized": "Behavioural - Interpersonal"
             }
           }
         ]
@@ -2767,11 +3105,13 @@
         "key": "continuous_learning",
         "name": {
           "en": "Continuous Learning",
-          "fr": "Apprentissage continu"
+          "fr": "Apprentissage continu",
+          "localized": "Continuous Learning"
         },
         "description": {
           "en": "Demonstrated ability to continually gain, develop, and apply new knowledge and skills.",
-          "fr": "Capacité démontrée d’acquérir, de développer et d’appliquer continuellement de nouvelles connaissances et compétences."
+          "fr": "Capacité démontrée d’acquérir, de développer et d’appliquer continuellement de nouvelles connaissances et compétences.",
+          "localized": "Demonstrated ability to continually gain, develop, and apply new knowledge and skills."
         },
         "keywords": {
           "en": [
@@ -2796,11 +3136,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           },
           {
@@ -2808,11 +3150,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -2822,11 +3166,13 @@
         "key": "courage",
         "name": {
           "en": "Courage",
-          "fr": "Courage"
+          "fr": "Courage",
+          "localized": "Courage"
         },
         "description": {
           "en": "Demonstrated ability to confront difficult situations without allowing fear to become a barrier.",
-          "fr": "Capacité démontrée à faire face à des situations difficiles sans laisser la peur devenir un obstacle."
+          "fr": "Capacité démontrée à faire face à des situations difficiles sans laisser la peur devenir un obstacle.",
+          "localized": "Demonstrated ability to confront difficult situations without allowing fear to become a barrier."
         },
         "keywords": {
           "en": ["Bravery", "Determination", "Grit", "Boldness", "Resolution"],
@@ -2841,11 +3187,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -2855,11 +3203,13 @@
         "key": "cplusplus",
         "name": {
           "en": "C++",
-          "fr": "C++"
+          "fr": "C++",
+          "localized": "C++"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this language to develop a variety of projects.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de cette langue pour développer une variété de projets."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de cette langue pour développer une variété de projets.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this language to develop a variety of projects."
         },
         "keywords": {
           "en": null,
@@ -2874,11 +3224,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -2888,11 +3240,13 @@
         "key": "creating_inclusive_environments",
         "name": {
           "en": "Creating Inclusive Environments",
-          "fr": "Création d’environnements inclusifs"
+          "fr": "Création d’environnements inclusifs",
+          "localized": "Creating Inclusive Environments"
         },
         "description": {
           "en": "Demonstrated ability to create a space where every person feels respected and appreciated.",
-          "fr": "Capacité démontrée à créer un espace où chaque personne se sent respectée et appréciée."
+          "fr": "Capacité démontrée à créer un espace où chaque personne se sent respectée et appréciée.",
+          "localized": "Demonstrated ability to create a space where every person feels respected and appreciated."
         },
         "keywords": {
           "en": [
@@ -2915,11 +3269,13 @@
             "key": "interpersonal",
             "name": {
               "en": "Interpersonal Behaviours",
-              "fr": "Comportements interpersonnels"
+              "fr": "Comportements interpersonnels",
+              "localized": "Interpersonal Behaviours"
             },
             "description": {
               "en": "Behavioural - Interpersonal",
-              "fr": "Comportemental - Interpersonnel"
+              "fr": "Comportemental - Interpersonnel",
+              "localized": "Behavioural - Interpersonal"
             }
           },
           {
@@ -2927,11 +3283,13 @@
             "key": "leadership",
             "name": {
               "en": "Leadership - General Behaviours",
-              "fr": "Leadership - Comportements généraux"
+              "fr": "Leadership - Comportements généraux",
+              "localized": "Leadership - General Behaviours"
             },
             "description": {
               "en": "Behavioural - Leadership",
-              "fr": "Comportemental - Leadership"
+              "fr": "Comportemental - Leadership",
+              "localized": "Behavioural - Leadership"
             }
           }
         ]
@@ -2941,11 +3299,13 @@
         "key": "creative_thinking",
         "name": {
           "en": "Creative Thinking",
-          "fr": "Pensée créative"
+          "fr": "Pensée créative",
+          "localized": "Creative Thinking"
         },
         "description": {
           "en": "Demonstrated ability to generate new, unusual, or clever ideas about a topic or to solve an issue.",
-          "fr": "Capacité démontrée à générer des idées nouvelles, inhabituelles ou intelligentes sur un sujet ou à résoudre un problème."
+          "fr": "Capacité démontrée à générer des idées nouvelles, inhabituelles ou intelligentes sur un sujet ou à résoudre un problème.",
+          "localized": "Demonstrated ability to generate new, unusual, or clever ideas about a topic or to solve an issue."
         },
         "keywords": {
           "en": [
@@ -2970,11 +3330,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -2984,11 +3346,13 @@
         "key": "critical_thinking",
         "name": {
           "en": "Critical Thinking",
-          "fr": "Pensée critique"
+          "fr": "Pensée critique",
+          "localized": "Critical Thinking"
         },
         "description": {
           "en": "Demonstrated ability to take a structured and objective approach to evaluating information before forming an opinion about a topic.",
-          "fr": "Capacité démontrée d’adopter une approche structurée et objective pour évaluer l’information avant de se forger une opinion sur un sujet."
+          "fr": "Capacité démontrée d’adopter une approche structurée et objective pour évaluer l’information avant de se forger une opinion sur un sujet.",
+          "localized": "Demonstrated ability to take a structured and objective approach to evaluating information before forming an opinion about a topic."
         },
         "keywords": {
           "en": [
@@ -3015,11 +3379,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -3029,11 +3395,13 @@
         "key": "cryptographic_applications",
         "name": {
           "en": "Cryptographic Applications",
-          "fr": "Applications cryptographiques"
+          "fr": "Applications cryptographiques",
+          "localized": "Cryptographic Applications"
         },
         "description": {
           "en": "Demonstrated the ability to design and implement coded algorithms and cryptographic solutions to protect and obscure transmitted information and ensure only authorized parties have the ability to decrypt and have access to it.",
-          "fr": "Capacité démontrée de concevoir et de mettre en œuvre des algorithmes codés et des solutions cryptographiques pour protéger et obscurcir l’information transmise et s’assurer que seules les parties autorisées sont capables de la décrypter et d’y accéder."
+          "fr": "Capacité démontrée de concevoir et de mettre en œuvre des algorithmes codés et des solutions cryptographiques pour protéger et obscurcir l’information transmise et s’assurer que seules les parties autorisées sont capables de la décrypter et d’y accéder.",
+          "localized": "Demonstrated the ability to design and implement coded algorithms and cryptographic solutions to protect and obscure transmitted information and ensure only authorized parties have the ability to decrypt and have access to it."
         },
         "keywords": {
           "en": ["Cryptographic", "Applications"],
@@ -3048,11 +3416,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -3062,11 +3432,13 @@
         "key": "csharp",
         "name": {
           "en": "C#",
-          "fr": "C#"
+          "fr": "C#",
+          "localized": "C#"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this language to develop a variety of projects.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de cette langue pour développer une variété de projets."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de cette langue pour développer une variété de projets.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this language to develop a variety of projects."
         },
         "keywords": {
           "en": null,
@@ -3081,11 +3453,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -3095,11 +3469,13 @@
         "key": "cultural_archival_knowledge",
         "name": {
           "en": "Cultural, Historical or Archival Knowledge",
-          "fr": "Connaissances culturelles, historiques ou archivistiques"
+          "fr": "Connaissances culturelles, historiques ou archivistiques",
+          "localized": "Cultural, Historical or Archival Knowledge"
         },
         "description": {
           "en": "Demonstrated knowledge of approaches to protect and preserve cultural or historical traditions.",
-          "fr": "Connaissance démontrée des approches visant à protéger et à préserver les traditions culturelles ou historiques."
+          "fr": "Connaissance démontrée des approches visant à protéger et à préserver les traditions culturelles ou historiques.",
+          "localized": "Demonstrated knowledge of approaches to protect and preserve cultural or historical traditions."
         },
         "keywords": {
           "en": null,
@@ -3114,11 +3490,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           }
         ]
@@ -3128,11 +3506,13 @@
         "key": "curiosity",
         "name": {
           "en": "Curiosity",
-          "fr": "Curiosité"
+          "fr": "Curiosité",
+          "localized": "Curiosity"
         },
         "description": {
           "en": "Demonstrated drive to seek out and discover new information.",
-          "fr": "Volonté démontrée de rechercher et de découvrir de nouvelles informations."
+          "fr": "Volonté démontrée de rechercher et de découvrir de nouvelles informations.",
+          "localized": "Demonstrated drive to seek out and discover new information."
         },
         "keywords": {
           "en": ["Inquisitive", "Thirst for Knowledge", "Eagerness to Learn"],
@@ -3147,11 +3527,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -3161,11 +3543,13 @@
         "key": "cyber_operations_security",
         "name": {
           "en": "Cyber Operations Security",
-          "fr": "Sécurité des cyberopérations"
+          "fr": "Sécurité des cyberopérations",
+          "localized": "Cyber Operations Security"
         },
         "description": {
           "en": "Demonstrated ability to manage, implement, and support cyber security technologies to protect business assets.",
-          "fr": "Capacité démontrée à gérer, mettre en œuvre et soutenir les technologies de cybersécurité pour protéger les actifs de l'entreprise."
+          "fr": "Capacité démontrée à gérer, mettre en œuvre et soutenir les technologies de cybersécurité pour protéger les actifs de l'entreprise.",
+          "localized": "Demonstrated ability to manage, implement, and support cyber security technologies to protect business assets."
         },
         "keywords": {
           "en": ["Cyber", "Operations", "Security"],
@@ -3180,11 +3564,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           }
         ]
@@ -3194,11 +3580,13 @@
         "key": "cyber_security_event_management",
         "name": {
           "en": "Cyber Security Event Management",
-          "fr": "Gestion des événements de cybersécurité"
+          "fr": "Gestion des événements de cybersécurité",
+          "localized": "Cyber Security Event Management"
         },
         "description": {
           "en": "Demonstrated ability to use security information and event management (SIEM) tools to detect, respond and recover from cyber security events and incidents.",
-          "fr": "Capacité démontrée à utiliser des outils de gestion des informations et des événements de sécurité (GIES) pour détecter les événements et incidents de cybersécurité, y répondre et y remédier."
+          "fr": "Capacité démontrée à utiliser des outils de gestion des informations et des événements de sécurité (GIES) pour détecter les événements et incidents de cybersécurité, y répondre et y remédier.",
+          "localized": "Demonstrated ability to use security information and event management (SIEM) tools to detect, respond and recover from cyber security events and incidents."
         },
         "keywords": {
           "en": ["Cyber", "Security", "Event", "Management"],
@@ -3213,11 +3601,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           }
         ]
@@ -3227,11 +3617,13 @@
         "key": "cybersecurity_principles",
         "name": {
           "en": "Application of Cyber Security Principles, Methods, and Policies",
-          "fr": "Application des principes, méthodes et politiques de cybersécurité"
+          "fr": "Application des principes, méthodes et politiques de cybersécurité",
+          "localized": "Application of Cyber Security Principles, Methods, and Policies"
         },
         "description": {
           "en": "Demonstrated ability to understand and follow best practices and policies to protect electronic information from digital attacks.",
-          "fr": "Capacité démontrée à comprendre et à suivre les meilleures pratiques et politiques pour protéger les informations électroniques contre les attaques numériques."
+          "fr": "Capacité démontrée à comprendre et à suivre les meilleures pratiques et politiques pour protéger les informations électroniques contre les attaques numériques.",
+          "localized": "Demonstrated ability to understand and follow best practices and policies to protect electronic information from digital attacks."
         },
         "keywords": {
           "en": null,
@@ -3246,11 +3638,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           }
         ]
@@ -3260,11 +3654,13 @@
         "key": "data_analysis",
         "name": {
           "en": "Data Analysis",
-          "fr": "Analyse des données"
+          "fr": "Analyse des données",
+          "localized": "Data Analysis"
         },
         "description": {
           "en": "Demonstrated ability to use data to discover useful information, inform conclusions, and support decision-making.",
-          "fr": "Capacité démontrée à utiliser les données pour découvrir des informations utiles, éclairer les conclusions et soutenir la prise de décisions."
+          "fr": "Capacité démontrée à utiliser les données pour découvrir des informations utiles, éclairer les conclusions et soutenir la prise de décisions.",
+          "localized": "Demonstrated ability to use data to discover useful information, inform conclusions, and support decision-making."
         },
         "keywords": {
           "en": null,
@@ -3279,11 +3675,13 @@
             "key": "database_design___data_administration",
             "name": {
               "en": "Database Management",
-              "fr": "Gestion des bases de données"
+              "fr": "Gestion des bases de données",
+              "localized": "Database Management"
             },
             "description": {
               "en": "IT generic work stream - Database Management",
-              "fr": "Flux de travail générique de TI - Gestion des bases de données"
+              "fr": "Flux de travail générique de TI - Gestion des bases de données",
+              "localized": "IT generic work stream - Database Management"
             }
           },
           {
@@ -3291,11 +3689,13 @@
             "key": "information_management",
             "name": {
               "en": "Information and Data Governance - Operations",
-              "fr": "Gouvernance de l'information et des données - Opérations"
+              "fr": "Gouvernance de l'information et des données - Opérations",
+              "localized": "Information and Data Governance - Operations"
             },
             "description": {
               "en": "IM-Operations involves overseeing the efficient and effective application of life-cycle management practices for records and documents within information management systems, serving business and legal purposes.",
-              "fr": "Les opérations de GI consistent à superviser l'application efficiente et efficace des pratiques de gestion du cycle de vie des dossiers et des documents au sein des systèmes de gestion de l'information, à des fins commerciales et juridiques."
+              "fr": "Les opérations de GI consistent à superviser l'application efficiente et efficace des pratiques de gestion du cycle de vie des dossiers et des documents au sein des systèmes de gestion de l'information, à des fins commerciales et juridiques.",
+              "localized": "IM-Operations involves overseeing the efficient and effective application of life-cycle management practices for records and documents within information management systems, serving business and legal purposes."
             }
           }
         ]
@@ -3305,11 +3705,13 @@
         "key": "data_analysis_and_synthesis",
         "name": {
           "en": "Data Analysis and Synthesis",
-          "fr": "Analyse et synthèse des données"
+          "fr": "Analyse et synthèse des données",
+          "localized": "Data Analysis and Synthesis"
         },
         "description": {
           "en": "Demonstrated ability to prepare data for usage using basic techniques for analyzing data and synthesizing findings to enable informed decision-making as well as evaluate decisions based on data and present clear takeaways that colleagues can readily understand and utilize.",
-          "fr": "Capacité démontrée à préparer des données en vue de leur utilisation en appliquant des techniques de base pour l’analyse des données et la synthèse des résultats afin de permettre une prise de décisions éclairée, ainsi qu’à évaluer les décisions fondées sur les données et à présenter des conclusions claires que les collègues peuvent facilement comprendre et utiliser."
+          "fr": "Capacité démontrée à préparer des données en vue de leur utilisation en appliquant des techniques de base pour l’analyse des données et la synthèse des résultats afin de permettre une prise de décisions éclairée, ainsi qu’à évaluer les décisions fondées sur les données et à présenter des conclusions claires que les collègues peuvent facilement comprendre et utiliser.",
+          "localized": "Demonstrated ability to prepare data for usage using basic techniques for analyzing data and synthesizing findings to enable informed decision-making as well as evaluate decisions based on data and present clear takeaways that colleagues can readily understand and utilize."
         },
         "keywords": {
           "en": ["Data", "Analysis", "Synthesis."],
@@ -3324,11 +3726,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           },
           {
@@ -3336,11 +3740,13 @@
             "key": "data_services_data_systems",
             "name": {
               "en": "Data Services - Data Systems Operations",
-              "fr": "Services de données - Opérations des systèmes de données"
+              "fr": "Services de données - Opérations des systèmes de données",
+              "localized": "Data Services - Data Systems Operations"
             },
             "description": {
               "en": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes.",
-              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux."
+              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux.",
+              "localized": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes."
             }
           }
         ]
@@ -3350,11 +3756,13 @@
         "key": "data_architecture",
         "name": {
           "en": "Data Architecture",
-          "fr": "Architecture des données"
+          "fr": "Architecture des données",
+          "localized": "Data Architecture"
         },
         "description": {
           "en": "Demonstrated ability to design and manage data structures, databases, and systems, ensuring data integrity, security, and performance.",
-          "fr": "Capacité démontrée à concevoir et à gérer des structures de données, des bases de données et des systèmes, en assurant l'intégrité, la sécurité et la performance des données."
+          "fr": "Capacité démontrée à concevoir et à gérer des structures de données, des bases de données et des systèmes, en assurant l'intégrité, la sécurité et la performance des données.",
+          "localized": "Demonstrated ability to design and manage data structures, databases, and systems, ensuring data integrity, security, and performance."
         },
         "keywords": {
           "en": ["Data", "Architecture"],
@@ -3369,11 +3777,13 @@
             "key": "im_data_governance_information_architecture",
             "name": {
               "en": "Information and Data Governance - Information Architecture",
-              "fr": "Gouvernance de l'information et des données - Architecture de l'information"
+              "fr": "Gouvernance de l'information et des données - Architecture de l'information",
+              "localized": "Information and Data Governance - Information Architecture"
             },
             "description": {
               "en": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes.",
-              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus."
+              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus.",
+              "localized": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes."
             }
           }
         ]
@@ -3383,11 +3793,13 @@
         "key": "data_cleaning",
         "name": {
           "en": "Data Cleaning",
-          "fr": "Nettoyage des données"
+          "fr": "Nettoyage des données",
+          "localized": "Data Cleaning"
         },
         "description": {
           "en": "Demonstrated ability to inspect, cleanse, and transform data to prepare it for analysis.",
-          "fr": "Capacité démontrée d’inspecter, de nettoyer et de transformer des données pour les préparer à l’analyse."
+          "fr": "Capacité démontrée d’inspecter, de nettoyer et de transformer des données pour les préparer à l’analyse.",
+          "localized": "Demonstrated ability to inspect, cleanse, and transform data to prepare it for analysis."
         },
         "keywords": {
           "en": null,
@@ -3402,11 +3814,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           },
           {
@@ -3414,11 +3828,13 @@
             "key": "information_management",
             "name": {
               "en": "Information and Data Governance - Operations",
-              "fr": "Gouvernance de l'information et des données - Opérations"
+              "fr": "Gouvernance de l'information et des données - Opérations",
+              "localized": "Information and Data Governance - Operations"
             },
             "description": {
               "en": "IM-Operations involves overseeing the efficient and effective application of life-cycle management practices for records and documents within information management systems, serving business and legal purposes.",
-              "fr": "Les opérations de GI consistent à superviser l'application efficiente et efficace des pratiques de gestion du cycle de vie des dossiers et des documents au sein des systèmes de gestion de l'information, à des fins commerciales et juridiques."
+              "fr": "Les opérations de GI consistent à superviser l'application efficiente et efficace des pratiques de gestion du cycle de vie des dossiers et des documents au sein des systèmes de gestion de l'information, à des fins commerciales et juridiques.",
+              "localized": "IM-Operations involves overseeing the efficient and effective application of life-cycle management practices for records and documents within information management systems, serving business and legal purposes."
             }
           },
           {
@@ -3426,11 +3842,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           },
           {
@@ -3438,11 +3856,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -3452,11 +3872,13 @@
         "key": "data_communication",
         "name": {
           "en": "Data Communication",
-          "fr": "Communication de données"
+          "fr": "Communication de données",
+          "localized": "Data Communication"
         },
         "description": {
           "en": "Demonstrated ability to communicate technical information in a clear and concise manner to both technical and non-technical stakeholders as well as support and host discussions within a multidisciplinary team, incorporate stakeholder feedback and encourage interaction to enhance the data communication process.",
-          "fr": "Capacité démontrée à communiquer des informations techniques de manière claire et concise aux parties prenantes techniques et non techniques, ainsi qu’à appuyer et à animer des discussions au sein d’une équipe pluridisciplinaire, à intégrer la rétroaction des parties prenantes et à encourager une interaction avec ceux-ci et les membres de l’équipe afin d’améliorer le processus de communication des données."
+          "fr": "Capacité démontrée à communiquer des informations techniques de manière claire et concise aux parties prenantes techniques et non techniques, ainsi qu’à appuyer et à animer des discussions au sein d’une équipe pluridisciplinaire, à intégrer la rétroaction des parties prenantes et à encourager une interaction avec ceux-ci et les membres de l’équipe afin d’améliorer le processus de communication des données.",
+          "localized": "Demonstrated ability to communicate technical information in a clear and concise manner to both technical and non-technical stakeholders as well as support and host discussions within a multidisciplinary team, incorporate stakeholder feedback and encourage interaction to enhance the data communication process."
         },
         "keywords": {
           "en": ["Data", "Communication."],
@@ -3471,11 +3893,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           },
           {
@@ -3483,11 +3907,13 @@
             "key": "data_services_data_systems",
             "name": {
               "en": "Data Services - Data Systems Operations",
-              "fr": "Services de données - Opérations des systèmes de données"
+              "fr": "Services de données - Opérations des systèmes de données",
+              "localized": "Data Services - Data Systems Operations"
             },
             "description": {
               "en": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes.",
-              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux."
+              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux.",
+              "localized": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes."
             }
           }
         ]
@@ -3497,11 +3923,13 @@
         "key": "data_discovery_and_profiling",
         "name": {
           "en": "Data Discovery and Profiling",
-          "fr": "Découverte et profilage de données"
+          "fr": "Découverte et profilage de données",
+          "localized": "Data Discovery and Profiling"
         },
         "description": {
           "en": "Demonstrated ability to analyze and assess data to identify patterns, anomalies, and data quality issues.",
-          "fr": "Capacité manifeste à analyser et à évaluer des données afin d’y relever les tendances, les anomalies et les problèmes de qualité des données."
+          "fr": "Capacité manifeste à analyser et à évaluer des données afin d’y relever les tendances, les anomalies et les problèmes de qualité des données.",
+          "localized": "Demonstrated ability to analyze and assess data to identify patterns, anomalies, and data quality issues."
         },
         "keywords": {
           "en": ["Data", "Discovery", "and", "Profiling"],
@@ -3516,11 +3944,13 @@
             "key": "information_management",
             "name": {
               "en": "Information and Data Governance - Operations",
-              "fr": "Gouvernance de l'information et des données - Opérations"
+              "fr": "Gouvernance de l'information et des données - Opérations",
+              "localized": "Information and Data Governance - Operations"
             },
             "description": {
               "en": "IM-Operations involves overseeing the efficient and effective application of life-cycle management practices for records and documents within information management systems, serving business and legal purposes.",
-              "fr": "Les opérations de GI consistent à superviser l'application efficiente et efficace des pratiques de gestion du cycle de vie des dossiers et des documents au sein des systèmes de gestion de l'information, à des fins commerciales et juridiques."
+              "fr": "Les opérations de GI consistent à superviser l'application efficiente et efficace des pratiques de gestion du cycle de vie des dossiers et des documents au sein des systèmes de gestion de l'information, à des fins commerciales et juridiques.",
+              "localized": "IM-Operations involves overseeing the efficient and effective application of life-cycle management practices for records and documents within information management systems, serving business and legal purposes."
             }
           }
         ]
@@ -3530,11 +3960,13 @@
         "key": "data_engineering",
         "name": {
           "en": "Data Engineering",
-          "fr": "Ingénierie des données"
+          "fr": "Ingénierie des données",
+          "localized": "Data Engineering"
         },
         "description": {
           "en": "Demonstrated ability to design, build, and maintain data pipelines, ensuring data availability and reliability for analysis and reporting.",
-          "fr": "Capacité démontrée à concevoir, construire et maintenir des pipelines de données, en assurant la disponibilité et la fiabilité des données pour l'analyse et les rapports."
+          "fr": "Capacité démontrée à concevoir, construire et maintenir des pipelines de données, en assurant la disponibilité et la fiabilité des données pour l'analyse et les rapports.",
+          "localized": "Demonstrated ability to design, build, and maintain data pipelines, ensuring data availability and reliability for analysis and reporting."
         },
         "keywords": {
           "en": ["Data", "Engineering"],
@@ -3549,11 +3981,13 @@
             "key": "im_data_governance_information_architecture",
             "name": {
               "en": "Information and Data Governance - Information Architecture",
-              "fr": "Gouvernance de l'information et des données - Architecture de l'information"
+              "fr": "Gouvernance de l'information et des données - Architecture de l'information",
+              "localized": "Information and Data Governance - Information Architecture"
             },
             "description": {
               "en": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes.",
-              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus."
+              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus.",
+              "localized": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes."
             }
           }
         ]
@@ -3563,11 +3997,13 @@
         "key": "data_engineering_and_manipulation",
         "name": {
           "en": "Data Engineering and Manipulation",
-          "fr": "Ingénierie et manipulation des données"
+          "fr": "Ingénierie et manipulation des données",
+          "localized": "Data Engineering and Manipulation"
         },
         "description": {
           "en": "Demonstrated ability to construct the infrastructure to ensure uninterrupted data flows between servers and applications and develop and maintain the architecture used in machine learning modelling.",
-          "fr": "Capacité démontrée à construire l'infrastructure nécessaire pour garantir des flux de données ininterrompus entre les serveurs et les applications, et à développer et maintenir l'architecture utilisée dans la modélisation de l'apprentissage automatique."
+          "fr": "Capacité démontrée à construire l'infrastructure nécessaire pour garantir des flux de données ininterrompus entre les serveurs et les applications, et à développer et maintenir l'architecture utilisée dans la modélisation de l'apprentissage automatique.",
+          "localized": "Demonstrated ability to construct the infrastructure to ensure uninterrupted data flows between servers and applications and develop and maintain the architecture used in machine learning modelling."
         },
         "keywords": {
           "en": ["Data", "Engineering", "Manipulation."],
@@ -3582,11 +4018,13 @@
             "key": "data_services_data_science",
             "name": {
               "en": "Data Services - Data Science",
-              "fr": "Services de données - Science des données"
+              "fr": "Services de données - Science des données",
+              "localized": "Data Services - Data Science"
             },
             "description": {
               "en": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources.",
-              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses."
+              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses.",
+              "localized": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources."
             }
           }
         ]
@@ -3596,11 +4034,13 @@
         "key": "data_ethics_and_privacy",
         "name": {
           "en": "Data Ethics and Privacy",
-          "fr": "Éthique des données et protection des renseignements personnels"
+          "fr": "Éthique des données et protection des renseignements personnels",
+          "localized": "Data Ethics and Privacy"
         },
         "description": {
           "en": "Demonstrated ability to ensure ethical practices in acquiring, using, interpreting and sharing data across the data lifecycle as well as proactively identify ethical issues, privacy implications and barriers to data accessibility and identify indicators of bias to prevent the reinforcement of unintended biases within policies, programs, products, or services.",
-          "fr": "Capacité démontrée à garantir des pratiques éthiques dans l’acquisition, l’utilisation, l’interprétation et le partage des données tout au long de leur cycle de vie, ainsi qu’à identifier de manière proactive les questions éthiques, les implications en matière de respect de la vie privée et les obstacles à l’accessibilité des données, et à identifier les indicateurs de partialité afin d’éviter le renforcement de préjugés involontaires dans les politiques, les programmes, les produits ou les services."
+          "fr": "Capacité démontrée à garantir des pratiques éthiques dans l’acquisition, l’utilisation, l’interprétation et le partage des données tout au long de leur cycle de vie, ainsi qu’à identifier de manière proactive les questions éthiques, les implications en matière de respect de la vie privée et les obstacles à l’accessibilité des données, et à identifier les indicateurs de partialité afin d’éviter le renforcement de préjugés involontaires dans les politiques, les programmes, les produits ou les services.",
+          "localized": "Demonstrated ability to ensure ethical practices in acquiring, using, interpreting and sharing data across the data lifecycle as well as proactively identify ethical issues, privacy implications and barriers to data accessibility and identify indicators of bias to prevent the reinforcement of unintended biases within policies, programs, products, or services."
         },
         "keywords": {
           "en": ["Data", "Ethics", "Privacy."],
@@ -3621,11 +4061,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           },
           {
@@ -3633,11 +4075,13 @@
             "key": "data_services_data_systems",
             "name": {
               "en": "Data Services - Data Systems Operations",
-              "fr": "Services de données - Opérations des systèmes de données"
+              "fr": "Services de données - Opérations des systèmes de données",
+              "localized": "Data Services - Data Systems Operations"
             },
             "description": {
               "en": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes.",
-              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux."
+              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux.",
+              "localized": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes."
             }
           }
         ]
@@ -3647,11 +4091,13 @@
         "key": "data_innovation",
         "name": {
           "en": "Data Innovation",
-          "fr": "Innovation en matière de données"
+          "fr": "Innovation en matière de données",
+          "localized": "Data Innovation"
         },
         "description": {
           "en": "Demonstrated ability to acknowledge emerging trends in data tools, analysis, data usage and understands the impact on the organization as well as implements new tools and processes when they will improve usability of data and organizational outcomes.",
-          "fr": "Capacité démontrée à reconnaître les nouvelles tendances en matière d’outils de données, d’analyse et d’utilisation des données, à comprendre leur impact sur l’organisation et à mettre en œuvre de nouveaux outils et processus lorsqu’ils permettent d’améliorer l’utilisation des données et les résultats de l’organisation."
+          "fr": "Capacité démontrée à reconnaître les nouvelles tendances en matière d’outils de données, d’analyse et d’utilisation des données, à comprendre leur impact sur l’organisation et à mettre en œuvre de nouveaux outils et processus lorsqu’ils permettent d’améliorer l’utilisation des données et les résultats de l’organisation.",
+          "localized": "Demonstrated ability to acknowledge emerging trends in data tools, analysis, data usage and understands the impact on the organization as well as implements new tools and processes when they will improve usability of data and organizational outcomes."
         },
         "keywords": {
           "en": ["Data", "Innovation."],
@@ -3666,11 +4112,13 @@
             "key": "data_services_data_systems",
             "name": {
               "en": "Data Services - Data Systems Operations",
-              "fr": "Services de données - Opérations des systèmes de données"
+              "fr": "Services de données - Opérations des systèmes de données",
+              "localized": "Data Services - Data Systems Operations"
             },
             "description": {
               "en": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes.",
-              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux."
+              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux.",
+              "localized": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes."
             }
           }
         ]
@@ -3680,11 +4128,13 @@
         "key": "data_integration",
         "name": {
           "en": "Data Integration",
-          "fr": "Intégration des données"
+          "fr": "Intégration des données",
+          "localized": "Data Integration"
         },
         "description": {
           "en": "Demonstrated ability to select and implement the appropriate technologies to deliver resilient, scalable and future-proofed data solutions as well as ensure that solutions are designed for usability and interoperability and provide value to users.",
-          "fr": "Capacité démontrée à sélectionner et à mettre en œuvre les technologies appropriées pour fournir des solutions de données résilientes, évolutives et à l’épreuve du temps, et à veiller à ce que les solutions soient conçues pour être utilisables et interopérables, et qu’elles apportent une valeur ajoutée aux utilisateurs."
+          "fr": "Capacité démontrée à sélectionner et à mettre en œuvre les technologies appropriées pour fournir des solutions de données résilientes, évolutives et à l’épreuve du temps, et à veiller à ce que les solutions soient conçues pour être utilisables et interopérables, et qu’elles apportent une valeur ajoutée aux utilisateurs.",
+          "localized": "Demonstrated ability to select and implement the appropriate technologies to deliver resilient, scalable and future-proofed data solutions as well as ensure that solutions are designed for usability and interoperability and provide value to users."
         },
         "keywords": {
           "en": ["Data", "Integration."],
@@ -3699,11 +4149,13 @@
             "key": "data_services_data_systems",
             "name": {
               "en": "Data Services - Data Systems Operations",
-              "fr": "Services de données - Opérations des systèmes de données"
+              "fr": "Services de données - Opérations des systèmes de données",
+              "localized": "Data Services - Data Systems Operations"
             },
             "description": {
               "en": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes.",
-              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux."
+              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux.",
+              "localized": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes."
             }
           }
         ]
@@ -3713,11 +4165,13 @@
         "key": "data_interoperability",
         "name": {
           "en": "Data Interoperability",
-          "fr": "Interopérabilité des données"
+          "fr": "Interopérabilité des données",
+          "localized": "Data Interoperability"
         },
         "description": {
           "en": "Demonstrated ability to ensure that different devices, applications, or components can connect and exchange data.",
-          "fr": "Capacité démontrée à s’assurer que différents appareils, applications ou composants peuvent se connecter et échanger des données."
+          "fr": "Capacité démontrée à s’assurer que différents appareils, applications ou composants peuvent se connecter et échanger des données.",
+          "localized": "Demonstrated ability to ensure that different devices, applications, or components can connect and exchange data."
         },
         "keywords": {
           "en": null,
@@ -3732,11 +4186,13 @@
             "key": "database_design___data_administration",
             "name": {
               "en": "Database Management",
-              "fr": "Gestion des bases de données"
+              "fr": "Gestion des bases de données",
+              "localized": "Database Management"
             },
             "description": {
               "en": "IT generic work stream - Database Management",
-              "fr": "Flux de travail générique de TI - Gestion des bases de données"
+              "fr": "Flux de travail générique de TI - Gestion des bases de données",
+              "localized": "IT generic work stream - Database Management"
             }
           }
         ]
@@ -3746,11 +4202,13 @@
         "key": "data_management",
         "name": {
           "en": "Data Management",
-          "fr": "Gestion des données"
+          "fr": "Gestion des données",
+          "localized": "Data Management"
         },
         "description": {
           "en": "Demonstrated ability to navigate internal and external systems to access, organize, curate, protect and store data in relation to the organization's data governance structure and data needs.",
-          "fr": "Capacité démontrée à naviguer dans les systèmes internes et externes pour accéder aux données, les organiser, les conserver, les protéger et les stocker en fonction de la structure de gouvernance des données de l’organisation et de ses besoins en la matière."
+          "fr": "Capacité démontrée à naviguer dans les systèmes internes et externes pour accéder aux données, les organiser, les conserver, les protéger et les stocker en fonction de la structure de gouvernance des données de l’organisation et de ses besoins en la matière.",
+          "localized": "Demonstrated ability to navigate internal and external systems to access, organize, curate, protect and store data in relation to the organization's data governance structure and data needs."
         },
         "keywords": {
           "en": ["Data", "Management."],
@@ -3765,11 +4223,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           },
           {
@@ -3777,11 +4237,13 @@
             "key": "data_services_data_systems",
             "name": {
               "en": "Data Services - Data Systems Operations",
-              "fr": "Services de données - Opérations des systèmes de données"
+              "fr": "Services de données - Opérations des systèmes de données",
+              "localized": "Data Services - Data Systems Operations"
             },
             "description": {
               "en": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes.",
-              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux."
+              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux.",
+              "localized": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes."
             }
           }
         ]
@@ -3791,11 +4253,13 @@
         "key": "data_modelling_cleaning_and_enrichment",
         "name": {
           "en": "Data Modelling, Cleaning and Enrichment",
-          "fr": "Modélisation, nettoyage et enrichissement des données"
+          "fr": "Modélisation, nettoyage et enrichissement des données",
+          "localized": "Data Modelling, Cleaning and Enrichment"
         },
         "description": {
           "en": "Demonstrated ability to explain the concepts and principles of data modelling as well as produce, maintain, and update relevant data models for an organisation’s specific needs and reverse-engineer data models from a live system.",
-          "fr": "Capacité démontrée à expliquer les concepts et les principes de la modélisation des données ainsi qu’à produire, maintenir et mettre à jour des modèles de données pertinents pour les besoins spécifiques d’une organisation et à faire de la rétro-ingénierie de modèles de données à partir d’un système réel."
+          "fr": "Capacité démontrée à expliquer les concepts et les principes de la modélisation des données ainsi qu’à produire, maintenir et mettre à jour des modèles de données pertinents pour les besoins spécifiques d’une organisation et à faire de la rétro-ingénierie de modèles de données à partir d’un système réel.",
+          "localized": "Demonstrated ability to explain the concepts and principles of data modelling as well as produce, maintain, and update relevant data models for an organisation’s specific needs and reverse-engineer data models from a live system."
         },
         "keywords": {
           "en": ["Data", "Modelling", "Cleaning", "Enrichment."],
@@ -3810,11 +4274,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           },
           {
@@ -3822,11 +4288,13 @@
             "key": "data_services_data_systems",
             "name": {
               "en": "Data Services - Data Systems Operations",
-              "fr": "Services de données - Opérations des systèmes de données"
+              "fr": "Services de données - Opérations des systèmes de données",
+              "localized": "Data Services - Data Systems Operations"
             },
             "description": {
               "en": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes.",
-              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux."
+              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux.",
+              "localized": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes."
             }
           }
         ]
@@ -3836,11 +4304,13 @@
         "key": "data_movement",
         "name": {
           "en": "Data Movement",
-          "fr": "Mouvement des données"
+          "fr": "Mouvement des données",
+          "localized": "Data Movement"
         },
         "description": {
           "en": "Demonstrated ability to uphold data integrity and minimize potential downtime when transferring and synchronizing data between different systems, databases, or platforms.",
-          "fr": "Capacité manifeste à préserver l’intégrité des données et à réduire au minimum les possibles temps d’arrêt lors du transfert et de la synchronisation de données entre différents systèmes, différentes bases de données ou différentes plateformes."
+          "fr": "Capacité manifeste à préserver l’intégrité des données et à réduire au minimum les possibles temps d’arrêt lors du transfert et de la synchronisation de données entre différents systèmes, différentes bases de données ou différentes plateformes.",
+          "localized": "Demonstrated ability to uphold data integrity and minimize potential downtime when transferring and synchronizing data between different systems, databases, or platforms."
         },
         "keywords": {
           "en": ["Data", "Movement"],
@@ -3855,11 +4325,13 @@
             "key": "information_management",
             "name": {
               "en": "Information and Data Governance - Operations",
-              "fr": "Gouvernance de l'information et des données - Opérations"
+              "fr": "Gouvernance de l'information et des données - Opérations",
+              "localized": "Information and Data Governance - Operations"
             },
             "description": {
               "en": "IM-Operations involves overseeing the efficient and effective application of life-cycle management practices for records and documents within information management systems, serving business and legal purposes.",
-              "fr": "Les opérations de GI consistent à superviser l'application efficiente et efficace des pratiques de gestion du cycle de vie des dossiers et des documents au sein des systèmes de gestion de l'information, à des fins commerciales et juridiques."
+              "fr": "Les opérations de GI consistent à superviser l'application efficiente et efficace des pratiques de gestion du cycle de vie des dossiers et des documents au sein des systèmes de gestion de l'information, à des fins commerciales et juridiques.",
+              "localized": "IM-Operations involves overseeing the efficient and effective application of life-cycle management practices for records and documents within information management systems, serving business and legal purposes."
             }
           }
         ]
@@ -3869,11 +4341,13 @@
         "key": "data_product_and_service_development",
         "name": {
           "en": "Data Product and Service Development",
-          "fr": "Élaboration de produits et de services de données"
+          "fr": "Élaboration de produits et de services de données",
+          "localized": "Data Product and Service Development"
         },
         "description": {
           "en": "Demonstrated ability to design, build and test data systems and products using project management principles and practices as well as contribute to well-rounded teams to complete projects, ensuring the effective management of resources throughout.",
-          "fr": "Capacité démontrée à concevoir, construire et tester des systèmes de données et des produits en utilisant des principes et des pratiques de gestion de projets, ainsi qu’à contribuer à des équipes bien rodées pour mener à bien des projets, en veillant à une gestion efficace des ressources tout au long du processus."
+          "fr": "Capacité démontrée à concevoir, construire et tester des systèmes de données et des produits en utilisant des principes et des pratiques de gestion de projets, ainsi qu’à contribuer à des équipes bien rodées pour mener à bien des projets, en veillant à une gestion efficace des ressources tout au long du processus.",
+          "localized": "Demonstrated ability to design, build and test data systems and products using project management principles and practices as well as contribute to well-rounded teams to complete projects, ensuring the effective management of resources throughout."
         },
         "keywords": {
           "en": ["Data", "Product", "Service", "Development."],
@@ -3888,11 +4362,13 @@
             "key": "data_services_data_systems",
             "name": {
               "en": "Data Services - Data Systems Operations",
-              "fr": "Services de données - Opérations des systèmes de données"
+              "fr": "Services de données - Opérations des systèmes de données",
+              "localized": "Data Services - Data Systems Operations"
             },
             "description": {
               "en": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes.",
-              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux."
+              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux.",
+              "localized": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes."
             }
           }
         ]
@@ -3902,11 +4378,13 @@
         "key": "data_project_management",
         "name": {
           "en": "Data Project Management",
-          "fr": "Gestion de projets de données"
+          "fr": "Gestion de projets de données",
+          "localized": "Data Project Management"
         },
         "description": {
           "en": "Demonstrated ability to apply knowledge and experience of project management methodologies, including tools and techniques and adopt those most appropriate for the environment as well as support the delivery of digital projects within the data analysis domain.",
-          "fr": "Capacité démontrée à appliquer les connaissances et l’expérience des méthodologies de gestion de projet, y compris les outils et les techniques, et à adopter celles qui conviennent le mieux à l’environnement, ainsi qu’à appuyer la réalisation de projets numériques dans le domaine de l’analyse des données."
+          "fr": "Capacité démontrée à appliquer les connaissances et l’expérience des méthodologies de gestion de projet, y compris les outils et les techniques, et à adopter celles qui conviennent le mieux à l’environnement, ainsi qu’à appuyer la réalisation de projets numériques dans le domaine de l’analyse des données.",
+          "localized": "Demonstrated ability to apply knowledge and experience of project management methodologies, including tools and techniques and adopt those most appropriate for the environment as well as support the delivery of digital projects within the data analysis domain."
         },
         "keywords": {
           "en": ["Data", "Project", "Management."],
@@ -3921,11 +4399,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           }
         ]
@@ -3935,11 +4415,13 @@
         "key": "data_quality_assurance_validation_and_linkage",
         "name": {
           "en": "Data Quality Assurance, Validation and Linkage",
-          "fr": "Validation, couplage et assurance de la qualité des données"
+          "fr": "Validation, couplage et assurance de la qualité des données",
+          "localized": "Data Quality Assurance, Validation and Linkage"
         },
         "description": {
           "en": "Demonstrated ability to identify appropriate methods for collecting, collating, and preparing data, ensuring they are fit for purpose, assess data sources to determine their accuracy and suitability in meeting organizational needs, while identifying and rectifying errors, and adhere to organizational policies, procedures, and standards to ensure the acquisition of high-quality data.",
-          "fr": "Capacité démontrée à identifier les méthodes appropriées pour collecter, rassembler et préparer les données, en s’assurant qu’elles sont adaptées à l’objectif visé, à évaluer les sources de données pour déterminer leur exactitude et leur adéquation aux besoins de l’organisation, tout en identifiant et en rectifiant les erreurs, et à respecter les politiques, procédures et normes de l’organisation pour garantir l’acquisition de données de haute qualité."
+          "fr": "Capacité démontrée à identifier les méthodes appropriées pour collecter, rassembler et préparer les données, en s’assurant qu’elles sont adaptées à l’objectif visé, à évaluer les sources de données pour déterminer leur exactitude et leur adéquation aux besoins de l’organisation, tout en identifiant et en rectifiant les erreurs, et à respecter les politiques, procédures et normes de l’organisation pour garantir l’acquisition de données de haute qualité.",
+          "localized": "Demonstrated ability to identify appropriate methods for collecting, collating, and preparing data, ensuring they are fit for purpose, assess data sources to determine their accuracy and suitability in meeting organizational needs, while identifying and rectifying errors, and adhere to organizational policies, procedures, and standards to ensure the acquisition of high-quality data."
         },
         "keywords": {
           "en": ["Data", "Quality", "Assurance", "Validation", "Linkage."],
@@ -3954,11 +4436,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           }
         ]
@@ -3968,11 +4452,13 @@
         "key": "data_security_and_recovery",
         "name": {
           "en": "Data Security and Recovery",
-          "fr": "Sécurité et récupération des données"
+          "fr": "Sécurité et récupération des données",
+          "localized": "Data Security and Recovery"
         },
         "description": {
           "en": "Demonstrated ability to protect databases from damage and intrusion while ensuring they are able to recovery quickly in the event of a failure.",
-          "fr": "Capacité démontrée à protéger les bases de données contre les dommages et les intrusions tout en veillant à ce qu’elles puissent être récupérées rapidement en cas de défaillance."
+          "fr": "Capacité démontrée à protéger les bases de données contre les dommages et les intrusions tout en veillant à ce qu’elles puissent être récupérées rapidement en cas de défaillance.",
+          "localized": "Demonstrated ability to protect databases from damage and intrusion while ensuring they are able to recovery quickly in the event of a failure."
         },
         "keywords": {
           "en": null,
@@ -3987,11 +4473,13 @@
             "key": "database_design___data_administration",
             "name": {
               "en": "Database Management",
-              "fr": "Gestion des bases de données"
+              "fr": "Gestion des bases de données",
+              "localized": "Database Management"
             },
             "description": {
               "en": "IT generic work stream - Database Management",
-              "fr": "Flux de travail générique de TI - Gestion des bases de données"
+              "fr": "Flux de travail générique de TI - Gestion des bases de données",
+              "localized": "IT generic work stream - Database Management"
             }
           }
         ]
@@ -4001,11 +4489,13 @@
         "key": "data_systems",
         "name": {
           "en": "Data Systems",
-          "fr": "Systèmes de données"
+          "fr": "Systèmes de données",
+          "localized": "Data Systems"
         },
         "description": {
           "en": "Demonstrated ability to use tools, software, platforms, and processes to design and deliver data systems into the organisation effectively and in alignment with organizational needs.",
-          "fr": "Capacité démontrée à utiliser des outils, des logiciels, des plateformes et des processus pour concevoir et mettre en place des systèmes de données au sein de l’organisation de manière efficace et en conformité avec les besoins de l’organisation."
+          "fr": "Capacité démontrée à utiliser des outils, des logiciels, des plateformes et des processus pour concevoir et mettre en place des systèmes de données au sein de l’organisation de manière efficace et en conformité avec les besoins de l’organisation.",
+          "localized": "Demonstrated ability to use tools, software, platforms, and processes to design and deliver data systems into the organisation effectively and in alignment with organizational needs."
         },
         "keywords": {
           "en": ["Data", "Systems."],
@@ -4020,11 +4510,13 @@
             "key": "data_services_data_systems",
             "name": {
               "en": "Data Services - Data Systems Operations",
-              "fr": "Services de données - Opérations des systèmes de données"
+              "fr": "Services de données - Opérations des systèmes de données",
+              "localized": "Data Services - Data Systems Operations"
             },
             "description": {
               "en": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes.",
-              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux."
+              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux.",
+              "localized": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes."
             }
           }
         ]
@@ -4034,11 +4526,13 @@
         "key": "data_tools",
         "name": {
           "en": "Data Tools",
-          "fr": "Outils de données"
+          "fr": "Outils de données",
+          "localized": "Data Tools"
         },
         "description": {
           "en": "Demonstrated ability to choose the most relevant tool in line with the core technical concepts related to the data job and practically apply tools in line with industry best practices.",
-          "fr": "Capacité démontrée à choisir l’outil le plus approprié en fonction des concepts techniques fondamentaux liés au travail sur les données et à appliquer concrètement les outils conformément aux pratiques exemplaires du secteur."
+          "fr": "Capacité démontrée à choisir l’outil le plus approprié en fonction des concepts techniques fondamentaux liés au travail sur les données et à appliquer concrètement les outils conformément aux pratiques exemplaires du secteur.",
+          "localized": "Demonstrated ability to choose the most relevant tool in line with the core technical concepts related to the data job and practically apply tools in line with industry best practices."
         },
         "keywords": {
           "en": ["Data", "Tools."],
@@ -4053,11 +4547,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           },
           {
@@ -4065,11 +4561,13 @@
             "key": "data_services_data_systems",
             "name": {
               "en": "Data Services - Data Systems Operations",
-              "fr": "Services de données - Opérations des systèmes de données"
+              "fr": "Services de données - Opérations des systèmes de données",
+              "localized": "Data Services - Data Systems Operations"
             },
             "description": {
               "en": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes.",
-              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux."
+              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux.",
+              "localized": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes."
             }
           }
         ]
@@ -4079,11 +4577,13 @@
         "key": "data_troubleshooting_and_problem_resolution",
         "name": {
           "en": "Data Troubleshooting and Problem Resolution",
-          "fr": "Dépannage et résolution des problèmes de données"
+          "fr": "Dépannage et résolution des problèmes de données",
+          "localized": "Data Troubleshooting and Problem Resolution"
         },
         "description": {
           "en": "Demonstrated ability to troubleshoot and identify solutions to respond to problems in databases, data processes and data products as well as leverage diagnostic and monitoring tools to resolve problems and implement preventative measures to mitigate future problems.",
-          "fr": "Capacité démontrée à dépanner et à identifier des solutions pour répondre aux problèmes dans les bases de données, les processus de données et les produits de données, ainsi qu’à utiliser des outils de diagnostic et de suivi pour résoudre les problèmes et mettre en œuvre des mesures préventives afin d’atténuer les problèmes futurs."
+          "fr": "Capacité démontrée à dépanner et à identifier des solutions pour répondre aux problèmes dans les bases de données, les processus de données et les produits de données, ainsi qu’à utiliser des outils de diagnostic et de suivi pour résoudre les problèmes et mettre en œuvre des mesures préventives afin d’atténuer les problèmes futurs.",
+          "localized": "Demonstrated ability to troubleshoot and identify solutions to respond to problems in databases, data processes and data products as well as leverage diagnostic and monitoring tools to resolve problems and implement preventative measures to mitigate future problems."
         },
         "keywords": {
           "en": ["Data", "Troubleshooting", "Problem", "Resolution."],
@@ -4098,11 +4598,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           },
           {
@@ -4110,11 +4612,13 @@
             "key": "data_services_data_systems",
             "name": {
               "en": "Data Services - Data Systems Operations",
-              "fr": "Services de données - Opérations des systèmes de données"
+              "fr": "Services de données - Opérations des systèmes de données",
+              "localized": "Data Services - Data Systems Operations"
             },
             "description": {
               "en": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes.",
-              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux."
+              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux.",
+              "localized": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes."
             }
           }
         ]
@@ -4124,11 +4628,13 @@
         "key": "data_warehousing",
         "name": {
           "en": "Data Warehousing",
-          "fr": "Entreposage des données"
+          "fr": "Entreposage des données",
+          "localized": "Data Warehousing"
         },
         "description": {
           "en": "Demonstrated ability to design, implement, and manage efficient, scalable, and secure data warehousing systems. This may include database design, ETL processes, data integration, SQL query optimization, data governance, performance tuning, BI tools, cloud solutions, and scripting.",
-          "fr": "Capacité démontrée à concevoir, mettre en œuvre et gérer des systèmes d’entreposage de données efficaces, évolutifs et sécurisés. Cela peut inclure la conception de bases de données, les processus ETL, l’intégration de données, l’optimisation des requêtes SQL, la gouvernance des données, l’optimisation des rendements, les outils d’informatique décisionnelle, les solutions infonuagiques et le scriptage."
+          "fr": "Capacité démontrée à concevoir, mettre en œuvre et gérer des systèmes d’entreposage de données efficaces, évolutifs et sécurisés. Cela peut inclure la conception de bases de données, les processus ETL, l’intégration de données, l’optimisation des requêtes SQL, la gouvernance des données, l’optimisation des rendements, les outils d’informatique décisionnelle, les solutions infonuagiques et le scriptage.",
+          "localized": "Demonstrated ability to design, implement, and manage efficient, scalable, and secure data warehousing systems. This may include database design, ETL processes, data integration, SQL query optimization, data governance, performance tuning, BI tools, cloud solutions, and scripting."
         },
         "keywords": {
           "en": ["Data", "Warehousing"],
@@ -4143,11 +4649,13 @@
             "key": "im_data_governance_information_architecture",
             "name": {
               "en": "Information and Data Governance - Information Architecture",
-              "fr": "Gouvernance de l'information et des données - Architecture de l'information"
+              "fr": "Gouvernance de l'information et des données - Architecture de l'information",
+              "localized": "Information and Data Governance - Information Architecture"
             },
             "description": {
               "en": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes.",
-              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus."
+              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus.",
+              "localized": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes."
             }
           }
         ]
@@ -4157,11 +4665,13 @@
         "key": "database_design___management",
         "name": {
           "en": "Database Design",
-          "fr": "Conception des bases de données"
+          "fr": "Conception des bases de données",
+          "localized": "Database Design"
         },
         "description": {
           "en": "Demonstrated ability to develop database models that meet data requirements, using best practices.",
-          "fr": "Capacité démontrée à élaborer des modèles de base de données qui répondent aux exigences en matière de données, en utilisant les meilleures pratiques."
+          "fr": "Capacité démontrée à élaborer des modèles de base de données qui répondent aux exigences en matière de données, en utilisant les meilleures pratiques.",
+          "localized": "Demonstrated ability to develop database models that meet data requirements, using best practices."
         },
         "keywords": {
           "en": ["database", "design."],
@@ -4176,11 +4686,13 @@
             "key": "database_design___data_administration",
             "name": {
               "en": "Database Management",
-              "fr": "Gestion des bases de données"
+              "fr": "Gestion des bases de données",
+              "localized": "Database Management"
             },
             "description": {
               "en": "IT generic work stream - Database Management",
-              "fr": "Flux de travail générique de TI - Gestion des bases de données"
+              "fr": "Flux de travail générique de TI - Gestion des bases de données",
+              "localized": "IT generic work stream - Database Management"
             }
           }
         ]
@@ -4190,11 +4702,13 @@
         "key": "database_migration",
         "name": {
           "en": "Database Migration",
-          "fr": "Migration de base de données"
+          "fr": "Migration de base de données",
+          "localized": "Database Migration"
         },
         "description": {
           "en": "Demonstrated ability to plan, execute, and manage the migration of databases to ensure data integrity, minimal downtime, and optimal performance. For example from on-premises systems to cloud-based environments.",
-          "fr": "Capacité démontrée à planifier, exécuter et gérer la migration de bases de données pour garantir l'intégrité des données, un temps d'arrêt minimal et des performances optimales. Par exemple, de systèmes sur site vers des environnements basés sur le cloud."
+          "fr": "Capacité démontrée à planifier, exécuter et gérer la migration de bases de données pour garantir l'intégrité des données, un temps d'arrêt minimal et des performances optimales. Par exemple, de systèmes sur site vers des environnements basés sur le cloud.",
+          "localized": "Demonstrated ability to plan, execute, and manage the migration of databases to ensure data integrity, minimal downtime, and optimal performance. For example from on-premises systems to cloud-based environments."
         },
         "keywords": {
           "en": ["Database", "migration"],
@@ -4209,11 +4723,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           }
         ]
@@ -4223,11 +4739,13 @@
         "key": "database_programming_tools",
         "name": {
           "en": "Database Programming Tools",
-          "fr": "Outils de programmation de bases de données"
+          "fr": "Outils de programmation de bases de données",
+          "localized": "Database Programming Tools"
         },
         "description": {
           "en": "Demonstrated ability to use and work in data programming tools such as SQL, NSQL, Excel, or other ETL (extract, transform, load) tools.",
-          "fr": "Capacité démontrée à utiliser et à travailler avec des outils de programmation de données tels que SQL, NSQL, Excel ou d’autres outils ETL (extraction, transformation, chargement)."
+          "fr": "Capacité démontrée à utiliser et à travailler avec des outils de programmation de données tels que SQL, NSQL, Excel ou d’autres outils ETL (extraction, transformation, chargement).",
+          "localized": "Demonstrated ability to use and work in data programming tools such as SQL, NSQL, Excel, or other ETL (extract, transform, load) tools."
         },
         "keywords": {
           "en": null,
@@ -4242,11 +4760,13 @@
             "key": "database_design___data_administration",
             "name": {
               "en": "Database Management",
-              "fr": "Gestion des bases de données"
+              "fr": "Gestion des bases de données",
+              "localized": "Database Management"
             },
             "description": {
               "en": "IT generic work stream - Database Management",
-              "fr": "Flux de travail générique de TI - Gestion des bases de données"
+              "fr": "Flux de travail générique de TI - Gestion des bases de données",
+              "localized": "IT generic work stream - Database Management"
             }
           },
           {
@@ -4254,11 +4774,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -4268,11 +4790,13 @@
         "key": "database_software_installation_processes_and_techniques",
         "name": {
           "en": "Database Software Installation Processes and Techniques",
-          "fr": "Processus et techniques d’installation des logiciels de base de données"
+          "fr": "Processus et techniques d’installation des logiciels de base de données",
+          "localized": "Database Software Installation Processes and Techniques"
         },
         "description": {
           "en": "Demonstrated ability to install and configure database software to ensure proper functionality.",
-          "fr": "Capacité manifeste à installer et à configurer des logiciels de base de données pour en assurer le bon fonctionnement."
+          "fr": "Capacité manifeste à installer et à configurer des logiciels de base de données pour en assurer le bon fonctionnement.",
+          "localized": "Demonstrated ability to install and configure database software to ensure proper functionality."
         },
         "keywords": {
           "en": ["Database", "software", "installation"],
@@ -4295,11 +4819,13 @@
             "key": "database_design___data_administration",
             "name": {
               "en": "Database Management",
-              "fr": "Gestion des bases de données"
+              "fr": "Gestion des bases de données",
+              "localized": "Database Management"
             },
             "description": {
               "en": "IT generic work stream - Database Management",
-              "fr": "Flux de travail générique de TI - Gestion des bases de données"
+              "fr": "Flux de travail générique de TI - Gestion des bases de données",
+              "localized": "IT generic work stream - Database Management"
             }
           }
         ]
@@ -4309,11 +4835,13 @@
         "key": "database_systems",
         "name": {
           "en": "Database Systems",
-          "fr": "Systèmes de bases de données"
+          "fr": "Systèmes de bases de données",
+          "localized": "Database Systems"
         },
         "description": {
           "en": "Demonstrated ability to work with database systems such as Oracle, MySQL, MariaDB or PostgreSQL.",
-          "fr": "Capacité démontrée à travailler avec des systèmes de base de données tels qu’Oracle, MySQL, MariaDB ou PostgreSQL."
+          "fr": "Capacité démontrée à travailler avec des systèmes de base de données tels qu’Oracle, MySQL, MariaDB ou PostgreSQL.",
+          "localized": "Demonstrated ability to work with database systems such as Oracle, MySQL, MariaDB or PostgreSQL."
         },
         "keywords": {
           "en": null,
@@ -4328,11 +4856,13 @@
             "key": "database_design___data_administration",
             "name": {
               "en": "Database Management",
-              "fr": "Gestion des bases de données"
+              "fr": "Gestion des bases de données",
+              "localized": "Database Management"
             },
             "description": {
               "en": "IT generic work stream - Database Management",
-              "fr": "Flux de travail générique de TI - Gestion des bases de données"
+              "fr": "Flux de travail générique de TI - Gestion des bases de données",
+              "localized": "IT generic work stream - Database Management"
             }
           },
           {
@@ -4340,11 +4870,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -4354,11 +4886,13 @@
         "key": "database_trends_and_directions",
         "name": {
           "en": "Database Trends and Directions",
-          "fr": "Tendances et orientations en matière de bases de données"
+          "fr": "Tendances et orientations en matière de bases de données",
+          "localized": "Database Trends and Directions"
         },
         "description": {
           "en": "Demonstrated knowledge of modern standards, tools, and best practices in database design and management, as well as demonstrated understanding of anticipated future industry evolutions.",
-          "fr": "Connaissance avérée des normes, des outils et des meilleures pratiques modernes en matière de conception et de gestion de bases de données, ainsi que compréhension démontrée des évolutions futures prévues de l’industrie."
+          "fr": "Connaissance avérée des normes, des outils et des meilleures pratiques modernes en matière de conception et de gestion de bases de données, ainsi que compréhension démontrée des évolutions futures prévues de l’industrie.",
+          "localized": "Demonstrated knowledge of modern standards, tools, and best practices in database design and management, as well as demonstrated understanding of anticipated future industry evolutions."
         },
         "keywords": {
           "en": null,
@@ -4373,11 +4907,13 @@
             "key": "database_design___data_administration",
             "name": {
               "en": "Database Management",
-              "fr": "Gestion des bases de données"
+              "fr": "Gestion des bases de données",
+              "localized": "Database Management"
             },
             "description": {
               "en": "IT generic work stream - Database Management",
-              "fr": "Flux de travail générique de TI - Gestion des bases de données"
+              "fr": "Flux de travail générique de TI - Gestion des bases de données",
+              "localized": "IT generic work stream - Database Management"
             }
           }
         ]
@@ -4387,11 +4923,13 @@
         "key": "dax",
         "name": {
           "en": "Data Analysis Expressions (DAX)",
-          "fr": "Data Analysis Expressions (DAX)"
+          "fr": "Data Analysis Expressions (DAX)",
+          "localized": "Data Analysis Expressions (DAX)"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this formula expression language to create custom calculations and aggregations in products such as Analysis Services, Power BI and Power Pivot.",
-          "fr": "Capacité démontrée à appliquer une connaissance concrète de ce langage d'expression de formules pour créer des calculs personnalisés et des agrégations dans des produits tels que Analysis Services, Power BI et Power Pivot."
+          "fr": "Capacité démontrée à appliquer une connaissance concrète de ce langage d'expression de formules pour créer des calculs personnalisés et des agrégations dans des produits tels que Analysis Services, Power BI et Power Pivot.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this formula expression language to create custom calculations and aggregations in products such as Analysis Services, Power BI and Power Pivot."
         },
         "keywords": {
           "en": ["DAX"],
@@ -4406,11 +4944,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           }
         ]
@@ -4420,11 +4960,13 @@
         "key": "decision_making",
         "name": {
           "en": "Decision-Making",
-          "fr": "Prise de décision"
+          "fr": "Prise de décision",
+          "localized": "Decision-Making"
         },
         "description": {
           "en": "Demonstrated ability to select a course of action in a rational and timely way, weighing factors such as feasibility, benefits, risks, competing concerns, and alternative choices.",
-          "fr": "Aptitude avérée à choisir un plan d’action de manière rationnelle et opportune, en soupesant des facteurs tels que la faisabilité, les avantages, les risques, les préoccupations concurrentes et les choix alternatifs."
+          "fr": "Aptitude avérée à choisir un plan d’action de manière rationnelle et opportune, en soupesant des facteurs tels que la faisabilité, les avantages, les risques, les préoccupations concurrentes et les choix alternatifs.",
+          "localized": "Demonstrated ability to select a course of action in a rational and timely way, weighing factors such as feasibility, benefits, risks, competing concerns, and alternative choices."
         },
         "keywords": {
           "en": ["Judgement", "Judgment", "Decisiveness"],
@@ -4439,11 +4981,13 @@
             "key": "leadership",
             "name": {
               "en": "Leadership - General Behaviours",
-              "fr": "Leadership - Comportements généraux"
+              "fr": "Leadership - Comportements généraux",
+              "localized": "Leadership - General Behaviours"
             },
             "description": {
               "en": "Behavioural - Leadership",
-              "fr": "Comportemental - Leadership"
+              "fr": "Comportemental - Leadership",
+              "localized": "Behavioural - Leadership"
             }
           },
           {
@@ -4451,11 +4995,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -4465,11 +5011,13 @@
         "key": "deep_learning_and_neural_networks",
         "name": {
           "en": "Deep Learning and Neural Networks",
-          "fr": "Apprentissage profond et réseaux neuronaux"
+          "fr": "Apprentissage profond et réseaux neuronaux",
+          "localized": "Deep Learning and Neural Networks"
         },
         "description": {
           "en": "Demonstrated ability to develop and program interconnected nodes (neurons) in a layered structure to recognize data patterns of pictures, images, texts and sounds to produce accurate insights and predictions to feed and train models, make predictions and render judgments to propose recommendations and make decisions.",
-          "fr": "Capacité démontrée à développer et à programmer des nœuds interconnectés (neurones) dans une structure en couches pour reconnaître des modèles de données d'images, de textes et de sons afin de produire des informations et des prédictions précises pour alimenter et former des modèles, faire des prédictions et rendre des jugements afin de proposer des recommandations et de prendre des décisions."
+          "fr": "Capacité démontrée à développer et à programmer des nœuds interconnectés (neurones) dans une structure en couches pour reconnaître des modèles de données d'images, de textes et de sons afin de produire des informations et des prédictions précises pour alimenter et former des modèles, faire des prédictions et rendre des jugements afin de proposer des recommandations et de prendre des décisions.",
+          "localized": "Demonstrated ability to develop and program interconnected nodes (neurons) in a layered structure to recognize data patterns of pictures, images, texts and sounds to produce accurate insights and predictions to feed and train models, make predictions and render judgments to propose recommendations and make decisions."
         },
         "keywords": {
           "en": ["Deep", "Learning", "Neural", "Networks."],
@@ -4484,11 +5032,13 @@
             "key": "data_services_data_science",
             "name": {
               "en": "Data Services - Data Science",
-              "fr": "Services de données - Science des données"
+              "fr": "Services de données - Science des données",
+              "localized": "Data Services - Data Science"
             },
             "description": {
               "en": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources.",
-              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses."
+              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses.",
+              "localized": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources."
             }
           }
         ]
@@ -4498,11 +5048,13 @@
         "key": "dependability",
         "name": {
           "en": "Dependability",
-          "fr": "Fiabilité"
+          "fr": "Fiabilité",
+          "localized": "Dependability"
         },
         "description": {
           "en": "Demonstrated ability to finish tasks in a trustworthy way, openly communicating about progress and concerns.",
-          "fr": "Capacité démontrée à terminer les tâches de manière fiable, en communiquant ouvertement sur les progrès et les préoccupations."
+          "fr": "Capacité démontrée à terminer les tâches de manière fiable, en communiquant ouvertement sur les progrès et les préoccupations.",
+          "localized": "Demonstrated ability to finish tasks in a trustworthy way, openly communicating about progress and concerns."
         },
         "keywords": {
           "en": [
@@ -4522,11 +5074,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -4536,11 +5090,13 @@
         "key": "design_systems",
         "name": {
           "en": "Design Systems",
-          "fr": "Systèmes de design"
+          "fr": "Systèmes de design",
+          "localized": "Design Systems"
         },
         "description": {
           "en": "Demonstrated ability to create reusable components and apply knowledge of design principals such as typography, color theory, layout and visual hierarchy to produce consistent and efficient digital products while maintaining brand identity.",
-          "fr": "Capacité démontrée à créer des composants réutilisables et à appliquer des connaissances en matière de principes de design tels que la typographie, la théorie des couleurs, la mise en page et la hiérarchie visuelle pour produire des produits numériques cohérents et efficaces tout en préservant l'identité de marque."
+          "fr": "Capacité démontrée à créer des composants réutilisables et à appliquer des connaissances en matière de principes de design tels que la typographie, la théorie des couleurs, la mise en page et la hiérarchie visuelle pour produire des produits numériques cohérents et efficaces tout en préservant l'identité de marque.",
+          "localized": "Demonstrated ability to create reusable components and apply knowledge of design principals such as typography, color theory, layout and visual hierarchy to produce consistent and efficient digital products while maintaining brand identity."
         },
         "keywords": {
           "en": ["Design", "Systems"],
@@ -4555,11 +5111,13 @@
             "key": "user_experience_and_interface_design",
             "name": {
               "en": "Software Solutions - Product Design",
-              "fr": "Solutions logicielles - Conception de produits"
+              "fr": "Solutions logicielles - Conception de produits",
+              "localized": "Software Solutions - Product Design"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur",
+              "localized": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design"
             }
           }
         ]
@@ -4569,11 +5127,13 @@
         "key": "design_thinking",
         "name": {
           "en": "Design Thinking",
-          "fr": "Orienté vers la conception"
+          "fr": "Orienté vers la conception",
+          "localized": "Design Thinking"
         },
         "description": {
           "en": "Demonstrated ability to design products and services with users always in mind, leveraging best practices and approaches to create clear, user-informed products.",
-          "fr": "Capacité démontrée à concevoir des produits et des services en gardant toujours les utilisateurs à l’esprit, en tirant parti des meilleures pratiques et approches pour créer des produits clairs et éclairés par l’utilisateur."
+          "fr": "Capacité démontrée à concevoir des produits et des services en gardant toujours les utilisateurs à l’esprit, en tirant parti des meilleures pratiques et approches pour créer des produits clairs et éclairés par l’utilisateur.",
+          "localized": "Demonstrated ability to design products and services with users always in mind, leveraging best practices and approaches to create clear, user-informed products."
         },
         "keywords": {
           "en": [
@@ -4596,11 +5156,13 @@
             "key": "user_experience_and_interface_design",
             "name": {
               "en": "Software Solutions - Product Design",
-              "fr": "Solutions logicielles - Conception de produits"
+              "fr": "Solutions logicielles - Conception de produits",
+              "localized": "Software Solutions - Product Design"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur",
+              "localized": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design"
             }
           }
         ]
@@ -4610,11 +5172,13 @@
         "key": "developing_others",
         "name": {
           "en": "Developing Others",
-          "fr": "Amélioration des autres"
+          "fr": "Amélioration des autres",
+          "localized": "Developing Others"
         },
         "description": {
           "en": "Demonstrated ability to support the growth and learning of others as they progress in their careers. This includes being directly responsible for creating opportunities for enhancing the technical skills and behavioural competencies of others.",
-          "fr": "Capacité démontrée à soutenir la croissance et l’apprentissage des autres au fur et à mesure qu’ils progressent dans leur carrière. Il s’agit notamment d’être directement responsable de la création d’occasions d’améliorer les compétences techniques et comportementales des autres."
+          "fr": "Capacité démontrée à soutenir la croissance et l’apprentissage des autres au fur et à mesure qu’ils progressent dans leur carrière. Il s’agit notamment d’être directement responsable de la création d’occasions d’améliorer les compétences techniques et comportementales des autres.",
+          "localized": "Demonstrated ability to support the growth and learning of others as they progress in their careers. This includes being directly responsible for creating opportunities for enhancing the technical skills and behavioural competencies of others."
         },
         "keywords": {
           "en": ["Coaching", "Mentorship", "Guidance"],
@@ -4629,11 +5193,13 @@
             "key": "leadership",
             "name": {
               "en": "Leadership - General Behaviours",
-              "fr": "Leadership - Comportements généraux"
+              "fr": "Leadership - Comportements généraux",
+              "localized": "Leadership - General Behaviours"
             },
             "description": {
               "en": "Behavioural - Leadership",
-              "fr": "Comportemental - Leadership"
+              "fr": "Comportemental - Leadership",
+              "localized": "Behavioural - Leadership"
             }
           }
         ]
@@ -4643,11 +5209,13 @@
         "key": "development_delivery_training_sessions",
         "name": {
           "en": "Development and Delivery of Training Sessions",
-          "fr": "Développement et prestation de sessions de formation"
+          "fr": "Développement et prestation de sessions de formation",
+          "localized": "Development and Delivery of Training Sessions"
         },
         "description": {
           "en": "Demonstrated ability to develop educational content on work-related processes and procedures, and effectively present it to audiences in an engaging and educational manner.",
-          "fr": "Capacité démontrée à développer du contenu éducatif sur les processus et procédures liés au travail, et à le présenter efficacement au public de manière engageante et éducative."
+          "fr": "Capacité démontrée à développer du contenu éducatif sur les processus et procédures liés au travail, et à le présenter efficacement au public de manière engageante et éducative.",
+          "localized": "Demonstrated ability to develop educational content on work-related processes and procedures, and effectively present it to audiences in an engaging and educational manner."
         },
         "keywords": {
           "en": null,
@@ -4662,11 +5230,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           }
         ]
@@ -4676,11 +5246,13 @@
         "key": "devops",
         "name": {
           "en": "DevOps",
-          "fr": "Opérations de développement"
+          "fr": "Opérations de développement",
+          "localized": "DevOps"
         },
         "description": {
           "en": "Demonstrated ability to manage the lifecycle operations of a software product, with automation of release pipelines from testing to building and deployment. This often includes the configuration of cloud hosting platforms and cross-team communications.",
-          "fr": "Capacité démontrée à gérer les opérations du cycle de vie d'un produit logiciel, avec automatisation des pipelines de versions, depuis les tests jusqu'à la création et le déploiement. Cela inclut souvent la configuration des plates-formes d'hébergement cloud et les communications entre équipes."
+          "fr": "Capacité démontrée à gérer les opérations du cycle de vie d'un produit logiciel, avec automatisation des pipelines de versions, depuis les tests jusqu'à la création et le déploiement. Cela inclut souvent la configuration des plates-formes d'hébergement cloud et les communications entre équipes.",
+          "localized": "Demonstrated ability to manage the lifecycle operations of a software product, with automation of release pipelines from testing to building and deployment. This often includes the configuration of cloud hosting platforms and cross-team communications."
         },
         "keywords": {
           "en": null,
@@ -4695,11 +5267,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           },
           {
@@ -4707,11 +5281,13 @@
             "key": "infrastructure_operations",
             "name": {
               "en": "IT Infrastructure Operations",
-              "fr": "Opérations d'infrastructure informatique"
+              "fr": "Opérations d'infrastructure informatique",
+              "localized": "IT Infrastructure Operations"
             },
             "description": {
               "en": "IT generic work stream - Infrastructure Operations",
-              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique"
+              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique",
+              "localized": "IT generic work stream - Infrastructure Operations"
             }
           },
           {
@@ -4719,11 +5295,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           },
           {
@@ -4731,11 +5309,13 @@
             "key": "user_experience_and_interface_design",
             "name": {
               "en": "Software Solutions - Product Design",
-              "fr": "Solutions logicielles - Conception de produits"
+              "fr": "Solutions logicielles - Conception de produits",
+              "localized": "Software Solutions - Product Design"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur",
+              "localized": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design"
             }
           },
           {
@@ -4743,11 +5323,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -4757,11 +5339,13 @@
         "key": "devsecops",
         "name": {
           "en": "DevSecOps",
-          "fr": "DevSecOps"
+          "fr": "DevSecOps",
+          "localized": "DevSecOps"
         },
         "description": {
           "en": "Demonstrated ability to ensure that security is seamlessly and effectively integrated across the software development life cycle (SDLC) using continuous integration and continuous deployment (CI/CD) pipelines.",
-          "fr": "Capacité démontrée à intégrer la sécurité de manière transparente et efficace dans le cycle de vie du développement logiciel (SDLC) à l'aide de pipelines d'intégration et de déploiement continus (CI/CD)."
+          "fr": "Capacité démontrée à intégrer la sécurité de manière transparente et efficace dans le cycle de vie du développement logiciel (SDLC) à l'aide de pipelines d'intégration et de déploiement continus (CI/CD).",
+          "localized": "Demonstrated ability to ensure that security is seamlessly and effectively integrated across the software development life cycle (SDLC) using continuous integration and continuous deployment (CI/CD) pipelines."
         },
         "keywords": {
           "en": ["dev", "sec", "ops"],
@@ -4776,11 +5360,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           },
           {
@@ -4788,11 +5374,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -4802,11 +5390,13 @@
         "key": "digital_and_it_project_management",
         "name": {
           "en": "Digital and IT Project Management",
-          "fr": "Gestion de projets numériques et informatiques"
+          "fr": "Gestion de projets numériques et informatiques",
+          "localized": "Digital and IT Project Management"
         },
         "description": {
           "en": "Demonstrated ability to coordinate, oversee and support the advancement of digital and IT projects. This includes establishing accountabilities and objectives, delivering on outcomes, and enabling planning, monitoring, and reporting throughout the project lifecycle.",
-          "fr": "Capacité démontrée à coordonner, superviser et soutenir l’avancement de projets numériques et informatiques. Il s’agit notamment d’établir des responsabilités et des objectifs, d’obtenir des résultats et de permettre la planification, le suivi et la production de rapports tout au long du cycle de vie du projet."
+          "fr": "Capacité démontrée à coordonner, superviser et soutenir l’avancement de projets numériques et informatiques. Il s’agit notamment d’établir des responsabilités et des objectifs, d’obtenir des résultats et de permettre la planification, le suivi et la production de rapports tout au long du cycle de vie du projet.",
+          "localized": "Demonstrated ability to coordinate, oversee and support the advancement of digital and IT projects. This includes establishing accountabilities and objectives, delivering on outcomes, and enabling planning, monitoring, and reporting throughout the project lifecycle."
         },
         "keywords": {
           "en": ["digital", "IT", "project", "management."],
@@ -4821,11 +5411,13 @@
             "key": "it_management",
             "name": {
               "en": "Digital Project Portfolio Management",
-              "fr": "Gestion de portefeuille de projets numériques"
+              "fr": "Gestion de portefeuille de projets numériques",
+              "localized": "Digital Project Portfolio Management"
             },
             "description": {
               "en": "IT generic work stream - Digital project portfolio management",
-              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques"
+              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques",
+              "localized": "IT generic work stream - Digital project portfolio management"
             }
           },
           {
@@ -4833,11 +5425,13 @@
             "key": "it_project_management",
             "name": {
               "en": "Digital Business Line Advisory Services",
-              "fr": "Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Services consultatifs auprès des secteurs de la numérique",
+              "localized": "Digital Business Line Advisory Services"
             },
             "description": {
               "en": "IT generic work stream - Business Line Advisory Services",
-              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique",
+              "localized": "IT generic work stream - Business Line Advisory Services"
             }
           }
         ]
@@ -4847,11 +5441,13 @@
         "key": "digital_asset_management",
         "name": {
           "en": "Digital Asset Management",
-          "fr": "Gestion des actifs numériques"
+          "fr": "Gestion des actifs numériques",
+          "localized": "Digital Asset Management"
         },
         "description": {
           "en": "Demonstrated ability to organize, store, and manage digital assets to ensure their accessibility, usability, and security",
-          "fr": "Capacité démontrée à organiser, stocker et gérer des actifs numériques de manière à en assurer l’accessibilité, la facilité d’utilisation et la sécurité."
+          "fr": "Capacité démontrée à organiser, stocker et gérer des actifs numériques de manière à en assurer l’accessibilité, la facilité d’utilisation et la sécurité.",
+          "localized": "Demonstrated ability to organize, store, and manage digital assets to ensure their accessibility, usability, and security"
         },
         "keywords": {
           "en": ["Digital", "Asset", "Management"],
@@ -4866,11 +5462,13 @@
             "key": "im_data_governance_information_architecture",
             "name": {
               "en": "Information and Data Governance - Information Architecture",
-              "fr": "Gouvernance de l'information et des données - Architecture de l'information"
+              "fr": "Gouvernance de l'information et des données - Architecture de l'information",
+              "localized": "Information and Data Governance - Information Architecture"
             },
             "description": {
               "en": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes.",
-              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus."
+              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus.",
+              "localized": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes."
             }
           }
         ]
@@ -4880,11 +5478,13 @@
         "key": "digital_credentials",
         "name": {
           "en": "Digital Credentials",
-          "fr": "Informations d'identification numériques"
+          "fr": "Informations d'identification numériques",
+          "localized": "Digital Credentials"
         },
         "description": {
           "en": "Demonstrated ability to provide technical advice on establishing and integrating verifiable digital credentials into the flow of digital products and services, using approaches that show awareness of technical considerations and modern standards.",
-          "fr": "Capacité démontrée à fournir des conseils techniques sur l’établissement et l’intégration de justificatifs d’identité numériques vérifiables dans le flux de produits et de services numériques, en utilisant des approches qui montrent une connaissance des considérations techniques et des normes modernes."
+          "fr": "Capacité démontrée à fournir des conseils techniques sur l’établissement et l’intégration de justificatifs d’identité numériques vérifiables dans le flux de produits et de services numériques, en utilisant des approches qui montrent une connaissance des considérations techniques et des normes modernes.",
+          "localized": "Demonstrated ability to provide technical advice on establishing and integrating verifiable digital credentials into the flow of digital products and services, using approaches that show awareness of technical considerations and modern standards."
         },
         "keywords": {
           "en": null,
@@ -4899,11 +5499,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           },
           {
@@ -4911,11 +5513,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           },
           {
@@ -4923,11 +5527,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -4937,11 +5543,13 @@
         "key": "digital_identity",
         "name": {
           "en": "Digital Identity",
-          "fr": "Identité numérique"
+          "fr": "Identité numérique",
+          "localized": "Digital Identity"
         },
         "description": {
           "en": "Demonstrated ability to apply knowledge of key digital identity standards and experience working with identity, access, and privileged account management solutions.",
-          "fr": "Capacité démontrée à appliquer les connaissances des principales normes en matière d'identité numérique et l'expérience  avec des solutions de gestion des identités, des accès et des comptes privilégiés."
+          "fr": "Capacité démontrée à appliquer les connaissances des principales normes en matière d'identité numérique et l'expérience  avec des solutions de gestion des identités, des accès et des comptes privilégiés.",
+          "localized": "Demonstrated ability to apply knowledge of key digital identity standards and experience working with identity, access, and privileged account management solutions."
         },
         "keywords": {
           "en": ["digital identity", "digital credentials"],
@@ -4956,11 +5564,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           },
           {
@@ -4968,11 +5578,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           },
           {
@@ -4980,11 +5592,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -4994,11 +5608,13 @@
         "key": "digital_literacy",
         "name": {
           "en": "Digital Literacy",
-          "fr": "Connaissances du numérique"
+          "fr": "Connaissances du numérique",
+          "localized": "Digital Literacy"
         },
         "description": {
           "en": "Demonstrated ability to learn, understand, and use modern technology to find, evaluate, and communicate information.",
-          "fr": "Capacité démontrée d’apprendre, de comprendre et d’utiliser la technologie moderne pour trouver, évaluer et communiquer de l’information."
+          "fr": "Capacité démontrée d’apprendre, de comprendre et d’utiliser la technologie moderne pour trouver, évaluer et communiquer de l’information.",
+          "localized": "Demonstrated ability to learn, understand, and use modern technology to find, evaluate, and communicate information."
         },
         "keywords": {
           "en": ["Computer Skills", "Digital Competence"],
@@ -5013,11 +5629,13 @@
             "key": "working_in_government",
             "name": {
               "en": "Working in Government",
-              "fr": "Travailler au sein du gouvernement"
+              "fr": "Travailler au sein du gouvernement",
+              "localized": "Working in Government"
             },
             "description": {
               "en": "Technical skills family - Working in Government",
-              "fr": "Groupe de compétences techniques - Travailler au sein du gouvernement"
+              "fr": "Groupe de compétences techniques - Travailler au sein du gouvernement",
+              "localized": "Technical skills family - Working in Government"
             }
           }
         ]
@@ -5027,11 +5645,13 @@
         "key": "digital_preservation",
         "name": {
           "en": "Digital Preservation",
-          "fr": "Préservation numérique"
+          "fr": "Préservation numérique",
+          "localized": "Digital Preservation"
         },
         "description": {
           "en": "Demonstrated ability to manage and maintain digital records and archives to ensure long-term preservation and accessibility.",
-          "fr": "Capacité démontrée à gérer et à conserver des documents et des archives numériques de manière à en assurer la préservation et l’accessibilité à long terme."
+          "fr": "Capacité démontrée à gérer et à conserver des documents et des archives numériques de manière à en assurer la préservation et l’accessibilité à long terme.",
+          "localized": "Demonstrated ability to manage and maintain digital records and archives to ensure long-term preservation and accessibility."
         },
         "keywords": {
           "en": ["Digital", "Preservation"],
@@ -5046,11 +5666,13 @@
             "key": "im_data_governance_information_architecture",
             "name": {
               "en": "Information and Data Governance - Information Architecture",
-              "fr": "Gouvernance de l'information et des données - Architecture de l'information"
+              "fr": "Gouvernance de l'information et des données - Architecture de l'information",
+              "localized": "Information and Data Governance - Information Architecture"
             },
             "description": {
               "en": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes.",
-              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus."
+              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus.",
+              "localized": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes."
             }
           }
         ]
@@ -5060,11 +5682,13 @@
         "key": "digital_product_accessibility",
         "name": {
           "en": "Digital Product Accessibility",
-          "fr": "Accessibilité des produits numériques"
+          "fr": "Accessibilité des produits numériques",
+          "localized": "Digital Product Accessibility"
         },
         "description": {
           "en": "Demonstrated ability to produce, review, test, and recommend improvements to digital products to meet minimum government standards for accessibility. This includes demonstrating applied knowledge of  best practices and industry standards in accessible digital product design and delivery.",
-          "fr": "Capacité démontrée de produire, d’examiner, de mettre à l’essai et de recommander des améliorations aux produits numériques afin de respecter les normes minimales du gouvernement en matière d’accessibilité. Il s’agit notamment de démontrer une connaissance appliquée des meilleures pratiques et des normes de l’industrie en matière de conception et de livraison de produits numériques accessibles."
+          "fr": "Capacité démontrée de produire, d’examiner, de mettre à l’essai et de recommander des améliorations aux produits numériques afin de respecter les normes minimales du gouvernement en matière d’accessibilité. Il s’agit notamment de démontrer une connaissance appliquée des meilleures pratiques et des normes de l’industrie en matière de conception et de livraison de produits numériques accessibles.",
+          "localized": "Demonstrated ability to produce, review, test, and recommend improvements to digital products to meet minimum government standards for accessibility. This includes demonstrating applied knowledge of  best practices and industry standards in accessible digital product design and delivery."
         },
         "keywords": {
           "en": null,
@@ -5079,11 +5703,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           },
           {
@@ -5091,11 +5717,13 @@
             "key": "it_project_management",
             "name": {
               "en": "Digital Business Line Advisory Services",
-              "fr": "Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Services consultatifs auprès des secteurs de la numérique",
+              "localized": "Digital Business Line Advisory Services"
             },
             "description": {
               "en": "IT generic work stream - Business Line Advisory Services",
-              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique",
+              "localized": "IT generic work stream - Business Line Advisory Services"
             }
           },
           {
@@ -5103,11 +5731,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           },
           {
@@ -5115,11 +5745,13 @@
             "key": "user_experience_and_interface_design",
             "name": {
               "en": "Software Solutions - Product Design",
-              "fr": "Solutions logicielles - Conception de produits"
+              "fr": "Solutions logicielles - Conception de produits",
+              "localized": "Software Solutions - Product Design"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur",
+              "localized": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design"
             }
           },
           {
@@ -5127,11 +5759,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -5141,11 +5775,13 @@
         "key": "digital_product_management",
         "name": {
           "en": "Digital Product Management",
-          "fr": "Gestion des produits numériques"
+          "fr": "Gestion des produits numériques",
+          "localized": "Digital Product Management"
         },
         "description": {
           "en": "Demonstrated ability to conceive, define, deliver, monitor and refine digital products in order to maximize business results.",
-          "fr": "Capacité démontrée à concevoir, définir, livrer, surveiller et peaufiner des produits numériques afin de maximiser les résultats commerciaux."
+          "fr": "Capacité démontrée à concevoir, définir, livrer, surveiller et peaufiner des produits numériques afin de maximiser les résultats commerciaux.",
+          "localized": "Demonstrated ability to conceive, define, deliver, monitor and refine digital products in order to maximize business results."
         },
         "keywords": {
           "en": ["digital", "product", "management."],
@@ -5160,11 +5796,13 @@
             "key": "it_management",
             "name": {
               "en": "Digital Project Portfolio Management",
-              "fr": "Gestion de portefeuille de projets numériques"
+              "fr": "Gestion de portefeuille de projets numériques",
+              "localized": "Digital Project Portfolio Management"
             },
             "description": {
               "en": "IT generic work stream - Digital project portfolio management",
-              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques"
+              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques",
+              "localized": "IT generic work stream - Digital project portfolio management"
             }
           },
           {
@@ -5172,11 +5810,13 @@
             "key": "it_project_management",
             "name": {
               "en": "Digital Business Line Advisory Services",
-              "fr": "Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Services consultatifs auprès des secteurs de la numérique",
+              "localized": "Digital Business Line Advisory Services"
             },
             "description": {
               "en": "IT generic work stream - Business Line Advisory Services",
-              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique",
+              "localized": "IT generic work stream - Business Line Advisory Services"
             }
           }
         ]
@@ -5186,11 +5826,13 @@
         "key": "digital_product_prototyping",
         "name": {
           "en": "Digital Product Prototyping",
-          "fr": "Prototypage numérique de produits"
+          "fr": "Prototypage numérique de produits",
+          "localized": "Digital Product Prototyping"
         },
         "description": {
           "en": "Demonstrated ability to gather requirements and produce low-fidelity prototypes, such as wireframes and feature sketches. This includes the ability to use this low-fidelity prototype to simulate product use, test with users, and improve elements prior to advancing the prototype to the development phase.",
-          "fr": "Capacité démontrée à recueillir les exigences et à produire des prototypes basse fidélité, tels que des wireframes et des croquis de fonctionnalités. Cela inclut la possibilité d'utiliser ce prototype basse fidélité pour simuler l'utilisation du produit, tester avec les utilisateurs et améliorer les éléments avant de faire passer le prototype à la phase de développement."
+          "fr": "Capacité démontrée à recueillir les exigences et à produire des prototypes basse fidélité, tels que des wireframes et des croquis de fonctionnalités. Cela inclut la possibilité d'utiliser ce prototype basse fidélité pour simuler l'utilisation du produit, tester avec les utilisateurs et améliorer les éléments avant de faire passer le prototype à la phase de développement.",
+          "localized": "Demonstrated ability to gather requirements and produce low-fidelity prototypes, such as wireframes and feature sketches. This includes the ability to use this low-fidelity prototype to simulate product use, test with users, and improve elements prior to advancing the prototype to the development phase."
         },
         "keywords": {
           "en": null,
@@ -5205,11 +5847,13 @@
             "key": "user_experience_and_interface_design",
             "name": {
               "en": "Software Solutions - Product Design",
-              "fr": "Solutions logicielles - Conception de produits"
+              "fr": "Solutions logicielles - Conception de produits",
+              "localized": "Software Solutions - Product Design"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur",
+              "localized": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design"
             }
           }
         ]
@@ -5219,11 +5863,13 @@
         "key": "digital_product_user_experience_design",
         "name": {
           "en": "User Experience Design for Digital Product",
-          "fr": "Conception de l’expérience utilisateur pour les produits numériques"
+          "fr": "Conception de l’expérience utilisateur pour les produits numériques",
+          "localized": "User Experience Design for Digital Product"
         },
         "description": {
           "en": "Demonstrated ability to leverage user experience design methods to map, develop and improve digital products.",
-          "fr": "Capacité avérée à exploiter les méthodes de conception de l’expérience utilisateur pour planifier, développer et améliorer les produits numériques."
+          "fr": "Capacité avérée à exploiter les méthodes de conception de l’expérience utilisateur pour planifier, développer et améliorer les produits numériques.",
+          "localized": "Demonstrated ability to leverage user experience design methods to map, develop and improve digital products."
         },
         "keywords": {
           "en": ["UX", "UI", "design"],
@@ -5238,11 +5884,13 @@
             "key": "user_experience_and_interface_design",
             "name": {
               "en": "Software Solutions - Product Design",
-              "fr": "Solutions logicielles - Conception de produits"
+              "fr": "Solutions logicielles - Conception de produits",
+              "localized": "Software Solutions - Product Design"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur",
+              "localized": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design"
             }
           }
         ]
@@ -5252,11 +5900,13 @@
         "key": "dimensional_data_modelling",
         "name": {
           "en": "Dimensional Data Modelling",
-          "fr": "Modélisation dimensionnelle des données"
+          "fr": "Modélisation dimensionnelle des données",
+          "localized": "Dimensional Data Modelling"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this technique to structure data into measurable, quantitative data points and attributes for streamlined analysis and reporting within data warehousing and business intelligence contexts.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de cette technique pour structurer les données en points de données mesurables et quantitatifs ainsi que des attributs pour une analyse et un rapport simplifiés dans les contextes de l'entreposage de données et de l'intelligence d'affaires."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de cette technique pour structurer les données en points de données mesurables et quantitatifs ainsi que des attributs pour une analyse et un rapport simplifiés dans les contextes de l'entreposage de données et de l'intelligence d'affaires.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this technique to structure data into measurable, quantitative data points and attributes for streamlined analysis and reporting within data warehousing and business intelligence contexts."
         },
         "keywords": {
           "en": ["Dimensional", "Data", "Modelling"],
@@ -5271,11 +5921,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           }
         ]
@@ -5285,11 +5937,13 @@
         "key": "docker",
         "name": {
           "en": "Docker",
-          "fr": "Docker"
+          "fr": "Docker",
+          "localized": "Docker"
         },
         "description": {
           "en": "Demonstrated ability to leverage platform features to develop and manage applications, including demonstrated knowledge of best practice for using containers and security features.",
-          "fr": "Capacité démontrée à tirer parti des fonctionnalités de la plateforme pour développer et gérer des applications, y compris une connaissance avérée des meilleures pratiques d’utilisation des conteneurs et des fonctionnalités de sécurité."
+          "fr": "Capacité démontrée à tirer parti des fonctionnalités de la plateforme pour développer et gérer des applications, y compris une connaissance avérée des meilleures pratiques d’utilisation des conteneurs et des fonctionnalités de sécurité.",
+          "localized": "Demonstrated ability to leverage platform features to develop and manage applications, including demonstrated knowledge of best practice for using containers and security features."
         },
         "keywords": {
           "en": null,
@@ -5304,11 +5958,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -5318,11 +5974,13 @@
         "key": "document_management_legal_terminology",
         "name": {
           "en": "Preparation of Briefing Materials - Legal Terminology",
-          "fr": "Préparation des documents d’information - Terminologie juridique"
+          "fr": "Préparation des documents d’information - Terminologie juridique",
+          "localized": "Preparation of Briefing Materials - Legal Terminology"
         },
         "description": {
           "en": "Demonstrated ability to handle, interpret and prepare briefing documents with legal terminology, ensuring accuracy and compliance.",
-          "fr": "Aptitude avérée à manipuler, interpréter et préparer des documents d’information avec une terminologie juridique, en veillant à l’exactitude et à la conformité."
+          "fr": "Aptitude avérée à manipuler, interpréter et préparer des documents d’information avec une terminologie juridique, en veillant à l’exactitude et à la conformité.",
+          "localized": "Demonstrated ability to handle, interpret and prepare briefing documents with legal terminology, ensuring accuracy and compliance."
         },
         "keywords": {
           "en": null,
@@ -5337,11 +5995,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           }
         ]
@@ -5351,11 +6011,13 @@
         "key": "document_review",
         "name": {
           "en": "High-Volume Document Review",
-          "fr": "Examen d’un volume élevé de documents"
+          "fr": "Examen d’un volume élevé de documents",
+          "localized": "High-Volume Document Review"
         },
         "description": {
           "en": "Demonstrated ability to maintain focus while reading and assessing large volumes of materials, including being able to identify and summarize important points drawn from multiple sources of information.",
-          "fr": "Capacité démontrée à maintenir sa concentration tout en lisant et en évaluant un volume élevé de documents, notamment la capacité de cerner et de résumer les points importants tirés de multiples sources d’information."
+          "fr": "Capacité démontrée à maintenir sa concentration tout en lisant et en évaluant un volume élevé de documents, notamment la capacité de cerner et de résumer les points importants tirés de multiples sources d’information.",
+          "localized": "Demonstrated ability to maintain focus while reading and assessing large volumes of materials, including being able to identify and summarize important points drawn from multiple sources of information."
         },
         "keywords": {
           "en": null,
@@ -5370,11 +6032,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           }
         ]
@@ -5384,11 +6048,13 @@
         "key": "domain_name_system_dns",
         "name": {
           "en": "Domain name system (DNS)",
-          "fr": "Système de Noms de Domaine (DNS)"
+          "fr": "Système de Noms de Domaine (DNS)",
+          "localized": "Domain name system (DNS)"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of DNS services to establish and troubleshoot basic physical or software connectivity.",
-          "fr": "Capacité démontrée à appliquer une connaissance concrète des services DNS pour établir et dépanner une connectivité physique ou logicielle de base."
+          "fr": "Capacité démontrée à appliquer une connaissance concrète des services DNS pour établir et dépanner une connectivité physique ou logicielle de base.",
+          "localized": "Demonstrated ability to apply concrete knowledge of DNS services to establish and troubleshoot basic physical or software connectivity."
         },
         "keywords": {
           "en": ["Domain name system", "DNS"],
@@ -5403,11 +6069,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -5417,11 +6085,13 @@
         "key": "dotnet_programming",
         "name": {
           "en": ".NET Programming",
-          "fr": "Programmation .NET"
+          "fr": "Programmation .NET",
+          "localized": ".NET Programming"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this language to develop a variety of projects.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de cette langue pour développer une variété de projets."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de cette langue pour développer une variété de projets.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this language to develop a variety of projects."
         },
         "keywords": {
           "en": null,
@@ -5436,11 +6106,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -5450,11 +6122,13 @@
         "key": "drupal",
         "name": {
           "en": "Drupal",
-          "fr": "Drupal"
+          "fr": "Drupal",
+          "localized": "Drupal"
         },
         "description": {
           "en": "Demonstrated ability to develop, configure, and manage this open-source content management system to create a variety of web applications. This may include creating custom modules, theming, and optimizing performance to meet specific business needs.",
-          "fr": "Capacité démontrée à développer, configurer et gérer ce système de gestion de contenu libre pour créer une variété d’applications web. Cela peut inclure la création de modules personnalisés, le développement de thèmes et l'optimisation des rendements pour répondre aux besoins opérationnels spécifiques."
+          "fr": "Capacité démontrée à développer, configurer et gérer ce système de gestion de contenu libre pour créer une variété d’applications web. Cela peut inclure la création de modules personnalisés, le développement de thèmes et l'optimisation des rendements pour répondre aux besoins opérationnels spécifiques.",
+          "localized": "Demonstrated ability to develop, configure, and manage this open-source content management system to create a variety of web applications. This may include creating custom modules, theming, and optimizing performance to meet specific business needs."
         },
         "keywords": {
           "en": ["Drupal"],
@@ -5469,11 +6143,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -5483,11 +6159,13 @@
         "key": "ebxml",
         "name": {
           "en": "Electronic Business using eXtensible Markup Language (EbXML)",
-          "fr": "Commerce électronique utilisant le langage de balisage extensible (EbXML)"
+          "fr": "Commerce électronique utilisant le langage de balisage extensible (EbXML)",
+          "localized": "Electronic Business using eXtensible Markup Language (EbXML)"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this framework to standardize the secure exchange of business data for consistent data exchange.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes liées à ce cadre afin de normaliser les échanges sécurisés de données opérationnelles et d’assurer ainsi un échange de données cohérent."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes liées à ce cadre afin de normaliser les échanges sécurisés de données opérationnelles et d’assurer ainsi un échange de données cohérent.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this framework to standardize the secure exchange of business data for consistent data exchange."
         },
         "keywords": {
           "en": ["EbXML"],
@@ -5502,11 +6180,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -5516,11 +6196,13 @@
         "key": "electronic_signature",
         "name": {
           "en": "Electronic Signature",
-          "fr": "Signature électronique"
+          "fr": "Signature électronique",
+          "localized": "Electronic Signature"
         },
         "description": {
           "en": "Demonstrated ability to provide advice on the establishment of electronic signature functionality for digital products and services, demonstrating awareness of technical, legal and security-related considerations.",
-          "fr": "Capacité démontrée à fournir des conseils sur la mise en place d'une fonctionnalité de signature électronique pour les produits et services numériques, démontrant une connaissance des considérations techniques, juridiques et liées à la sécurité."
+          "fr": "Capacité démontrée à fournir des conseils sur la mise en place d'une fonctionnalité de signature électronique pour les produits et services numériques, démontrant une connaissance des considérations techniques, juridiques et liées à la sécurité.",
+          "localized": "Demonstrated ability to provide advice on the establishment of electronic signature functionality for digital products and services, demonstrating awareness of technical, legal and security-related considerations."
         },
         "keywords": {
           "en": null,
@@ -5535,11 +6217,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           },
           {
@@ -5547,11 +6231,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -5561,11 +6247,13 @@
         "key": "elt",
         "name": {
           "en": "Extract, Load, and Transform (ELT)",
-          "fr": "Extraire, Charger et Transformer (ECT)"
+          "fr": "Extraire, Charger et Transformer (ECT)",
+          "localized": "Extract, Load, and Transform (ELT)"
         },
         "description": {
           "en": "Demonstrated ability to move raw data from source systems directly to target systems, performing necessary transformations within the target environment.",
-          "fr": "Capacité démontrée à déplacer des données brutes depuis les systèmes sources directement vers les systèmes cibles, en effectuant les transformations nécessaires au sein de l'environnement cible."
+          "fr": "Capacité démontrée à déplacer des données brutes depuis les systèmes sources directement vers les systèmes cibles, en effectuant les transformations nécessaires au sein de l'environnement cible.",
+          "localized": "Demonstrated ability to move raw data from source systems directly to target systems, performing necessary transformations within the target environment."
         },
         "keywords": {
           "en": ["ELT"],
@@ -5580,11 +6268,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -5594,11 +6284,13 @@
         "key": "empathy",
         "name": {
           "en": "Empathy",
-          "fr": "Empathie"
+          "fr": "Empathie",
+          "localized": "Empathy"
         },
         "description": {
           "en": "Demonstrated willingness to understand the feelings and viewpoints of others. This includes making an effort to gain insights into the perspectives of others, being sensitive to the feelings of others, and taking this information into account when designing or delivering products and services.",
-          "fr": "Volonté démontrée de comprendre les sentiments et les points de vue des autres. Il s’agit notamment de s’efforcer de mieux comprendre les points de vue des autres, d’être sensible aux sentiments des autres et de tenir compte de ces informations lors de la conception ou de la livraison de produits et de services."
+          "fr": "Volonté démontrée de comprendre les sentiments et les points de vue des autres. Il s’agit notamment de s’efforcer de mieux comprendre les points de vue des autres, d’être sensible aux sentiments des autres et de tenir compte de ces informations lors de la conception ou de la livraison de produits et de services.",
+          "localized": "Demonstrated willingness to understand the feelings and viewpoints of others. This includes making an effort to gain insights into the perspectives of others, being sensitive to the feelings of others, and taking this information into account when designing or delivering products and services."
         },
         "keywords": {
           "en": [
@@ -5625,11 +6317,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -5639,11 +6333,13 @@
         "key": "endpoint_security",
         "name": {
           "en": "Endpoint Security",
-          "fr": "Sécurité des points d'accès"
+          "fr": "Sécurité des points d'accès",
+          "localized": "Endpoint Security"
         },
         "description": {
           "en": "Demonstrated ability to apply common cyber security approaches and use intrusion detection and prevention tools to safeguard data and operations.",
-          "fr": "Capacité démontrée à appliquer des approches communes en matière de cybersécurité et à utiliser des outils de détection et de prévention des intrusions pour protéger les données et les opérations."
+          "fr": "Capacité démontrée à appliquer des approches communes en matière de cybersécurité et à utiliser des outils de détection et de prévention des intrusions pour protéger les données et les opérations.",
+          "localized": "Demonstrated ability to apply common cyber security approaches and use intrusion detection and prevention tools to safeguard data and operations."
         },
         "keywords": {
           "en": ["Endpoint", "Security"],
@@ -5658,11 +6354,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           },
           {
@@ -5670,11 +6368,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -5684,11 +6384,13 @@
         "key": "enhanced_management_framework_for_it_projects",
         "name": {
           "en": "Enhanced Management Framework for IT Projects",
-          "fr": "Cadre amélioré de gestion des projets informatiques"
+          "fr": "Cadre amélioré de gestion des projets informatiques",
+          "localized": "Enhanced Management Framework for IT Projects"
         },
         "description": {
           "en": "",
-          "fr": ""
+          "fr": "",
+          "localized": ""
         },
         "keywords": {
           "en": [],
@@ -5703,11 +6405,13 @@
             "key": "it_project_management",
             "name": {
               "en": "Digital Business Line Advisory Services",
-              "fr": "Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Services consultatifs auprès des secteurs de la numérique",
+              "localized": "Digital Business Line Advisory Services"
             },
             "description": {
               "en": "IT generic work stream - Business Line Advisory Services",
-              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique",
+              "localized": "IT generic work stream - Business Line Advisory Services"
             }
           }
         ]
@@ -5717,11 +6421,13 @@
         "key": "enterprise_information_technology_architecture",
         "name": {
           "en": "Enterprise Information Technology Architecture",
-          "fr": "Architecture des technologies de l’information de l’entreprise"
+          "fr": "Architecture des technologies de l’information de l’entreprise",
+          "localized": "Enterprise Information Technology Architecture"
         },
         "description": {
           "en": "Demonstrated ability to describe and document guidelines for acquiring, building, or modifying an organization's IT resources.",
-          "fr": "Capacité démontrée à décrire et à documenter les lignes directrices pour l’acquisition, la création ou la modification des ressources informatiques d’une organisation."
+          "fr": "Capacité démontrée à décrire et à documenter les lignes directrices pour l’acquisition, la création ou la modification des ressources informatiques d’une organisation.",
+          "localized": "Demonstrated ability to describe and document guidelines for acquiring, building, or modifying an organization's IT resources."
         },
         "keywords": {
           "en": null,
@@ -5736,11 +6442,13 @@
             "key": "infrastructure_operations",
             "name": {
               "en": "IT Infrastructure Operations",
-              "fr": "Opérations d'infrastructure informatique"
+              "fr": "Opérations d'infrastructure informatique",
+              "localized": "IT Infrastructure Operations"
             },
             "description": {
               "en": "IT generic work stream - Infrastructure Operations",
-              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique"
+              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique",
+              "localized": "IT generic work stream - Infrastructure Operations"
             }
           },
           {
@@ -5748,11 +6456,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           }
         ]
@@ -5762,11 +6472,13 @@
         "key": "enterprise_software",
         "name": {
           "en": "Enterprise Software",
-          "fr": "Logiciels d’entreprise"
+          "fr": "Logiciels d’entreprise",
+          "localized": "Enterprise Software"
         },
         "description": {
           "en": "Demonstrated ability to manage, implement and support enterprise wide applications.",
-          "fr": "Capacité démontrée de gérer, de mettre en œuvre et de soutenir des applications à l’échelle de l’entreprise."
+          "fr": "Capacité démontrée de gérer, de mettre en œuvre et de soutenir des applications à l’échelle de l’entreprise.",
+          "localized": "Demonstrated ability to manage, implement and support enterprise wide applications."
         },
         "keywords": {
           "en": ["Enterprise", "Software"],
@@ -5781,11 +6493,13 @@
             "key": "infrastructure_operations",
             "name": {
               "en": "IT Infrastructure Operations",
-              "fr": "Opérations d'infrastructure informatique"
+              "fr": "Opérations d'infrastructure informatique",
+              "localized": "IT Infrastructure Operations"
             },
             "description": {
               "en": "IT generic work stream - Infrastructure Operations",
-              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique"
+              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique",
+              "localized": "IT generic work stream - Infrastructure Operations"
             }
           }
         ]
@@ -5795,11 +6509,13 @@
         "key": "entra_id",
         "name": {
           "en": "Entra ID",
-          "fr": "Entra ID"
+          "fr": "Entra ID",
+          "localized": "Entra ID"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this identity and access management service to a variety of projects.",
-          "fr": "Capacité démontrée à appliquer une connaissance concrète de ce service de gestion des identités et des accès à une variété de projets."
+          "fr": "Capacité démontrée à appliquer une connaissance concrète de ce service de gestion des identités et des accès à une variété de projets.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this identity and access management service to a variety of projects."
         },
         "keywords": {
           "en": ["Entra ID"],
@@ -5814,11 +6530,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -5828,11 +6546,13 @@
         "key": "entrepreneurial_thinking",
         "name": {
           "en": "Entrepreneurial Thinking",
-          "fr": "Pensée entrepreneuriale"
+          "fr": "Pensée entrepreneuriale",
+          "localized": "Entrepreneurial Thinking"
         },
         "description": {
           "en": "Demonstrated ability to come up with unconventional ideas and new opportunities. This includes being creative and strategic in bringing opportunities forward, and demonstrating the ability to gather the necessary support and resources to advance concepts beyond the initial discussion stage.",
-          "fr": "Capacité démontrée à trouver des idées non conventionnelles et de nouvelles opportunités. Il s’agit notamment de faire preuve de créativité et de stratégie pour présenter des opportunités, et de démontrer la capacité de rassembler le soutien et les ressources nécessaires pour faire avancer les concepts au-delà de l’étape de la discussion initiale."
+          "fr": "Capacité démontrée à trouver des idées non conventionnelles et de nouvelles opportunités. Il s’agit notamment de faire preuve de créativité et de stratégie pour présenter des opportunités, et de démontrer la capacité de rassembler le soutien et les ressources nécessaires pour faire avancer les concepts au-delà de l’étape de la discussion initiale.",
+          "localized": "Demonstrated ability to come up with unconventional ideas and new opportunities. This includes being creative and strategic in bringing opportunities forward, and demonstrating the ability to gather the necessary support and resources to advance concepts beyond the initial discussion stage."
         },
         "keywords": {
           "en": ["Entrepreneurial Spirit", "Enterprising", "Pioneering"],
@@ -5847,11 +6567,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -5861,11 +6583,13 @@
         "key": "ethical_decision_making",
         "name": {
           "en": "Ethical Decision-Making",
-          "fr": "Prise de décisions éthiques"
+          "fr": "Prise de décisions éthiques",
+          "localized": "Ethical Decision-Making"
         },
         "description": {
           "en": "Demonstrated ability to make decisions without bias or self-interest, ensuring fairness for all people involved.",
-          "fr": "Capacité démontrée à prendre des décisions sans parti pris ni intérêt personnel, en assurant l’équité pour toutes les personnes concernées."
+          "fr": "Capacité démontrée à prendre des décisions sans parti pris ni intérêt personnel, en assurant l’équité pour toutes les personnes concernées.",
+          "localized": "Demonstrated ability to make decisions without bias or self-interest, ensuring fairness for all people involved."
         },
         "keywords": {
           "en": ["Judgment", "Decisiveness", "Integrity", "Ethical Leadership"],
@@ -5880,11 +6604,13 @@
             "key": "leadership",
             "name": {
               "en": "Leadership - General Behaviours",
-              "fr": "Leadership - Comportements généraux"
+              "fr": "Leadership - Comportements généraux",
+              "localized": "Leadership - General Behaviours"
             },
             "description": {
               "en": "Behavioural - Leadership",
-              "fr": "Comportemental - Leadership"
+              "fr": "Comportemental - Leadership",
+              "localized": "Behavioural - Leadership"
             }
           },
           {
@@ -5892,11 +6618,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -5906,11 +6634,13 @@
         "key": "etl",
         "name": {
           "en": "Extract, transform, and load (ETL)",
-          "fr": "Extraire, transformer et charger (ETL)"
+          "fr": "Extraire, transformer et charger (ETL)",
+          "localized": "Extract, transform, and load (ETL)"
         },
         "description": {
           "en": "Demonstrated ability to develop, implement, and optimize pipelines by extracting data from various sources, transforming it according to business requirements, and loading it into systems for analytics and reporting purposes.",
-          "fr": "Capacité démontrée à développer, mettre en œuvre et optimiser des pipelines en extrayant des données de diverses sources, en les transformant en fonction des exigences opérationnelles et en les chargeant dans des systèmes à des fins d’analyse et d’établissement de rapports."
+          "fr": "Capacité démontrée à développer, mettre en œuvre et optimiser des pipelines en extrayant des données de diverses sources, en les transformant en fonction des exigences opérationnelles et en les chargeant dans des systèmes à des fins d’analyse et d’établissement de rapports.",
+          "localized": "Demonstrated ability to develop, implement, and optimize pipelines by extracting data from various sources, transforming it according to business requirements, and loading it into systems for analytics and reporting purposes."
         },
         "keywords": {
           "en": ["ETL"],
@@ -5925,11 +6655,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -5939,11 +6671,13 @@
         "key": "evidence_integrity",
         "name": {
           "en": "Evidence Integrity",
-          "fr": "Intégrité des données probantes"
+          "fr": "Intégrité des données probantes",
+          "localized": "Evidence Integrity"
         },
         "description": {
           "en": "Demonstrated ability to maintain the reliability and unaltered state of evidence and organizational records, ensuring that digital documentation and artifacts remain accurate and trustworthy throughout their lifecycle.",
-          "fr": "Capacité démontrée à maintenir la fiabilité et l’état non altéré des données probantes et des enregistrements organisationnels, en veillant à ce que la documentation et les artéfacts numériques restent précis et fiables pendant tout leur cycle de vie."
+          "fr": "Capacité démontrée à maintenir la fiabilité et l’état non altéré des données probantes et des enregistrements organisationnels, en veillant à ce que la documentation et les artéfacts numériques restent précis et fiables pendant tout leur cycle de vie.",
+          "localized": "Demonstrated ability to maintain the reliability and unaltered state of evidence and organizational records, ensuring that digital documentation and artifacts remain accurate and trustworthy throughout their lifecycle."
         },
         "keywords": {
           "en": ["Evidence", "Integrity"],
@@ -5958,11 +6692,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           }
         ]
@@ -5972,11 +6708,13 @@
         "key": "executive_leadership_database_management",
         "name": {
           "en": "Executive Leadership of Database Management",
-          "fr": "Leadership exécutif de la gestion de bases de données"
+          "fr": "Leadership exécutif de la gestion de bases de données",
+          "localized": "Executive Leadership of Database Management"
         },
         "description": {
           "en": "Demonstrated ability at the executive level to lead Database Management initiatives, which may include setting vision and direction, directing implementation and operations, and ensuring delivery of results",
-          "fr": "Capacité démontrée au niveau de la direction à diriger des initiatives de gestion de bases de données, ce qui peut inclure la définition d'une vision et d'une orientation, la direction de la mise en œuvre et des opérations et la garantie de l'obtention des résultats."
+          "fr": "Capacité démontrée au niveau de la direction à diriger des initiatives de gestion de bases de données, ce qui peut inclure la définition d'une vision et d'une orientation, la direction de la mise en œuvre et des opérations et la garantie de l'obtention des résultats.",
+          "localized": "Demonstrated ability at the executive level to lead Database Management initiatives, which may include setting vision and direction, directing implementation and operations, and ensuring delivery of results"
         },
         "keywords": {
           "en": ["Executive", "Leadership"],
@@ -5991,11 +6729,13 @@
             "key": "executive_leadership",
             "name": {
               "en": "Leadership - Executive Technical Skills",
-              "fr": "Leadership - Compétences techniques des cadres"
+              "fr": "Leadership - Compétences techniques des cadres",
+              "localized": "Leadership - Executive Technical Skills"
             },
             "description": {
               "en": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation",
-              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX"
+              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX",
+              "localized": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation"
             }
           }
         ]
@@ -6005,11 +6745,13 @@
         "key": "executive_leadership_digital_planning_reporting",
         "name": {
           "en": "Executive Leadership of Digital Planning and Reporting",
-          "fr": "Leadership exécutif de la planification et établissement de rapports en matière de la numérique"
+          "fr": "Leadership exécutif de la planification et établissement de rapports en matière de la numérique",
+          "localized": "Executive Leadership of Digital Planning and Reporting"
         },
         "description": {
           "en": "Demonstrated ability at the executive level to lead Digital Planning and Reporting initiatives, which may include setting vision and direction, directing implementation and operations, and ensuring delivery of results",
-          "fr": "Capacité démontrée au niveau de la direction à diriger des initiatives de planification et établissement de rapports en matière de la numérique, ce qui peut inclure la définition d'une vision et d'une orientation, la direction de la mise en œuvre et des opérations et la garantie de l'obtention des résultats"
+          "fr": "Capacité démontrée au niveau de la direction à diriger des initiatives de planification et établissement de rapports en matière de la numérique, ce qui peut inclure la définition d'une vision et d'une orientation, la direction de la mise en œuvre et des opérations et la garantie de l'obtention des résultats",
+          "localized": "Demonstrated ability at the executive level to lead Digital Planning and Reporting initiatives, which may include setting vision and direction, directing implementation and operations, and ensuring delivery of results"
         },
         "keywords": {
           "en": ["Executive", "Leadership"],
@@ -6024,11 +6766,13 @@
             "key": "executive_leadership",
             "name": {
               "en": "Leadership - Executive Technical Skills",
-              "fr": "Leadership - Compétences techniques des cadres"
+              "fr": "Leadership - Compétences techniques des cadres",
+              "localized": "Leadership - Executive Technical Skills"
             },
             "description": {
               "en": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation",
-              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX"
+              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX",
+              "localized": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation"
             }
           }
         ]
@@ -6038,11 +6782,13 @@
         "key": "executive_leadership_digital_project_portfolio_management",
         "name": {
           "en": "Executive Leadership of Digital Project Portfolio Management",
-          "fr": "Leadership exécutif de la gestion de portefeuille de projets numériques"
+          "fr": "Leadership exécutif de la gestion de portefeuille de projets numériques",
+          "localized": "Executive Leadership of Digital Project Portfolio Management"
         },
         "description": {
           "en": "Demonstrated ability at the executive level to lead Digital Project Portfolio Management initiatives, which may include setting vision and direction, directing implementation and operations, and ensuring delivery of results",
-          "fr": "Capacité démontrée au niveau de la direction à diriger des initiatives de gestion de portefeuille de projets numériques, ce qui peut inclure la définition d'une vision et d'une orientation, la direction de la mise en œuvre et des opérations et la garantie de l'obtention des résultats"
+          "fr": "Capacité démontrée au niveau de la direction à diriger des initiatives de gestion de portefeuille de projets numériques, ce qui peut inclure la définition d'une vision et d'une orientation, la direction de la mise en œuvre et des opérations et la garantie de l'obtention des résultats",
+          "localized": "Demonstrated ability at the executive level to lead Digital Project Portfolio Management initiatives, which may include setting vision and direction, directing implementation and operations, and ensuring delivery of results"
         },
         "keywords": {
           "en": ["Executive", "Leadership"],
@@ -6057,11 +6803,13 @@
             "key": "executive_leadership",
             "name": {
               "en": "Leadership - Executive Technical Skills",
-              "fr": "Leadership - Compétences techniques des cadres"
+              "fr": "Leadership - Compétences techniques des cadres",
+              "localized": "Leadership - Executive Technical Skills"
             },
             "description": {
               "en": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation",
-              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX"
+              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX",
+              "localized": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation"
             }
           }
         ]
@@ -6071,11 +6819,13 @@
         "key": "executive_leadership_digtial_business_line_advisory",
         "name": {
           "en": "Executive Leadership of Digital Business Line Advisory Services",
-          "fr": "Leadership exécutif des services consultatifs auprès des secteurs de la numérique"
+          "fr": "Leadership exécutif des services consultatifs auprès des secteurs de la numérique",
+          "localized": "Executive Leadership of Digital Business Line Advisory Services"
         },
         "description": {
           "en": "Demonstrated ability at the executive level to lead Digital Business Line Advisory Services, which may include setting vision and direction, directing implementation and operations, and ensuring delivery of results",
-          "fr": "Capacité démontrée au niveau de la direction à diriger les services consultatifs auprès des secteurs de la numérique, ce qui peut inclure la définition d'une vision et d'une orientation, la direction de la mise en œuvre et des opérations et la garantie de l'obtention des résultats"
+          "fr": "Capacité démontrée au niveau de la direction à diriger les services consultatifs auprès des secteurs de la numérique, ce qui peut inclure la définition d'une vision et d'une orientation, la direction de la mise en œuvre et des opérations et la garantie de l'obtention des résultats",
+          "localized": "Demonstrated ability at the executive level to lead Digital Business Line Advisory Services, which may include setting vision and direction, directing implementation and operations, and ensuring delivery of results"
         },
         "keywords": {
           "en": ["Executive", "Leadership"],
@@ -6090,11 +6840,13 @@
             "key": "executive_leadership",
             "name": {
               "en": "Leadership - Executive Technical Skills",
-              "fr": "Leadership - Compétences techniques des cadres"
+              "fr": "Leadership - Compétences techniques des cadres",
+              "localized": "Leadership - Executive Technical Skills"
             },
             "description": {
               "en": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation",
-              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX"
+              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX",
+              "localized": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation"
             }
           }
         ]
@@ -6104,11 +6856,13 @@
         "key": "executive_leadership_enterprise_architecture",
         "name": {
           "en": "Executive Leadership of Enterprise Architecture",
-          "fr": "Leadership exécutif de l'architecture intégrée de la numérique"
+          "fr": "Leadership exécutif de l'architecture intégrée de la numérique",
+          "localized": "Executive Leadership of Enterprise Architecture"
         },
         "description": {
           "en": "Demonstrated ability at the executive level to lead Enterprise Architecture initiatives, which may include setting vision and direction, directing implementation and operations, and ensuring delivery of results",
-          "fr": "Capacité démontrée au niveau de la direction à diriger des initiatives d'architecture intégrée de la numérique, ce qui peut inclure la définition d'une vision et d'une orientation, la direction de la mise en œuvre et des opérations et la garantie de l'obtention des résultats"
+          "fr": "Capacité démontrée au niveau de la direction à diriger des initiatives d'architecture intégrée de la numérique, ce qui peut inclure la définition d'une vision et d'une orientation, la direction de la mise en œuvre et des opérations et la garantie de l'obtention des résultats",
+          "localized": "Demonstrated ability at the executive level to lead Enterprise Architecture initiatives, which may include setting vision and direction, directing implementation and operations, and ensuring delivery of results"
         },
         "keywords": {
           "en": ["Executive", "Leadership"],
@@ -6123,11 +6877,13 @@
             "key": "executive_leadership",
             "name": {
               "en": "Leadership - Executive Technical Skills",
-              "fr": "Leadership - Compétences techniques des cadres"
+              "fr": "Leadership - Compétences techniques des cadres",
+              "localized": "Leadership - Executive Technical Skills"
             },
             "description": {
               "en": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation",
-              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX"
+              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX",
+              "localized": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation"
             }
           }
         ]
@@ -6137,11 +6893,13 @@
         "key": "executive_leadership_financial_resources",
         "name": {
           "en": "Executive Leadership of Financial Resources",
-          "fr": "Leadership exécutif des ressources financières"
+          "fr": "Leadership exécutif des ressources financières",
+          "localized": "Executive Leadership of Financial Resources"
         },
         "description": {
           "en": "Demonstrated ability at the executive level to manage financial resources, including: holding financial delegation for a budget, forecasting, planning, budget allocation, and reporting",
-          "fr": "Capacité démontrée au niveau de la direction à gérer des ressources financières, notamment : détenir une délégation financière pour un budget, faire des prévisions, planifier, allouer un budget et produire des rapports"
+          "fr": "Capacité démontrée au niveau de la direction à gérer des ressources financières, notamment : détenir une délégation financière pour un budget, faire des prévisions, planifier, allouer un budget et produire des rapports",
+          "localized": "Demonstrated ability at the executive level to manage financial resources, including: holding financial delegation for a budget, forecasting, planning, budget allocation, and reporting"
         },
         "keywords": {
           "en": null,
@@ -6156,11 +6914,13 @@
             "key": "executive_leadership",
             "name": {
               "en": "Leadership - Executive Technical Skills",
-              "fr": "Leadership - Compétences techniques des cadres"
+              "fr": "Leadership - Compétences techniques des cadres",
+              "localized": "Leadership - Executive Technical Skills"
             },
             "description": {
               "en": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation",
-              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX"
+              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX",
+              "localized": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation"
             }
           }
         ]
@@ -6170,11 +6930,13 @@
         "key": "executive_leadership_human_resources",
         "name": {
           "en": "Executive Leadership of Human Resources",
-          "fr": "Leadership exécutif des ressources humaines"
+          "fr": "Leadership exécutif des ressources humaines",
+          "localized": "Executive Leadership of Human Resources"
         },
         "description": {
           "en": "Demonstrated ability at the executive level to manage teams and human resources, including: assigning work, establishing performance objectives and indicators, developing resourcing plans, determining needs and approving training",
-          "fr": "Capacité démontrée au niveau de la direction à gérer des équipes et des ressources humaines, notamment : attribuer du travail, établir des objectifs et des indicateurs de rendement, élaborer des plans de ressources, déterminer les besoins et approuver la formation."
+          "fr": "Capacité démontrée au niveau de la direction à gérer des équipes et des ressources humaines, notamment : attribuer du travail, établir des objectifs et des indicateurs de rendement, élaborer des plans de ressources, déterminer les besoins et approuver la formation.",
+          "localized": "Demonstrated ability at the executive level to manage teams and human resources, including: assigning work, establishing performance objectives and indicators, developing resourcing plans, determining needs and approving training"
         },
         "keywords": {
           "en": null,
@@ -6189,11 +6951,13 @@
             "key": "executive_leadership",
             "name": {
               "en": "Leadership - Executive Technical Skills",
-              "fr": "Leadership - Compétences techniques des cadres"
+              "fr": "Leadership - Compétences techniques des cadres",
+              "localized": "Leadership - Executive Technical Skills"
             },
             "description": {
               "en": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation",
-              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX"
+              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX",
+              "localized": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation"
             }
           }
         ]
@@ -6203,11 +6967,13 @@
         "key": "executive_leadership_instrastructure_operations",
         "name": {
           "en": "Executive Leadership of Infrastructure Operations",
-          "fr": "Leadership exécutif des opérations d’infrastructure"
+          "fr": "Leadership exécutif des opérations d’infrastructure",
+          "localized": "Executive Leadership of Infrastructure Operations"
         },
         "description": {
           "en": "Demonstrated ability at the executive level to lead Infrastructure Operations initiatives, which may include setting vision and direction, directing implementation and operations, and ensuring delivery of results",
-          "fr": "Capacité démontrée au niveau de la direction à diriger des initiatives d'opérations d'infrastructure, ce qui peut inclure la définition d'une vision et d'une orientation, la direction de la mise en œuvre et des opérations et l'assurance de l'obtention des résultats."
+          "fr": "Capacité démontrée au niveau de la direction à diriger des initiatives d'opérations d'infrastructure, ce qui peut inclure la définition d'une vision et d'une orientation, la direction de la mise en œuvre et des opérations et l'assurance de l'obtention des résultats.",
+          "localized": "Demonstrated ability at the executive level to lead Infrastructure Operations initiatives, which may include setting vision and direction, directing implementation and operations, and ensuring delivery of results"
         },
         "keywords": {
           "en": ["Executive", "Leadership"],
@@ -6222,11 +6988,13 @@
             "key": "executive_leadership",
             "name": {
               "en": "Leadership - Executive Technical Skills",
-              "fr": "Leadership - Compétences techniques des cadres"
+              "fr": "Leadership - Compétences techniques des cadres",
+              "localized": "Leadership - Executive Technical Skills"
             },
             "description": {
               "en": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation",
-              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX"
+              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX",
+              "localized": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation"
             }
           }
         ]
@@ -6236,11 +7004,13 @@
         "key": "executive_leadership_it_security",
         "name": {
           "en": "Executive Leadership of IT Security and Cyber",
-          "fr": "Leadership exécutif de la sécurité informatique et de la cybersécurité"
+          "fr": "Leadership exécutif de la sécurité informatique et de la cybersécurité",
+          "localized": "Executive Leadership of IT Security and Cyber"
         },
         "description": {
           "en": "Demonstrated ability at the executive level to lead IT Security and Cyber initiatives, which may include setting vision and direction, directing implementation and operations, and ensuring delivery of results",
-          "fr": "Capacité démontrée au niveau de la direction à diriger des initiatives de sécurité informatique et de cybersécurité, ce qui peut inclure la définition d'une vision et d'une orientation, la direction de la mise en œuvre et des opérations et l'assurance de l'obtention des résultats."
+          "fr": "Capacité démontrée au niveau de la direction à diriger des initiatives de sécurité informatique et de cybersécurité, ce qui peut inclure la définition d'une vision et d'une orientation, la direction de la mise en œuvre et des opérations et l'assurance de l'obtention des résultats.",
+          "localized": "Demonstrated ability at the executive level to lead IT Security and Cyber initiatives, which may include setting vision and direction, directing implementation and operations, and ensuring delivery of results"
         },
         "keywords": {
           "en": ["Executive", "Leadership"],
@@ -6255,11 +7025,13 @@
             "key": "executive_leadership",
             "name": {
               "en": "Leadership - Executive Technical Skills",
-              "fr": "Leadership - Compétences techniques des cadres"
+              "fr": "Leadership - Compétences techniques des cadres",
+              "localized": "Leadership - Executive Technical Skills"
             },
             "description": {
               "en": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation",
-              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX"
+              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX",
+              "localized": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation"
             }
           }
         ]
@@ -6269,11 +7041,13 @@
         "key": "executive_leadership_of_data_services",
         "name": {
           "en": "Executive Leadership of data services",
-          "fr": "Leadership exécutif des services de données"
+          "fr": "Leadership exécutif des services de données",
+          "localized": "Executive Leadership of data services"
         },
         "description": {
           "en": "Demonstrated ability at the executive level to lead data services initiatives, which may include setting vision and direction, directing implementation and operations, and ensuring delivery of results.",
-          "fr": "Capacité démontrée au niveau des services de données, ce qui peut inclure la définition d'une vision et d'une orientation, la direction de la mise en œuvre et des opérations et l'assurance de l'obtention des résultats."
+          "fr": "Capacité démontrée au niveau des services de données, ce qui peut inclure la définition d'une vision et d'une orientation, la direction de la mise en œuvre et des opérations et l'assurance de l'obtention des résultats.",
+          "localized": "Demonstrated ability at the executive level to lead data services initiatives, which may include setting vision and direction, directing implementation and operations, and ensuring delivery of results."
         },
         "keywords": {
           "en": ["Executive", "Leadership", "of", "data", "services"],
@@ -6288,11 +7062,13 @@
             "key": "executive_leadership",
             "name": {
               "en": "Leadership - Executive Technical Skills",
-              "fr": "Leadership - Compétences techniques des cadres"
+              "fr": "Leadership - Compétences techniques des cadres",
+              "localized": "Leadership - Executive Technical Skills"
             },
             "description": {
               "en": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation",
-              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX"
+              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX",
+              "localized": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation"
             }
           }
         ]
@@ -6302,11 +7078,13 @@
         "key": "executive_leadership_of_information_and_data_governance",
         "name": {
           "en": "Executive Leadership of information and data governance",
-          "fr": "Leadership exécutif de la gouvernance de l'information et des données"
+          "fr": "Leadership exécutif de la gouvernance de l'information et des données",
+          "localized": "Executive Leadership of information and data governance"
         },
         "description": {
           "en": "Demonstrated ability at the executive level to lead information and data governance initiatives, which may include setting vision and direction, directing implementation and operations, and ensuring delivery of results.",
-          "fr": "Capacité démontrée au niveau de la direction à diriger des initiatives de la gouvernance de l'information et des données, ce qui peut inclure la définition d'une vision et d'une orientation, la direction de la mise en œuvre et des opérations et l'assurance de l'obtention des résultats."
+          "fr": "Capacité démontrée au niveau de la direction à diriger des initiatives de la gouvernance de l'information et des données, ce qui peut inclure la définition d'une vision et d'une orientation, la direction de la mise en œuvre et des opérations et l'assurance de l'obtention des résultats.",
+          "localized": "Demonstrated ability at the executive level to lead information and data governance initiatives, which may include setting vision and direction, directing implementation and operations, and ensuring delivery of results."
         },
         "keywords": {
           "en": [
@@ -6338,11 +7116,13 @@
             "key": "executive_leadership",
             "name": {
               "en": "Leadership - Executive Technical Skills",
-              "fr": "Leadership - Compétences techniques des cadres"
+              "fr": "Leadership - Compétences techniques des cadres",
+              "localized": "Leadership - Executive Technical Skills"
             },
             "description": {
               "en": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation",
-              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX"
+              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX",
+              "localized": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation"
             }
           }
         ]
@@ -6352,11 +7132,13 @@
         "key": "executive_leadership_software_solutions",
         "name": {
           "en": "Executive Leadership of Software Solutions",
-          "fr": "Leadership exécutif des solutions logicielles"
+          "fr": "Leadership exécutif des solutions logicielles",
+          "localized": "Executive Leadership of Software Solutions"
         },
         "description": {
           "en": "Demonstrated ability at the executive level to lead Software Solutions initiatives, which may include setting vision and direction, directing implementation and operations, and ensuring delivery of results",
-          "fr": "Capacité démontrée au niveau de la direction à diriger des initiatives de solutions logicielles, ce qui peut inclure la définition d'une vision et d'une orientation, la direction de la mise en œuvre et des opérations et la garantie de l'obtention des résultats."
+          "fr": "Capacité démontrée au niveau de la direction à diriger des initiatives de solutions logicielles, ce qui peut inclure la définition d'une vision et d'une orientation, la direction de la mise en œuvre et des opérations et la garantie de l'obtention des résultats.",
+          "localized": "Demonstrated ability at the executive level to lead Software Solutions initiatives, which may include setting vision and direction, directing implementation and operations, and ensuring delivery of results"
         },
         "keywords": {
           "en": ["Executive", "Leadership"],
@@ -6371,11 +7153,13 @@
             "key": "executive_leadership",
             "name": {
               "en": "Leadership - Executive Technical Skills",
-              "fr": "Leadership - Compétences techniques des cadres"
+              "fr": "Leadership - Compétences techniques des cadres",
+              "localized": "Leadership - Executive Technical Skills"
             },
             "description": {
               "en": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation",
-              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX"
+              "fr": "Compétences techniques requises pour le leadership exécutif pour les rôles numériques, conçues pour soutenir la création d’affiches EX",
+              "localized": "Technical skills required for executive leadership for digital roles, designed to support EX poster creation"
             }
           }
         ]
@@ -6385,11 +7169,13 @@
         "key": "figma",
         "name": {
           "en": "Figma",
-          "fr": "Figma"
+          "fr": "Figma",
+          "localized": "Figma"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this tool to develop a variety of products.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de cet outil pour développer une variété de produits."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de cet outil pour développer une variété de produits.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this tool to develop a variety of products."
         },
         "keywords": {
           "en": null,
@@ -6404,11 +7190,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -6418,11 +7206,13 @@
         "key": "flexibility",
         "name": {
           "en": "Flexibility",
-          "fr": "Flexibilité"
+          "fr": "Flexibilité",
+          "localized": "Flexibility"
         },
         "description": {
           "en": "Demonstrated willingness to try a different approach or method when current efforts are not working or when circumstances require a shift in thinking.",
-          "fr": "Volonté démontrée d’essayer une approche ou une méthode différente lorsque les efforts actuels ne fonctionnent pas ou lorsque les circonstances exigent un changement de mentalité."
+          "fr": "Volonté démontrée d’essayer une approche ou une méthode différente lorsque les efforts actuels ne fonctionnent pas ou lorsque les circonstances exigent un changement de mentalité.",
+          "localized": "Demonstrated willingness to try a different approach or method when current efforts are not working or when circumstances require a shift in thinking."
         },
         "keywords": {
           "en": ["Resilience", "Adaptability", "Versatility"],
@@ -6437,11 +7227,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -6451,11 +7243,13 @@
         "key": "front_end_development",
         "name": {
           "en": "Front-end Development",
-          "fr": "Développement frontal"
+          "fr": "Développement frontal",
+          "localized": "Front-end Development"
         },
         "description": {
           "en": "Demonstrated ability to build client-side functionalities of web applications. This includes using programming languages such as HTML, CSS, React, or JavaScript to build the user interface and visual elements of applications.",
-          "fr": "Capacité démontrée à créer des fonctionnalités côté client pour les applications Web. Il s’agit notamment d’utiliser des langages de programmation tels que HTML, CSS, React ou JavaScript pour bâtir l’interface utilisateur et les éléments visuels des applications."
+          "fr": "Capacité démontrée à créer des fonctionnalités côté client pour les applications Web. Il s’agit notamment d’utiliser des langages de programmation tels que HTML, CSS, React ou JavaScript pour bâtir l’interface utilisateur et les éléments visuels des applications.",
+          "localized": "Demonstrated ability to build client-side functionalities of web applications. This includes using programming languages such as HTML, CSS, React, or JavaScript to build the user interface and visual elements of applications."
         },
         "keywords": {
           "en": null,
@@ -6470,11 +7264,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           },
           {
@@ -6482,11 +7278,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -6496,11 +7294,13 @@
         "key": "fsharp_or_visual_basic",
         "name": {
           "en": "F# or Visual Basic",
-          "fr": "F# ou Visual Basic"
+          "fr": "F# ou Visual Basic",
+          "localized": "F# or Visual Basic"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this language to develop a variety of projects.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de cette langue pour développer une variété de projets."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de cette langue pour développer une variété de projets.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this language to develop a variety of projects."
         },
         "keywords": {
           "en": null,
@@ -6515,11 +7315,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -6529,11 +7331,13 @@
         "key": "full_stack_development",
         "name": {
           "en": "Full Stack development",
-          "fr": "Développement pile complète"
+          "fr": "Développement pile complète",
+          "localized": "Full Stack development"
         },
         "description": {
           "en": "Demonstrated ability to develop, deploy and maintain end-to-end applications, including both front-end user interfaces and back-end server logic. This includes front-end technologies such as HTML, CSS, and JavaScript and back-end technologies such as databases, server-side languages, and APIs.",
-          "fr": "Capacité démontrée à développer, déployer et maintenir des applications de bout en bout, y compris les interfaces utilisateur-ordinateur frontales et la logique de serveur dorsal. Cela comprend les technologies frontales telles que HTML, CSS et JavaScript et les technologies dorsales telles que les bases de données, les langages côté serveur et les API."
+          "fr": "Capacité démontrée à développer, déployer et maintenir des applications de bout en bout, y compris les interfaces utilisateur-ordinateur frontales et la logique de serveur dorsal. Cela comprend les technologies frontales telles que HTML, CSS et JavaScript et les technologies dorsales telles que les bases de données, les langages côté serveur et les API.",
+          "localized": "Demonstrated ability to develop, deploy and maintain end-to-end applications, including both front-end user interfaces and back-end server logic. This includes front-end technologies such as HTML, CSS, and JavaScript and back-end technologies such as databases, server-side languages, and APIs."
         },
         "keywords": {
           "en": ["Full", "Stack", "development"],
@@ -6548,11 +7352,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -6562,11 +7368,13 @@
         "key": "functional_testing",
         "name": {
           "en": "Functional Testing",
-          "fr": "Tests fonctionnels"
+          "fr": "Tests fonctionnels",
+          "localized": "Functional Testing"
         },
         "description": {
           "en": "Demonstrated ability to assess the functionality of applications to see if they meet specified requirements.",
-          "fr": "Capacité démontrée d’évaluer la fonctionnalité des applications pour voir si elles répondent à des exigences spécifiées."
+          "fr": "Capacité démontrée d’évaluer la fonctionnalité des applications pour voir si elles répondent à des exigences spécifiées.",
+          "localized": "Demonstrated ability to assess the functionality of applications to see if they meet specified requirements."
         },
         "keywords": {
           "en": null,
@@ -6581,11 +7389,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           },
           {
@@ -6593,11 +7403,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           },
           {
@@ -6605,11 +7417,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -6619,11 +7433,13 @@
         "key": "gbaplus",
         "name": {
           "en": "GBA+",
-          "fr": "GBA+"
+          "fr": "GBA+",
+          "localized": "GBA+"
         },
         "description": {
           "en": "Demonstrated knowledge of approaches for advancing equality in Canada, including the ability to use gender theory, antiracism, and intersectional analysis to identify systemic inequalities in policies, programs, and initiatives.",
-          "fr": "Connaissance avérée des approches visant à faire progresser l’égalité au Canada, y compris la capacité d’utiliser la théorie du genre, l’antiracisme et l’analyse intersectionnelle pour identifier les inégalités systémiques dans les politiques, les programmes et les initiatives."
+          "fr": "Connaissance avérée des approches visant à faire progresser l’égalité au Canada, y compris la capacité d’utiliser la théorie du genre, l’antiracisme et l’analyse intersectionnelle pour identifier les inégalités systémiques dans les politiques, les programmes et les initiatives.",
+          "localized": "Demonstrated knowledge of approaches for advancing equality in Canada, including the ability to use gender theory, antiracism, and intersectional analysis to identify systemic inequalities in policies, programs, and initiatives."
         },
         "keywords": {
           "en": ["Gender Equality", "Gender Analysis"],
@@ -6638,11 +7454,13 @@
             "key": "working_in_government",
             "name": {
               "en": "Working in Government",
-              "fr": "Travailler au sein du gouvernement"
+              "fr": "Travailler au sein du gouvernement",
+              "localized": "Working in Government"
             },
             "description": {
               "en": "Technical skills family - Working in Government",
-              "fr": "Groupe de compétences techniques - Travailler au sein du gouvernement"
+              "fr": "Groupe de compétences techniques - Travailler au sein du gouvernement",
+              "localized": "Technical skills family - Working in Government"
             }
           }
         ]
@@ -6652,11 +7470,13 @@
         "key": "general_communication",
         "name": {
           "en": "General Communication",
-          "fr": "Communication générale"
+          "fr": "Communication générale",
+          "localized": "General Communication"
         },
         "description": {
           "en": "Demonstrated ability to receive, understand, develop, and share information in a clear, logical, respectful manner through verbal, visual and written interactions with others.",
-          "fr": "Capacité démontrée de recevoir, de comprendre, d’élaborer et de partager de l’information de manière claire, logique et respectueuse par le biais d’interactions verbales, visuelles et écrites avec les autres."
+          "fr": "Capacité démontrée de recevoir, de comprendre, d’élaborer et de partager de l’information de manière claire, logique et respectueuse par le biais d’interactions verbales, visuelles et écrites avec les autres.",
+          "localized": "Demonstrated ability to receive, understand, develop, and share information in a clear, logical, respectful manner through verbal, visual and written interactions with others."
         },
         "keywords": {
           "en": [
@@ -6683,11 +7503,13 @@
             "key": "communication",
             "name": {
               "en": "Communication Skills",
-              "fr": "Compétences en communication"
+              "fr": "Compétences en communication",
+              "localized": "Communication Skills"
             },
             "description": {
               "en": "Behavioural - Communication",
-              "fr": "Comportemental - Communication"
+              "fr": "Comportemental - Communication",
+              "localized": "Behavioural - Communication"
             }
           }
         ]
@@ -6697,11 +7519,13 @@
         "key": "geographic_information_system_product_suites",
         "name": {
           "en": "Geographic Information System (GIS) product suites",
-          "fr": "Suites de produits de Système d'Information Géographique (SIG)"
+          "fr": "Suites de produits de Système d'Information Géographique (SIG)",
+          "localized": "Geographic Information System (GIS) product suites"
         },
         "description": {
           "en": "Demonstrated ability to use a collection of software tools and applications designed to support spatial data management analysis, visualization, and decision making. This may include products such as ArcGUIS Online, ArcGIS Pro, ArcGIS Enterprise, IGiS Enterprise Suite, QGIS, GRASS GIS and related.",
-          "fr": "Capacité démontrée à utiliser une collection d'outils logiciels et d'applications conçus pour soutenir la gestion des données spatiales, l'analyse, la visualisation et la prise de décision. Cela peut inclure des produits tels que ArcGIS Online, ArcGIS Pro, ArcGIS Enterprise, IGiS Enterprise Suite, QGIS, GRASS GIS et apparentés."
+          "fr": "Capacité démontrée à utiliser une collection d'outils logiciels et d'applications conçus pour soutenir la gestion des données spatiales, l'analyse, la visualisation et la prise de décision. Cela peut inclure des produits tels que ArcGIS Online, ArcGIS Pro, ArcGIS Enterprise, IGiS Enterprise Suite, QGIS, GRASS GIS et apparentés.",
+          "localized": "Demonstrated ability to use a collection of software tools and applications designed to support spatial data management analysis, visualization, and decision making. This may include products such as ArcGUIS Online, ArcGIS Pro, ArcGIS Enterprise, IGiS Enterprise Suite, QGIS, GRASS GIS and related."
         },
         "keywords": {
           "en": ["GIS"],
@@ -6716,11 +7540,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -6730,11 +7556,13 @@
         "key": "geomatics",
         "name": {
           "en": "Geomatics",
-          "fr": "Géomatique"
+          "fr": "Géomatique",
+          "localized": "Geomatics"
         },
         "description": {
           "en": "Demonstrated ability to apply Geomatics principles and techniques in acquiring, managing, analyzing, and interpreting spatial data for diverse applications. This may include utilizing tools such as Geographic Information System (GIS), remote sensing, Global navigation satellite system (GNSS), surveying, and cartography.",
-          "fr": "Capacité démontrée à appliquer les principes et techniques de la géomatique dans l'acquisition, la gestion, l'analyse et l'interprétation des données spatiales pour diverses applications. Cela peut inclure l'utilisation d'outils tels que les Systèmes d'Information Géographique (SIG), la télédétection, les systèmes de navigation par satellite (GNSS), la topographie et la cartographie."
+          "fr": "Capacité démontrée à appliquer les principes et techniques de la géomatique dans l'acquisition, la gestion, l'analyse et l'interprétation des données spatiales pour diverses applications. Cela peut inclure l'utilisation d'outils tels que les Systèmes d'Information Géographique (SIG), la télédétection, les systèmes de navigation par satellite (GNSS), la topographie et la cartographie.",
+          "localized": "Demonstrated ability to apply Geomatics principles and techniques in acquiring, managing, analyzing, and interpreting spatial data for diverse applications. This may include utilizing tools such as Geographic Information System (GIS), remote sensing, Global navigation satellite system (GNSS), surveying, and cartography."
         },
         "keywords": {
           "en": ["Geomatics"],
@@ -6749,11 +7577,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -6763,11 +7593,13 @@
         "key": "gis_development",
         "name": {
           "en": "Geographic Information System (GIS) development",
-          "fr": "Développement de Système d'Information Géographique (SIG)"
+          "fr": "Développement de Système d'Information Géographique (SIG)",
+          "localized": "Geographic Information System (GIS) development"
         },
         "description": {
           "en": "Demonstrated ability to develop and implement Geographic Information Systems (GIS) solutions, including data collection, spatial analysis, and visualization, for various applications.",
-          "fr": "Capacité démontrée à développer et mettre en œuvre des solutions de Systèmes d'Information Géographique (SIG), incluant la collecte de données, l'analyse spatiale et la visualisation, pour diverses applications."
+          "fr": "Capacité démontrée à développer et mettre en œuvre des solutions de Systèmes d'Information Géographique (SIG), incluant la collecte de données, l'analyse spatiale et la visualisation, pour diverses applications.",
+          "localized": "Demonstrated ability to develop and implement Geographic Information Systems (GIS) solutions, including data collection, spatial analysis, and visualization, for various applications."
         },
         "keywords": {
           "en": ["GIS", "development"],
@@ -6782,11 +7614,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           }
         ]
@@ -6796,11 +7630,13 @@
         "key": "gis_portal",
         "name": {
           "en": "Geographic Information System Portal (GIS Portal)",
-          "fr": "Un portail Système d'Information Géographique (un portal SIG)"
+          "fr": "Un portail Système d'Information Géographique (un portal SIG)",
+          "localized": "Geographic Information System Portal (GIS Portal)"
         },
         "description": {
           "en": "Demonstrated ability to develop, configure, and manage a web-based platform to provide access to  geospatial data, tools, and services for visualization, analysis, and decision-making purposes.",
-          "fr": "Capacité démontrée à développer, configurer et gérer des portails SIG, facilitant l'accès aux données géospatiales, aux outils et aux services pour la visualisation, l'analyse et la prise de décision."
+          "fr": "Capacité démontrée à développer, configurer et gérer des portails SIG, facilitant l'accès aux données géospatiales, aux outils et aux services pour la visualisation, l'analyse et la prise de décision.",
+          "localized": "Demonstrated ability to develop, configure, and manage a web-based platform to provide access to  geospatial data, tools, and services for visualization, analysis, and decision-making purposes."
         },
         "keywords": {
           "en": ["GIS", "Portal"],
@@ -6815,11 +7651,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -6829,11 +7667,13 @@
         "key": "git",
         "name": {
           "en": "Git",
-          "fr": "Git"
+          "fr": "Git",
+          "localized": "Git"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this tool to manage repositories.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de cet outil pour gérer des référentiels."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de cet outil pour gérer des référentiels.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this tool to manage repositories."
         },
         "keywords": {
           "en": null,
@@ -6848,11 +7688,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -6862,11 +7704,13 @@
         "key": "government_and_department_policies_and_standards",
         "name": {
           "en": "Government and Department Policies and Standards",
-          "fr": "Politiques et normes du gouvernement et des ministères"
+          "fr": "Politiques et normes du gouvernement et des ministères",
+          "localized": "Government and Department Policies and Standards"
         },
         "description": {
           "en": "Demonstrated knowledge of and experience developing government or departmental policies, procedures, or guidelines.",
-          "fr": "Connaissance et expérience démontrées de l’élaboration de politiques, de procédures ou de lignes directrices gouvernementales ou ministérielles."
+          "fr": "Connaissance et expérience démontrées de l’élaboration de politiques, de procédures ou de lignes directrices gouvernementales ou ministérielles.",
+          "localized": "Demonstrated knowledge of and experience developing government or departmental policies, procedures, or guidelines."
         },
         "keywords": {
           "en": null,
@@ -6881,11 +7725,13 @@
             "key": "it_management",
             "name": {
               "en": "Digital Project Portfolio Management",
-              "fr": "Gestion de portefeuille de projets numériques"
+              "fr": "Gestion de portefeuille de projets numériques",
+              "localized": "Digital Project Portfolio Management"
             },
             "description": {
               "en": "IT generic work stream - Digital project portfolio management",
-              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques"
+              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques",
+              "localized": "IT generic work stream - Digital project portfolio management"
             }
           },
           {
@@ -6893,11 +7739,13 @@
             "key": "working_in_government",
             "name": {
               "en": "Working in Government",
-              "fr": "Travailler au sein du gouvernement"
+              "fr": "Travailler au sein du gouvernement",
+              "localized": "Working in Government"
             },
             "description": {
               "en": "Technical skills family - Working in Government",
-              "fr": "Groupe de compétences techniques - Travailler au sein du gouvernement"
+              "fr": "Groupe de compétences techniques - Travailler au sein du gouvernement",
+              "localized": "Technical skills family - Working in Government"
             }
           }
         ]
@@ -6907,11 +7755,13 @@
         "key": "government_of_canada_it_policies_and_standards",
         "name": {
           "en": "Government of Canada IT Policies and Standards",
-          "fr": "Politiques et normes du gouvernement du Canada en matière de TI"
+          "fr": "Politiques et normes du gouvernement du Canada en matière de TI",
+          "localized": "Government of Canada IT Policies and Standards"
         },
         "description": {
           "en": "Demonstrated knowledge of Government of Canada requirements related to the successful and secure operation of government IT systems and services to Canadians. This includes the ability to apply knowledge of IT policies and standards to live operations.",
-          "fr": "Connaissance démontrée des exigences du gouvernement du Canada liées au fonctionnement réussi et sécurisé des systèmes et services informatiques gouvernementaux destinés aux Canadiens. Cela inclut la capacité d'appliquer la connaissance des politiques et des normes informatiques aux opérations en direct."
+          "fr": "Connaissance démontrée des exigences du gouvernement du Canada liées au fonctionnement réussi et sécurisé des systèmes et services informatiques gouvernementaux destinés aux Canadiens. Cela inclut la capacité d'appliquer la connaissance des politiques et des normes informatiques aux opérations en direct.",
+          "localized": "Demonstrated knowledge of Government of Canada requirements related to the successful and secure operation of government IT systems and services to Canadians. This includes the ability to apply knowledge of IT policies and standards to live operations."
         },
         "keywords": {
           "en": null,
@@ -6926,11 +7776,13 @@
             "key": "infrastructure_operations",
             "name": {
               "en": "IT Infrastructure Operations",
-              "fr": "Opérations d'infrastructure informatique"
+              "fr": "Opérations d'infrastructure informatique",
+              "localized": "IT Infrastructure Operations"
             },
             "description": {
               "en": "IT generic work stream - Infrastructure Operations",
-              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique"
+              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique",
+              "localized": "IT generic work stream - Infrastructure Operations"
             }
           },
           {
@@ -6938,11 +7790,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           },
           {
@@ -6950,11 +7804,13 @@
             "key": "it_project_management",
             "name": {
               "en": "Digital Business Line Advisory Services",
-              "fr": "Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Services consultatifs auprès des secteurs de la numérique",
+              "localized": "Digital Business Line Advisory Services"
             },
             "description": {
               "en": "IT generic work stream - Business Line Advisory Services",
-              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique",
+              "localized": "IT generic work stream - Business Line Advisory Services"
             }
           },
           {
@@ -6962,11 +7818,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           },
           {
@@ -6974,11 +7832,13 @@
             "key": "technical_advising",
             "name": {
               "en": "IT Planning and Reporting",
-              "fr": "Planification et établissement de rapports en matière de la numérique"
+              "fr": "Planification et établissement de rapports en matière de la numérique",
+              "localized": "IT Planning and Reporting"
             },
             "description": {
               "en": "IT generic work stream - IT Planning and Reporting",
-              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique"
+              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique",
+              "localized": "IT generic work stream - IT Planning and Reporting"
             }
           }
         ]
@@ -6988,11 +7848,13 @@
         "key": "government_of_canada_reporting_cycles",
         "name": {
           "en": "Supporting Government of Canada Reporting Cycles",
-          "fr": "Soutenir les cycles de reporting du gouvernement du Canada"
+          "fr": "Soutenir les cycles de reporting du gouvernement du Canada",
+          "localized": "Supporting Government of Canada Reporting Cycles"
         },
         "description": {
           "en": "Demonstrated ability to support or lead activities and process related to Government of Canada reporting cycles, including reporting, tracking, and measurement of results.",
-          "fr": "Capacité démontrée à soutenir ou à diriger des activités et des processus liés aux cycles de reporting du gouvernement du Canada, y compris la production de rapports, le suivi et la mesure des résultats."
+          "fr": "Capacité démontrée à soutenir ou à diriger des activités et des processus liés aux cycles de reporting du gouvernement du Canada, y compris la production de rapports, le suivi et la mesure des résultats.",
+          "localized": "Demonstrated ability to support or lead activities and process related to Government of Canada reporting cycles, including reporting, tracking, and measurement of results."
         },
         "keywords": {
           "en": ["government", "reporting", "cycle."],
@@ -7007,11 +7869,13 @@
             "key": "working_in_government",
             "name": {
               "en": "Working in Government",
-              "fr": "Travailler au sein du gouvernement"
+              "fr": "Travailler au sein du gouvernement",
+              "localized": "Working in Government"
             },
             "description": {
               "en": "Technical skills family - Working in Government",
-              "fr": "Groupe de compétences techniques - Travailler au sein du gouvernement"
+              "fr": "Groupe de compétences techniques - Travailler au sein du gouvernement",
+              "localized": "Technical skills family - Working in Government"
             }
           }
         ]
@@ -7021,11 +7885,13 @@
         "key": "graph_ql",
         "name": {
           "en": "GraphQL",
-          "fr": "GraphQL"
+          "fr": "GraphQL",
+          "localized": "GraphQL"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this query language to work with data, including knowledge of best practices when working with APIs.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce langage de requête pour travailler avec des données, y compris la connaissance des meilleures pratiques lors de l’utilisation d’API."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce langage de requête pour travailler avec des données, y compris la connaissance des meilleures pratiques lors de l’utilisation d’API.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this query language to work with data, including knowledge of best practices when working with APIs."
         },
         "keywords": {
           "en": ["Programming language", "GraphQL."],
@@ -7040,11 +7906,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -7054,11 +7922,13 @@
         "key": "graphic_design",
         "name": {
           "en": "Graphic Design for Digital Products",
-          "fr": "Conception graphique"
+          "fr": "Conception graphique",
+          "localized": "Graphic Design for Digital Products"
         },
         "description": {
           "en": "Demonstrated ability to create visual content and brands for websites and applications, communicating key messages that enhance existing language and features. This includes the ability to create original content and modify existing elements (with an understanding of copyright and open source practices).",
-          "fr": "Capacité démontrée à créer du contenu visuel et des marques pour des sites Web et des applications, en communiquant des messages clés qui améliorent le langage et les fonctionnalités existants. Cela inclut la capacité de créer du contenu original et de modifier des éléments existants (avec une compréhension des pratiques de rédaction et d'open source)."
+          "fr": "Capacité démontrée à créer du contenu visuel et des marques pour des sites Web et des applications, en communiquant des messages clés qui améliorent le langage et les fonctionnalités existants. Cela inclut la capacité de créer du contenu original et de modifier des éléments existants (avec une compréhension des pratiques de rédaction et d'open source).",
+          "localized": "Demonstrated ability to create visual content and brands for websites and applications, communicating key messages that enhance existing language and features. This includes the ability to create original content and modify existing elements (with an understanding of copyright and open source practices)."
         },
         "keywords": {
           "en": null,
@@ -7073,11 +7943,13 @@
             "key": "user_experience_and_interface_design",
             "name": {
               "en": "Software Solutions - Product Design",
-              "fr": "Solutions logicielles - Conception de produits"
+              "fr": "Solutions logicielles - Conception de produits",
+              "localized": "Software Solutions - Product Design"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur",
+              "localized": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design"
             }
           }
         ]
@@ -7087,11 +7959,13 @@
         "key": "handling_personal_information_sharing_agreements",
         "name": {
           "en": "Handling of Personal Information Sharing Agreements",
-          "fr": "Traitement des accords de partage d’informations personnelles"
+          "fr": "Traitement des accords de partage d’informations personnelles",
+          "localized": "Handling of Personal Information Sharing Agreements"
         },
         "description": {
           "en": "Demonstrated ability to work on information sharing agreements involving personal information, including facilitating the legal and ethical exchange of personal data while ensuring privacy compliance and data security.",
-          "fr": "Capacité démontrée à travailler sur des accords de partage d'informations impliquant des informations personnelles, notamment en facilitant l'échange légal et éthique de données personnelles tout en garantissant le respect de la confidentialité et la sécurité des données."
+          "fr": "Capacité démontrée à travailler sur des accords de partage d'informations impliquant des informations personnelles, notamment en facilitant l'échange légal et éthique de données personnelles tout en garantissant le respect de la confidentialité et la sécurité des données.",
+          "localized": "Demonstrated ability to work on information sharing agreements involving personal information, including facilitating the legal and ethical exchange of personal data while ensuring privacy compliance and data security."
         },
         "keywords": {
           "en": null,
@@ -7106,11 +7980,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           }
         ]
@@ -7120,11 +7996,13 @@
         "key": "html",
         "name": {
           "en": "HTML",
-          "fr": "HTML"
+          "fr": "HTML",
+          "localized": "HTML"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this markup language to develop a variety of web projects.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce langage de balisage pour développer une variété de projets Web."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce langage de balisage pour développer une variété de projets Web.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this markup language to develop a variety of web projects."
         },
         "keywords": {
           "en": null,
@@ -7139,11 +8017,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -7153,11 +8033,13 @@
         "key": "human_resources_administration",
         "name": {
           "en": "Human Resources Administration",
-          "fr": "Administration des ressources humaines"
+          "fr": "Administration des ressources humaines",
+          "localized": "Human Resources Administration"
         },
         "description": {
           "en": "Demonstrated ability to navigate and handle HR-related tasks, documentation and processes and familiarity with HR terminology.",
-          "fr": "Capacité démontrée à naviguer et à gérer les tâches, la documentation et les processus liés aux RH et connaissance de la terminologie des RH."
+          "fr": "Capacité démontrée à naviguer et à gérer les tâches, la documentation et les processus liés aux RH et connaissance de la terminologie des RH.",
+          "localized": "Demonstrated ability to navigate and handle HR-related tasks, documentation and processes and familiarity with HR terminology."
         },
         "keywords": {
           "en": null,
@@ -7172,11 +8054,13 @@
             "key": "management_competencies",
             "name": {
               "en": "Leadership - General Technical Skills",
-              "fr": "Leadership - Compétences techniques générales"
+              "fr": "Leadership - Compétences techniques générales",
+              "localized": "Leadership - General Technical Skills"
             },
             "description": {
               "en": "Management skills at the non-executive level for oversight of finances, human resources, initiatives, and accountabilities",
-              "fr": "Compétences en gestion au niveau non exécutif pour la surveillance des finances, des ressources humaines, des initiatives et des responsabilités"
+              "fr": "Compétences en gestion au niveau non exécutif pour la surveillance des finances, des ressources humaines, des initiatives et des responsabilités",
+              "localized": "Management skills at the non-executive level for oversight of finances, human resources, initiatives, and accountabilities"
             }
           }
         ]
@@ -7186,11 +8070,13 @@
         "key": "human_resources_management",
         "name": {
           "en": "Human Resources Management",
-          "fr": "Gestion des ressources humaines"
+          "fr": "Gestion des ressources humaines",
+          "localized": "Human Resources Management"
         },
         "description": {
           "en": "Demonstrated ability (at a non-executive level) to manage teams, contractors, and employees, including: assigning work, establishing performance objectives and indicators, developing resourcing plans, determining needs and approving training",
-          "fr": "Capacité démontrée (à un niveau non exécutif) à gérer des équipes, des sous-traitants et des employés, notamment : attribuer du travail, établir des objectifs et des indicateurs de performance, élaborer des plans de ressources, déterminer les besoins et approuver la formation"
+          "fr": "Capacité démontrée (à un niveau non exécutif) à gérer des équipes, des sous-traitants et des employés, notamment : attribuer du travail, établir des objectifs et des indicateurs de performance, élaborer des plans de ressources, déterminer les besoins et approuver la formation",
+          "localized": "Demonstrated ability (at a non-executive level) to manage teams, contractors, and employees, including: assigning work, establishing performance objectives and indicators, developing resourcing plans, determining needs and approving training"
         },
         "keywords": {
           "en": null,
@@ -7205,11 +8091,13 @@
             "key": "management_competencies",
             "name": {
               "en": "Leadership - General Technical Skills",
-              "fr": "Leadership - Compétences techniques générales"
+              "fr": "Leadership - Compétences techniques générales",
+              "localized": "Leadership - General Technical Skills"
             },
             "description": {
               "en": "Management skills at the non-executive level for oversight of finances, human resources, initiatives, and accountabilities",
-              "fr": "Compétences en gestion au niveau non exécutif pour la surveillance des finances, des ressources humaines, des initiatives et des responsabilités"
+              "fr": "Compétences en gestion au niveau non exécutif pour la surveillance des finances, des ressources humaines, des initiatives et des responsabilités",
+              "localized": "Management skills at the non-executive level for oversight of finances, human resources, initiatives, and accountabilities"
             }
           }
         ]
@@ -7219,11 +8107,13 @@
         "key": "human_resources_supervision",
         "name": {
           "en": "Human Resources Supervision",
-          "fr": "Supervision des ressources humaines"
+          "fr": "Supervision des ressources humaines",
+          "localized": "Human Resources Supervision"
         },
         "description": {
           "en": "Demonstrated ability to supervise employees or contractors, including working with management to set work plans, overseeing the completion of tasks, monitoring performance, supporting learning objectives, and mentoring",
-          "fr": "Capacité démontrée à superviser des employés ou des entrepreneurs, notamment en travaillant avec la direction pour établir des plans de travail, en supervisant l'exécution des tâches, en surveillant les performances, en soutenant les objectifs d'apprentissage et en faisant du mentorat"
+          "fr": "Capacité démontrée à superviser des employés ou des entrepreneurs, notamment en travaillant avec la direction pour établir des plans de travail, en supervisant l'exécution des tâches, en surveillant les performances, en soutenant les objectifs d'apprentissage et en faisant du mentorat",
+          "localized": "Demonstrated ability to supervise employees or contractors, including working with management to set work plans, overseeing the completion of tasks, monitoring performance, supporting learning objectives, and mentoring"
         },
         "keywords": {
           "en": null,
@@ -7238,11 +8128,13 @@
             "key": "management_competencies",
             "name": {
               "en": "Leadership - General Technical Skills",
-              "fr": "Leadership - Compétences techniques générales"
+              "fr": "Leadership - Compétences techniques générales",
+              "localized": "Leadership - General Technical Skills"
             },
             "description": {
               "en": "Management skills at the non-executive level for oversight of finances, human resources, initiatives, and accountabilities",
-              "fr": "Compétences en gestion au niveau non exécutif pour la surveillance des finances, des ressources humaines, des initiatives et des responsabilités"
+              "fr": "Compétences en gestion au niveau non exécutif pour la surveillance des finances, des ressources humaines, des initiatives et des responsabilités",
+              "localized": "Management skills at the non-executive level for oversight of finances, human resources, initiatives, and accountabilities"
             }
           }
         ]
@@ -7252,11 +8144,13 @@
         "key": "humility",
         "name": {
           "en": "Humility",
-          "fr": "Humilité"
+          "fr": "Humilité",
+          "localized": "Humility"
         },
         "description": {
           "en": "Demonstrated awareness of the true value one brings to a team, expressed with modesty and an appreciation for the strengths, skills and contributions of others.",
-          "fr": "Conscience démontrée de la véritable valeur que l’on apporte à une équipe, exprimée avec modestie et appréciation des forces, des compétences et des contributions des autres."
+          "fr": "Conscience démontrée de la véritable valeur que l’on apporte à une équipe, exprimée avec modestie et appréciation des forces, des compétences et des contributions des autres.",
+          "localized": "Demonstrated awareness of the true value one brings to a team, expressed with modesty and an appreciation for the strengths, skills and contributions of others."
         },
         "keywords": {
           "en": ["Humbleness", "Modesty", "Unpretentious"],
@@ -7271,11 +8165,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -7285,11 +8181,13 @@
         "key": "identity_credential_access_management",
         "name": {
           "en": "Identity, Credential and Access Management",
-          "fr": "Gestion des identités, des informations d'identification et des accès"
+          "fr": "Gestion des identités, des informations d'identification et des accès",
+          "localized": "Identity, Credential and Access Management"
         },
         "description": {
           "en": "Demonstrated ability to work with (and provide advice on) the establishment, management, and integration of digital identity, digital credentials and access management into digital products and services.  This includes demonstrating awareness of security considerations, user experience, enterprise direction and modern approaches to user flows. It also includes undertaking activities such as technical implementation and supporting the creation of architectures, requirements, frameworks, policies, and procedures.",
-          "fr": "Capacité démontrée à travailler (et à fournir des conseils sur) l'établissement, la gestion et l'intégration de l'identité numérique, des informations d'identification numériques et de la gestion des accès dans les produits et services numériques. Cela implique de démontrer une prise de conscience des considérations de sécurité, de l'expérience utilisateur, de l'orientation de l'entreprise et des approches modernes des flux d'utilisateurs. Cela comprend également la réalisation d'activités telles que la mise en œuvre technique et le soutien à la création d'architectures, d'exigences, de cadres, de politiques et de procédures."
+          "fr": "Capacité démontrée à travailler (et à fournir des conseils sur) l'établissement, la gestion et l'intégration de l'identité numérique, des informations d'identification numériques et de la gestion des accès dans les produits et services numériques. Cela implique de démontrer une prise de conscience des considérations de sécurité, de l'expérience utilisateur, de l'orientation de l'entreprise et des approches modernes des flux d'utilisateurs. Cela comprend également la réalisation d'activités telles que la mise en œuvre technique et le soutien à la création d'architectures, d'exigences, de cadres, de politiques et de procédures.",
+          "localized": "Demonstrated ability to work with (and provide advice on) the establishment, management, and integration of digital identity, digital credentials and access management into digital products and services.  This includes demonstrating awareness of security considerations, user experience, enterprise direction and modern approaches to user flows. It also includes undertaking activities such as technical implementation and supporting the creation of architectures, requirements, frameworks, policies, and procedures."
         },
         "keywords": {
           "en": null,
@@ -7304,11 +8202,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           },
           {
@@ -7316,11 +8216,13 @@
             "key": "infrastructure_operations",
             "name": {
               "en": "IT Infrastructure Operations",
-              "fr": "Opérations d'infrastructure informatique"
+              "fr": "Opérations d'infrastructure informatique",
+              "localized": "IT Infrastructure Operations"
             },
             "description": {
               "en": "IT generic work stream - Infrastructure Operations",
-              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique"
+              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique",
+              "localized": "IT generic work stream - Infrastructure Operations"
             }
           },
           {
@@ -7328,11 +8230,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           },
           {
@@ -7340,11 +8244,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -7354,11 +8260,13 @@
         "key": "identity_federation",
         "name": {
           "en": "Federation",
-          "fr": "Fédération"
+          "fr": "Fédération",
+          "localized": "Federation"
         },
         "description": {
           "en": "Demonstrated ability to provide expert advice and establish systems of identity and authentication in the context of networked systems, while respecting security considerations, localized environment constraints, and international best practices.",
-          "fr": "Capacité démontrée à fournir des conseils d'expert et à établir des systèmes d'identité et d'authentification dans le contexte de systèmes en réseau, tout en respectant les considérations de sécurité, les contraintes de l'environnement localisé et les meilleures pratiques internationales."
+          "fr": "Capacité démontrée à fournir des conseils d'expert et à établir des systèmes d'identité et d'authentification dans le contexte de systèmes en réseau, tout en respectant les considérations de sécurité, les contraintes de l'environnement localisé et les meilleures pratiques internationales.",
+          "localized": "Demonstrated ability to provide expert advice and establish systems of identity and authentication in the context of networked systems, while respecting security considerations, localized environment constraints, and international best practices."
         },
         "keywords": {
           "en": null,
@@ -7373,11 +8281,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           },
           {
@@ -7385,11 +8295,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           },
           {
@@ -7397,11 +8309,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -7411,11 +8325,13 @@
         "key": "im_document_handling",
         "name": {
           "en": "Information Management and Document Handling",
-          "fr": "Gestion de l’information et traitement des documents"
+          "fr": "Gestion de l’information et traitement des documents",
+          "localized": "Information Management and Document Handling"
         },
         "description": {
           "en": "Demonstrated ability to follow document handling and information management procedures in a professional environment as part of a service or business function.",
-          "fr": "Capacité manifeste à suivre les procédures de traitement des documents et de gestion de l’information dans un environnement professionnel, dans le contexte d’un service ou d’une fonction opérationnelle."
+          "fr": "Capacité manifeste à suivre les procédures de traitement des documents et de gestion de l’information dans un environnement professionnel, dans le contexte d’un service ou d’une fonction opérationnelle.",
+          "localized": "Demonstrated ability to follow document handling and information management procedures in a professional environment as part of a service or business function."
         },
         "keywords": {
           "en": null,
@@ -7430,11 +8346,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           }
         ]
@@ -7444,11 +8362,13 @@
         "key": "implementation_and_enforcement_of_policies",
         "name": {
           "en": "Implementation and Enforcement of Policies",
-          "fr": "Mise en œuvre et application des politiques"
+          "fr": "Mise en œuvre et application des politiques",
+          "localized": "Implementation and Enforcement of Policies"
         },
         "description": {
           "en": "",
-          "fr": ""
+          "fr": "",
+          "localized": ""
         },
         "keywords": {
           "en": [],
@@ -7463,11 +8383,13 @@
             "key": "it_management",
             "name": {
               "en": "Digital Project Portfolio Management",
-              "fr": "Gestion de portefeuille de projets numériques"
+              "fr": "Gestion de portefeuille de projets numériques",
+              "localized": "Digital Project Portfolio Management"
             },
             "description": {
               "en": "IT generic work stream - Digital project portfolio management",
-              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques"
+              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques",
+              "localized": "IT generic work stream - Digital project portfolio management"
             }
           }
         ]
@@ -7477,11 +8399,13 @@
         "key": "implementation_of_gc_digital_standards_in_operations",
         "name": {
           "en": "Implementation of GC Digital Standards in Operations",
-          "fr": "Mise en œuvre des normes relatives au numérique du GC dans les opérations"
+          "fr": "Mise en œuvre des normes relatives au numérique du GC dans les opérations",
+          "localized": "Implementation of GC Digital Standards in Operations"
         },
         "description": {
           "en": "Demonstrated ability to apply all of the Government of Canada Digital Standards (or an equivalent provincial or international standard) in IT operations, demonstrating a modern approach.",
-          "fr": "Capacité démontrée d’appliquer toutes les normes relatives au numérique du gouvernement du Canada (ou une norme provinciale ou internationale équivalente) dans les opérations de technologies de l’information, en démontrant une approche moderne."
+          "fr": "Capacité démontrée d’appliquer toutes les normes relatives au numérique du gouvernement du Canada (ou une norme provinciale ou internationale équivalente) dans les opérations de technologies de l’information, en démontrant une approche moderne.",
+          "localized": "Demonstrated ability to apply all of the Government of Canada Digital Standards (or an equivalent provincial or international standard) in IT operations, demonstrating a modern approach."
         },
         "keywords": {
           "en": ["Implementation", "Digital", "Standards", "Operations"],
@@ -7506,11 +8430,13 @@
             "key": "it_management",
             "name": {
               "en": "Digital Project Portfolio Management",
-              "fr": "Gestion de portefeuille de projets numériques"
+              "fr": "Gestion de portefeuille de projets numériques",
+              "localized": "Digital Project Portfolio Management"
             },
             "description": {
               "en": "IT generic work stream - Digital project portfolio management",
-              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques"
+              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques",
+              "localized": "IT generic work stream - Digital project portfolio management"
             }
           },
           {
@@ -7518,11 +8444,13 @@
             "key": "it_project_management",
             "name": {
               "en": "Digital Business Line Advisory Services",
-              "fr": "Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Services consultatifs auprès des secteurs de la numérique",
+              "localized": "Digital Business Line Advisory Services"
             },
             "description": {
               "en": "IT generic work stream - Business Line Advisory Services",
-              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique",
+              "localized": "IT generic work stream - Business Line Advisory Services"
             }
           }
         ]
@@ -7532,11 +8460,13 @@
         "key": "inclusive_mindset",
         "name": {
           "en": "Inclusive Mindset",
-          "fr": "Esprit d’inclusivité"
+          "fr": "Esprit d’inclusivité",
+          "localized": "Inclusive Mindset"
         },
         "description": {
           "en": "Demonstrated ability to involve others in activities, including being aware of and removing barriers so everyone can participate and contribute.",
-          "fr": "Capacité démontrée à faire participer les autres aux activités, notamment en étant conscient des obstacles et en les éliminant afin que tout le monde puisse participer et contribuer."
+          "fr": "Capacité démontrée à faire participer les autres aux activités, notamment en étant conscient des obstacles et en les éliminant afin que tout le monde puisse participer et contribuer.",
+          "localized": "Demonstrated ability to involve others in activities, including being aware of and removing barriers so everyone can participate and contribute."
         },
         "keywords": {
           "en": [
@@ -7559,11 +8489,13 @@
             "key": "interpersonal",
             "name": {
               "en": "Interpersonal Behaviours",
-              "fr": "Comportements interpersonnels"
+              "fr": "Comportements interpersonnels",
+              "localized": "Interpersonal Behaviours"
             },
             "description": {
               "en": "Behavioural - Interpersonal",
-              "fr": "Comportemental - Interpersonnel"
+              "fr": "Comportemental - Interpersonnel",
+              "localized": "Behavioural - Interpersonal"
             }
           },
           {
@@ -7571,11 +8503,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -7585,11 +8519,13 @@
         "key": "incremental_procedures_improvement",
         "name": {
           "en": "Incremental Procedures Improvement",
-          "fr": "Amélioration progressive des procédures"
+          "fr": "Amélioration progressive des procédures",
+          "localized": "Incremental Procedures Improvement"
         },
         "description": {
           "en": "Demonstrated resourcefulness to improve or update procedures, including seeking approval required for such changes and monitoring progress.",
-          "fr": "Capacité manifeste à améliorer ou à mettre à jour les procédures, y compris l’obtention des approbations nécessaires à de tels changements, et à en surveiller l’avancement."
+          "fr": "Capacité manifeste à améliorer ou à mettre à jour les procédures, y compris l’obtention des approbations nécessaires à de tels changements, et à en surveiller l’avancement.",
+          "localized": "Demonstrated resourcefulness to improve or update procedures, including seeking approval required for such changes and monitoring progress."
         },
         "keywords": {
           "en": null,
@@ -7604,11 +8540,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           }
         ]
@@ -7618,11 +8556,13 @@
         "key": "indigenous_cultural_competency",
         "name": {
           "en": "Indigenous Cultural Competency",
-          "fr": "Compétence culturelle autochtone"
+          "fr": "Compétence culturelle autochtone",
+          "localized": "Indigenous Cultural Competency"
         },
         "description": {
           "en": "Demonstrated commitment to fostering positive relationships with Indigenous peoples by looking inward to identify harmful beliefs and biases, and taking action to change them.",
-          "fr": "Engagement manifeste à favoriser des relations positives avec les peuples autochtones en faisant une introspection pour connaître les croyances et les préjugés nuisibles, et en prenant des mesures pour les changer."
+          "fr": "Engagement manifeste à favoriser des relations positives avec les peuples autochtones en faisant une introspection pour connaître les croyances et les préjugés nuisibles, et en prenant des mesures pour les changer.",
+          "localized": "Demonstrated commitment to fostering positive relationships with Indigenous peoples by looking inward to identify harmful beliefs and biases, and taking action to change them."
         },
         "keywords": {
           "en": ["Cultural Sensitivity", "Diversity"],
@@ -7637,11 +8577,13 @@
             "key": "working_in_government",
             "name": {
               "en": "Working in Government",
-              "fr": "Travailler au sein du gouvernement"
+              "fr": "Travailler au sein du gouvernement",
+              "localized": "Working in Government"
             },
             "description": {
               "en": "Technical skills family - Working in Government",
-              "fr": "Groupe de compétences techniques - Travailler au sein du gouvernement"
+              "fr": "Groupe de compétences techniques - Travailler au sein du gouvernement",
+              "localized": "Technical skills family - Working in Government"
             }
           }
         ]
@@ -7651,11 +8593,13 @@
         "key": "information_architecture_advice",
         "name": {
           "en": "Information Architecture Advice",
-          "fr": "Conseil en architecture de l'information"
+          "fr": "Conseil en architecture de l'information",
+          "localized": "Information Architecture Advice"
         },
         "description": {
           "en": "Demonstrated ability to provide guidance on the development and maintenance of information architecture artefacts.",
-          "fr": "Capacité démontrée à fournir des orientations sur le développement et la maintenance des artefacts de l'architecture de l'information."
+          "fr": "Capacité démontrée à fournir des orientations sur le développement et la maintenance des artefacts de l'architecture de l'information.",
+          "localized": "Demonstrated ability to provide guidance on the development and maintenance of information architecture artefacts."
         },
         "keywords": {
           "en": ["Information", "Architecture", "Advice."],
@@ -7670,11 +8614,13 @@
             "key": "im_data_governance_information_architecture",
             "name": {
               "en": "Information and Data Governance - Information Architecture",
-              "fr": "Gouvernance de l'information et des données - Architecture de l'information"
+              "fr": "Gouvernance de l'information et des données - Architecture de l'information",
+              "localized": "Information and Data Governance - Information Architecture"
             },
             "description": {
               "en": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes.",
-              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus."
+              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus.",
+              "localized": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes."
             }
           }
         ]
@@ -7684,11 +8630,13 @@
         "key": "information_architecture_advocacy",
         "name": {
           "en": "Information Architecture Advocacy",
-          "fr": "Appui à l'architecture de l'information"
+          "fr": "Appui à l'architecture de l'information",
+          "localized": "Information Architecture Advocacy"
         },
         "description": {
           "en": "Demonstrated ability to drive a culture that values information and data sharing and advocates good information architecture practices to enable seamless sharing and reuse of information.",
-          "fr": "Capacité démontrée à promouvoir une culture qui valorise le partage de l'information et des données et qui préconise de bonnes pratiques en matière d'architecture de l'information afin de permettre un partage et une réutilisation transparents de l'information."
+          "fr": "Capacité démontrée à promouvoir une culture qui valorise le partage de l'information et des données et qui préconise de bonnes pratiques en matière d'architecture de l'information afin de permettre un partage et une réutilisation transparents de l'information.",
+          "localized": "Demonstrated ability to drive a culture that values information and data sharing and advocates good information architecture practices to enable seamless sharing and reuse of information."
         },
         "keywords": {
           "en": ["Information", "Architecture", "Advocacy."],
@@ -7703,11 +8651,13 @@
             "key": "im_data_governance_information_architecture",
             "name": {
               "en": "Information and Data Governance - Information Architecture",
-              "fr": "Gouvernance de l'information et des données - Architecture de l'information"
+              "fr": "Gouvernance de l'information et des données - Architecture de l'information",
+              "localized": "Information and Data Governance - Information Architecture"
             },
             "description": {
               "en": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes.",
-              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus."
+              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus.",
+              "localized": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes."
             }
           }
         ]
@@ -7717,11 +8667,13 @@
         "key": "information_architecture_design",
         "name": {
           "en": "Information Architecture Design",
-          "fr": "Conception de l'architecture de l'information"
+          "fr": "Conception de l'architecture de l'information",
+          "localized": "Information Architecture Design"
         },
         "description": {
           "en": "Demonstrated ability to design and model information architecture artefacts including enterprise taxonomies, vocabularies, classification schemes, namespaces and ontologies.",
-          "fr": "Capacité démontrée à concevoir et à modéliser des artefacts d'architecture de l'information, y compris des taxonomies, des vocabulaires, des systèmes de classification, des espaces de noms et des ontologies d'entreprise."
+          "fr": "Capacité démontrée à concevoir et à modéliser des artefacts d'architecture de l'information, y compris des taxonomies, des vocabulaires, des systèmes de classification, des espaces de noms et des ontologies d'entreprise.",
+          "localized": "Demonstrated ability to design and model information architecture artefacts including enterprise taxonomies, vocabularies, classification schemes, namespaces and ontologies."
         },
         "keywords": {
           "en": ["Information", "Architecture", "Design."],
@@ -7736,11 +8688,13 @@
             "key": "im_data_governance_information_architecture",
             "name": {
               "en": "Information and Data Governance - Information Architecture",
-              "fr": "Gouvernance de l'information et des données - Architecture de l'information"
+              "fr": "Gouvernance de l'information et des données - Architecture de l'information",
+              "localized": "Information and Data Governance - Information Architecture"
             },
             "description": {
               "en": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes.",
-              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus."
+              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus.",
+              "localized": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes."
             }
           }
         ]
@@ -7750,11 +8704,13 @@
         "key": "information_architecture_implementation",
         "name": {
           "en": "Information Architecture Implementation",
-          "fr": "Mise en œuvre de l'architecture de l'information"
+          "fr": "Mise en œuvre de l'architecture de l'information",
+          "localized": "Information Architecture Implementation"
         },
         "description": {
           "en": "Demonstrated ability to apply information architecture conventions and best practices.",
-          "fr": "Habilité démontrée en matière d’application des conventions et des pratiques exemplaires en matière d’architecture de l’information."
+          "fr": "Habilité démontrée en matière d’application des conventions et des pratiques exemplaires en matière d’architecture de l’information.",
+          "localized": "Demonstrated ability to apply information architecture conventions and best practices."
         },
         "keywords": {
           "en": ["Information", "Architecture", "Implementation."],
@@ -7769,11 +8725,13 @@
             "key": "im_data_governance_information_architecture",
             "name": {
               "en": "Information and Data Governance - Information Architecture",
-              "fr": "Gouvernance de l'information et des données - Architecture de l'information"
+              "fr": "Gouvernance de l'information et des données - Architecture de l'information",
+              "localized": "Information and Data Governance - Information Architecture"
             },
             "description": {
               "en": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes.",
-              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus."
+              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus.",
+              "localized": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes."
             }
           }
         ]
@@ -7783,11 +8741,13 @@
         "key": "information_architecture_leadership",
         "name": {
           "en": "Information Architecture Leadership",
-          "fr": "Leadership en matière d'architecture de l'information"
+          "fr": "Leadership en matière d'architecture de l'information",
+          "localized": "Information Architecture Leadership"
         },
         "description": {
           "en": "Demonstrated ability to lead information architecture initiatives, and understands how they relate to other enterprise architectural domains.",
-          "fr": "Capacité démontrée à diriger des initiatives en matière d'architecture de l'information et à comprendre leurs liens avec d'autres domaines architecturaux de l'entreprise."
+          "fr": "Capacité démontrée à diriger des initiatives en matière d'architecture de l'information et à comprendre leurs liens avec d'autres domaines architecturaux de l'entreprise.",
+          "localized": "Demonstrated ability to lead information architecture initiatives, and understands how they relate to other enterprise architectural domains."
         },
         "keywords": {
           "en": ["Information", "Architecture", "Leadership."],
@@ -7802,11 +8762,13 @@
             "key": "im_data_governance_information_architecture",
             "name": {
               "en": "Information and Data Governance - Information Architecture",
-              "fr": "Gouvernance de l'information et des données - Architecture de l'information"
+              "fr": "Gouvernance de l'information et des données - Architecture de l'information",
+              "localized": "Information and Data Governance - Information Architecture"
             },
             "description": {
               "en": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes.",
-              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus."
+              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus.",
+              "localized": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes."
             }
           }
         ]
@@ -7816,11 +8778,13 @@
         "key": "information_architecture_maintenance",
         "name": {
           "en": "Information Architecture Maintenance",
-          "fr": "Maintenance de l'architecture de l'information"
+          "fr": "Maintenance de l'architecture de l'information",
+          "localized": "Information Architecture Maintenance"
         },
         "description": {
           "en": "Demonstrated ability to use and maintain information architecture artefacts including enterprise taxonomies, vocabularies, classification schemes, namespaces and ontologies.",
-          "fr": "Capacité démontrée à utiliser et à maintenir des artefacts d'architecture de l'information, notamment des taxonomies, des vocabulaires, des systèmes de classification, des espaces de noms et des ontologies d'entreprise."
+          "fr": "Capacité démontrée à utiliser et à maintenir des artefacts d'architecture de l'information, notamment des taxonomies, des vocabulaires, des systèmes de classification, des espaces de noms et des ontologies d'entreprise.",
+          "localized": "Demonstrated ability to use and maintain information architecture artefacts including enterprise taxonomies, vocabularies, classification schemes, namespaces and ontologies."
         },
         "keywords": {
           "en": ["Information", "Architecture", "Maintenance."],
@@ -7835,11 +8799,13 @@
             "key": "im_data_governance_information_architecture",
             "name": {
               "en": "Information and Data Governance - Information Architecture",
-              "fr": "Gouvernance de l'information et des données - Architecture de l'information"
+              "fr": "Gouvernance de l'information et des données - Architecture de l'information",
+              "localized": "Information and Data Governance - Information Architecture"
             },
             "description": {
               "en": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes.",
-              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus."
+              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus.",
+              "localized": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes."
             }
           }
         ]
@@ -7849,11 +8815,13 @@
         "key": "information_life_cycle",
         "name": {
           "en": "Information Life Cycle",
-          "fr": "Cycle de vie de l’information"
+          "fr": "Cycle de vie de l’information",
+          "localized": "Information Life Cycle"
         },
         "description": {
           "en": "Demonstrated understanding of the stages data passes through from its creation to destruction.",
-          "fr": "Compréhension démontrée des étapes par lesquelles passent les données, de leur création à leur destruction."
+          "fr": "Compréhension démontrée des étapes par lesquelles passent les données, de leur création à leur destruction.",
+          "localized": "Demonstrated understanding of the stages data passes through from its creation to destruction."
         },
         "keywords": {
           "en": null,
@@ -7868,11 +8836,13 @@
             "key": "information_management",
             "name": {
               "en": "Information and Data Governance - Operations",
-              "fr": "Gouvernance de l'information et des données - Opérations"
+              "fr": "Gouvernance de l'information et des données - Opérations",
+              "localized": "Information and Data Governance - Operations"
             },
             "description": {
               "en": "IM-Operations involves overseeing the efficient and effective application of life-cycle management practices for records and documents within information management systems, serving business and legal purposes.",
-              "fr": "Les opérations de GI consistent à superviser l'application efficiente et efficace des pratiques de gestion du cycle de vie des dossiers et des documents au sein des systèmes de gestion de l'information, à des fins commerciales et juridiques."
+              "fr": "Les opérations de GI consistent à superviser l'application efficiente et efficace des pratiques de gestion du cycle de vie des dossiers et des documents au sein des systèmes de gestion de l'information, à des fins commerciales et juridiques.",
+              "localized": "IM-Operations involves overseeing the efficient and effective application of life-cycle management practices for records and documents within information management systems, serving business and legal purposes."
             }
           }
         ]
@@ -7882,11 +8852,13 @@
         "key": "information_privacy_laws",
         "name": {
           "en": "Information Privacy Laws",
-          "fr": "Lois sur la confidentialité des informations"
+          "fr": "Lois sur la confidentialité des informations",
+          "localized": "Information Privacy Laws"
         },
         "description": {
           "en": "Demonstrated ability to interpret and apply privacy regulations, safeguard personal data, and ensure compliance with relevant laws.",
-          "fr": "Capacité manifeste à interpréter et à appliquer des règlements sur la protection des renseignements personnels, à protéger des données personnelles et à assurer le respect des lois pertinentes."
+          "fr": "Capacité manifeste à interpréter et à appliquer des règlements sur la protection des renseignements personnels, à protéger des données personnelles et à assurer le respect des lois pertinentes.",
+          "localized": "Demonstrated ability to interpret and apply privacy regulations, safeguard personal data, and ensure compliance with relevant laws."
         },
         "keywords": {
           "en": ["Information", "Privacy", "Laws"],
@@ -7901,11 +8873,13 @@
             "key": "information_management",
             "name": {
               "en": "Information and Data Governance - Operations",
-              "fr": "Gouvernance de l'information et des données - Opérations"
+              "fr": "Gouvernance de l'information et des données - Opérations",
+              "localized": "Information and Data Governance - Operations"
             },
             "description": {
               "en": "IM-Operations involves overseeing the efficient and effective application of life-cycle management practices for records and documents within information management systems, serving business and legal purposes.",
-              "fr": "Les opérations de GI consistent à superviser l'application efficiente et efficace des pratiques de gestion du cycle de vie des dossiers et des documents au sein des systèmes de gestion de l'information, à des fins commerciales et juridiques."
+              "fr": "Les opérations de GI consistent à superviser l'application efficiente et efficace des pratiques de gestion du cycle de vie des dossiers et des documents au sein des systèmes de gestion de l'information, à des fins commerciales et juridiques.",
+              "localized": "IM-Operations involves overseeing the efficient and effective application of life-cycle management practices for records and documents within information management systems, serving business and legal purposes."
             }
           }
         ]
@@ -7915,11 +8889,13 @@
         "key": "information_request_analysis",
         "name": {
           "en": "Information Requests - Analysis",
-          "fr": "Demandes d'information - Analyse"
+          "fr": "Demandes d'information - Analyse",
+          "localized": "Information Requests - Analysis"
         },
         "description": {
           "en": "Demonstrated ability to analyze and interpret access to information (ATI), freedom of information (FOI) or personal information (Privacy) requests",
-          "fr": "Capacité démontrée à analyser et à interpréter les demandes d'accès à l'information (AAI), d'accès à l'information (AAI) ou de renseignements personnels (confidentialité)"
+          "fr": "Capacité démontrée à analyser et à interpréter les demandes d'accès à l'information (AAI), d'accès à l'information (AAI) ou de renseignements personnels (confidentialité)",
+          "localized": "Demonstrated ability to analyze and interpret access to information (ATI), freedom of information (FOI) or personal information (Privacy) requests"
         },
         "keywords": {
           "en": null,
@@ -7934,11 +8910,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           }
         ]
@@ -7948,11 +8926,13 @@
         "key": "information_request_processing",
         "name": {
           "en": "Information Requests - Processing",
-          "fr": "Demandes d'informations - Traitement"
+          "fr": "Demandes d'informations - Traitement",
+          "localized": "Information Requests - Processing"
         },
         "description": {
           "en": "Demonstrated ability to process access to information (ATI), freedom of information (FOI) or personal information (Privacy) requests.",
-          "fr": "Capacité manifeste à traiter les demandes d’accès à l’information (AI), de liberté d’accès à l’information (LAI) ou de protection des renseignements personnels."
+          "fr": "Capacité manifeste à traiter les demandes d’accès à l’information (AI), de liberté d’accès à l’information (LAI) ou de protection des renseignements personnels.",
+          "localized": "Demonstrated ability to process access to information (ATI), freedom of information (FOI) or personal information (Privacy) requests."
         },
         "keywords": {
           "en": null,
@@ -7967,11 +8947,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           }
         ]
@@ -7981,11 +8963,13 @@
         "key": "information_requests_review",
         "name": {
           "en": "Information Requests - Reviewing",
-          "fr": "Demandes d'informations - Examen"
+          "fr": "Demandes d'informations - Examen",
+          "localized": "Information Requests - Reviewing"
         },
         "description": {
           "en": "Demonstrated ability to conduct quality reviews of sensitive and complex access to information (ATI), freedom of information (FOI) or personal information (Privacy) requests.",
-          "fr": "Capacité démontrée à effectuer des examens de qualité de demandes sensibles et complexes d’accès à l’information (ATI), d’accès à l’information (FOI) ou de renseignements personnels (confidentialité)."
+          "fr": "Capacité démontrée à effectuer des examens de qualité de demandes sensibles et complexes d’accès à l’information (ATI), d’accès à l’information (FOI) ou de renseignements personnels (confidentialité).",
+          "localized": "Demonstrated ability to conduct quality reviews of sensitive and complex access to information (ATI), freedom of information (FOI) or personal information (Privacy) requests."
         },
         "keywords": {
           "en": null,
@@ -8000,11 +8984,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           }
         ]
@@ -8014,11 +9000,13 @@
         "key": "information_technology_systems_and_solutions",
         "name": {
           "en": "Information Technology Systems and Solutions",
-          "fr": "Systèmes et solutions de technologies de l’information"
+          "fr": "Systèmes et solutions de technologies de l’information",
+          "localized": "Information Technology Systems and Solutions"
         },
         "description": {
           "en": "Demonstrated ability to apply best practices in the design, development, and support of computer-based information systems and products.",
-          "fr": "Capacité démontrée à appliquer les pratiques exemplaires en matière de conception, l’élaboration et le soutien des systèmes et produits d’information informatisés."
+          "fr": "Capacité démontrée à appliquer les pratiques exemplaires en matière de conception, l’élaboration et le soutien des systèmes et produits d’information informatisés.",
+          "localized": "Demonstrated ability to apply best practices in the design, development, and support of computer-based information systems and products."
         },
         "keywords": {
           "en": null,
@@ -8033,11 +9021,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           }
         ]
@@ -8047,11 +9037,13 @@
         "key": "initiative",
         "name": {
           "en": "Initiative",
-          "fr": "Initiative"
+          "fr": "Initiative",
+          "localized": "Initiative"
         },
         "description": {
           "en": "Demonstrated ability to take helpful action proactively, without being asked or directed to do so.",
-          "fr": "Capacité démontrée à prendre des mesures utiles de manière proactive, sans qu’on le lui demande ou qu’on lui demande de le faire."
+          "fr": "Capacité démontrée à prendre des mesures utiles de manière proactive, sans qu’on le lui demande ou qu’on lui demande de le faire.",
+          "localized": "Demonstrated ability to take helpful action proactively, without being asked or directed to do so."
         },
         "keywords": {
           "en": ["Drive", "Resourcefulness", "Leadership", "Ambition"],
@@ -8066,11 +9058,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -8080,11 +9074,13 @@
         "key": "innovation",
         "name": {
           "en": "Innovation",
-          "fr": "Innovation"
+          "fr": "Innovation",
+          "localized": "Innovation"
         },
         "description": {
           "en": "Demonstrated ability to foster novel ideas and turn them into solutions that are effective and valuable to others.",
-          "fr": "Capacité démontrée à favoriser des idées novatrices et à les transformer en solutions efficaces et utiles aux autres."
+          "fr": "Capacité démontrée à favoriser des idées novatrices et à les transformer en solutions efficaces et utiles aux autres.",
+          "localized": "Demonstrated ability to foster novel ideas and turn them into solutions that are effective and valuable to others."
         },
         "keywords": {
           "en": [
@@ -8111,11 +9107,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -8125,11 +9123,13 @@
         "key": "insight",
         "name": {
           "en": "Insight",
-          "fr": "Aperçu"
+          "fr": "Aperçu",
+          "localized": "Insight"
         },
         "description": {
           "en": "Demonstrated ability to perceptively analyze situations, allowing for a deep and accurate understanding of the issue.",
-          "fr": "Capacité démontrée d’analyser les situations avec perspicacité, ce qui permet une compréhension approfondie et précise du problème."
+          "fr": "Capacité démontrée d’analyser les situations avec perspicacité, ce qui permet une compréhension approfondie et précise du problème.",
+          "localized": "Demonstrated ability to perceptively analyze situations, allowing for a deep and accurate understanding of the issue."
         },
         "keywords": {
           "en": ["Understanding", "Perception", "Awareness"],
@@ -8144,11 +9144,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -8158,11 +9160,13 @@
         "key": "installing_and_configuring_software_and_hardware_devices",
         "name": {
           "en": "Installing and Configuring Software and Hardware Devices",
-          "fr": "Installer et configurer les dispositifs logiciels et matériels"
+          "fr": "Installer et configurer les dispositifs logiciels et matériels",
+          "localized": "Installing and Configuring Software and Hardware Devices"
         },
         "description": {
           "en": "Demonstrated ability to install equipment, machines, wiring or programs to meet specifications. This includes the ability to change the default attributes of software or hardware devices according to a defined build or baseline of technical specifications.",
-          "fr": "Capacité démontrée d’installer de l’équipement, des machines, du câblage ou des programmes pour répondre aux spécifications. Cela inclut la possibilité de modifier les attributs par défaut des périphériques logiciels ou matériels en fonction d’une version définie ou d’une base de spécifications techniques."
+          "fr": "Capacité démontrée d’installer de l’équipement, des machines, du câblage ou des programmes pour répondre aux spécifications. Cela inclut la possibilité de modifier les attributs par défaut des périphériques logiciels ou matériels en fonction d’une version définie ou d’une base de spécifications techniques.",
+          "localized": "Demonstrated ability to install equipment, machines, wiring or programs to meet specifications. This includes the ability to change the default attributes of software or hardware devices according to a defined build or baseline of technical specifications."
         },
         "keywords": {
           "en": null,
@@ -8177,11 +9181,13 @@
             "key": "infrastructure_operations",
             "name": {
               "en": "IT Infrastructure Operations",
-              "fr": "Opérations d'infrastructure informatique"
+              "fr": "Opérations d'infrastructure informatique",
+              "localized": "IT Infrastructure Operations"
             },
             "description": {
               "en": "IT generic work stream - Infrastructure Operations",
-              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique"
+              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique",
+              "localized": "IT generic work stream - Infrastructure Operations"
             }
           }
         ]
@@ -8191,11 +9197,13 @@
         "key": "integrating_gc_digital_standards_into_technical_advice",
         "name": {
           "en": "Integrating GC Digital Standards into Technical Advice",
-          "fr": "Intégration des normes numériques du GC aux conseils techniques"
+          "fr": "Intégration des normes numériques du GC aux conseils techniques",
+          "localized": "Integrating GC Digital Standards into Technical Advice"
         },
         "description": {
           "en": "Demonstrated ability to align recommendations and guidance with the principles outlined in the Government of Canada's Digital Standards when providing strategic advice to stakeholders.",
-          "fr": "Capacité démontrée d’harmoniser les recommandations et les orientations sur les principes énoncés dans les normes relatives au numérique du gouvernement du Canada (GC) au moment de prodiguer des conseils stratégiques aux intervenants."
+          "fr": "Capacité démontrée d’harmoniser les recommandations et les orientations sur les principes énoncés dans les normes relatives au numérique du gouvernement du Canada (GC) au moment de prodiguer des conseils stratégiques aux intervenants.",
+          "localized": "Demonstrated ability to align recommendations and guidance with the principles outlined in the Government of Canada's Digital Standards when providing strategic advice to stakeholders."
         },
         "keywords": {
           "en": ["Integrating", "GC", "Digital", "Standards", "Advice"],
@@ -8210,11 +9218,13 @@
             "key": "technical_advising",
             "name": {
               "en": "IT Planning and Reporting",
-              "fr": "Planification et établissement de rapports en matière de la numérique"
+              "fr": "Planification et établissement de rapports en matière de la numérique",
+              "localized": "IT Planning and Reporting"
             },
             "description": {
               "en": "IT generic work stream - IT Planning and Reporting",
-              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique"
+              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique",
+              "localized": "IT generic work stream - IT Planning and Reporting"
             }
           }
         ]
@@ -8224,11 +9234,13 @@
         "key": "integrity",
         "name": {
           "en": "Integrity",
-          "fr": "Intégrité"
+          "fr": "Intégrité",
+          "localized": "Integrity"
         },
         "description": {
           "en": "Demonstrated commitment to upholding the public's trust by acting in an honest, fair, and ethical manner.",
-          "fr": "Engagement démontré à maintenir la confiance du public en agissant de manière honnête, juste et éthique."
+          "fr": "Engagement démontré à maintenir la confiance du public en agissant de manière honnête, juste et éthique.",
+          "localized": "Demonstrated commitment to upholding the public's trust by acting in an honest, fair, and ethical manner."
         },
         "keywords": {
           "en": ["Honesty", "Morality", "Virtue", "Trustworthiness", "Ethical"],
@@ -8243,11 +9255,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -8257,11 +9271,13 @@
         "key": "intrusion_technology",
         "name": {
           "en": "Intrusion Technology",
-          "fr": "Technologie d’intrusion"
+          "fr": "Technologie d’intrusion",
+          "localized": "Intrusion Technology"
         },
         "description": {
           "en": "Demonstrated ability to deploy, configure, and manage applications that monitor network traffic and search for known threats, suspicious patterns or malicious activity.",
-          "fr": "Capacité démontrée de déployer, de configurer et de gérer des applications qui surveillent le trafic sur le réseau et de rechercher des menaces connues, des configurations suspectes et des activités malveillantes."
+          "fr": "Capacité démontrée de déployer, de configurer et de gérer des applications qui surveillent le trafic sur le réseau et de rechercher des menaces connues, des configurations suspectes et des activités malveillantes.",
+          "localized": "Demonstrated ability to deploy, configure, and manage applications that monitor network traffic and search for known threats, suspicious patterns or malicious activity."
         },
         "keywords": {
           "en": ["Intrusion", "Technology"],
@@ -8276,11 +9292,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           }
         ]
@@ -8290,11 +9308,13 @@
         "key": "intune",
         "name": {
           "en": "Intune",
-          "fr": "Intune"
+          "fr": "Intune",
+          "localized": "Intune"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this cloud-based endpoint management solution to a variety of projects.",
-          "fr": "Capacité démontrée à appliquer une connaissance concrète de cette solution  infonuagique de gestion des points terminaux à une variété de projets."
+          "fr": "Capacité démontrée à appliquer une connaissance concrète de cette solution  infonuagique de gestion des points terminaux à une variété de projets.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this cloud-based endpoint management solution to a variety of projects."
         },
         "keywords": {
           "en": ["Intune"],
@@ -8309,11 +9329,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -8323,11 +9345,13 @@
         "key": "it_architecture",
         "name": {
           "en": "IT Architecture",
-          "fr": "Architecture informatique"
+          "fr": "Architecture informatique",
+          "localized": "IT Architecture"
         },
         "description": {
           "en": "Demonstrated ability to apply architecture theories, principles, concepts, practices, methodologies and frameworks to IT solutions.",
-          "fr": "Capacité démontrée à appliquer les théories, les principes, les concepts, les pratiques, les méthodologies et les cadres d'applications aux solutions informatiques."
+          "fr": "Capacité démontrée à appliquer les théories, les principes, les concepts, les pratiques, les méthodologies et les cadres d'applications aux solutions informatiques.",
+          "localized": "Demonstrated ability to apply architecture theories, principles, concepts, practices, methodologies and frameworks to IT solutions."
         },
         "keywords": {
           "en": null,
@@ -8342,11 +9366,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           }
         ]
@@ -8356,11 +9382,13 @@
         "key": "it_business_line_advisory",
         "name": {
           "en": "IT Business Line Advisory",
-          "fr": "Secteur d’activité consultatif sur la TI"
+          "fr": "Secteur d’activité consultatif sur la TI",
+          "localized": "IT Business Line Advisory"
         },
         "description": {
           "en": "Demonstrated ability to provide analysis, research and strategic advice to clients and organisations in support of effective digital business solutions.",
-          "fr": "Capacité démontrée à fournir des analyses, des recherches et des conseils stratégiques aux clients et aux organisations à l’appui de solutions d’affaires numériques efficaces."
+          "fr": "Capacité démontrée à fournir des analyses, des recherches et des conseils stratégiques aux clients et aux organisations à l’appui de solutions d’affaires numériques efficaces.",
+          "localized": "Demonstrated ability to provide analysis, research and strategic advice to clients and organisations in support of effective digital business solutions."
         },
         "keywords": {
           "en": ["it", "business", "line", "advisory."],
@@ -8375,11 +9403,13 @@
             "key": "it_management",
             "name": {
               "en": "Digital Project Portfolio Management",
-              "fr": "Gestion de portefeuille de projets numériques"
+              "fr": "Gestion de portefeuille de projets numériques",
+              "localized": "Digital Project Portfolio Management"
             },
             "description": {
               "en": "IT generic work stream - Digital project portfolio management",
-              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques"
+              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques",
+              "localized": "IT generic work stream - Digital project portfolio management"
             }
           },
           {
@@ -8387,11 +9417,13 @@
             "key": "it_project_management",
             "name": {
               "en": "Digital Business Line Advisory Services",
-              "fr": "Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Services consultatifs auprès des secteurs de la numérique",
+              "localized": "Digital Business Line Advisory Services"
             },
             "description": {
               "en": "IT generic work stream - Business Line Advisory Services",
-              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique",
+              "localized": "IT generic work stream - Business Line Advisory Services"
             }
           }
         ]
@@ -8401,11 +9433,13 @@
         "key": "it_change_management",
         "name": {
           "en": "IT Change Management",
-          "fr": "Gestion des changements informatiques"
+          "fr": "Gestion des changements informatiques",
+          "localized": "IT Change Management"
         },
         "description": {
           "en": "Demonstrated ability to review and plan proposed changes to IT systems or services, with minimal disruptions to IT services when they're implemented.",
-          "fr": "Capacité démontrée d’examiner et de planifier les changements proposés aux systèmes ou services informatiques, avec un minimum d’interruptions des services informatiques lorsqu’ils sont mis en œuvre."
+          "fr": "Capacité démontrée d’examiner et de planifier les changements proposés aux systèmes ou services informatiques, avec un minimum d’interruptions des services informatiques lorsqu’ils sont mis en œuvre.",
+          "localized": "Demonstrated ability to review and plan proposed changes to IT systems or services, with minimal disruptions to IT services when they're implemented."
         },
         "keywords": {
           "en": null,
@@ -8420,11 +9454,13 @@
             "key": "it_project_management",
             "name": {
               "en": "Digital Business Line Advisory Services",
-              "fr": "Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Services consultatifs auprès des secteurs de la numérique",
+              "localized": "Digital Business Line Advisory Services"
             },
             "description": {
               "en": "IT generic work stream - Business Line Advisory Services",
-              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique",
+              "localized": "IT generic work stream - Business Line Advisory Services"
             }
           }
         ]
@@ -8434,11 +9470,13 @@
         "key": "it_database_management",
         "name": {
           "en": "IT Database Management",
-          "fr": "Gestion des bases de données de la TI"
+          "fr": "Gestion des bases de données de la TI",
+          "localized": "IT Database Management"
         },
         "description": {
           "en": "Demonstrated ability to provide technical IT services and advice in the development, installation, administration, monitoring and support of database management solutions.",
-          "fr": "Aptitude avérée à fournir des services et des conseils techniques en matière de TI dans le développement, l’installation, l’administration, la surveillance et le soutien de solutions de gestion de bases de données."
+          "fr": "Aptitude avérée à fournir des services et des conseils techniques en matière de TI dans le développement, l’installation, l’administration, la surveillance et le soutien de solutions de gestion de bases de données.",
+          "localized": "Demonstrated ability to provide technical IT services and advice in the development, installation, administration, monitoring and support of database management solutions."
         },
         "keywords": {
           "en": ["database", "management."],
@@ -8453,11 +9491,13 @@
             "key": "database_design___data_administration",
             "name": {
               "en": "Database Management",
-              "fr": "Gestion des bases de données"
+              "fr": "Gestion des bases de données",
+              "localized": "Database Management"
             },
             "description": {
               "en": "IT generic work stream - Database Management",
-              "fr": "Flux de travail générique de TI - Gestion des bases de données"
+              "fr": "Flux de travail générique de TI - Gestion des bases de données",
+              "localized": "IT generic work stream - Database Management"
             }
           }
         ]
@@ -8467,11 +9507,13 @@
         "key": "it_disaster_recovery_management",
         "name": {
           "en": "IT Disaster Recovery Management",
-          "fr": "Gestion de la reprise après sinistre informatique"
+          "fr": "Gestion de la reprise après sinistre informatique",
+          "localized": "IT Disaster Recovery Management"
         },
         "description": {
           "en": "",
-          "fr": ""
+          "fr": "",
+          "localized": ""
         },
         "keywords": {
           "en": [],
@@ -8486,11 +9528,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -8500,11 +9544,13 @@
         "key": "it_disaster_recovery_planning",
         "name": {
           "en": "IT Disaster Recovery Planning",
-          "fr": "Planification de la reprise après sinistre informatique"
+          "fr": "Planification de la reprise après sinistre informatique",
+          "localized": "IT Disaster Recovery Planning"
         },
         "description": {
           "en": "",
-          "fr": ""
+          "fr": "",
+          "localized": ""
         },
         "keywords": {
           "en": [],
@@ -8519,11 +9565,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -8533,11 +9581,13 @@
         "key": "it_governance_documentation",
         "name": {
           "en": "IT Governance Documentation",
-          "fr": "Documentation de gouvernance des technologies de l'information"
+          "fr": "Documentation de gouvernance des technologies de l'information",
+          "localized": "IT Governance Documentation"
         },
         "description": {
           "en": "Demonstrated ability to craft comprehensive governance documentation such as Authority to Operate (ATO), Concept of Operations (ConOps), and Standard Operating Procedures (SOP).",
-          "fr": "Capacité démontrée à élaborer une documentation de gouvernance complète telle que l'Autorisation d'Exploitation (ATO), le Concept d'Opérations (ConOps) et les Procédures Opérationnelles Standard (SOP)."
+          "fr": "Capacité démontrée à élaborer une documentation de gouvernance complète telle que l'Autorisation d'Exploitation (ATO), le Concept d'Opérations (ConOps) et les Procédures Opérationnelles Standard (SOP).",
+          "localized": "Demonstrated ability to craft comprehensive governance documentation such as Authority to Operate (ATO), Concept of Operations (ConOps), and Standard Operating Procedures (SOP)."
         },
         "keywords": {
           "en": ["Governance", "Documentation"],
@@ -8552,11 +9602,13 @@
             "key": "technical_advising",
             "name": {
               "en": "IT Planning and Reporting",
-              "fr": "Planification et établissement de rapports en matière de la numérique"
+              "fr": "Planification et établissement de rapports en matière de la numérique",
+              "localized": "IT Planning and Reporting"
             },
             "description": {
               "en": "IT generic work stream - IT Planning and Reporting",
-              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique"
+              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique",
+              "localized": "IT generic work stream - IT Planning and Reporting"
             }
           }
         ]
@@ -8566,11 +9618,13 @@
         "key": "it_incident_tracking",
         "name": {
           "en": "IT Incident Tracking",
-          "fr": "Suivi des incidents informatiques"
+          "fr": "Suivi des incidents informatiques",
+          "localized": "IT Incident Tracking"
         },
         "description": {
           "en": "Demonstrated ability to use an issue tracking solution to monitor software and hardware bugs and issues and their resolution.",
-          "fr": "Capacité démontrée à utiliser une solution de suivi des problèmes pour surveiller les bogues et les problèmes logiciels et matériels et leur résolution."
+          "fr": "Capacité démontrée à utiliser une solution de suivi des problèmes pour surveiller les bogues et les problèmes logiciels et matériels et leur résolution.",
+          "localized": "Demonstrated ability to use an issue tracking solution to monitor software and hardware bugs and issues and their resolution."
         },
         "keywords": {
           "en": null,
@@ -8585,11 +9639,13 @@
             "key": "infrastructure_operations",
             "name": {
               "en": "IT Infrastructure Operations",
-              "fr": "Opérations d'infrastructure informatique"
+              "fr": "Opérations d'infrastructure informatique",
+              "localized": "IT Infrastructure Operations"
             },
             "description": {
               "en": "IT generic work stream - Infrastructure Operations",
-              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique"
+              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique",
+              "localized": "IT generic work stream - Infrastructure Operations"
             }
           }
         ]
@@ -8599,11 +9655,13 @@
         "key": "it_infrastructure_management",
         "name": {
           "en": "IT Infrastructure Management",
-          "fr": "Gestion de l’infrastructure informatique"
+          "fr": "Gestion de l’infrastructure informatique",
+          "localized": "IT Infrastructure Management"
         },
         "description": {
           "en": "Demonstrated ability to oversee and coordinate essential operational infrastructure-related tasks.",
-          "fr": "Capacité démontrée à superviser et à coordonner des tâches essentielles liées à l'infrastructure opérationnelle."
+          "fr": "Capacité démontrée à superviser et à coordonner des tâches essentielles liées à l'infrastructure opérationnelle.",
+          "localized": "Demonstrated ability to oversee and coordinate essential operational infrastructure-related tasks."
         },
         "keywords": {
           "en": null,
@@ -8618,11 +9676,13 @@
             "key": "infrastructure_operations",
             "name": {
               "en": "IT Infrastructure Operations",
-              "fr": "Opérations d'infrastructure informatique"
+              "fr": "Opérations d'infrastructure informatique",
+              "localized": "IT Infrastructure Operations"
             },
             "description": {
               "en": "IT generic work stream - Infrastructure Operations",
-              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique"
+              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique",
+              "localized": "IT generic work stream - Infrastructure Operations"
             }
           }
         ]
@@ -8632,11 +9692,13 @@
         "key": "it_infrastructure_operations",
         "name": {
           "en": "IT Infrastructure Operations",
-          "fr": "Opérations liées à l’infrastructure de la TI"
+          "fr": "Opérations liées à l’infrastructure de la TI",
+          "localized": "IT Infrastructure Operations"
         },
         "description": {
           "en": "Demonstrated ability to support the development, implementation, integration, maintenance, analysis, and client support services of IT infrastructure operations.",
-          "fr": "Capacité démontrée à prendre en charge les services de développement, de mise en œuvre, d’intégration, de maintenance, d’analyse et de support client des opérations d’infrastructure informatique."
+          "fr": "Capacité démontrée à prendre en charge les services de développement, de mise en œuvre, d’intégration, de maintenance, d’analyse et de support client des opérations d’infrastructure informatique.",
+          "localized": "Demonstrated ability to support the development, implementation, integration, maintenance, analysis, and client support services of IT infrastructure operations."
         },
         "keywords": {
           "en": ["infrastructure", "operations."],
@@ -8651,11 +9713,13 @@
             "key": "infrastructure_operations",
             "name": {
               "en": "IT Infrastructure Operations",
-              "fr": "Opérations d'infrastructure informatique"
+              "fr": "Opérations d'infrastructure informatique",
+              "localized": "IT Infrastructure Operations"
             },
             "description": {
               "en": "IT generic work stream - Infrastructure Operations",
-              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique"
+              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique",
+              "localized": "IT generic work stream - Infrastructure Operations"
             }
           }
         ]
@@ -8665,11 +9729,13 @@
         "key": "it_operations_security",
         "name": {
           "en": "IT Operations Security",
-          "fr": "Sécurité des opérations informatiques"
+          "fr": "Sécurité des opérations informatiques",
+          "localized": "IT Operations Security"
         },
         "description": {
           "en": "",
-          "fr": ""
+          "fr": "",
+          "localized": ""
         },
         "keywords": {
           "en": [],
@@ -8684,11 +9750,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -8698,11 +9766,13 @@
         "key": "it_project_estimating_and_planning_techniques",
         "name": {
           "en": "IT Project Estimating and Planning Techniques",
-          "fr": "Techniques d’estimation et de planification des projets informatiques"
+          "fr": "Techniques d’estimation et de planification des projets informatiques",
+          "localized": "IT Project Estimating and Planning Techniques"
         },
         "description": {
           "en": "Demonstrated ability to work with clients and technical experts to estimate and plan all components of the IT project lifecycle, including scoping for financial, operational, and security requirements. This includes demonstrating awareness of industry best practices and frequently used methodologies.",
-          "fr": "Capacité démontrée à travailler avec des clients et des experts techniques pour estimer et planifier tous les composants du cycle de vie d'un projet informatique, y compris la définition des exigences financières, opérationnelles et de sécurité. Cela inclut la démonstration d’une connaissance des meilleures pratiques de l’industrie et des méthodologies fréquemment utilisées."
+          "fr": "Capacité démontrée à travailler avec des clients et des experts techniques pour estimer et planifier tous les composants du cycle de vie d'un projet informatique, y compris la définition des exigences financières, opérationnelles et de sécurité. Cela inclut la démonstration d’une connaissance des meilleures pratiques de l’industrie et des méthodologies fréquemment utilisées.",
+          "localized": "Demonstrated ability to work with clients and technical experts to estimate and plan all components of the IT project lifecycle, including scoping for financial, operational, and security requirements. This includes demonstrating awareness of industry best practices and frequently used methodologies."
         },
         "keywords": {
           "en": null,
@@ -8717,11 +9787,13 @@
             "key": "it_management",
             "name": {
               "en": "Digital Project Portfolio Management",
-              "fr": "Gestion de portefeuille de projets numériques"
+              "fr": "Gestion de portefeuille de projets numériques",
+              "localized": "Digital Project Portfolio Management"
             },
             "description": {
               "en": "IT generic work stream - Digital project portfolio management",
-              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques"
+              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques",
+              "localized": "IT generic work stream - Digital project portfolio management"
             }
           },
           {
@@ -8729,11 +9801,13 @@
             "key": "it_project_management",
             "name": {
               "en": "Digital Business Line Advisory Services",
-              "fr": "Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Services consultatifs auprès des secteurs de la numérique",
+              "localized": "Digital Business Line Advisory Services"
             },
             "description": {
               "en": "IT generic work stream - Business Line Advisory Services",
-              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique",
+              "localized": "IT generic work stream - Business Line Advisory Services"
             }
           },
           {
@@ -8741,11 +9815,13 @@
             "key": "technical_advising",
             "name": {
               "en": "IT Planning and Reporting",
-              "fr": "Planification et établissement de rapports en matière de la numérique"
+              "fr": "Planification et établissement de rapports en matière de la numérique",
+              "localized": "IT Planning and Reporting"
             },
             "description": {
               "en": "IT generic work stream - IT Planning and Reporting",
-              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique"
+              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique",
+              "localized": "IT generic work stream - IT Planning and Reporting"
             }
           }
         ]
@@ -8755,11 +9831,13 @@
         "key": "it_project_portfolio_management_tools",
         "name": {
           "en": "IT Project Portfolio Management Tools",
-          "fr": "Outils de gestion de portefeuille de projets informatiques"
+          "fr": "Outils de gestion de portefeuille de projets informatiques",
+          "localized": "IT Project Portfolio Management Tools"
         },
         "description": {
           "en": "Demonstrated ability to use and work in project portfolio management tools, such as Clarity PPM.",
-          "fr": "Capacité démontrée à utiliser et à travailler avec des outils de gestion de portefeuille de projets, tels que Clarity PPM."
+          "fr": "Capacité démontrée à utiliser et à travailler avec des outils de gestion de portefeuille de projets, tels que Clarity PPM.",
+          "localized": "Demonstrated ability to use and work in project portfolio management tools, such as Clarity PPM."
         },
         "keywords": {
           "en": null,
@@ -8774,11 +9852,13 @@
             "key": "it_management",
             "name": {
               "en": "Digital Project Portfolio Management",
-              "fr": "Gestion de portefeuille de projets numériques"
+              "fr": "Gestion de portefeuille de projets numériques",
+              "localized": "Digital Project Portfolio Management"
             },
             "description": {
               "en": "IT generic work stream - Digital project portfolio management",
-              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques"
+              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques",
+              "localized": "IT generic work stream - Digital project portfolio management"
             }
           },
           {
@@ -8786,11 +9866,13 @@
             "key": "it_project_management",
             "name": {
               "en": "Digital Business Line Advisory Services",
-              "fr": "Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Services consultatifs auprès des secteurs de la numérique",
+              "localized": "Digital Business Line Advisory Services"
             },
             "description": {
               "en": "IT generic work stream - Business Line Advisory Services",
-              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique",
+              "localized": "IT generic work stream - Business Line Advisory Services"
             }
           },
           {
@@ -8798,11 +9880,13 @@
             "key": "technical_advising",
             "name": {
               "en": "IT Planning and Reporting",
-              "fr": "Planification et établissement de rapports en matière de la numérique"
+              "fr": "Planification et établissement de rapports en matière de la numérique",
+              "localized": "IT Planning and Reporting"
             },
             "description": {
               "en": "IT generic work stream - IT Planning and Reporting",
-              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique"
+              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique",
+              "localized": "IT generic work stream - IT Planning and Reporting"
             }
           }
         ]
@@ -8812,11 +9896,13 @@
         "key": "it_project_progress_monitoring",
         "name": {
           "en": "IT Project Progress Monitoring",
-          "fr": "Suivi de l’avancement des projets informatiques"
+          "fr": "Suivi de l’avancement des projets informatiques",
+          "localized": "IT Project Progress Monitoring"
         },
         "description": {
           "en": "Demonstrated ability to work with established procedures to track IT projects, including demonstrating awareness of best practices in IT project planning, working with clients to gather data, and ensuring attention to detail.",
-          "fr": "Capacité démontrée à travailler avec des procédures établies pour suivre les projets informatiques, notamment en démontrant une connaissance des meilleures pratiques en matière de planification de projets informatiques, en travaillant avec les clients pour recueillir des données et en garantissant le souci du détail."
+          "fr": "Capacité démontrée à travailler avec des procédures établies pour suivre les projets informatiques, notamment en démontrant une connaissance des meilleures pratiques en matière de planification de projets informatiques, en travaillant avec les clients pour recueillir des données et en garantissant le souci du détail.",
+          "localized": "Demonstrated ability to work with established procedures to track IT projects, including demonstrating awareness of best practices in IT project planning, working with clients to gather data, and ensuring attention to detail."
         },
         "keywords": {
           "en": null,
@@ -8831,11 +9917,13 @@
             "key": "it_management",
             "name": {
               "en": "Digital Project Portfolio Management",
-              "fr": "Gestion de portefeuille de projets numériques"
+              "fr": "Gestion de portefeuille de projets numériques",
+              "localized": "Digital Project Portfolio Management"
             },
             "description": {
               "en": "IT generic work stream - Digital project portfolio management",
-              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques"
+              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques",
+              "localized": "IT generic work stream - Digital project portfolio management"
             }
           },
           {
@@ -8843,11 +9931,13 @@
             "key": "it_project_management",
             "name": {
               "en": "Digital Business Line Advisory Services",
-              "fr": "Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Services consultatifs auprès des secteurs de la numérique",
+              "localized": "Digital Business Line Advisory Services"
             },
             "description": {
               "en": "IT generic work stream - Business Line Advisory Services",
-              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique",
+              "localized": "IT generic work stream - Business Line Advisory Services"
             }
           },
           {
@@ -8855,11 +9945,13 @@
             "key": "technical_advising",
             "name": {
               "en": "IT Planning and Reporting",
-              "fr": "Planification et établissement de rapports en matière de la numérique"
+              "fr": "Planification et établissement de rapports en matière de la numérique",
+              "localized": "IT Planning and Reporting"
             },
             "description": {
               "en": "IT generic work stream - IT Planning and Reporting",
-              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique"
+              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique",
+              "localized": "IT generic work stream - IT Planning and Reporting"
             }
           }
         ]
@@ -8869,11 +9961,13 @@
         "key": "it_security",
         "name": {
           "en": "IT Security",
-          "fr": "Sécurité de la TI"
+          "fr": "Sécurité de la TI",
+          "localized": "IT Security"
         },
         "description": {
           "en": "Demonstrated ability to undertake the development, implementation, integration, support, and maintenance of IT security solutions to protect the confidentiality, availability and integrity of digital assets.",
-          "fr": "Capacité démontrée à entreprendre le développement, la mise en œuvre, l'intégration, le soutien et la maintenance de solutions de sécurité informatique afin de protéger la confidentialité, la disponibilité et l'intégrité des ressources numériques."
+          "fr": "Capacité démontrée à entreprendre le développement, la mise en œuvre, l'intégration, le soutien et la maintenance de solutions de sécurité informatique afin de protéger la confidentialité, la disponibilité et l'intégrité des ressources numériques.",
+          "localized": "Demonstrated ability to undertake the development, implementation, integration, support, and maintenance of IT security solutions to protect the confidentiality, availability and integrity of digital assets."
         },
         "keywords": {
           "en": ["IT", "security", "digital", "assets."],
@@ -8888,11 +9982,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -8902,11 +9998,13 @@
         "key": "it_security_principles__methods__and_policies",
         "name": {
           "en": "IT Security Principles, Methods, and Policies",
-          "fr": "Principes, méthodes et politiques de sécurité des TI"
+          "fr": "Principes, méthodes et politiques de sécurité des TI",
+          "localized": "IT Security Principles, Methods, and Policies"
         },
         "description": {
           "en": "Demonstrated ability to apply IT security practices, standards, technologies or solutions to protect digital assets.",
-          "fr": "Capacité avérée à appliquer des pratiques, des normes, des technologies ou des solutions de sécurité informatique pour protéger les ressources numériques."
+          "fr": "Capacité avérée à appliquer des pratiques, des normes, des technologies ou des solutions de sécurité informatique pour protéger les ressources numériques.",
+          "localized": "Demonstrated ability to apply IT security practices, standards, technologies or solutions to protect digital assets."
         },
         "keywords": {
           "en": null,
@@ -8921,11 +10019,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -8935,11 +10035,13 @@
         "key": "it_software_and_hardware_security_requirements",
         "name": {
           "en": "IT Software and Hardware Security Requirements",
-          "fr": "Exigences en matière de sécurité des logiciels et du matériel informatique"
+          "fr": "Exigences en matière de sécurité des logiciels et du matériel informatique",
+          "localized": "IT Software and Hardware Security Requirements"
         },
         "description": {
           "en": "Demonstrated ability to identify vulnerabilities, conduct risk assessments and ensure compliance with industry standards whole designing and implementing robust IT software and hardware security requirements.",
-          "fr": "Capacité manifeste à repérer les vulnérabilités, à effectuer des évaluations des risques et à assurer la conformité avec les normes de l’industrie dans le cadre de la conception et de la mise en œuvre de robustes exigences en matière de sécurité pour des logiciels et du matériel informatique."
+          "fr": "Capacité manifeste à repérer les vulnérabilités, à effectuer des évaluations des risques et à assurer la conformité avec les normes de l’industrie dans le cadre de la conception et de la mise en œuvre de robustes exigences en matière de sécurité pour des logiciels et du matériel informatique.",
+          "localized": "Demonstrated ability to identify vulnerabilities, conduct risk assessments and ensure compliance with industry standards whole designing and implementing robust IT software and hardware security requirements."
         },
         "keywords": {
           "en": ["Software", "Hardware", "Security", "Requirements"],
@@ -8966,11 +10068,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -8980,11 +10084,13 @@
         "key": "it_software_solutions",
         "name": {
           "en": "IT Software Solutions",
-          "fr": "Solutions logicielles de la TI"
+          "fr": "Solutions logicielles de la TI",
+          "localized": "IT Software Solutions"
         },
         "description": {
           "en": "Demonstrated ability to provide technical IT services and advice in the development, testing, implementation, integration, and maintenance of software solutions.",
-          "fr": "Capacité démontrée à fournir des services informatiques techniques et des conseils dans le développement, les tests, la mise en œuvre, l'intégration et la maintenance de solutions logicielles."
+          "fr": "Capacité démontrée à fournir des services informatiques techniques et des conseils dans le développement, les tests, la mise en œuvre, l'intégration et la maintenance de solutions logicielles.",
+          "localized": "Demonstrated ability to provide technical IT services and advice in the development, testing, implementation, integration, and maintenance of software solutions."
         },
         "keywords": {
           "en": ["software", "solutions."],
@@ -8999,11 +10105,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           }
         ]
@@ -9013,11 +10121,13 @@
         "key": "it_strategy_development",
         "name": {
           "en": "Digital Strategy Development",
-          "fr": "Élaboration de la stratégie numérique"
+          "fr": "Élaboration de la stratégie numérique",
+          "localized": "Digital Strategy Development"
         },
         "description": {
           "en": "Demonstrated ability to identify key operational, environmental, security, and business factors related to a digital initiative, and then establish business goals and a viable path forward that takes those factors into account.",
-          "fr": "Capacité démontrée à identifier les principaux facteurs opérationnels, environnementaux, sécuritaires et d’affaires liés à une initiative numérique, puis à établir des objectifs d’affaires et une voie viable qui tienne compte de ces facteurs."
+          "fr": "Capacité démontrée à identifier les principaux facteurs opérationnels, environnementaux, sécuritaires et d’affaires liés à une initiative numérique, puis à établir des objectifs d’affaires et une voie viable qui tienne compte de ces facteurs.",
+          "localized": "Demonstrated ability to identify key operational, environmental, security, and business factors related to a digital initiative, and then establish business goals and a viable path forward that takes those factors into account."
         },
         "keywords": {
           "en": ["Digital", "Strategy", "Development"],
@@ -9032,11 +10142,13 @@
             "key": "it_management",
             "name": {
               "en": "Digital Project Portfolio Management",
-              "fr": "Gestion de portefeuille de projets numériques"
+              "fr": "Gestion de portefeuille de projets numériques",
+              "localized": "Digital Project Portfolio Management"
             },
             "description": {
               "en": "IT generic work stream - Digital project portfolio management",
-              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques"
+              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques",
+              "localized": "IT generic work stream - Digital project portfolio management"
             }
           },
           {
@@ -9044,11 +10156,13 @@
             "key": "it_project_management",
             "name": {
               "en": "Digital Business Line Advisory Services",
-              "fr": "Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Services consultatifs auprès des secteurs de la numérique",
+              "localized": "Digital Business Line Advisory Services"
             },
             "description": {
               "en": "IT generic work stream - Business Line Advisory Services",
-              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique",
+              "localized": "IT generic work stream - Business Line Advisory Services"
             }
           },
           {
@@ -9056,11 +10170,13 @@
             "key": "technical_advising",
             "name": {
               "en": "IT Planning and Reporting",
-              "fr": "Planification et établissement de rapports en matière de la numérique"
+              "fr": "Planification et établissement de rapports en matière de la numérique",
+              "localized": "IT Planning and Reporting"
             },
             "description": {
               "en": "IT generic work stream - IT Planning and Reporting",
-              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique"
+              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique",
+              "localized": "IT generic work stream - IT Planning and Reporting"
             }
           }
         ]
@@ -9070,11 +10186,13 @@
         "key": "it_systems_administration",
         "name": {
           "en": "IT Systems Administration",
-          "fr": "Administration des systèmes informatiques"
+          "fr": "Administration des systèmes informatiques",
+          "localized": "IT Systems Administration"
         },
         "description": {
           "en": "Demonstrated ability to deliver the upkeep, configuration, and reliable operation of computer systems, especially multi-user computers such as servers.",
-          "fr": "Capacité démontrée à assurer l'entretien, la configuration et le fonctionnement fiable des systèmes informatiques, en particulier des ordinateurs multi-utilisateurs tels que les serveurs."
+          "fr": "Capacité démontrée à assurer l'entretien, la configuration et le fonctionnement fiable des systèmes informatiques, en particulier des ordinateurs multi-utilisateurs tels que les serveurs.",
+          "localized": "Demonstrated ability to deliver the upkeep, configuration, and reliable operation of computer systems, especially multi-user computers such as servers."
         },
         "keywords": {
           "en": null,
@@ -9089,11 +10207,13 @@
             "key": "infrastructure_operations",
             "name": {
               "en": "IT Infrastructure Operations",
-              "fr": "Opérations d'infrastructure informatique"
+              "fr": "Opérations d'infrastructure informatique",
+              "localized": "IT Infrastructure Operations"
             },
             "description": {
               "en": "IT generic work stream - Infrastructure Operations",
-              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique"
+              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique",
+              "localized": "IT generic work stream - Infrastructure Operations"
             }
           }
         ]
@@ -9103,11 +10223,13 @@
         "key": "it_troubleshooting",
         "name": {
           "en": "IT Troubleshooting",
-          "fr": "Dépannage informatique"
+          "fr": "Dépannage informatique",
+          "localized": "IT Troubleshooting"
         },
         "description": {
           "en": "Demonstrated ability to determine causes of operating errors, make recommendations about how to correct errors, and in some cases, test solutions and take corrective action.",
-          "fr": "Capacité démontrée à déterminer les causes des erreurs de fonctionnement, à formuler des recommandations sur la façon de corriger les erreurs et, dans certains cas, à tester des solutions et à prendre des mesures correctives."
+          "fr": "Capacité démontrée à déterminer les causes des erreurs de fonctionnement, à formuler des recommandations sur la façon de corriger les erreurs et, dans certains cas, à tester des solutions et à prendre des mesures correctives.",
+          "localized": "Demonstrated ability to determine causes of operating errors, make recommendations about how to correct errors, and in some cases, test solutions and take corrective action."
         },
         "keywords": {
           "en": null,
@@ -9122,11 +10244,13 @@
             "key": "infrastructure_operations",
             "name": {
               "en": "IT Infrastructure Operations",
-              "fr": "Opérations d'infrastructure informatique"
+              "fr": "Opérations d'infrastructure informatique",
+              "localized": "IT Infrastructure Operations"
             },
             "description": {
               "en": "IT generic work stream - Infrastructure Operations",
-              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique"
+              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique",
+              "localized": "IT generic work stream - Infrastructure Operations"
             }
           }
         ]
@@ -9136,11 +10260,13 @@
         "key": "java",
         "name": {
           "en": "Java",
-          "fr": "Java"
+          "fr": "Java",
+          "localized": "Java"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this programming language to develop mobile apps, web apps, desktop apps or games.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce langage de programmation pour développer des applications mobiles, des applications Web, des applications de bureau ou des jeux."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce langage de programmation pour développer des applications mobiles, des applications Web, des applications de bureau ou des jeux.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this programming language to develop mobile apps, web apps, desktop apps or games."
         },
         "keywords": {
           "en": null,
@@ -9155,11 +10281,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -9169,11 +10297,13 @@
         "key": "javascript",
         "name": {
           "en": "JavaScript",
-          "fr": "JavaScript"
+          "fr": "JavaScript",
+          "localized": "JavaScript"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this programming language to develop a variety of projects.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce langage de programmation pour développer une variété de projets."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce langage de programmation pour développer une variété de projets.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this programming language to develop a variety of projects."
         },
         "keywords": {
           "en": ["JavaScript", "language."],
@@ -9188,11 +10318,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -9202,11 +10334,13 @@
         "key": "jquery",
         "name": {
           "en": "jQuery",
-          "fr": "jQuery"
+          "fr": "jQuery",
+          "localized": "jQuery"
         },
         "description": {
           "en": "Demonstrated ability to leverage this JavaScript library to develop a variety of products, such as HTML document traversing and manipulation, browser event handling, CSS animations, and cross-browser JavaScript development.",
-          "fr": "Capacité démontrée à exploiter cette bibliothèque JavaScript pour développer une variété de produits, tels que la traversée et la manipulation de documents HTML, la gestion des événements du navigateur, les animations CSS et le développement JavaScript entre navigateurs."
+          "fr": "Capacité démontrée à exploiter cette bibliothèque JavaScript pour développer une variété de produits, tels que la traversée et la manipulation de documents HTML, la gestion des événements du navigateur, les animations CSS et le développement JavaScript entre navigateurs.",
+          "localized": "Demonstrated ability to leverage this JavaScript library to develop a variety of products, such as HTML document traversing and manipulation, browser event handling, CSS animations, and cross-browser JavaScript development."
         },
         "keywords": {
           "en": ["jQuery", "language."],
@@ -9221,11 +10355,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -9235,11 +10371,13 @@
         "key": "jsp",
         "name": {
           "en": "JSP",
-          "fr": "JSP"
+          "fr": "JSP",
+          "localized": "JSP"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this Java servlet to develop dynamic web content.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce servlet Java pour développer du contenu Web dynamique."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce servlet Java pour développer du contenu Web dynamique.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this Java servlet to develop dynamic web content."
         },
         "keywords": {
           "en": null,
@@ -9254,11 +10392,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -9268,11 +10408,13 @@
         "key": "judgement",
         "name": {
           "en": "Judgement",
-          "fr": "Jugement"
+          "fr": "Jugement",
+          "localized": "Judgement"
         },
         "description": {
           "en": "Demonstrated ability to take all relevant information into account and make well-informed, evidence-based decisions.",
-          "fr": "Capacité démontrée à prendre en compte toutes les informations pertinentes et à prendre des décisions éclairées et fondées sur des preuves."
+          "fr": "Capacité démontrée à prendre en compte toutes les informations pertinentes et à prendre des décisions éclairées et fondées sur des preuves.",
+          "localized": "Demonstrated ability to take all relevant information into account and make well-informed, evidence-based decisions."
         },
         "keywords": {
           "en": ["Decision", "Evaluation", "Assessment", "Discretion"],
@@ -9287,11 +10429,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -9301,11 +10445,13 @@
         "key": "klc_collab",
         "name": {
           "en": "Collaborate with Partners and Stakeholders",
-          "fr": "Collaborer avec les partenaires et les intervenants"
+          "fr": "Collaborer avec les partenaires et les intervenants",
+          "localized": "Collaborate with Partners and Stakeholders"
         },
         "description": {
           "en": "Leaders are deliberate and resourceful about seeking the widest possible spectrum of perspectives. They demonstrate openness and flexibility to forge consensus and improve outcomes. They bring a whole-of-government perspective to their interactions. In negotiating solutions, they are open to alternatives and skillful at managing expectations. Leaders share recognition with their teams and partners.",
-          "fr": "Les dirigeants cherchent à obtenir, de façon délibérée et ingénieuse, le plus grand éventail possible de perspectives. Ils font preuve d'ouverture et de souplesse afin de parvenir à un consensus et d'améliorer les résultats. Ils apportent une perspective pangouvernementale à leurs interactions. Lorsqu'ils négocient pour en arriver à des solutions, ils n'excluent pas les solutions de rechange et gèrent les attentes avec compétence. Les dirigeants partagent la reconnaissance avec leurs équipes et partenaires."
+          "fr": "Les dirigeants cherchent à obtenir, de façon délibérée et ingénieuse, le plus grand éventail possible de perspectives. Ils font preuve d'ouverture et de souplesse afin de parvenir à un consensus et d'améliorer les résultats. Ils apportent une perspective pangouvernementale à leurs interactions. Lorsqu'ils négocient pour en arriver à des solutions, ils n'excluent pas les solutions de rechange et gèrent les attentes avec compétence. Les dirigeants partagent la reconnaissance avec leurs équipes et partenaires.",
+          "localized": "Leaders are deliberate and resourceful about seeking the widest possible spectrum of perspectives. They demonstrate openness and flexibility to forge consensus and improve outcomes. They bring a whole-of-government perspective to their interactions. In negotiating solutions, they are open to alternatives and skillful at managing expectations. Leaders share recognition with their teams and partners."
         },
         "keywords": {
           "en": ["klc", "collaboration", "partner", "stakeholders"],
@@ -9320,11 +10466,13 @@
             "key": "klc",
             "name": {
               "en": "Leadership - Executive Behaviours",
-              "fr": "Leadership - Comportements des cadres"
+              "fr": "Leadership - Comportements des cadres",
+              "localized": "Leadership - Executive Behaviours"
             },
             "description": {
               "en": "Behavioural - Key Leadership Competencies",
-              "fr": "Comportemental – Compétences clés en leadership"
+              "fr": "Comportemental – Compétences clés en leadership",
+              "localized": "Behavioural - Key Leadership Competencies"
             }
           }
         ]
@@ -9334,11 +10482,13 @@
         "key": "klc_innovation",
         "name": {
           "en": "Promote Innovation and Guide Change",
-          "fr": "Promouvoir l'innovation et orienter le changement"
+          "fr": "Promouvoir l'innovation et orienter le changement",
+          "localized": "Promote Innovation and Guide Change"
         },
         "description": {
           "en": "Leaders have the courage and resilience to challenge convention. They create an environment that supports bold thinking, experimentation and intelligent risk taking. They use setbacks as a valuable source of insight and learning. Leaders take change in their stride, aligning and adjusting milestones and targets to maintain forward momentum.",
-          "fr": "Les dirigeants ont le courage et la résilience nécessaires pour remettre en question les idées conventionnelles. Ils créent un environnement propice aux idées audacieuses, à l'expérimentation et à la prise de risques en toute connaissance de cause. Ils perçoivent les revers comme une bonne occasion de comprendre et d'apprendre. Les dirigeants s'adaptent au changement en harmonisant et en modifiant les jalons et les objectifs afin de maintenir leur dynamisme."
+          "fr": "Les dirigeants ont le courage et la résilience nécessaires pour remettre en question les idées conventionnelles. Ils créent un environnement propice aux idées audacieuses, à l'expérimentation et à la prise de risques en toute connaissance de cause. Ils perçoivent les revers comme une bonne occasion de comprendre et d'apprendre. Les dirigeants s'adaptent au changement en harmonisant et en modifiant les jalons et les objectifs afin de maintenir leur dynamisme.",
+          "localized": "Leaders have the courage and resilience to challenge convention. They create an environment that supports bold thinking, experimentation and intelligent risk taking. They use setbacks as a valuable source of insight and learning. Leaders take change in their stride, aligning and adjusting milestones and targets to maintain forward momentum."
         },
         "keywords": {
           "en": ["klc", "innovation", "guide", "change"],
@@ -9360,11 +10510,13 @@
             "key": "klc",
             "name": {
               "en": "Leadership - Executive Behaviours",
-              "fr": "Leadership - Comportements des cadres"
+              "fr": "Leadership - Comportements des cadres",
+              "localized": "Leadership - Executive Behaviours"
             },
             "description": {
               "en": "Behavioural - Key Leadership Competencies",
-              "fr": "Comportemental – Compétences clés en leadership"
+              "fr": "Comportemental – Compétences clés en leadership",
+              "localized": "Behavioural - Key Leadership Competencies"
             }
           }
         ]
@@ -9374,11 +10526,13 @@
         "key": "klc_mobilize",
         "name": {
           "en": "Mobilize People",
-          "fr": "Mobiliser les personnes"
+          "fr": "Mobiliser les personnes",
+          "localized": "Mobilize People"
         },
         "description": {
           "en": "Leaders inspire and motivate the people they lead. They manage performance, provide constructive and respectful feedback to encourage and enable performance excellence. They lead by example, setting goals for themselves that are more demanding than those that they set for others.",
-          "fr": "Les dirigeants inspirent et motivent les personnes qu'ils dirigent. Ils gèrent le rendement, offrent de la rétroaction constructive et respectueuse pour encourager et rendre possible l'excellence en matière de rendement. Ils donnent l'exemple en se fixant des objectifs pour eux-mêmes qui sont plus exigeants que ceux qu'ils fixent pour les autres."
+          "fr": "Les dirigeants inspirent et motivent les personnes qu'ils dirigent. Ils gèrent le rendement, offrent de la rétroaction constructive et respectueuse pour encourager et rendre possible l'excellence en matière de rendement. Ils donnent l'exemple en se fixant des objectifs pour eux-mêmes qui sont plus exigeants que ceux qu'ils fixent pour les autres.",
+          "localized": "Leaders inspire and motivate the people they lead. They manage performance, provide constructive and respectful feedback to encourage and enable performance excellence. They lead by example, setting goals for themselves that are more demanding than those that they set for others."
         },
         "keywords": {
           "en": ["klc", "mobilize"],
@@ -9393,11 +10547,13 @@
             "key": "klc",
             "name": {
               "en": "Leadership - Executive Behaviours",
-              "fr": "Leadership - Comportements des cadres"
+              "fr": "Leadership - Comportements des cadres",
+              "localized": "Leadership - Executive Behaviours"
             },
             "description": {
               "en": "Behavioural - Key Leadership Competencies",
-              "fr": "Comportemental – Compétences clés en leadership"
+              "fr": "Comportemental – Compétences clés en leadership",
+              "localized": "Behavioural - Key Leadership Competencies"
             }
           }
         ]
@@ -9407,11 +10563,13 @@
         "key": "klc_respect",
         "name": {
           "en": "Uphold Integrity and Respect",
-          "fr": "Préserver l'intégrité et le respect"
+          "fr": "Préserver l'intégrité et le respect",
+          "localized": "Uphold Integrity and Respect"
         },
         "description": {
           "en": "Leaders exemplify ethical practices, professionalism and personal integrity. They create respectful and trusting work environments where sound advice is valued. They encourage the expression of diverse opinions and perspectives, while fostering collegiality. Leaders are self-aware and seek out opportunities for personal growth.",
-          "fr": "Les dirigeants donnent l'exemple sur le plan des pratiques éthiques, du professionnalisme et de l'intégrité personnelle. Ils créent des environnements de travail empreints de respect et de confiance, où les conseils judicieux sont valorisés. Ils encouragent l'expression d'opinions et de perspectives différentes, tout en favorisant la collégialité. Les dirigeants ont une conscience de soi et recherchent les occasions d'épanouissement personnel."
+          "fr": "Les dirigeants donnent l'exemple sur le plan des pratiques éthiques, du professionnalisme et de l'intégrité personnelle. Ils créent des environnements de travail empreints de respect et de confiance, où les conseils judicieux sont valorisés. Ils encouragent l'expression d'opinions et de perspectives différentes, tout en favorisant la collégialité. Les dirigeants ont une conscience de soi et recherchent les occasions d'épanouissement personnel.",
+          "localized": "Leaders exemplify ethical practices, professionalism and personal integrity. They create respectful and trusting work environments where sound advice is valued. They encourage the expression of diverse opinions and perspectives, while fostering collegiality. Leaders are self-aware and seek out opportunities for personal growth."
         },
         "keywords": {
           "en": ["respect", "KLC", "integrity", "uphold"],
@@ -9426,11 +10584,13 @@
             "key": "klc",
             "name": {
               "en": "Leadership - Executive Behaviours",
-              "fr": "Leadership - Comportements des cadres"
+              "fr": "Leadership - Comportements des cadres",
+              "localized": "Leadership - Executive Behaviours"
             },
             "description": {
               "en": "Behavioural - Key Leadership Competencies",
-              "fr": "Comportemental – Compétences clés en leadership"
+              "fr": "Comportemental – Compétences clés en leadership",
+              "localized": "Behavioural - Key Leadership Competencies"
             }
           }
         ]
@@ -9440,11 +10600,13 @@
         "key": "klc_results",
         "name": {
           "en": "Achieve Results",
-          "fr": "Obtenir des résultats"
+          "fr": "Obtenir des résultats",
+          "localized": "Achieve Results"
         },
         "description": {
           "en": "Leaders mobilize and manage resources to deliver on the priorities of the Government, improve outcomes and add value. They consider context, risks and business intelligence to support high-quality and timely decisions. They anticipate, plan, monitor progress and adjust as needed. Leaders take personal responsibility for their actions and outcomes of their decisions.",
-          "fr": "Les dirigeants mobilisent et gèrent les ressources afin de réaliser les priorités du gouvernement, d'améliorer les résultats et d'apporter une valeur ajoutée. Ils tiennent compte du contexte, des risques et des renseignements organisationnels dont ils disposent afin d'appuyer la prise de décisions de qualité élevée en temps opportun. Ils anticipent, planifient, suivent les progrès et apportent des correctifs au besoin. Les dirigeants assument la responsabilité personnelle à l'égard de leurs actions et des résultats de leurs décisions."
+          "fr": "Les dirigeants mobilisent et gèrent les ressources afin de réaliser les priorités du gouvernement, d'améliorer les résultats et d'apporter une valeur ajoutée. Ils tiennent compte du contexte, des risques et des renseignements organisationnels dont ils disposent afin d'appuyer la prise de décisions de qualité élevée en temps opportun. Ils anticipent, planifient, suivent les progrès et apportent des correctifs au besoin. Les dirigeants assument la responsabilité personnelle à l'égard de leurs actions et des résultats de leurs décisions.",
+          "localized": "Leaders mobilize and manage resources to deliver on the priorities of the Government, improve outcomes and add value. They consider context, risks and business intelligence to support high-quality and timely decisions. They anticipate, plan, monitor progress and adjust as needed. Leaders take personal responsibility for their actions and outcomes of their decisions."
         },
         "keywords": {
           "en": ["klc", "results"],
@@ -9459,11 +10621,13 @@
             "key": "klc",
             "name": {
               "en": "Leadership - Executive Behaviours",
-              "fr": "Leadership - Comportements des cadres"
+              "fr": "Leadership - Comportements des cadres",
+              "localized": "Leadership - Executive Behaviours"
             },
             "description": {
               "en": "Behavioural - Key Leadership Competencies",
-              "fr": "Comportemental – Compétences clés en leadership"
+              "fr": "Comportemental – Compétences clés en leadership",
+              "localized": "Behavioural - Key Leadership Competencies"
             }
           }
         ]
@@ -9473,11 +10637,13 @@
         "key": "klc_vision",
         "name": {
           "en": "Create Vision and Strategy",
-          "fr": "Créer une vision et une stratégie"
+          "fr": "Créer une vision et une stratégie",
+          "localized": "Create Vision and Strategy"
         },
         "description": {
           "en": "Leaders define the future and chart a path forward. They are adept at understanding and communicating context, factoring in the economic, social and political environment. Intellectually agile, they leverage their deep and broad knowledge, build on diverse ideas and perspectives and create consensus around compelling visions. Leaders balance organizational and government-wide priorities and improve outcomes for Canada and Canadians.",
-          "fr": "Les dirigeants définissent l'avenir et tracent la voie à suivre. Ils comprennent et communiquent le contexte avec la plus grande aisance, en tenant compte de l'environnement économique, social et politique. Agiles sur le plan intellectuel, ils mettent à contribution leurs connaissances vastes et approfondies, s'inspirent de différentes idées et perspectives, et dégagent un consensus sur les visions convaincantes. Les dirigeants assurent l'équilibre entre les priorités organisationnelles et pangouvernementales, et contribuent à améliorer les résultats pour le Canada et les Canadiens."
+          "fr": "Les dirigeants définissent l'avenir et tracent la voie à suivre. Ils comprennent et communiquent le contexte avec la plus grande aisance, en tenant compte de l'environnement économique, social et politique. Agiles sur le plan intellectuel, ils mettent à contribution leurs connaissances vastes et approfondies, s'inspirent de différentes idées et perspectives, et dégagent un consensus sur les visions convaincantes. Les dirigeants assurent l'équilibre entre les priorités organisationnelles et pangouvernementales, et contribuent à améliorer les résultats pour le Canada et les Canadiens.",
+          "localized": "Leaders define the future and chart a path forward. They are adept at understanding and communicating context, factoring in the economic, social and political environment. Intellectually agile, they leverage their deep and broad knowledge, build on diverse ideas and perspectives and create consensus around compelling visions. Leaders balance organizational and government-wide priorities and improve outcomes for Canada and Canadians."
         },
         "keywords": {
           "en": ["Vision", "KLC"],
@@ -9492,11 +10658,13 @@
             "key": "klc",
             "name": {
               "en": "Leadership - Executive Behaviours",
-              "fr": "Leadership - Comportements des cadres"
+              "fr": "Leadership - Comportements des cadres",
+              "localized": "Leadership - Executive Behaviours"
             },
             "description": {
               "en": "Behavioural - Key Leadership Competencies",
-              "fr": "Comportemental – Compétences clés en leadership"
+              "fr": "Comportemental – Compétences clés en leadership",
+              "localized": "Behavioural - Key Leadership Competencies"
             }
           }
         ]
@@ -9506,11 +10674,13 @@
         "key": "low_code",
         "name": {
           "en": "Low Code",
-          "fr": "Low Code"
+          "fr": "Low Code",
+          "localized": "Low Code"
         },
         "description": {
           "en": "Demonstrated ability to leverage automated code generation tools to develop or enhance digital products. This includes the ability to use tools such as Appian, Microsoft Power Platform, Mendix, Outsystems, Salesforce, and ServiceNow.",
-          "fr": "Capacité démontrée à tirer parti des outils de génération de code automatisés pour développer ou améliorer des produits numériques. Cela inclut la possibilité d'utiliser des outils tels que Appian, Microsoft Power Platform, Mendix, Outsystems, Salesforce et ServiceNow."
+          "fr": "Capacité démontrée à tirer parti des outils de génération de code automatisés pour développer ou améliorer des produits numériques. Cela inclut la possibilité d'utiliser des outils tels que Appian, Microsoft Power Platform, Mendix, Outsystems, Salesforce et ServiceNow.",
+          "localized": "Demonstrated ability to leverage automated code generation tools to develop or enhance digital products. This includes the ability to use tools such as Appian, Microsoft Power Platform, Mendix, Outsystems, Salesforce, and ServiceNow."
         },
         "keywords": {
           "en": [
@@ -9539,11 +10709,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -9553,11 +10725,13 @@
         "key": "m365_administration",
         "name": {
           "en": "M365 Administration",
-          "fr": "Administration M365"
+          "fr": "Administration M365",
+          "localized": "M365 Administration"
         },
         "description": {
           "en": "Demonstrated ability to manage the deployment, use, maintenance, and support of the Microsoft 365 platform, which includes user management, data security, and compliance within an organization.",
-          "fr": "Capacité démontrée à gérer le déploiement, l'utilisation, la maintenance et le support de la plateforme Microsoft 365, ce qui inclut la gestion des utilisateurs, la sécurité des données et la conformité au sein d'une organisation."
+          "fr": "Capacité démontrée à gérer le déploiement, l'utilisation, la maintenance et le support de la plateforme Microsoft 365, ce qui inclut la gestion des utilisateurs, la sécurité des données et la conformité au sein d'une organisation.",
+          "localized": "Demonstrated ability to manage the deployment, use, maintenance, and support of the Microsoft 365 platform, which includes user management, data security, and compliance within an organization."
         },
         "keywords": {
           "en": ["M365", "Administration"],
@@ -9572,11 +10746,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -9586,11 +10762,13 @@
         "key": "machine_learning_algorithms",
         "name": {
           "en": "Machine Learning Algorithms",
-          "fr": "Algorithmes d'apprentissage automatique"
+          "fr": "Algorithmes d'apprentissage automatique",
+          "localized": "Machine Learning Algorithms"
         },
         "description": {
           "en": "Demonstrated ability to develop and program algorithms capable of receiving and analyzing input data to predict output values within an acceptable range and in turn are capable of learning and optimizing their operations to improve performance, and developing intelligence through experience.",
-          "fr": "Capacité démontrée à développer et à programmer des algorithmes capables de recevoir et d'analyser des données d'entrée pour prédire des valeurs de sortie dans une fourchette acceptable et, à leur tour, capables d'apprendre et d'optimiser leurs opérations pour améliorer les performances, et de développer l'intelligence par l'expérience."
+          "fr": "Capacité démontrée à développer et à programmer des algorithmes capables de recevoir et d'analyser des données d'entrée pour prédire des valeurs de sortie dans une fourchette acceptable et, à leur tour, capables d'apprendre et d'optimiser leurs opérations pour améliorer les performances, et de développer l'intelligence par l'expérience.",
+          "localized": "Demonstrated ability to develop and program algorithms capable of receiving and analyzing input data to predict output values within an acceptable range and in turn are capable of learning and optimizing their operations to improve performance, and developing intelligence through experience."
         },
         "keywords": {
           "en": ["Machine", "Learning", "Algorithms."],
@@ -9605,11 +10783,13 @@
             "key": "data_services_data_science",
             "name": {
               "en": "Data Services - Data Science",
-              "fr": "Services de données - Science des données"
+              "fr": "Services de données - Science des données",
+              "localized": "Data Services - Data Science"
             },
             "description": {
               "en": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources.",
-              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses."
+              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses.",
+              "localized": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources."
             }
           }
         ]
@@ -9619,11 +10799,13 @@
         "key": "machine_learning_modeling",
         "name": {
           "en": "Machine Learning Modeling",
-          "fr": "Modélisation de l'apprentissage automatique"
+          "fr": "Modélisation de l'apprentissage automatique",
+          "localized": "Machine Learning Modeling"
         },
         "description": {
           "en": "Demonstrated ability to use algorithm models, data models and learning models to build machine learning models that can spot patterns, anticipate outcomes, make decisions, and gain knowledge from experience.",
-          "fr": "Capacité démontrée à utiliser des modèles algorithmiques, des modèles de données et des modèles d'apprentissage pour construire des modèles d'apprentissage automatique capables de repérer des schémas, d'anticiper des résultats, de prendre des décisions et d'acquérir des connaissances à partir de l'expérience."
+          "fr": "Capacité démontrée à utiliser des modèles algorithmiques, des modèles de données et des modèles d'apprentissage pour construire des modèles d'apprentissage automatique capables de repérer des schémas, d'anticiper des résultats, de prendre des décisions et d'acquérir des connaissances à partir de l'expérience.",
+          "localized": "Demonstrated ability to use algorithm models, data models and learning models to build machine learning models that can spot patterns, anticipate outcomes, make decisions, and gain knowledge from experience."
         },
         "keywords": {
           "en": ["Machine", "Learning", "Modeling."],
@@ -9638,11 +10820,13 @@
             "key": "data_services_data_science",
             "name": {
               "en": "Data Services - Data Science",
-              "fr": "Services de données - Science des données"
+              "fr": "Services de données - Science des données",
+              "localized": "Data Services - Data Science"
             },
             "description": {
               "en": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources.",
-              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses."
+              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses.",
+              "localized": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources."
             }
           }
         ]
@@ -9652,11 +10836,13 @@
         "key": "malware_detection",
         "name": {
           "en": "Malware Detection",
-          "fr": "Détection des logiciels malveillants"
+          "fr": "Détection des logiciels malveillants",
+          "localized": "Malware Detection"
         },
         "description": {
           "en": "Demonstrated ability to identify, document, analyze, and mitigate malicious software (malware) within computer systems and networks.",
-          "fr": "Capacité démontrée de détecter les logiciels malveillants (maliciels), de les documenter et de les analyser au sein des systèmes et des réseaux informatiques, et d’en atténuer les effets."
+          "fr": "Capacité démontrée de détecter les logiciels malveillants (maliciels), de les documenter et de les analyser au sein des systèmes et des réseaux informatiques, et d’en atténuer les effets.",
+          "localized": "Demonstrated ability to identify, document, analyze, and mitigate malicious software (malware) within computer systems and networks."
         },
         "keywords": {
           "en": ["Malware Detection"],
@@ -9671,11 +10857,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           }
         ]
@@ -9685,11 +10873,13 @@
         "key": "managing_privacy_breaches",
         "name": {
           "en": "Managing Privacy Breaches",
-          "fr": "Gestion des atteintes à la vie privée"
+          "fr": "Gestion des atteintes à la vie privée",
+          "localized": "Managing Privacy Breaches"
         },
         "description": {
           "en": "Demonstrated ability to effectively handle incidents involving compromised private information, including assessing, mitigating and communicating to ensure compliance and trust restoration.",
-          "fr": "Capacité démontrée à gérer efficacement les incidents impliquant des informations privées compromises, y compris l’évaluation, l’atténuation et la communication pour assurer la conformité et le rétablissement de la confiance."
+          "fr": "Capacité démontrée à gérer efficacement les incidents impliquant des informations privées compromises, y compris l’évaluation, l’atténuation et la communication pour assurer la conformité et le rétablissement de la confiance.",
+          "localized": "Demonstrated ability to effectively handle incidents involving compromised private information, including assessing, mitigating and communicating to ensure compliance and trust restoration."
         },
         "keywords": {
           "en": null,
@@ -9704,11 +10894,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           }
         ]
@@ -9718,11 +10910,13 @@
         "key": "manual_testing",
         "name": {
           "en": "Manual Testing",
-          "fr": "Test manuel"
+          "fr": "Test manuel",
+          "localized": "Manual Testing"
         },
         "description": {
           "en": "Demonstrated ability to create, manually perform, and document comprehensive test cases that review and test software or applications for errors, defects, and vulnerabilities.",
-          "fr": "Aptitude démontrée à créer, exécuter manuellement et documenter des cas de test complets qui examinent et testent les logiciels ou les applications pour détecter les erreurs, les anomalies et les vulnérabilités."
+          "fr": "Aptitude démontrée à créer, exécuter manuellement et documenter des cas de test complets qui examinent et testent les logiciels ou les applications pour détecter les erreurs, les anomalies et les vulnérabilités.",
+          "localized": "Demonstrated ability to create, manually perform, and document comprehensive test cases that review and test software or applications for errors, defects, and vulnerabilities."
         },
         "keywords": {
           "en": ["Manual", "Testing"],
@@ -9737,11 +10931,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           }
         ]
@@ -9751,11 +10947,13 @@
         "key": "mathematical_and_statistical_methods",
         "name": {
           "en": "Mathematical and Statistical Methods",
-          "fr": "Méthodes mathématiques et statistiques"
+          "fr": "Méthodes mathématiques et statistiques",
+          "localized": "Mathematical and Statistical Methods"
         },
         "description": {
           "en": "Demonstrated ability to recognize patterns and trends within data to identify relationships and generate insight as well as accessing, manipulating, querying and analyzing data using a variety of methods, tools, and processes.",
-          "fr": "Capacité démontrée à reconnaître les schémas et les tendances au sein des données afin d’identifier les relations et d’obtenir des informations, ainsi qu’à accéder aux données, à les manipuler, à les interroger et à les analyser à l’aide d’une variété de méthodes, d’outils et de processus."
+          "fr": "Capacité démontrée à reconnaître les schémas et les tendances au sein des données afin d’identifier les relations et d’obtenir des informations, ainsi qu’à accéder aux données, à les manipuler, à les interroger et à les analyser à l’aide d’une variété de méthodes, d’outils et de processus.",
+          "localized": "Demonstrated ability to recognize patterns and trends within data to identify relationships and generate insight as well as accessing, manipulating, querying and analyzing data using a variety of methods, tools, and processes."
         },
         "keywords": {
           "en": ["Mathematical", "Statistical", "Methods."],
@@ -9770,11 +10968,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           }
         ]
@@ -9784,11 +10984,13 @@
         "key": "mentoring",
         "name": {
           "en": "Mentoring",
-          "fr": "Mentorat"
+          "fr": "Mentorat",
+          "localized": "Mentoring"
         },
         "description": {
           "en": "Demonstrated ability to provide advice, guidance, and support to individuals to aid in their professional development.",
-          "fr": "Capacité démontrée de fournir des conseils, des orientations et un soutien à des personnes afin de contribuer à leur perfectionnement professionnel."
+          "fr": "Capacité démontrée de fournir des conseils, des orientations et un soutien à des personnes afin de contribuer à leur perfectionnement professionnel.",
+          "localized": "Demonstrated ability to provide advice, guidance, and support to individuals to aid in their professional development."
         },
         "keywords": {
           "en": ["Mentoring"],
@@ -9803,11 +11005,13 @@
             "key": "management_competencies",
             "name": {
               "en": "Leadership - General Technical Skills",
-              "fr": "Leadership - Compétences techniques générales"
+              "fr": "Leadership - Compétences techniques générales",
+              "localized": "Leadership - General Technical Skills"
             },
             "description": {
               "en": "Management skills at the non-executive level for oversight of finances, human resources, initiatives, and accountabilities",
-              "fr": "Compétences en gestion au niveau non exécutif pour la surveillance des finances, des ressources humaines, des initiatives et des responsabilités"
+              "fr": "Compétences en gestion au niveau non exécutif pour la surveillance des finances, des ressources humaines, des initiatives et des responsabilités",
+              "localized": "Management skills at the non-executive level for oversight of finances, human resources, initiatives, and accountabilities"
             }
           }
         ]
@@ -9817,11 +11021,13 @@
         "key": "microsoft_access",
         "name": {
           "en": "Microsoft Access",
-          "fr": "Microsoft Access"
+          "fr": "Microsoft Access",
+          "localized": "Microsoft Access"
         },
         "description": {
           "en": "Demonstrated ability to use this relational database management system to develop working applications in a low code environment.",
-          "fr": "Capacité démontrer à utiliser ce système de gestion de base de données relationnelle afin de mettre au point des applications fonctionnelles dans un environnement à programmation schématisée."
+          "fr": "Capacité démontrer à utiliser ce système de gestion de base de données relationnelle afin de mettre au point des applications fonctionnelles dans un environnement à programmation schématisée.",
+          "localized": "Demonstrated ability to use this relational database management system to develop working applications in a low code environment."
         },
         "keywords": {
           "en": ["MS", "Microsoft", "Access"],
@@ -9836,11 +11042,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -9850,11 +11058,13 @@
         "key": "microsoft_defender",
         "name": {
           "en": "Microsoft Defender",
-          "fr": "Microsoft Defender"
+          "fr": "Microsoft Defender",
+          "localized": "Microsoft Defender"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this antivirus software when working on a variety of projects.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce logiciel antivirus dans le cadre de divers projets."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce logiciel antivirus dans le cadre de divers projets.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this antivirus software when working on a variety of projects."
         },
         "keywords": {
           "en": ["Microsoft Defender"],
@@ -9869,11 +11079,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -9883,11 +11095,13 @@
         "key": "microsoft_dynamics",
         "name": {
           "en": "Microsoft Dynamics",
-          "fr": "Microsoft Dynamics"
+          "fr": "Microsoft Dynamics",
+          "localized": "Microsoft Dynamics"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this software tool to develop a variety of projects.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de cet outil logiciel pour développer une variété de projets."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de cet outil logiciel pour développer une variété de projets.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this software tool to develop a variety of projects."
         },
         "keywords": {
           "en": null,
@@ -9902,11 +11116,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -9916,11 +11132,13 @@
         "key": "microsoft_fabric",
         "name": {
           "en": "Microsoft Fabric",
-          "fr": "Microsoft Fabric"
+          "fr": "Microsoft Fabric",
+          "localized": "Microsoft Fabric"
         },
         "description": {
           "en": "Demonstrated ability to leverage this software as a service for end-to-end analytics to enable unified data management, governance and discovery.",
-          "fr": "Capacité démontrée à exploiter ce logiciel en tant que service pour des analyses de bout en bout afin de permettre une gestion unifiée des données, la gouvernance et la découverte."
+          "fr": "Capacité démontrée à exploiter ce logiciel en tant que service pour des analyses de bout en bout afin de permettre une gestion unifiée des données, la gouvernance et la découverte.",
+          "localized": "Demonstrated ability to leverage this software as a service for end-to-end analytics to enable unified data management, governance and discovery."
         },
         "keywords": {
           "en": ["Microsoft", "Fabric"],
@@ -9935,11 +11153,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           }
         ]
@@ -9949,11 +11169,13 @@
         "key": "microsoft_project",
         "name": {
           "en": "Microsoft Project",
-          "fr": "Microsoft Project"
+          "fr": "Microsoft Project",
+          "localized": "Microsoft Project"
         },
         "description": {
           "en": "Demonstrated ability to use this project management software to initiate, oversee, and monitor projects from planning to completion.",
-          "fr": "Capacité démontrée à utiliser ce logiciel de gestion de projet pour créer, superviser et surveiller des projets, de la conception jusqu’à l’achèvement."
+          "fr": "Capacité démontrée à utiliser ce logiciel de gestion de projet pour créer, superviser et surveiller des projets, de la conception jusqu’à l’achèvement.",
+          "localized": "Demonstrated ability to use this project management software to initiate, oversee, and monitor projects from planning to completion."
         },
         "keywords": {
           "en": ["MS", "Microsoft", "Project"],
@@ -9968,11 +11190,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -9982,11 +11206,13 @@
         "key": "microsoft_purview",
         "name": {
           "en": "Microsoft Purview",
-          "fr": "Microsoft Purview"
+          "fr": "Microsoft Purview",
+          "localized": "Microsoft Purview"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this suite of tools to discover, classify and explore data in various environments.",
-          "fr": "Capacité démontrée à appliquer une connaissance concrète de cette suite d'outils pour trouver, classer et explorer des données dans divers environnements."
+          "fr": "Capacité démontrée à appliquer une connaissance concrète de cette suite d'outils pour trouver, classer et explorer des données dans divers environnements.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this suite of tools to discover, classify and explore data in various environments."
         },
         "keywords": {
           "en": ["Microsoft Purview"],
@@ -10001,11 +11227,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -10015,11 +11243,13 @@
         "key": "mobile_application_architecture",
         "name": {
           "en": "Mobile Application Architecture",
-          "fr": "Architecture des applications mobiles"
+          "fr": "Architecture des applications mobiles",
+          "localized": "Mobile Application Architecture"
         },
         "description": {
           "en": "Demonstrated ability to describe and document the patterns and techniques used to build an application for mobile devices.",
-          "fr": "Capacité démontrée à décrire et documenter les modèles et les techniques utilisés pour créer une application pour appareils mobiles."
+          "fr": "Capacité démontrée à décrire et documenter les modèles et les techniques utilisés pour créer une application pour appareils mobiles.",
+          "localized": "Demonstrated ability to describe and document the patterns and techniques used to build an application for mobile devices."
         },
         "keywords": {
           "en": null,
@@ -10034,11 +11264,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           }
         ]
@@ -10048,11 +11280,13 @@
         "key": "mobile_design",
         "name": {
           "en": "Responsive Design",
-          "fr": "Conception adaptative"
+          "fr": "Conception adaptative",
+          "localized": "Responsive Design"
         },
         "description": {
           "en": "Demonstrated ability to produce designs and features for web content and applications to ensure that users with various screen sizes experience an equivalent level of product quality, functionality, and accessibility.",
-          "fr": "Capacité démontrée à produire des conceptions et des caractéristiques pour le contenu et les applications web afin de garantir que les utilisateurs de différentes tailles d'écran bénéficient d'un niveau équivalent de qualité, de fonctionnalité et d'accessibilité du produit."
+          "fr": "Capacité démontrée à produire des conceptions et des caractéristiques pour le contenu et les applications web afin de garantir que les utilisateurs de différentes tailles d'écran bénéficient d'un niveau équivalent de qualité, de fonctionnalité et d'accessibilité du produit.",
+          "localized": "Demonstrated ability to produce designs and features for web content and applications to ensure that users with various screen sizes experience an equivalent level of product quality, functionality, and accessibility."
         },
         "keywords": {
           "en": ["Responsive", "Design"],
@@ -10067,11 +11301,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           },
           {
@@ -10079,11 +11315,13 @@
             "key": "user_experience_and_interface_design",
             "name": {
               "en": "Software Solutions - Product Design",
-              "fr": "Solutions logicielles - Conception de produits"
+              "fr": "Solutions logicielles - Conception de produits",
+              "localized": "Software Solutions - Product Design"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur",
+              "localized": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design"
             }
           },
           {
@@ -10091,11 +11329,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -10105,11 +11345,13 @@
         "key": "mongodb",
         "name": {
           "en": "MongoDB",
-          "fr": "MongoDB"
+          "fr": "MongoDB",
+          "localized": "MongoDB"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this database program to develop a variety of projects.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce programme de base de données pour développer une variété de projets."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce programme de base de données pour développer une variété de projets.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this database program to develop a variety of projects."
         },
         "keywords": {
           "en": null,
@@ -10124,11 +11366,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -10138,11 +11382,13 @@
         "key": "multifactor_authentication",
         "name": {
           "en": "Multi-Factor Authentication",
-          "fr": "Authentification multifacteur"
+          "fr": "Authentification multifacteur",
+          "localized": "Multi-Factor Authentication"
         },
         "description": {
           "en": "Demonstrated ability to provide technical advice on multi-factor authentication solutions for digital products and services, using approaches that demonstrate awareness of security considerations, user experience, enterprise direction and modern approaches to user flows. This includes activities such as supporting the creation of architectures, frameworks, policies, and procedures, as well as overseeing the technical implementation.",
-          "fr": "Capacité démontrée à fournir des conseils techniques sur les solutions d'authentification multifacteur pour les produits et services numériques, en utilisant des approches qui démontrent une prise en compte des considérations de sécurité, de l'expérience utilisateur, de l'orientation de l'entreprise et des approches modernes des flux d'utilisateurs. Cela comprend des activités telles que le soutien à la création d'architectures, de cadres, de politiques et de procédures, ainsi que la supervision de la mise en œuvre technique."
+          "fr": "Capacité démontrée à fournir des conseils techniques sur les solutions d'authentification multifacteur pour les produits et services numériques, en utilisant des approches qui démontrent une prise en compte des considérations de sécurité, de l'expérience utilisateur, de l'orientation de l'entreprise et des approches modernes des flux d'utilisateurs. Cela comprend des activités telles que le soutien à la création d'architectures, de cadres, de politiques et de procédures, ainsi que la supervision de la mise en œuvre technique.",
+          "localized": "Demonstrated ability to provide technical advice on multi-factor authentication solutions for digital products and services, using approaches that demonstrate awareness of security considerations, user experience, enterprise direction and modern approaches to user flows. This includes activities such as supporting the creation of architectures, frameworks, policies, and procedures, as well as overseeing the technical implementation."
         },
         "keywords": {
           "en": null,
@@ -10157,11 +11403,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           },
           {
@@ -10169,11 +11417,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           },
           {
@@ -10181,11 +11431,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -10195,11 +11447,13 @@
         "key": "mysql",
         "name": {
           "en": "MySQL",
-          "fr": "MySQL"
+          "fr": "MySQL",
+          "localized": "MySQL"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this database software to develop a variety of projects.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce logiciel de base de données pour développer une variété de projets."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce logiciel de base de données pour développer une variété de projets.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this database software to develop a variety of projects."
         },
         "keywords": {
           "en": null,
@@ -10214,11 +11468,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -10228,11 +11484,13 @@
         "key": "network_architecture",
         "name": {
           "en": "Network Architecture",
-          "fr": "Architecture de réseau"
+          "fr": "Architecture de réseau",
+          "localized": "Network Architecture"
         },
         "description": {
           "en": "Demonstrated ability to describe and document the connection between devices so they may access and share resources, including the ability to provide technical network architecture diagrams.",
-          "fr": "Capacité démontrée à décrire et documenter la connexion entre les appareils afin qu'ils puissent accéder et partager des ressources, y compris la capacité de fournir des diagrammes techniques d'architecture de réseau."
+          "fr": "Capacité démontrée à décrire et documenter la connexion entre les appareils afin qu'ils puissent accéder et partager des ressources, y compris la capacité de fournir des diagrammes techniques d'architecture de réseau.",
+          "localized": "Demonstrated ability to describe and document the connection between devices so they may access and share resources, including the ability to provide technical network architecture diagrams."
         },
         "keywords": {
           "en": null,
@@ -10247,11 +11505,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           }
         ]
@@ -10261,11 +11521,13 @@
         "key": "networking",
         "name": {
           "en": "Networking",
-          "fr": "Mise en réseau"
+          "fr": "Mise en réseau",
+          "localized": "Networking"
         },
         "description": {
           "en": "Demonstrated ability to seek out and form professional relationships with others in a way that benefits both parties.",
-          "fr": "Capacité démontrée à rechercher et à nouer des relations professionnelles avec les autres d'une manière qui profite aux deux parties."
+          "fr": "Capacité démontrée à rechercher et à nouer des relations professionnelles avec les autres d'une manière qui profite aux deux parties.",
+          "localized": "Demonstrated ability to seek out and form professional relationships with others in a way that benefits both parties."
         },
         "keywords": {
           "en": [
@@ -10290,11 +11552,13 @@
             "key": "interpersonal",
             "name": {
               "en": "Interpersonal Behaviours",
-              "fr": "Comportements interpersonnels"
+              "fr": "Comportements interpersonnels",
+              "localized": "Interpersonal Behaviours"
             },
             "description": {
               "en": "Behavioural - Interpersonal",
-              "fr": "Comportemental - Interpersonnel"
+              "fr": "Comportemental - Interpersonnel",
+              "localized": "Behavioural - Interpersonal"
             }
           }
         ]
@@ -10304,11 +11568,13 @@
         "key": "nginx",
         "name": {
           "en": "nginx",
-          "fr": "nginx"
+          "fr": "nginx",
+          "localized": "nginx"
         },
         "description": {
           "en": "Demonstrated ability to use this software to support web serving, reverse proxying, caching, and load balancing.",
-          "fr": "Capacité démontrée à utiliser ce logiciel pour prendre en charge le service Web, le proxy inverse, la mise en cache et l'équilibrage de charge."
+          "fr": "Capacité démontrée à utiliser ce logiciel pour prendre en charge le service Web, le proxy inverse, la mise en cache et l'équilibrage de charge.",
+          "localized": "Demonstrated ability to use this software to support web serving, reverse proxying, caching, and load balancing."
         },
         "keywords": {
           "en": null,
@@ -10323,11 +11589,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -10337,11 +11605,13 @@
         "key": "nodejs",
         "name": {
           "en": "NodeJS",
-          "fr": "NodeJS"
+          "fr": "NodeJS",
+          "localized": "NodeJS"
         },
         "description": {
           "en": "Demonstrated ability to leverage this JavaScript runtime environment to develop a variety of projects.",
-          "fr": "Capacité démontrée à exploiter cet environnement d’exécution JavaScript pour développer une variété de projets."
+          "fr": "Capacité démontrée à exploiter cet environnement d’exécution JavaScript pour développer une variété de projets.",
+          "localized": "Demonstrated ability to leverage this JavaScript runtime environment to develop a variety of projects."
         },
         "keywords": {
           "en": null,
@@ -10356,11 +11626,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -10370,11 +11642,13 @@
         "key": "office_software",
         "name": {
           "en": "Office Software",
-          "fr": "Logiciels de bureautique"
+          "fr": "Logiciels de bureautique",
+          "localized": "Office Software"
         },
         "description": {
           "en": "Demonstrated proficiency using general office software programs, including but not limited to Microsoft Suite (Excel, Word, Outlook, PowerPoint, Teams).",
-          "fr": "Maîtrise démontrée de l'utilisation de logiciels de bureautique généraux, y compris, mais sans s'y limiter, la suite Microsoft (Excel, Word, Outlook, PowerPoint, Teams)."
+          "fr": "Maîtrise démontrée de l'utilisation de logiciels de bureautique généraux, y compris, mais sans s'y limiter, la suite Microsoft (Excel, Word, Outlook, PowerPoint, Teams).",
+          "localized": "Demonstrated proficiency using general office software programs, including but not limited to Microsoft Suite (Excel, Word, Outlook, PowerPoint, Teams)."
         },
         "keywords": {
           "en": null,
@@ -10389,11 +11663,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           },
           {
@@ -10401,11 +11677,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -10415,11 +11693,13 @@
         "key": "on_premise_data_gateway",
         "name": {
           "en": "On-Premise Data Gateway",
-          "fr": "Passerelle de données sur site"
+          "fr": "Passerelle de données sur site",
+          "localized": "On-Premise Data Gateway"
         },
         "description": {
           "en": "Demonstrated ability to configure and manage On-Premises Data Gateways for seamless data transfer between on-premises data sources and Microsoft cloud services.",
-          "fr": "Capacité démontrée à configurer et gérer des passerelles de données sur site pour un transfert de données fluide entre les sources de données sur site et les services cloud de Microsoft."
+          "fr": "Capacité démontrée à configurer et gérer des passerelles de données sur site pour un transfert de données fluide entre les sources de données sur site et les services cloud de Microsoft.",
+          "localized": "Demonstrated ability to configure and manage On-Premises Data Gateways for seamless data transfer between on-premises data sources and Microsoft cloud services."
         },
         "keywords": {
           "en": ["On", "Premise", "Data", "Gateway"],
@@ -10434,11 +11714,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -10448,11 +11730,13 @@
         "key": "openness",
         "name": {
           "en": "Openness",
-          "fr": "Ouverture"
+          "fr": "Ouverture",
+          "localized": "Openness"
         },
         "description": {
           "en": "Demonstrated willingness to receive and share freely with others.",
-          "fr": "Volonté démontrée de recevoir et de partager librement avec les autres."
+          "fr": "Volonté démontrée de recevoir et de partager librement avec les autres.",
+          "localized": "Demonstrated willingness to receive and share freely with others."
         },
         "keywords": {
           "en": null,
@@ -10467,11 +11751,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -10481,11 +11767,13 @@
         "key": "organizational_acumen",
         "name": {
           "en": "Organizational Acumen",
-          "fr": "Sens de l’organisation"
+          "fr": "Sens de l’organisation",
+          "localized": "Organizational Acumen"
         },
         "description": {
           "en": "Demonstrated ability to understand the objectives and ecosystem of an organization, even when faced with complexity and change.",
-          "fr": "Capacité démontrée à comprendre les objectifs et l’écosystème d’une organisation, même face à la complexité et au changement."
+          "fr": "Capacité démontrée à comprendre les objectifs et l’écosystème d’une organisation, même face à la complexité et au changement.",
+          "localized": "Demonstrated ability to understand the objectives and ecosystem of an organization, even when faced with complexity and change."
         },
         "keywords": {
           "en": ["Business Savvy", "Business Sense"],
@@ -10500,11 +11788,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -10514,11 +11804,13 @@
         "key": "organizational_reporting",
         "name": {
           "en": "Organizational Reporting",
-          "fr": "Rapports organisationnels"
+          "fr": "Rapports organisationnels",
+          "localized": "Organizational Reporting"
         },
         "description": {
           "en": "Demonstrated ability to support or lead the preparation, analysis, and communication of financial and non-financial information reporting as required by organizational policy and timelines.",
-          "fr": "Capacité démontrée à soutenir ou à diriger la préparation, l'analyse et la communication d'informations financières et non financières conformément à la politique et aux délais de l'organisation."
+          "fr": "Capacité démontrée à soutenir ou à diriger la préparation, l'analyse et la communication d'informations financières et non financières conformément à la politique et aux délais de l'organisation.",
+          "localized": "Demonstrated ability to support or lead the preparation, analysis, and communication of financial and non-financial information reporting as required by organizational policy and timelines."
         },
         "keywords": {
           "en": null,
@@ -10533,11 +11825,13 @@
             "key": "im_data_governance_information_architecture",
             "name": {
               "en": "Information and Data Governance - Information Architecture",
-              "fr": "Gouvernance de l'information et des données - Architecture de l'information"
+              "fr": "Gouvernance de l'information et des données - Architecture de l'information",
+              "localized": "Information and Data Governance - Information Architecture"
             },
             "description": {
               "en": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes.",
-              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus."
+              "fr": "IM-Information Architecture développe, gère et communique des architectures d'information qui établissent, façonnent des systèmes et des produits d'information, pour soutenir la facilité d'utilisation, la trouvabilité et la compréhension des données structurées et non structurées, et guide le développement et la maintenance des artefacts d'architecture d'information sur la manière dont ils contribuent. à la réalisation de la stratégie d’une entreprise et à l’obtention des résultats commerciaux attendus.",
+              "localized": "IM-Information Architecture develops, manages and communicates information architectures that establish, shape information systems and products, to support usability, findability, and the understanding of structured and unstructured data, along with guides the development and maintenance of information architecture artefacts on how they contribute to the achievement of a business’ strategy and delivery of the expected business outcomes."
             }
           },
           {
@@ -10545,11 +11839,13 @@
             "key": "im_data_governance_strategy_direction",
             "name": {
               "en": "Information and Data Governance - Strategy and Direction",
-              "fr": "Gouvernance de l'information et des données - Stratégie et orientation"
+              "fr": "Gouvernance de l'information et des données - Stratégie et orientation",
+              "localized": "Information and Data Governance - Strategy and Direction"
             },
             "description": {
               "en": "IM-Strategy and Direction develops, manages and communicates directions (e.g. policies and strategies) for the governance and life-cycle management of information and data assets; establishes, supports and participates in governance bodies and anticipates future needs aimed at the transformation of delivery of services",
-              "fr": "La stratégie et la direction de la GI élabore, gère et communique des orientations (par exemple, des politiques et des stratégies) pour la gouvernance et la gestion du cycle de vie des actifs d'information et de données ; établit, soutient et participe aux instances de gouvernance et anticipe les besoins futurs visant la transformation de la prestation de services"
+              "fr": "La stratégie et la direction de la GI élabore, gère et communique des orientations (par exemple, des politiques et des stratégies) pour la gouvernance et la gestion du cycle de vie des actifs d'information et de données ; établit, soutient et participe aux instances de gouvernance et anticipe les besoins futurs visant la transformation de la prestation de services",
+              "localized": "IM-Strategy and Direction develops, manages and communicates directions (e.g. policies and strategies) for the governance and life-cycle management of information and data assets; establishes, supports and participates in governance bodies and anticipates future needs aimed at the transformation of delivery of services"
             }
           },
           {
@@ -10557,11 +11853,13 @@
             "key": "technical_advising",
             "name": {
               "en": "IT Planning and Reporting",
-              "fr": "Planification et établissement de rapports en matière de la numérique"
+              "fr": "Planification et établissement de rapports en matière de la numérique",
+              "localized": "IT Planning and Reporting"
             },
             "description": {
               "en": "IT generic work stream - IT Planning and Reporting",
-              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique"
+              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique",
+              "localized": "IT generic work stream - IT Planning and Reporting"
             }
           }
         ]
@@ -10571,11 +11869,13 @@
         "key": "originality",
         "name": {
           "en": "Originality",
-          "fr": "Originalité"
+          "fr": "Originalité",
+          "localized": "Originality"
         },
         "description": {
           "en": "Demonstrated ability to come up with new ideas about a given topic.",
-          "fr": "Capacité démontrée à trouver de nouvelles idées sur un sujet donné."
+          "fr": "Capacité démontrée à trouver de nouvelles idées sur un sujet donné.",
+          "localized": "Demonstrated ability to come up with new ideas about a given topic."
         },
         "keywords": {
           "en": [
@@ -10602,11 +11902,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -10616,11 +11918,13 @@
         "key": "passion",
         "name": {
           "en": "Passion",
-          "fr": "Passion"
+          "fr": "Passion",
+          "localized": "Passion"
         },
         "description": {
           "en": "Demonstrated and sustained enthusiasm for a task, initiative, or approach.",
-          "fr": "Enthousiasme démontré et soutenu pour une tâche, une initiative ou une approche."
+          "fr": "Enthousiasme démontré et soutenu pour une tâche, une initiative ou une approche.",
+          "localized": "Demonstrated and sustained enthusiasm for a task, initiative, or approach."
         },
         "keywords": {
           "en": ["Enthusiasm", "Eagerness", "Fervor", "Energy"],
@@ -10635,11 +11939,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -10649,11 +11955,13 @@
         "key": "performance_optimization",
         "name": {
           "en": "Performance optimization",
-          "fr": "Optimisation de la performance"
+          "fr": "Optimisation de la performance",
+          "localized": "Performance optimization"
         },
         "description": {
           "en": "Demonstrated ability to analyze, assess and optimize the end-to-end development and functionality of an application to improve the application speed and responsiveness.",
-          "fr": "Capacité avérée à analyser, évaluer et optimiser le développement et la fonctionnalité de bout en bout d’une application afin d’améliorer sa vitesse et sa réactivité."
+          "fr": "Capacité avérée à analyser, évaluer et optimiser le développement et la fonctionnalité de bout en bout d’une application afin d’améliorer sa vitesse et sa réactivité.",
+          "localized": "Demonstrated ability to analyze, assess and optimize the end-to-end development and functionality of an application to improve the application speed and responsiveness."
         },
         "keywords": {
           "en": ["Performance", "Optimisation"],
@@ -10668,11 +11976,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           }
         ]
@@ -10682,11 +11992,13 @@
         "key": "performance_testing",
         "name": {
           "en": "Performance testing",
-          "fr": "Test de performance"
+          "fr": "Test de performance",
+          "localized": "Performance testing"
         },
         "description": {
           "en": "Demonstrated ability to effectively evaluate and document the stability, speed, scalability, and responsiveness of an application by designing and executing comprehensive tests.",
-          "fr": "Capacité démontrée à évaluer et à documenter efficacement la stabilité, la vitesse, l’évolutivité et la réactivité d’une application en concevant et en exécutant des tests complets."
+          "fr": "Capacité démontrée à évaluer et à documenter efficacement la stabilité, la vitesse, l’évolutivité et la réactivité d’une application en concevant et en exécutant des tests complets.",
+          "localized": "Demonstrated ability to effectively evaluate and document the stability, speed, scalability, and responsiveness of an application by designing and executing comprehensive tests."
         },
         "keywords": {
           "en": ["Performance", "Testing"],
@@ -10701,11 +12013,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           }
         ]
@@ -10715,11 +12029,13 @@
         "key": "perl",
         "name": {
           "en": "Practical Extraction and Reporting Language (Perl)",
-          "fr": "Langage Pratique d'Extraction et de Rapport (Perl)"
+          "fr": "Langage Pratique d'Extraction et de Rapport (Perl)",
+          "localized": "Practical Extraction and Reporting Language (Perl)"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this programming language that supports procedural and object-oriented scripting to develop a variety of projects.",
-          "fr": "Capacité démontrée à appliquer une connaissance concrète de ce langage de programmation qui soutient le scripting procédural et orienté objet pour développer une variété de projets."
+          "fr": "Capacité démontrée à appliquer une connaissance concrète de ce langage de programmation qui soutient le scripting procédural et orienté objet pour développer une variété de projets.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this programming language that supports procedural and object-oriented scripting to develop a variety of projects."
         },
         "keywords": {
           "en": ["Perl"],
@@ -10734,11 +12050,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -10748,11 +12066,13 @@
         "key": "persistence",
         "name": {
           "en": "Persistence",
-          "fr": "Persistance"
+          "fr": "Persistance",
+          "localized": "Persistence"
         },
         "description": {
           "en": "Demonstrated effort to continuously work towards an outcome, despite challenges and setbacks.",
-          "fr": "Effort démontré pour travailler continuellement vers un résultat, malgré les défis et les revers."
+          "fr": "Effort démontré pour travailler continuellement vers un résultat, malgré les défis et les revers.",
+          "localized": "Demonstrated effort to continuously work towards an outcome, despite challenges and setbacks."
         },
         "keywords": {
           "en": [
@@ -10781,11 +12101,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -10795,11 +12117,13 @@
         "key": "php",
         "name": {
           "en": "PHP",
-          "fr": "PHP"
+          "fr": "PHP",
+          "localized": "PHP"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this language to develop a variety of projects.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce langage pour développer une variété de projets."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce langage pour développer une variété de projets.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this language to develop a variety of projects."
         },
         "keywords": {
           "en": null,
@@ -10814,11 +12138,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -10828,11 +12154,13 @@
         "key": "pl_sql",
         "name": {
           "en": "Structured Query Language - Procedural Language (PL/SQL)",
-          "fr": "Langage de requête structurée - Langage procédural (PL/SQL)"
+          "fr": "Langage de requête structurée - Langage procédural (PL/SQL)",
+          "localized": "Structured Query Language - Procedural Language (PL/SQL)"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this extension of SQL to write procedural code, such as loops, conditions and error handling.",
-          "fr": "Capacité démontrée à appliquer une connaissance concrète de cette extension de SQL pour écrire du code procédural, tel que des boucles, des conditions et la gestion des erreurs."
+          "fr": "Capacité démontrée à appliquer une connaissance concrète de cette extension de SQL pour écrire du code procédural, tel que des boucles, des conditions et la gestion des erreurs.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this extension of SQL to write procedural code, such as loops, conditions and error handling."
         },
         "keywords": {
           "en": ["PL/SQL"],
@@ -10847,11 +12175,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -10861,11 +12191,13 @@
         "key": "planning_and_reporting_for_digital_products_and_services",
         "name": {
           "en": "Planning and Reporting for Digital Products and Services",
-          "fr": "Planification et établissement de rapport pour les produits et services numériques"
+          "fr": "Planification et établissement de rapport pour les produits et services numériques",
+          "localized": "Planning and Reporting for Digital Products and Services"
         },
         "description": {
           "en": "Demonstrated ability to provide technical advice, coordination and logistical support for planning and reporting for digital products and services.",
-          "fr": "Capacité démontrée à fournir des conseils techniques, une coordination et un soutien logistique pour la planification et le reporting des produits et services numériques."
+          "fr": "Capacité démontrée à fournir des conseils techniques, une coordination et un soutien logistique pour la planification et le reporting des produits et services numériques.",
+          "localized": "Demonstrated ability to provide technical advice, coordination and logistical support for planning and reporting for digital products and services."
         },
         "keywords": {
           "en": ["planning", "reporting", "digital", "products", "services."],
@@ -10886,11 +12218,13 @@
             "key": "it_management",
             "name": {
               "en": "Digital Project Portfolio Management",
-              "fr": "Gestion de portefeuille de projets numériques"
+              "fr": "Gestion de portefeuille de projets numériques",
+              "localized": "Digital Project Portfolio Management"
             },
             "description": {
               "en": "IT generic work stream - Digital project portfolio management",
-              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques"
+              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques",
+              "localized": "IT generic work stream - Digital project portfolio management"
             }
           },
           {
@@ -10898,11 +12232,13 @@
             "key": "it_project_management",
             "name": {
               "en": "Digital Business Line Advisory Services",
-              "fr": "Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Services consultatifs auprès des secteurs de la numérique",
+              "localized": "Digital Business Line Advisory Services"
             },
             "description": {
               "en": "IT generic work stream - Business Line Advisory Services",
-              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique",
+              "localized": "IT generic work stream - Business Line Advisory Services"
             }
           }
         ]
@@ -10912,11 +12248,13 @@
         "key": "policies_procedures_quidelines_development",
         "name": {
           "en": "Policies, Procedures, or Guidelines development",
-          "fr": "Élaboration de politiques, de procédures ou de lignes directrices."
+          "fr": "Élaboration de politiques, de procédures ou de lignes directrices.",
+          "localized": "Policies, Procedures, or Guidelines development"
         },
         "description": {
           "en": "Demonstrated ability to interpret and develop varied policies, procedures or guidelines.",
-          "fr": "Capacité démontrée d’interpréter et d’élaborer diverses politiques, procédures ou lignes directrices."
+          "fr": "Capacité démontrée d’interpréter et d’élaborer diverses politiques, procédures ou lignes directrices.",
+          "localized": "Demonstrated ability to interpret and develop varied policies, procedures or guidelines."
         },
         "keywords": {
           "en": null,
@@ -10931,11 +12269,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           }
         ]
@@ -10945,11 +12285,13 @@
         "key": "policy_development",
         "name": {
           "en": "Policy Development",
-          "fr": "Élaboration de politiques"
+          "fr": "Élaboration de politiques",
+          "localized": "Policy Development"
         },
         "description": {
           "en": "Demonstrated ability to develop government or departmental policies, procedures, or guidelines.",
-          "fr": "Capacité démontrée à élaborer des politiques, des procédures ou des lignes directrices gouvernementales ou ministérielles."
+          "fr": "Capacité démontrée à élaborer des politiques, des procédures ou des lignes directrices gouvernementales ou ministérielles.",
+          "localized": "Demonstrated ability to develop government or departmental policies, procedures, or guidelines."
         },
         "keywords": {
           "en": null,
@@ -10964,11 +12306,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           },
           {
@@ -10976,11 +12320,13 @@
             "key": "im_data_governance_strategy_direction",
             "name": {
               "en": "Information and Data Governance - Strategy and Direction",
-              "fr": "Gouvernance de l'information et des données - Stratégie et orientation"
+              "fr": "Gouvernance de l'information et des données - Stratégie et orientation",
+              "localized": "Information and Data Governance - Strategy and Direction"
             },
             "description": {
               "en": "IM-Strategy and Direction develops, manages and communicates directions (e.g. policies and strategies) for the governance and life-cycle management of information and data assets; establishes, supports and participates in governance bodies and anticipates future needs aimed at the transformation of delivery of services",
-              "fr": "La stratégie et la direction de la GI élabore, gère et communique des orientations (par exemple, des politiques et des stratégies) pour la gouvernance et la gestion du cycle de vie des actifs d'information et de données ; établit, soutient et participe aux instances de gouvernance et anticipe les besoins futurs visant la transformation de la prestation de services"
+              "fr": "La stratégie et la direction de la GI élabore, gère et communique des orientations (par exemple, des politiques et des stratégies) pour la gouvernance et la gestion du cycle de vie des actifs d'information et de données ; établit, soutient et participe aux instances de gouvernance et anticipe les besoins futurs visant la transformation de la prestation de services",
+              "localized": "IM-Strategy and Direction develops, manages and communicates directions (e.g. policies and strategies) for the governance and life-cycle management of information and data assets; establishes, supports and participates in governance bodies and anticipates future needs aimed at the transformation of delivery of services"
             }
           },
           {
@@ -10988,11 +12334,13 @@
             "key": "working_in_government",
             "name": {
               "en": "Working in Government",
-              "fr": "Travailler au sein du gouvernement"
+              "fr": "Travailler au sein du gouvernement",
+              "localized": "Working in Government"
             },
             "description": {
               "en": "Technical skills family - Working in Government",
-              "fr": "Groupe de compétences techniques - Travailler au sein du gouvernement"
+              "fr": "Groupe de compétences techniques - Travailler au sein du gouvernement",
+              "localized": "Technical skills family - Working in Government"
             }
           }
         ]
@@ -11002,11 +12350,13 @@
         "key": "positive_attitude",
         "name": {
           "en": "Positive Attitude",
-          "fr": "Attitude positive"
+          "fr": "Attitude positive",
+          "localized": "Positive Attitude"
         },
         "description": {
           "en": "Demonstrated ability to face challenges with optimism and to make the best of bad situations.",
-          "fr": "Capacité démontrée à relever les défis avec optimisme et à tirer le meilleur parti des mauvaises situations."
+          "fr": "Capacité démontrée à relever les défis avec optimisme et à tirer le meilleur parti des mauvaises situations.",
+          "localized": "Demonstrated ability to face challenges with optimism and to make the best of bad situations."
         },
         "keywords": {
           "en": [
@@ -11031,11 +12381,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -11045,11 +12397,13 @@
         "key": "postgresql",
         "name": {
           "en": "PostgreSQL",
-          "fr": "PostgreSQL"
+          "fr": "PostgreSQL",
+          "localized": "PostgreSQL"
         },
         "description": {
           "en": "Demonstrated ability to use this object-relational database system to support the development of a variety of projects.",
-          "fr": "Capacité démontrée à utiliser ce système de base de données objet-relationnelle pour soutenir le développement d'une variété de projets."
+          "fr": "Capacité démontrée à utiliser ce système de base de données objet-relationnelle pour soutenir le développement d'une variété de projets.",
+          "localized": "Demonstrated ability to use this object-relational database system to support the development of a variety of projects."
         },
         "keywords": {
           "en": null,
@@ -11064,11 +12418,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -11078,11 +12434,13 @@
         "key": "power_bi",
         "name": {
           "en": "Power BI",
-          "fr": "Power BI"
+          "fr": "Power BI",
+          "localized": "Power BI"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this tool to analyze, design, develop and implement Power BI reports and dashboards.",
-          "fr": "Capacité démontrée à appliquer une connaissance concrète de cet outil pour analyser, concevoir, développer et mettre en œuvre des rapports et des tableaux de bord Power BI."
+          "fr": "Capacité démontrée à appliquer une connaissance concrète de cet outil pour analyser, concevoir, développer et mettre en œuvre des rapports et des tableaux de bord Power BI.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this tool to analyze, design, develop and implement Power BI reports and dashboards."
         },
         "keywords": {
           "en": ["Power", "BI"],
@@ -11097,11 +12455,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           }
         ]
@@ -11111,11 +12471,13 @@
         "key": "power_bi_desktop",
         "name": {
           "en": "Power BI Desktop",
-          "fr": "Power BI Desktop"
+          "fr": "Power BI Desktop",
+          "localized": "Power BI Desktop"
         },
         "description": {
           "en": "Demonstrated ability to utilize this tool for creating interactive visualizations and business intelligence reports, including the development of dashboards and data models.",
-          "fr": "Capacité démontrée à utiliser cet outil pour créer des visualisations interactives et des rapports d'informatique décisionnelle, y compris le développement de tableaux de bord et de modèles de données."
+          "fr": "Capacité démontrée à utiliser cet outil pour créer des visualisations interactives et des rapports d'informatique décisionnelle, y compris le développement de tableaux de bord et de modèles de données.",
+          "localized": "Demonstrated ability to utilize this tool for creating interactive visualizations and business intelligence reports, including the development of dashboards and data models."
         },
         "keywords": {
           "en": ["Power", "BI", "Desktop"],
@@ -11130,11 +12492,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           }
         ]
@@ -11144,11 +12508,13 @@
         "key": "power_bi_report_server",
         "name": {
           "en": "Power BI Report Server",
-          "fr": "Serveur de rapports Power BI"
+          "fr": "Serveur de rapports Power BI",
+          "localized": "Power BI Report Server"
         },
         "description": {
           "en": "Demonstrated ability to configure this tool and publish Power BI reports on-premise.",
-          "fr": "Capacité démontrée à configurer cet outil et à publier des rapports Power BI sur site."
+          "fr": "Capacité démontrée à configurer cet outil et à publier des rapports Power BI sur site.",
+          "localized": "Demonstrated ability to configure this tool and publish Power BI reports on-premise."
         },
         "keywords": {
           "en": ["Power", "BI", "Report", "Server"],
@@ -11163,11 +12529,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           }
         ]
@@ -11177,11 +12545,13 @@
         "key": "power_bi_service",
         "name": {
           "en": "Power BI Service",
-          "fr": "Service Power BI"
+          "fr": "Service Power BI",
+          "localized": "Power BI Service"
         },
         "description": {
           "en": "Demonstrated ability to configure this tool and deploy, manage, and optimize Power BI reports in the Azure cloud.",
-          "fr": "Capacité démontrée à déployer, gérer et optimiser des rapports à l'aide du service de rapports Power BI dans le nuage informatique Azure."
+          "fr": "Capacité démontrée à déployer, gérer et optimiser des rapports à l'aide du service de rapports Power BI dans le nuage informatique Azure.",
+          "localized": "Demonstrated ability to configure this tool and deploy, manage, and optimize Power BI reports in the Azure cloud."
         },
         "keywords": {
           "en": ["Power", "BI", "Service"],
@@ -11196,11 +12566,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           }
         ]
@@ -11210,11 +12582,13 @@
         "key": "power_builder",
         "name": {
           "en": "PowerBuilder",
-          "fr": "PowerBuilder"
+          "fr": "PowerBuilder",
+          "localized": "PowerBuilder"
         },
         "description": {
           "en": "Demonstrated ability to draw on concrete knowledge of this tool to create cloud-based Windows applications and components.",
-          "fr": "Capacité démontrée à s’appuyer sur des connaissances concrètes de cet outil pour créer des applications et des composants Windows basés sur le cloud."
+          "fr": "Capacité démontrée à s’appuyer sur des connaissances concrètes de cet outil pour créer des applications et des composants Windows basés sur le cloud.",
+          "localized": "Demonstrated ability to draw on concrete knowledge of this tool to create cloud-based Windows applications and components."
         },
         "keywords": {
           "en": ["SAP"],
@@ -11229,11 +12603,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -11243,11 +12619,13 @@
         "key": "power_platform",
         "name": {
           "en": "Power Platform",
-          "fr": "Power Platform"
+          "fr": "Power Platform",
+          "localized": "Power Platform"
         },
         "description": {
           "en": "Demonstrated ability to use this low code tool to support projects that leverage Microsoft tools such as Power Pages, Power BI, Power Apps, Power Automate, and Power Virtual Agents.",
-          "fr": "Capacité démontrée à utiliser cet outil low code pour prendre en charge des projets qui exploitent les outils Microsoft tels que Power Pages, Power BI, Power Apps, Power Automate et Power Virtual Agents."
+          "fr": "Capacité démontrée à utiliser cet outil low code pour prendre en charge des projets qui exploitent les outils Microsoft tels que Power Pages, Power BI, Power Apps, Power Automate et Power Virtual Agents.",
+          "localized": "Demonstrated ability to use this low code tool to support projects that leverage Microsoft tools such as Power Pages, Power BI, Power Apps, Power Automate, and Power Virtual Agents."
         },
         "keywords": {
           "en": ["Microsoft", "Low Code", "Power"],
@@ -11262,11 +12640,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -11276,11 +12656,13 @@
         "key": "power_platform_administration",
         "name": {
           "en": "Power Platform Administration",
-          "fr": "Administration de Power Platform"
+          "fr": "Administration de Power Platform",
+          "localized": "Power Platform Administration"
         },
         "description": {
           "en": "Demonstrated ability to manage and optimize Microsoft's Power Platform services including data access and protection and monitoring for applications such as Power Apps, Power Automate, Power Bi, Power Pages, and Power Virtual Agents.",
-          "fr": "Capacité démontrée à gérer et optimiser les services Power Platform de Microsoft, y compris l'accès aux données et la protection et la surveillance des applications telles que Power Apps, Power Automate, Power Bi, Power Pages et Power Virtual Agents."
+          "fr": "Capacité démontrée à gérer et optimiser les services Power Platform de Microsoft, y compris l'accès aux données et la protection et la surveillance des applications telles que Power Apps, Power Automate, Power Bi, Power Pages et Power Virtual Agents.",
+          "localized": "Demonstrated ability to manage and optimize Microsoft's Power Platform services including data access and protection and monitoring for applications such as Power Apps, Power Automate, Power Bi, Power Pages, and Power Virtual Agents."
         },
         "keywords": {
           "en": ["Power", "Platform", "Administration"],
@@ -11295,11 +12677,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -11309,11 +12693,13 @@
         "key": "power_query_m",
         "name": {
           "en": "Power Query (M)",
-          "fr": "Power Query (M)"
+          "fr": "Power Query (M)",
+          "localized": "Power Query (M)"
         },
         "description": {
           "en": "Demonstrated ability to use this tool to connect, transform and prepare data within Microsoft products for a variety of projects.",
-          "fr": "Capacité démontrée à utiliser ce logiciel pour connecter, transformer et préparer des données pour une variété de projets."
+          "fr": "Capacité démontrée à utiliser ce logiciel pour connecter, transformer et préparer des données pour une variété de projets.",
+          "localized": "Demonstrated ability to use this tool to connect, transform and prepare data within Microsoft products for a variety of projects."
         },
         "keywords": {
           "en": ["Power", "Query"],
@@ -11328,11 +12714,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -11342,11 +12730,13 @@
         "key": "powershell",
         "name": {
           "en": "PowerShell",
-          "fr": "PowerShell"
+          "fr": "PowerShell",
+          "localized": "PowerShell"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this tool to task automation and configuration management processes in a Microsoft environment.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de cet outil aux processus d'automatisation des tâches et de gestion de la configuration dans un environnement Microsoft."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de cet outil aux processus d'automatisation des tâches et de gestion de la configuration dans un environnement Microsoft.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this tool to task automation and configuration management processes in a Microsoft environment."
         },
         "keywords": {
           "en": ["PowerShell"],
@@ -11361,11 +12751,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -11375,11 +12767,13 @@
         "key": "preservation_planning_practices__policies__and_procedures",
         "name": {
           "en": "Preservation Planning Practices, Policies, and Procedures",
-          "fr": "Pratiques, politiques et procédures de planification de la préservation"
+          "fr": "Pratiques, politiques et procédures de planification de la préservation",
+          "localized": "Preservation Planning Practices, Policies, and Procedures"
         },
         "description": {
           "en": "",
-          "fr": ""
+          "fr": "",
+          "localized": ""
         },
         "keywords": {
           "en": [],
@@ -11394,11 +12788,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -11408,11 +12804,13 @@
         "key": "privacy_impact_assessments",
         "name": {
           "en": "Conducting Privacy Impact Assessments",
-          "fr": "Réalisation d’évaluations des facteurs relatifs à la vie privée"
+          "fr": "Réalisation d’évaluations des facteurs relatifs à la vie privée",
+          "localized": "Conducting Privacy Impact Assessments"
         },
         "description": {
           "en": "Demonstrated ability to assess and ensure compliance with data privacy regulations requiring expertise in legal frameworks, risk analysis and effective communication.",
-          "fr": "Capacité démontrée à évaluer et à assurer la conformité aux réglementations en matière de confidentialité des données, ce qui nécessite une expertise dans les cadres juridiques, l’analyse des risques et une communication efficace."
+          "fr": "Capacité démontrée à évaluer et à assurer la conformité aux réglementations en matière de confidentialité des données, ce qui nécessite une expertise dans les cadres juridiques, l’analyse des risques et une communication efficace.",
+          "localized": "Demonstrated ability to assess and ensure compliance with data privacy regulations requiring expertise in legal frameworks, risk analysis and effective communication."
         },
         "keywords": {
           "en": null,
@@ -11427,11 +12825,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           }
         ]
@@ -11441,11 +12841,13 @@
         "key": "problem_solving",
         "name": {
           "en": "Problem Solving",
-          "fr": "Résolution de problèmes"
+          "fr": "Résolution de problèmes",
+          "localized": "Problem Solving"
         },
         "description": {
           "en": "Demonstrated ability to identify the source of an issue, and find and implement an effective solution.",
-          "fr": "Capacité démontrée à identifier la source d’un problème, ainsi qu’à trouver et mettre en œuvre une solution efficace."
+          "fr": "Capacité démontrée à identifier la source d’un problème, ainsi qu’à trouver et mettre en œuvre une solution efficace.",
+          "localized": "Demonstrated ability to identify the source of an issue, and find and implement an effective solution."
         },
         "keywords": {
           "en": [
@@ -11470,11 +12872,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -11484,11 +12888,13 @@
         "key": "process_monitoring",
         "name": {
           "en": "Process Monitoring",
-          "fr": "Surveillance des processus"
+          "fr": "Surveillance des processus",
+          "localized": "Process Monitoring"
         },
         "description": {
           "en": "Demonstrated ability to understand and follow procedural steps, including updating and monitoring procedures, processes, and tools.",
-          "fr": "Capacité démontrée à comprendre et à suivre les étapes de procédure, y compris la mise à jour et la surveillance des procédures, des processus et des outils."
+          "fr": "Capacité démontrée à comprendre et à suivre les étapes de procédure, y compris la mise à jour et la surveillance des procédures, des processus et des outils.",
+          "localized": "Demonstrated ability to understand and follow procedural steps, including updating and monitoring procedures, processes, and tools."
         },
         "keywords": {
           "en": null,
@@ -11503,11 +12909,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           }
         ]
@@ -11517,11 +12925,13 @@
         "key": "project_management",
         "name": {
           "en": "Project Management",
-          "fr": "Gestion de projet"
+          "fr": "Gestion de projet",
+          "localized": "Project Management"
         },
         "description": {
           "en": "Demonstrated ability to prioritize the most impactful changes, managing competing priorities, advancing a continuous cycle of improvement.",
-          "fr": "Capacité démontrée à prioriser les changements les plus percutants, à gérer les priorités concurrentes et à faire progresser un cycle d’amélioration continue."
+          "fr": "Capacité démontrée à prioriser les changements les plus percutants, à gérer les priorités concurrentes et à faire progresser un cycle d’amélioration continue.",
+          "localized": "Demonstrated ability to prioritize the most impactful changes, managing competing priorities, advancing a continuous cycle of improvement."
         },
         "keywords": {
           "en": [
@@ -11546,11 +12956,13 @@
             "key": "management_competencies",
             "name": {
               "en": "Leadership - General Technical Skills",
-              "fr": "Leadership - Compétences techniques générales"
+              "fr": "Leadership - Compétences techniques générales",
+              "localized": "Leadership - General Technical Skills"
             },
             "description": {
               "en": "Management skills at the non-executive level for oversight of finances, human resources, initiatives, and accountabilities",
-              "fr": "Compétences en gestion au niveau non exécutif pour la surveillance des finances, des ressources humaines, des initiatives et des responsabilités"
+              "fr": "Compétences en gestion au niveau non exécutif pour la surveillance des finances, des ressources humaines, des initiatives et des responsabilités",
+              "localized": "Management skills at the non-executive level for oversight of finances, human resources, initiatives, and accountabilities"
             }
           }
         ]
@@ -11560,11 +12972,13 @@
         "key": "public_key_infrastructure",
         "name": {
           "en": "Public Key Infrastructure",
-          "fr": "Infrastructure à clé publique"
+          "fr": "Infrastructure à clé publique",
+          "localized": "Public Key Infrastructure"
         },
         "description": {
           "en": "Demonstrated ability to work with (and provide technical advice on) infrastructure, policies, and procedures needed to support digital certificates and public keys throughout their lifecycle, including creation, use, distribution, storage, access, management, revocation, and dissolution.",
-          "fr": "Capacité démontrée à travailler avec (et à fournir des conseils techniques sur) l'infrastructure, les politiques et les procédures nécessaires pour prendre en charge les certificats numériques et les clés publiques tout au long de leur cycle de vie, y compris la création, l'utilisation, la distribution, le stockage, l'accès, la gestion, la révocation et la dissolution."
+          "fr": "Capacité démontrée à travailler avec (et à fournir des conseils techniques sur) l'infrastructure, les politiques et les procédures nécessaires pour prendre en charge les certificats numériques et les clés publiques tout au long de leur cycle de vie, y compris la création, l'utilisation, la distribution, le stockage, l'accès, la gestion, la révocation et la dissolution.",
+          "localized": "Demonstrated ability to work with (and provide technical advice on) infrastructure, policies, and procedures needed to support digital certificates and public keys throughout their lifecycle, including creation, use, distribution, storage, access, management, revocation, and dissolution."
         },
         "keywords": {
           "en": null,
@@ -11579,11 +12993,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           },
           {
@@ -11591,11 +13007,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           },
           {
@@ -11603,11 +13021,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -11617,11 +13037,13 @@
         "key": "python",
         "name": {
           "en": "Python",
-          "fr": "Python"
+          "fr": "Python",
+          "localized": "Python"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this programming language to develop a variety of projects.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce langage de programmation pour développer une variété de projets."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce langage de programmation pour développer une variété de projets.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this programming language to develop a variety of projects."
         },
         "keywords": {
           "en": null,
@@ -11636,11 +13058,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -11650,11 +13074,13 @@
         "key": "quality_assurance_strategies",
         "name": {
           "en": "Quality Assurance Strategies",
-          "fr": "Stratégies relatives à l’assurance de la qualité"
+          "fr": "Stratégies relatives à l’assurance de la qualité",
+          "localized": "Quality Assurance Strategies"
         },
         "description": {
           "en": "Demonstrated ability to ensure product standards by implementing rigorous testing processes, identifying defects, and maintaining high standards throughout the software development lifecycle (SDLC).",
-          "fr": "Capacité démontrée à garantir les normes de produit en mettant en œuvre des processus rigoureux de mise à l’essai, en relevant les défauts et en maintenant des normes élevées tout au long du cycle de développement de logiciel (CVDL)."
+          "fr": "Capacité démontrée à garantir les normes de produit en mettant en œuvre des processus rigoureux de mise à l’essai, en relevant les défauts et en maintenant des normes élevées tout au long du cycle de développement de logiciel (CVDL).",
+          "localized": "Demonstrated ability to ensure product standards by implementing rigorous testing processes, identifying defects, and maintaining high standards throughout the software development lifecycle (SDLC)."
         },
         "keywords": {
           "en": ["Quality", "Assurance", "Strategies"],
@@ -11669,11 +13095,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           }
         ]
@@ -11683,11 +13111,13 @@
         "key": "r",
         "name": {
           "en": "R",
-          "fr": "R"
+          "fr": "R",
+          "localized": "R"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this programming language to generate statistical computing and data visualization.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce langage de programmation pour générer du calcul statistique et la visualisation de données."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce langage de programmation pour générer du calcul statistique et la visualisation de données.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this programming language to generate statistical computing and data visualization."
         },
         "keywords": {
           "en": null,
@@ -11702,11 +13132,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -11716,11 +13148,13 @@
         "key": "react",
         "name": {
           "en": "React",
-          "fr": "React"
+          "fr": "React",
+          "localized": "React"
         },
         "description": {
           "en": "Demonstrated ability to leverage this JavaScript library to develop a variety of projects.",
-          "fr": "Capacité démontrée à exploiter cette bibliothèque JavaScript pour développer une variété de projets."
+          "fr": "Capacité démontrée à exploiter cette bibliothèque JavaScript pour développer une variété de projets.",
+          "localized": "Demonstrated ability to leverage this JavaScript library to develop a variety of projects."
         },
         "keywords": {
           "en": null,
@@ -11735,11 +13169,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -11749,11 +13185,13 @@
         "key": "relationship_management",
         "name": {
           "en": "Relationship Management",
-          "fr": "Gestion des relations"
+          "fr": "Gestion des relations",
+          "localized": "Relationship Management"
         },
         "description": {
           "en": "Demonstrated ability to build rapport with clients and stakeholders and keep them engaged over a sustained amount of time.",
-          "fr": "Capacité démontrée à établir des relations avec les clients et les parties prenantes et à les maintenir engagés sur une période de temps prolongée."
+          "fr": "Capacité démontrée à établir des relations avec les clients et les parties prenantes et à les maintenir engagés sur une période de temps prolongée.",
+          "localized": "Demonstrated ability to build rapport with clients and stakeholders and keep them engaged over a sustained amount of time."
         },
         "keywords": {
           "en": [
@@ -11778,11 +13216,13 @@
             "key": "interpersonal",
             "name": {
               "en": "Interpersonal Behaviours",
-              "fr": "Comportements interpersonnels"
+              "fr": "Comportements interpersonnels",
+              "localized": "Interpersonal Behaviours"
             },
             "description": {
               "en": "Behavioural - Interpersonal",
-              "fr": "Comportemental - Interpersonnel"
+              "fr": "Comportemental - Interpersonnel",
+              "localized": "Behavioural - Interpersonal"
             }
           }
         ]
@@ -11792,11 +13232,13 @@
         "key": "release_management",
         "name": {
           "en": "Release Management",
-          "fr": "Gestion des versions"
+          "fr": "Gestion des versions",
+          "localized": "Release Management"
         },
         "description": {
           "en": "Demonstrated ability to oversee the development, testing, and deployment of software’s to ensure the standards meet client expectations.",
-          "fr": "Capacité avérée à superviser le développement, les tests et le déploiement de logiciels afin de s’assurer que les normes répondent aux attentes des clients."
+          "fr": "Capacité avérée à superviser le développement, les tests et le déploiement de logiciels afin de s’assurer que les normes répondent aux attentes des clients.",
+          "localized": "Demonstrated ability to oversee the development, testing, and deployment of software’s to ensure the standards meet client expectations."
         },
         "keywords": {
           "en": ["Release", "Management"],
@@ -11811,11 +13253,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           }
         ]
@@ -11825,11 +13269,13 @@
         "key": "requirements_analysis",
         "name": {
           "en": "Requirements Analysis",
-          "fr": "Analyse des besoins"
+          "fr": "Analyse des besoins",
+          "localized": "Requirements Analysis"
         },
         "description": {
           "en": "Demonstrated ability to determine users' needs and expectations for a new or modified product, and then document this in a way that enables product authorities to assess and move forward.",
-          "fr": "Capacité démontrée à déterminer les besoins et les attentes des utilisateurs concernant un produit nouveau ou modifié, puis à documenter cela de manière à permettre aux autorités responsables du produit d'évaluer et d'aller de l'avant."
+          "fr": "Capacité démontrée à déterminer les besoins et les attentes des utilisateurs concernant un produit nouveau ou modifié, puis à documenter cela de manière à permettre aux autorités responsables du produit d'évaluer et d'aller de l'avant.",
+          "localized": "Demonstrated ability to determine users' needs and expectations for a new or modified product, and then document this in a way that enables product authorities to assess and move forward."
         },
         "keywords": {
           "en": null,
@@ -11844,11 +13290,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           },
           {
@@ -11856,11 +13304,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           },
           {
@@ -11868,11 +13318,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           },
           {
@@ -11880,11 +13332,13 @@
             "key": "user_experience_and_interface_design",
             "name": {
               "en": "Software Solutions - Product Design",
-              "fr": "Solutions logicielles - Conception de produits"
+              "fr": "Solutions logicielles - Conception de produits",
+              "localized": "Software Solutions - Product Design"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur",
+              "localized": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design"
             }
           },
           {
@@ -11892,11 +13346,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -11906,11 +13362,13 @@
         "key": "research_and_analysis",
         "name": {
           "en": "Research and Analysis",
-          "fr": "Recherche et analyse"
+          "fr": "Recherche et analyse",
+          "localized": "Research and Analysis"
         },
         "description": {
           "en": "Demonstrated ability to research and analyze documents or case law in order to prepare recommendations.",
-          "fr": "Capacité démontrée à rechercher et analyser des documents ou de la jurisprudence afin de préparer des recommandations."
+          "fr": "Capacité démontrée à rechercher et analyser des documents ou de la jurisprudence afin de préparer des recommandations.",
+          "localized": "Demonstrated ability to research and analyze documents or case law in order to prepare recommendations."
         },
         "keywords": {
           "en": ["Research", "Analysis."],
@@ -11925,11 +13383,13 @@
             "key": "atip",
             "name": {
               "en": "Access to Information and Privacy",
-              "fr": "Accès à l’information et de la protection des renseignements personnels"
+              "fr": "Accès à l’information et de la protection des renseignements personnels",
+              "localized": "Access to Information and Privacy"
             },
             "description": {
               "en": "IM work stream - Technical skill family for ATIP (PM/AS classification)",
-              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP"
+              "fr": "IM - groupe de compétences techniques pour le volet de travail ATIP",
+              "localized": "IM work stream - Technical skill family for ATIP (PM/AS classification)"
             }
           },
           {
@@ -11937,11 +13397,13 @@
             "key": "information_management",
             "name": {
               "en": "Information and Data Governance - Operations",
-              "fr": "Gouvernance de l'information et des données - Opérations"
+              "fr": "Gouvernance de l'information et des données - Opérations",
+              "localized": "Information and Data Governance - Operations"
             },
             "description": {
               "en": "IM-Operations involves overseeing the efficient and effective application of life-cycle management practices for records and documents within information management systems, serving business and legal purposes.",
-              "fr": "Les opérations de GI consistent à superviser l'application efficiente et efficace des pratiques de gestion du cycle de vie des dossiers et des documents au sein des systèmes de gestion de l'information, à des fins commerciales et juridiques."
+              "fr": "Les opérations de GI consistent à superviser l'application efficiente et efficace des pratiques de gestion du cycle de vie des dossiers et des documents au sein des systèmes de gestion de l'information, à des fins commerciales et juridiques.",
+              "localized": "IM-Operations involves overseeing the efficient and effective application of life-cycle management practices for records and documents within information management systems, serving business and legal purposes."
             }
           }
         ]
@@ -11951,11 +13413,13 @@
         "key": "resilience",
         "name": {
           "en": "Resilience",
-          "fr": "Résilience"
+          "fr": "Résilience",
+          "localized": "Resilience"
         },
         "description": {
           "en": "Demonstrated ability to quickly recover from significant or sustained adversity, challenges, or change.",
-          "fr": "Capacité démontrée à se remettre rapidement d’une adversité, de défis ou d’un changement importants ou soutenus."
+          "fr": "Capacité démontrée à se remettre rapidement d’une adversité, de défis ou d’un changement importants ou soutenus.",
+          "localized": "Demonstrated ability to quickly recover from significant or sustained adversity, challenges, or change."
         },
         "keywords": {
           "en": ["Flexibility", "Adaptability", "Adjustability"],
@@ -11970,11 +13434,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -11984,11 +13450,13 @@
         "key": "resource_management",
         "name": {
           "en": "Resource Management",
-          "fr": "Gestion des ressources"
+          "fr": "Gestion des ressources",
+          "localized": "Resource Management"
         },
         "description": {
           "en": "Demonstrated ability to effectively develop, allocate, and manage assets as they are needed.",
-          "fr": "Capacité démontrée à développer, allouer et gérer efficacement les actifs selon les besoins."
+          "fr": "Capacité démontrée à développer, allouer et gérer efficacement les actifs selon les besoins.",
+          "localized": "Demonstrated ability to effectively develop, allocate, and manage assets as they are needed."
         },
         "keywords": {
           "en": [
@@ -12011,11 +13479,13 @@
             "key": "management_competencies",
             "name": {
               "en": "Leadership - General Technical Skills",
-              "fr": "Leadership - Compétences techniques générales"
+              "fr": "Leadership - Compétences techniques générales",
+              "localized": "Leadership - General Technical Skills"
             },
             "description": {
               "en": "Management skills at the non-executive level for oversight of finances, human resources, initiatives, and accountabilities",
-              "fr": "Compétences en gestion au niveau non exécutif pour la surveillance des finances, des ressources humaines, des initiatives et des responsabilités"
+              "fr": "Compétences en gestion au niveau non exécutif pour la surveillance des finances, des ressources humaines, des initiatives et des responsabilités",
+              "localized": "Management skills at the non-executive level for oversight of finances, human resources, initiatives, and accountabilities"
             }
           }
         ]
@@ -12025,11 +13495,13 @@
         "key": "respect",
         "name": {
           "en": "Respect",
-          "fr": "Respect"
+          "fr": "Respect",
+          "localized": "Respect"
         },
         "description": {
           "en": "Demonstrated commitment to creating an environment that is free from discrimination, harassment, and bullying.",
-          "fr": "Engagement démontré à créer un environnement exempt de discrimination, de harcèlement et d'intimidation."
+          "fr": "Engagement démontré à créer un environnement exempt de discrimination, de harcèlement et d'intimidation.",
+          "localized": "Demonstrated commitment to creating an environment that is free from discrimination, harassment, and bullying."
         },
         "keywords": {
           "en": ["Consideration", "Appreciation", "Professional", "Courteous"],
@@ -12049,11 +13521,13 @@
             "key": "interpersonal",
             "name": {
               "en": "Interpersonal Behaviours",
-              "fr": "Comportements interpersonnels"
+              "fr": "Comportements interpersonnels",
+              "localized": "Interpersonal Behaviours"
             },
             "description": {
               "en": "Behavioural - Interpersonal",
-              "fr": "Comportemental - Interpersonnel"
+              "fr": "Comportemental - Interpersonnel",
+              "localized": "Behavioural - Interpersonal"
             }
           }
         ]
@@ -12063,11 +13537,13 @@
         "key": "respect_for_diversity",
         "name": {
           "en": "Respect for Diversity",
-          "fr": "Respect de la diversité"
+          "fr": "Respect de la diversité",
+          "localized": "Respect for Diversity"
         },
         "description": {
           "en": "Demonstrated ability to appreciate the unique qualities and views that people from different backgrounds bring to a team, organization or project.",
-          "fr": "Capacité démontrée à apprécier les qualités et les points de vue uniques que des personnes d'horizons différents apportent à une équipe, une organisation ou un projet."
+          "fr": "Capacité démontrée à apprécier les qualités et les points de vue uniques que des personnes d'horizons différents apportent à une équipe, une organisation ou un projet.",
+          "localized": "Demonstrated ability to appreciate the unique qualities and views that people from different backgrounds bring to a team, organization or project."
         },
         "keywords": {
           "en": [
@@ -12090,11 +13566,13 @@
             "key": "interpersonal",
             "name": {
               "en": "Interpersonal Behaviours",
-              "fr": "Comportements interpersonnels"
+              "fr": "Comportements interpersonnels",
+              "localized": "Interpersonal Behaviours"
             },
             "description": {
               "en": "Behavioural - Interpersonal",
-              "fr": "Comportemental - Interpersonnel"
+              "fr": "Comportemental - Interpersonnel",
+              "localized": "Behavioural - Interpersonal"
             }
           }
         ]
@@ -12104,11 +13582,13 @@
         "key": "results_mindset",
         "name": {
           "en": "Results Mindset",
-          "fr": "Orienté vers les résultats"
+          "fr": "Orienté vers les résultats",
+          "localized": "Results Mindset"
         },
         "description": {
           "en": "Demonstrated ability to focus efforts on achieving quality results that are consistent with the overall vision.",
-          "fr": "Capacité démontrée à concentrer ses efforts sur l’obtention de résultats de qualité conformes à la vision globale."
+          "fr": "Capacité démontrée à concentrer ses efforts sur l’obtention de résultats de qualité conformes à la vision globale.",
+          "localized": "Demonstrated ability to focus efforts on achieving quality results that are consistent with the overall vision."
         },
         "keywords": {
           "en": ["Results-Oriented", "Goal-Driven", "Outcome-Oriented"],
@@ -12127,11 +13607,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -12141,11 +13623,13 @@
         "key": "risk_assessment",
         "name": {
           "en": "Risk Assessment",
-          "fr": "Évaluation du risque"
+          "fr": "Évaluation du risque",
+          "localized": "Risk Assessment"
         },
         "description": {
           "en": "Demonstrated ability to systematically identify hazards, risks, and potential outcomes, to analyze situations, and to propose mitigation measures that address risk factors.",
-          "fr": "Capacité démontrée à cerner systématiquement les dangers, les risques et les résultats potentiels, à analyser les situations ainsi qu'à proposer des mesures d'atténuation qui tiennent compte des facteurs de risque."
+          "fr": "Capacité démontrée à cerner systématiquement les dangers, les risques et les résultats potentiels, à analyser les situations ainsi qu'à proposer des mesures d'atténuation qui tiennent compte des facteurs de risque.",
+          "localized": "Demonstrated ability to systematically identify hazards, risks, and potential outcomes, to analyze situations, and to propose mitigation measures that address risk factors."
         },
         "keywords": {
           "en": ["risk", "hazard", "assessment."],
@@ -12160,11 +13644,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           },
           {
@@ -12172,11 +13658,13 @@
             "key": "it_management",
             "name": {
               "en": "Digital Project Portfolio Management",
-              "fr": "Gestion de portefeuille de projets numériques"
+              "fr": "Gestion de portefeuille de projets numériques",
+              "localized": "Digital Project Portfolio Management"
             },
             "description": {
               "en": "IT generic work stream - Digital project portfolio management",
-              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques"
+              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques",
+              "localized": "IT generic work stream - Digital project portfolio management"
             }
           },
           {
@@ -12184,11 +13672,13 @@
             "key": "it_project_management",
             "name": {
               "en": "Digital Business Line Advisory Services",
-              "fr": "Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Services consultatifs auprès des secteurs de la numérique",
+              "localized": "Digital Business Line Advisory Services"
             },
             "description": {
               "en": "IT generic work stream - Business Line Advisory Services",
-              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique",
+              "localized": "IT generic work stream - Business Line Advisory Services"
             }
           },
           {
@@ -12196,11 +13686,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           },
           {
@@ -12208,11 +13700,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           }
         ]
@@ -12222,11 +13716,13 @@
         "key": "risk_management",
         "name": {
           "en": "Risk Management",
-          "fr": "Gestion des risques"
+          "fr": "Gestion des risques",
+          "localized": "Risk Management"
         },
         "description": {
           "en": "Demonstrated ability to manage identified and potential risks and mitigate threats or uncertainties that can affect an organization. This includes analyzing the likelihood and impact of risks, developing strategies to minimize harm, and monitoring the effectiveness of risk mitigation efforts.",
-          "fr": "Capacité manifeste à gérer les risques identifiés et potentiels et à atténuer les menaces ou les incertitudes qui peuvent viser une organisation. Il s’agit notamment d’analyser la probabilité et l’incidence des risques, d’élaborer des stratégies visant à réduire au minimum les dommages et de surveiller l’efficacité des efforts d’atténuation des risques."
+          "fr": "Capacité manifeste à gérer les risques identifiés et potentiels et à atténuer les menaces ou les incertitudes qui peuvent viser une organisation. Il s’agit notamment d’analyser la probabilité et l’incidence des risques, d’élaborer des stratégies visant à réduire au minimum les dommages et de surveiller l’efficacité des efforts d’atténuation des risques.",
+          "localized": "Demonstrated ability to manage identified and potential risks and mitigate threats or uncertainties that can affect an organization. This includes analyzing the likelihood and impact of risks, developing strategies to minimize harm, and monitoring the effectiveness of risk mitigation efforts."
         },
         "keywords": {
           "en": ["Risk", "Management"],
@@ -12241,11 +13737,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -12255,11 +13753,13 @@
         "key": "risk_mindset",
         "name": {
           "en": "Risk Mindset",
-          "fr": "Orienté vers la prise de risque"
+          "fr": "Orienté vers la prise de risque",
+          "localized": "Risk Mindset"
         },
         "description": {
           "en": "Demonstrated ability to comfortably take calculated risks and learn from those that are unsuccessful.",
-          "fr": "Capacité démontrée à prendre confortablement des risques calculés et à apprendre de ceux qui échouent."
+          "fr": "Capacité démontrée à prendre confortablement des risques calculés et à apprendre de ceux qui échouent.",
+          "localized": "Demonstrated ability to comfortably take calculated risks and learn from those that are unsuccessful."
         },
         "keywords": {
           "en": ["Comfort with Risk", "Calculated Risk", "Risk Taking"],
@@ -12274,11 +13774,13 @@
             "key": "leadership",
             "name": {
               "en": "Leadership - General Behaviours",
-              "fr": "Leadership - Comportements généraux"
+              "fr": "Leadership - Comportements généraux",
+              "localized": "Leadership - General Behaviours"
             },
             "description": {
               "en": "Behavioural - Leadership",
-              "fr": "Comportemental - Leadership"
+              "fr": "Comportemental - Leadership",
+              "localized": "Behavioural - Leadership"
             }
           }
         ]
@@ -12288,11 +13790,13 @@
         "key": "root_cause_analysis",
         "name": {
           "en": "Root Cause Analysis",
-          "fr": "Analyse des causes profondes"
+          "fr": "Analyse des causes profondes",
+          "localized": "Root Cause Analysis"
         },
         "description": {
           "en": "Demonstrated ability to research and uncover underlying problems and mitigating factors that shape results and surface appearances. This includes advancing solutions by providing recommendations for addressing, preventing or resolving underlying problems.",
-          "fr": "Capacité démontrée à rechercher et à découvrir les problèmes sous-jacents et les facteurs atténuants qui façonnent les résultats et les apparences. Cela inclut la promotion de solutions en fournissant des recommandations pour aborder, prévenir ou résoudre les problèmes sous-jacents."
+          "fr": "Capacité démontrée à rechercher et à découvrir les problèmes sous-jacents et les facteurs atténuants qui façonnent les résultats et les apparences. Cela inclut la promotion de solutions en fournissant des recommandations pour aborder, prévenir ou résoudre les problèmes sous-jacents.",
+          "localized": "Demonstrated ability to research and uncover underlying problems and mitigating factors that shape results and surface appearances. This includes advancing solutions by providing recommendations for addressing, preventing or resolving underlying problems."
         },
         "keywords": {
           "en": null,
@@ -12307,11 +13811,13 @@
             "key": "user_experience_and_interface_design",
             "name": {
               "en": "Software Solutions - Product Design",
-              "fr": "Solutions logicielles - Conception de produits"
+              "fr": "Solutions logicielles - Conception de produits",
+              "localized": "Software Solutions - Product Design"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur",
+              "localized": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design"
             }
           }
         ]
@@ -12321,11 +13827,13 @@
         "key": "ruby_on_rails",
         "name": {
           "en": "Ruby on Rails",
-          "fr": "Ruby on Rails"
+          "fr": "Ruby on Rails",
+          "localized": "Ruby on Rails"
         },
         "description": {
           "en": "Demonstrated ability to leverage this full-stack framework to develop a variety of database-backed web applications.",
-          "fr": "Capacité démontrée à exploiter ce framework full-stack pour développer une variété d’applications Web basées sur des bases de données."
+          "fr": "Capacité démontrée à exploiter ce framework full-stack pour développer une variété d’applications Web basées sur des bases de données.",
+          "localized": "Demonstrated ability to leverage this full-stack framework to develop a variety of database-backed web applications."
         },
         "keywords": {
           "en": null,
@@ -12340,11 +13848,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -12354,11 +13864,13 @@
         "key": "sap_abap",
         "name": {
           "en": "SAP Advanced Business Application Programming (ABAP)",
-          "fr": "Programmation avancée des applications d’entreprise SAP (ABAP)"
+          "fr": "Programmation avancée des applications d’entreprise SAP (ABAP)",
+          "localized": "SAP Advanced Business Application Programming (ABAP)"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this programming language to develop a variety of business applications within the SAP environment.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes liées à ce langage de programmation afin de mettre au point une gamme d’applications d’entreprise dans l’environnement SAP."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes liées à ce langage de programmation afin de mettre au point une gamme d’applications d’entreprise dans l’environnement SAP.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this programming language to develop a variety of business applications within the SAP environment."
         },
         "keywords": {
           "en": ["ABAP"],
@@ -12373,11 +13885,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -12387,11 +13901,13 @@
         "key": "sap_basis",
         "name": {
           "en": "SAP Basis",
-          "fr": "SAP Basis"
+          "fr": "SAP Basis",
+          "localized": "SAP Basis"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of foundational SAP concepts and features to enable applications to be interoperable and portable across operating systems and database products.",
-          "fr": "Capacité démontrée à appliquer une connaissance concrète des concepts fondamentaux et des fonctionnalités de SAP pour permettre aux applications d'être interopérables et portables à travers les systèmes d'exploitation et les produits de base de données."
+          "fr": "Capacité démontrée à appliquer une connaissance concrète des concepts fondamentaux et des fonctionnalités de SAP pour permettre aux applications d'être interopérables et portables à travers les systèmes d'exploitation et les produits de base de données.",
+          "localized": "Demonstrated ability to apply concrete knowledge of foundational SAP concepts and features to enable applications to be interoperable and portable across operating systems and database products."
         },
         "keywords": {
           "en": ["SAP", "Basis"],
@@ -12406,11 +13922,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -12420,11 +13938,13 @@
         "key": "sap_business_objects_buisness_intelligence",
         "name": {
           "en": "SAP BusinessObjects Buisness Intelligence",
-          "fr": "SAP BusinessObjects Buisness Intelligence"
+          "fr": "SAP BusinessObjects Buisness Intelligence",
+          "localized": "SAP BusinessObjects Buisness Intelligence"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this suite of business intelligence (BI) tools for data reporting, visualization and analysis.",
-          "fr": "Capacité démontrée à appliquer une connaissance concrète de cette suite d'outils d'informatique décisionnelle (BI) pour le reporting, la visualisation et l'analyse des données."
+          "fr": "Capacité démontrée à appliquer une connaissance concrète de cette suite d'outils d'informatique décisionnelle (BI) pour le reporting, la visualisation et l'analyse des données.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this suite of business intelligence (BI) tools for data reporting, visualization and analysis."
         },
         "keywords": {
           "en": ["SAP", "BusinessObjects", "Buisness", "Intelligence"],
@@ -12439,11 +13959,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -12453,11 +13975,13 @@
         "key": "sap_data_services",
         "name": {
           "en": "SAP Data Services",
-          "fr": "SAP Data Services"
+          "fr": "SAP Data Services",
+          "localized": "SAP Data Services"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this enterprise information management solution for migration of data, text analysis, data quality and interconnectivity between SAP and non-SAP systems.",
-          "fr": "Capacité démontrée à appliquer une connaissance concrète de cette solution de gestion d'information d'entreprise pour la migration des données, l'analyse de texte, la qualité des données et l'interopérabilité entre les systèmes SAP et non-SAP."
+          "fr": "Capacité démontrée à appliquer une connaissance concrète de cette solution de gestion d'information d'entreprise pour la migration des données, l'analyse de texte, la qualité des données et l'interopérabilité entre les systèmes SAP et non-SAP.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this enterprise information management solution for migration of data, text analysis, data quality and interconnectivity between SAP and non-SAP systems."
         },
         "keywords": {
           "en": ["SAP Data Services"],
@@ -12472,11 +13996,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -12486,11 +14012,13 @@
         "key": "sap_datasphere",
         "name": {
           "en": "SAP Datasphere",
-          "fr": "SAP Datasphere"
+          "fr": "SAP Datasphere",
+          "localized": "SAP Datasphere"
         },
         "description": {
           "en": "Demonstrated ability to leverage this comprehensive data service for data integration, data cataloguing, semantic modeling, data warehousing, and data federation.",
-          "fr": "Capacité démontrée à exploiter ce service de données complet pour l'intégration de données, le catalogage des données, la modélisation sémantique, l'entrepôt de données et la fédération des données."
+          "fr": "Capacité démontrée à exploiter ce service de données complet pour l'intégration de données, le catalogage des données, la modélisation sémantique, l'entrepôt de données et la fédération des données.",
+          "localized": "Demonstrated ability to leverage this comprehensive data service for data integration, data cataloguing, semantic modeling, data warehousing, and data federation."
         },
         "keywords": {
           "en": ["SAP Datasphere"],
@@ -12505,11 +14033,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -12519,11 +14049,13 @@
         "key": "sap_fiori",
         "name": {
           "en": "SAP Fiori",
-          "fr": "SAP Fiori"
+          "fr": "SAP Fiori",
+          "localized": "SAP Fiori"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this design language to enhance user experiences in enterprise applications.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes liées à ce langage de conception afin d’améliorer l’expérience utilisateur dans les applications d’entreprise."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes liées à ce langage de conception afin d’améliorer l’expérience utilisateur dans les applications d’entreprise.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this design language to enhance user experiences in enterprise applications."
         },
         "keywords": {
           "en": ["SAP", "Fiori"],
@@ -12538,11 +14070,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -12552,11 +14086,13 @@
         "key": "sap_hana",
         "name": {
           "en": "SAP High-Performance Analytic Appliance (SAP HANA)",
-          "fr": "SAP High-Performance Analytic Appliance (SAP HANA)"
+          "fr": "SAP High-Performance Analytic Appliance (SAP HANA)",
+          "localized": "SAP High-Performance Analytic Appliance (SAP HANA)"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this in-memory, column-oriented relational database management system to process, store, analyze, and query data.",
-          "fr": "Capacité démontrée à appliquer une connaissance concrète de ce système de gestion de base de données relationnelle en mémoire et orienté colonnes pour traiter, stocker, analyser et interroger des données."
+          "fr": "Capacité démontrée à appliquer une connaissance concrète de ce système de gestion de base de données relationnelle en mémoire et orienté colonnes pour traiter, stocker, analyser et interroger des données.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this in-memory, column-oriented relational database management system to process, store, analyze, and query data."
         },
         "keywords": {
           "en": ["SAP", "HANA"],
@@ -12571,11 +14107,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -12585,11 +14123,13 @@
         "key": "sap_hcm",
         "name": {
           "en": "SAP Human Capital Management (HCM)",
-          "fr": "SAP Human Capital Management (HCM)"
+          "fr": "SAP Human Capital Management (HCM)",
+          "localized": "SAP Human Capital Management (HCM)"
         },
         "description": {
           "en": "Demonstrated ability to leverage this software solution for managing and optimizing human resources processes.",
-          "fr": "Capacité démontrée à exploiter cette solution logicielle pour gérer et optimiser les processus des ressources humaines."
+          "fr": "Capacité démontrée à exploiter cette solution logicielle pour gérer et optimiser les processus des ressources humaines.",
+          "localized": "Demonstrated ability to leverage this software solution for managing and optimizing human resources processes."
         },
         "keywords": {
           "en": ["SAP", "HCM"],
@@ -12604,11 +14144,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -12618,11 +14160,13 @@
         "key": "sap_lumira",
         "name": {
           "en": "SAP Lumira",
-          "fr": "SAP Lumira"
+          "fr": "SAP Lumira",
+          "localized": "SAP Lumira"
         },
         "description": {
           "en": "Demonstrated ability to leverage this solution to develop a variety of products such as interactive maps, charts, infographics, dashboards and business intelligence (BI) applications.",
-          "fr": "Capacité démontrée à exploiter cette solution pour développer une variété de produits tels que des cartes interactives, des graphiques, des infographies, des tableaux de bord et des applications d'informatique décisionnelle (BI)."
+          "fr": "Capacité démontrée à exploiter cette solution pour développer une variété de produits tels que des cartes interactives, des graphiques, des infographies, des tableaux de bord et des applications d'informatique décisionnelle (BI).",
+          "localized": "Demonstrated ability to leverage this solution to develop a variety of products such as interactive maps, charts, infographics, dashboards and business intelligence (BI) applications."
         },
         "keywords": {
           "en": ["SAP", "Lumira"],
@@ -12637,11 +14181,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -12651,11 +14197,13 @@
         "key": "sapui5",
         "name": {
           "en": "SAP User Interface for HTML 5 (SAPUI5)",
-          "fr": "SAP User Interface for HTML 5 (SAPUI5)"
+          "fr": "SAP User Interface for HTML 5 (SAPUI5)",
+          "localized": "SAP User Interface for HTML 5 (SAPUI5)"
         },
         "description": {
           "en": "Demonstrated ability to leverage this framework to build responsive web applications.",
-          "fr": "Capacité démontrée à exploiter ce cadre pour construire des applications web réactives."
+          "fr": "Capacité démontrée à exploiter ce cadre pour construire des applications web réactives.",
+          "localized": "Demonstrated ability to leverage this framework to build responsive web applications."
         },
         "keywords": {
           "en": ["SAPUI5"],
@@ -12670,11 +14218,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -12684,11 +14234,13 @@
         "key": "sass",
         "name": {
           "en": "Sass",
-          "fr": "Sass"
+          "fr": "Sass",
+          "localized": "Sass"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this CSS extension scripting language to develop a variety of projects.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce langage de script d’extension CSS pour développer une variété de projets."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce langage de script d’extension CSS pour développer une variété de projets.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this CSS extension scripting language to develop a variety of projects."
         },
         "keywords": {
           "en": null,
@@ -12703,11 +14255,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -12717,11 +14271,13 @@
         "key": "security_certification_procedures",
         "name": {
           "en": "Security Certification Procedures",
-          "fr": "Procédures de certification de sécurité"
+          "fr": "Procédures de certification de sécurité",
+          "localized": "Security Certification Procedures"
         },
         "description": {
           "en": "",
-          "fr": ""
+          "fr": "",
+          "localized": ""
         },
         "keywords": {
           "en": [],
@@ -12736,11 +14292,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           }
         ]
@@ -12750,11 +14308,13 @@
         "key": "security_event_correlation_tools",
         "name": {
           "en": "Security Event Correlation Tools",
-          "fr": "Outils de corrélation des événements de sécurité"
+          "fr": "Outils de corrélation des événements de sécurité",
+          "localized": "Security Event Correlation Tools"
         },
         "description": {
           "en": "",
-          "fr": ""
+          "fr": "",
+          "localized": ""
         },
         "keywords": {
           "en": [],
@@ -12769,11 +14329,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           }
         ]
@@ -12783,11 +14345,13 @@
         "key": "self_awareness",
         "name": {
           "en": "Self-Awareness",
-          "fr": "Conscience de soi"
+          "fr": "Conscience de soi",
+          "localized": "Self-Awareness"
         },
         "description": {
           "en": "Demonstrated ability to think objectively about one's own strengths and limitations.",
-          "fr": "Capacité démontrée à réfléchir objectivement à ses propres forces et limites."
+          "fr": "Capacité démontrée à réfléchir objectivement à ses propres forces et limites.",
+          "localized": "Demonstrated ability to think objectively about one's own strengths and limitations."
         },
         "keywords": {
           "en": [
@@ -12812,11 +14376,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -12826,11 +14392,13 @@
         "key": "self_hosted_integration_runtime",
         "name": {
           "en": "Self Hosted Integration Runtime (SHIR)",
-          "fr": "Runtime d'intégration auto-hébergé (SHIR)"
+          "fr": "Runtime d'intégration auto-hébergé (SHIR)",
+          "localized": "Self Hosted Integration Runtime (SHIR)"
         },
         "description": {
           "en": "Demonstrated ability to configure and manage Self-Hosted Integration Runtimes (SHIR) in Azure Data Factory, and Synapse pipelines for seamless data integration across private networks.",
-          "fr": "Capacité démontrée à configurer et gérer des Runtimes d'Intégration Auto-hébergés (SHIR) dans Azure Data Factory, ainsi que des pipelines Synapse pour une intégration de données fluide à travers des réseaux privés."
+          "fr": "Capacité démontrée à configurer et gérer des Runtimes d'Intégration Auto-hébergés (SHIR) dans Azure Data Factory, ainsi que des pipelines Synapse pour une intégration de données fluide à travers des réseaux privés.",
+          "localized": "Demonstrated ability to configure and manage Self-Hosted Integration Runtimes (SHIR) in Azure Data Factory, and Synapse pipelines for seamless data integration across private networks."
         },
         "keywords": {
           "en": ["Self Hosted Integration Runtime (SHIR)"],
@@ -12845,11 +14413,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -12859,11 +14429,13 @@
         "key": "service_design",
         "name": {
           "en": "Service Design",
-          "fr": "Conception de services"
+          "fr": "Conception de services",
+          "localized": "Service Design"
         },
         "description": {
           "en": "Demonstrated ability to apply recognized methodological approaches to explore and map current and planned services. This includes the ability to lead and document processes with users to design, test, and improve service flows and service solutions.",
-          "fr": "Capacité démontrée à appliquer des approches méthodologiques reconnues pour explorer et cartographier les services actuels et prévus. Cela inclut la capacité de diriger et de documenter les processus avec les utilisateurs pour concevoir, tester et améliorer les flux de services et les solutions de services."
+          "fr": "Capacité démontrée à appliquer des approches méthodologiques reconnues pour explorer et cartographier les services actuels et prévus. Cela inclut la capacité de diriger et de documenter les processus avec les utilisateurs pour concevoir, tester et améliorer les flux de services et les solutions de services.",
+          "localized": "Demonstrated ability to apply recognized methodological approaches to explore and map current and planned services. This includes the ability to lead and document processes with users to design, test, and improve service flows and service solutions."
         },
         "keywords": {
           "en": ["service", "design"],
@@ -12878,11 +14450,13 @@
             "key": "user_experience_and_interface_design",
             "name": {
               "en": "Software Solutions - Product Design",
-              "fr": "Solutions logicielles - Conception de produits"
+              "fr": "Solutions logicielles - Conception de produits",
+              "localized": "Software Solutions - Product Design"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur",
+              "localized": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design"
             }
           }
         ]
@@ -12892,11 +14466,13 @@
         "key": "sharepoint",
         "name": {
           "en": "SharePoint",
-          "fr": "SharePoint"
+          "fr": "SharePoint",
+          "localized": "SharePoint"
         },
         "description": {
           "en": "Demonstrated ability to leverage this document sharing platform to create, edit, and share documents, including being able to establish logical structures for document management and being able to use document permissions functions.",
-          "fr": "Capacité démontrée à tirer parti de cette plate-forme de partage de documents pour créer, modifier et partager des documents, notamment être capable d'établir des structures logiques pour la gestion des documents et d'être capable d'utiliser les fonctions d'autorisation des documents."
+          "fr": "Capacité démontrée à tirer parti de cette plate-forme de partage de documents pour créer, modifier et partager des documents, notamment être capable d'établir des structures logiques pour la gestion des documents et d'être capable d'utiliser les fonctions d'autorisation des documents.",
+          "localized": "Demonstrated ability to leverage this document sharing platform to create, edit, and share documents, including being able to establish logical structures for document management and being able to use document permissions functions."
         },
         "keywords": {
           "en": null,
@@ -12911,11 +14487,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -12925,11 +14503,13 @@
         "key": "sharepoint_administration",
         "name": {
           "en": "SharePoint Administration",
-          "fr": "Administration de SharePoint"
+          "fr": "Administration de SharePoint",
+          "localized": "SharePoint Administration"
         },
         "description": {
           "en": "Demonstrated ability to configure SharePoint. This may include integrating Office 365 applications.",
-          "fr": "Capacité démontrée à configurer SharePoint. Cela peut inclure l'intégration d'applications Office 365."
+          "fr": "Capacité démontrée à configurer SharePoint. Cela peut inclure l'intégration d'applications Office 365.",
+          "localized": "Demonstrated ability to configure SharePoint. This may include integrating Office 365 applications."
         },
         "keywords": {
           "en": ["SharePoint Administration"],
@@ -12944,11 +14524,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -12958,11 +14540,13 @@
         "key": "software_as_a_service",
         "name": {
           "en": "Software as a Service (SaaS)",
-          "fr": "Logiciel en tant que service"
+          "fr": "Logiciel en tant que service",
+          "localized": "Software as a Service (SaaS)"
         },
         "description": {
           "en": "Demonstrated ability to leverage cloud technologies to enhance service delivery and user experience.",
-          "fr": "Capacité démontrée à tirer parti des technologies infonuagiques  pour améliorer la prestation de services et l'expérience utilisateur."
+          "fr": "Capacité démontrée à tirer parti des technologies infonuagiques  pour améliorer la prestation de services et l'expérience utilisateur.",
+          "localized": "Demonstrated ability to leverage cloud technologies to enhance service delivery and user experience."
         },
         "keywords": {
           "en": ["software", "service."],
@@ -12977,11 +14561,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -12991,11 +14577,13 @@
         "key": "software_development_life_cycle",
         "name": {
           "en": "Software Development Life Cycle (SDLC)",
-          "fr": "Cycle de vie du développement des logiciels (CVDL)"
+          "fr": "Cycle de vie du développement des logiciels (CVDL)",
+          "localized": "Software Development Life Cycle (SDLC)"
         },
         "description": {
           "en": "Demonstrated ability to understand and navigate the various stages of software development, including requirements gathering, design, development, testing, deployment, ongoing maintenance, and decommissioning (if needed).",
-          "fr": "Capacité démontrée de comprendre et de franchir les divers stades de développement des logiciels, y compris la collecte des exigences, la conception, le développement, la mise à l’essai, le déploiement, la maintenance continue et la mise hors service (au besoin)."
+          "fr": "Capacité démontrée de comprendre et de franchir les divers stades de développement des logiciels, y compris la collecte des exigences, la conception, le développement, la mise à l’essai, le déploiement, la maintenance continue et la mise hors service (au besoin).",
+          "localized": "Demonstrated ability to understand and navigate the various stages of software development, including requirements gathering, design, development, testing, deployment, ongoing maintenance, and decommissioning (if needed)."
         },
         "keywords": {
           "en": ["Software", "Development", "Life", "Cycle", "SDLC"],
@@ -13019,11 +14607,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           },
           {
@@ -13031,11 +14621,13 @@
             "key": "it_project_management",
             "name": {
               "en": "Digital Business Line Advisory Services",
-              "fr": "Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Services consultatifs auprès des secteurs de la numérique",
+              "localized": "Digital Business Line Advisory Services"
             },
             "description": {
               "en": "IT generic work stream - Business Line Advisory Services",
-              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique",
+              "localized": "IT generic work stream - Business Line Advisory Services"
             }
           },
           {
@@ -13043,11 +14635,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           },
           {
@@ -13055,11 +14649,13 @@
             "key": "technical_advising",
             "name": {
               "en": "IT Planning and Reporting",
-              "fr": "Planification et établissement de rapports en matière de la numérique"
+              "fr": "Planification et établissement de rapports en matière de la numérique",
+              "localized": "IT Planning and Reporting"
             },
             "description": {
               "en": "IT generic work stream - IT Planning and Reporting",
-              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique"
+              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique",
+              "localized": "IT generic work stream - IT Planning and Reporting"
             }
           },
           {
@@ -13067,11 +14663,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -13081,11 +14679,13 @@
         "key": "solution_architecture",
         "name": {
           "en": "Solution Architecture",
-          "fr": "Architecture des solutions"
+          "fr": "Architecture des solutions",
+          "localized": "Solution Architecture"
         },
         "description": {
           "en": "Demonstrated ability to architect, design, and implement infrastructure technologies, solutions, and services such as: compute, storage, networking, physical infrastructures, software, commercial off the shelf (COTS) and Open-Source packages and solutions, virtual and cloud including PaaS, SaaS, using Azure, AWS, Xamarin, Java, C#, CSS or Python.",
-          "fr": "Capacité avérée à architecturer, concevoir et mettre en œuvre des technologies, des solutions et des services d'infrastructure tels que : calcul, stockage, réseau, infrastructures physiques, logiciels, progiciels et solutions commerciales (COTS) et Open-Source, virtuels et en nuage, y compris PaaS, SaaS, en utilisant Azure, AWS, Xamarin, Java, C#, CSS ou Python."
+          "fr": "Capacité avérée à architecturer, concevoir et mettre en œuvre des technologies, des solutions et des services d'infrastructure tels que : calcul, stockage, réseau, infrastructures physiques, logiciels, progiciels et solutions commerciales (COTS) et Open-Source, virtuels et en nuage, y compris PaaS, SaaS, en utilisant Azure, AWS, Xamarin, Java, C#, CSS ou Python.",
+          "localized": "Demonstrated ability to architect, design, and implement infrastructure technologies, solutions, and services such as: compute, storage, networking, physical infrastructures, software, commercial off the shelf (COTS) and Open-Source packages and solutions, virtual and cloud including PaaS, SaaS, using Azure, AWS, Xamarin, Java, C#, CSS or Python."
         },
         "keywords": {
           "en": null,
@@ -13100,11 +14700,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           }
         ]
@@ -13114,11 +14716,13 @@
         "key": "sql",
         "name": {
           "en": "Structured Query Language (SQL)",
-          "fr": "Langage de requête structurée (SQL)"
+          "fr": "Langage de requête structurée (SQL)",
+          "localized": "Structured Query Language (SQL)"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this language to store, manipulate, and retrieve data from database systems such as MySQL, SQL Server, MS Access, Oracle, Sybase, Informix, Postgres.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce langage pour stocker, manipuler et récupérer des données à partir de systèmes de bases de données tels que MySQL, SQL Server, MS Access, Oracle, Sybase, Informix, Postgres."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes de ce langage pour stocker, manipuler et récupérer des données à partir de systèmes de bases de données tels que MySQL, SQL Server, MS Access, Oracle, Sybase, Informix, Postgres.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this language to store, manipulate, and retrieve data from database systems such as MySQL, SQL Server, MS Access, Oracle, Sybase, Informix, Postgres."
         },
         "keywords": {
           "en": ["SQL"],
@@ -13133,11 +14737,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -13147,11 +14753,13 @@
         "key": "sql_sass",
         "name": {
           "en": "SQL Server Analysis Services (SSAS) Tabular",
-          "fr": "SQL Server Analysis Services (SSAS) Tabular"
+          "fr": "SQL Server Analysis Services (SSAS) Tabular",
+          "localized": "SQL Server Analysis Services (SSAS) Tabular"
         },
         "description": {
           "en": "Demonstrated ability to leverage the tabular modeling services in this data engine to develop and manage analytical data models.",
-          "fr": "Capacité démontrée à exploiter les services de modélisation tabulaire dans ce moteur de données pour développer et gérer des modèles de données analytiques."
+          "fr": "Capacité démontrée à exploiter les services de modélisation tabulaire dans ce moteur de données pour développer et gérer des modèles de données analytiques.",
+          "localized": "Demonstrated ability to leverage the tabular modeling services in this data engine to develop and manage analytical data models."
         },
         "keywords": {
           "en": ["SQL", "SSAS"],
@@ -13166,11 +14774,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           }
         ]
@@ -13180,11 +14790,13 @@
         "key": "sql_ssrs",
         "name": {
           "en": "SQL Server Reporting Services (SSRS)",
-          "fr": "Services de Rapports SQL Server (SSRS)"
+          "fr": "Services de Rapports SQL Server (SSRS)",
+          "localized": "SQL Server Reporting Services (SSRS)"
         },
         "description": {
           "en": "Demonstrated ability to use these on-premises tools and services to create, deploy and manage paginated reports for a variety of projects.",
-          "fr": "Capacité démontrée à utiliser ces outils et services sur site pour créer, déployer et gérer des rapports paginés pour divers projets."
+          "fr": "Capacité démontrée à utiliser ces outils et services sur site pour créer, déployer et gérer des rapports paginés pour divers projets.",
+          "localized": "Demonstrated ability to use these on-premises tools and services to create, deploy and manage paginated reports for a variety of projects."
         },
         "keywords": {
           "en": ["SQL", "SSRS"],
@@ -13199,11 +14811,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           }
         ]
@@ -13213,11 +14827,13 @@
         "key": "stakeholder_relations",
         "name": {
           "en": "Stakeholder Relations",
-          "fr": "Relations avec les parties prenantes"
+          "fr": "Relations avec les parties prenantes",
+          "localized": "Stakeholder Relations"
         },
         "description": {
           "en": "Demonstrated ability to communicate with invested parties to assess their needs, negotiate outcomes, and manage expectations.",
-          "fr": "Capacité démontrée à communiquer avec les parties investies pour évaluer leurs besoins, négocier les résultats et gérer les attentes."
+          "fr": "Capacité démontrée à communiquer avec les parties investies pour évaluer leurs besoins, négocier les résultats et gérer les attentes.",
+          "localized": "Demonstrated ability to communicate with invested parties to assess their needs, negotiate outcomes, and manage expectations."
         },
         "keywords": {
           "en": ["Relationship Management", "Client Service", "Negotiation"],
@@ -13236,11 +14852,13 @@
             "key": "interpersonal",
             "name": {
               "en": "Interpersonal Behaviours",
-              "fr": "Comportements interpersonnels"
+              "fr": "Comportements interpersonnels",
+              "localized": "Interpersonal Behaviours"
             },
             "description": {
               "en": "Behavioural - Interpersonal",
-              "fr": "Comportemental - Interpersonnel"
+              "fr": "Comportemental - Interpersonnel",
+              "localized": "Behavioural - Interpersonal"
             }
           }
         ]
@@ -13250,11 +14868,13 @@
         "key": "storytelling",
         "name": {
           "en": "Storytelling",
-          "fr": "Communication narrative"
+          "fr": "Communication narrative",
+          "localized": "Storytelling"
         },
         "description": {
           "en": "Demonstrated ability to communicate information, success stories, and lessons learned to diverse audiences in a clear, compelling manner.",
-          "fr": "Capacité démontrée à communiquer des informations, des réussites et des leçons apprises à des publics divers de manière claire et convaincante."
+          "fr": "Capacité démontrée à communiquer des informations, des réussites et des leçons apprises à des publics divers de manière claire et convaincante.",
+          "localized": "Demonstrated ability to communicate information, success stories, and lessons learned to diverse audiences in a clear, compelling manner."
         },
         "keywords": {
           "en": ["Creating narratives", "Communication", "Engagement"],
@@ -13269,11 +14889,13 @@
             "key": "communication",
             "name": {
               "en": "Communication Skills",
-              "fr": "Compétences en communication"
+              "fr": "Compétences en communication",
+              "localized": "Communication Skills"
             },
             "description": {
               "en": "Behavioural - Communication",
-              "fr": "Comportemental - Communication"
+              "fr": "Comportemental - Communication",
+              "localized": "Behavioural - Communication"
             }
           }
         ]
@@ -13283,11 +14905,13 @@
         "key": "strategic_thinking",
         "name": {
           "en": "Strategic Thinking",
-          "fr": "Réflexion stratégique"
+          "fr": "Réflexion stratégique",
+          "localized": "Strategic Thinking"
         },
         "description": {
           "en": "Demonstrated ability to assess various options in a given situation and select the option will produce the most desirable outcome.",
-          "fr": "La capacité démontrée à évaluer diverses options dans une situation donnée et à sélectionner l’option produira le résultat le plus souhaitable."
+          "fr": "La capacité démontrée à évaluer diverses options dans une situation donnée et à sélectionner l’option produira le résultat le plus souhaitable.",
+          "localized": "Demonstrated ability to assess various options in a given situation and select the option will produce the most desirable outcome."
         },
         "keywords": {
           "en": ["Strategic Planning", "Visionary", "Strategy Analysis"],
@@ -13306,11 +14930,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -13320,11 +14946,13 @@
         "key": "strategy_development",
         "name": {
           "en": "Strategy Development",
-          "fr": "Élaboration de la stratégie"
+          "fr": "Élaboration de la stratégie",
+          "localized": "Strategy Development"
         },
         "description": {
           "en": "Demonstrated ability to identify necessary components, risks, and most favourable objectives for an initiative, and then create a plan to achieve goals.",
-          "fr": "Capacité démontrée à identifier les composants nécessaires, les risques et les objectifs les plus favorables pour une initiative, puis à créer un plan pour atteindre les objectifs."
+          "fr": "Capacité démontrée à identifier les composants nécessaires, les risques et les objectifs les plus favorables pour une initiative, puis à créer un plan pour atteindre les objectifs.",
+          "localized": "Demonstrated ability to identify necessary components, risks, and most favourable objectives for an initiative, and then create a plan to achieve goals."
         },
         "keywords": {
           "en": ["Formulating Strategies", "Establishing Strategies"],
@@ -13339,11 +14967,13 @@
             "key": "leadership",
             "name": {
               "en": "Leadership - General Behaviours",
-              "fr": "Leadership - Comportements généraux"
+              "fr": "Leadership - Comportements généraux",
+              "localized": "Leadership - General Behaviours"
             },
             "description": {
               "en": "Behavioural - Leadership",
-              "fr": "Comportemental - Leadership"
+              "fr": "Comportemental - Leadership",
+              "localized": "Behavioural - Leadership"
             }
           }
         ]
@@ -13353,11 +14983,13 @@
         "key": "stress_management",
         "name": {
           "en": "Stress Management",
-          "fr": "Gestion du stress"
+          "fr": "Gestion du stress",
+          "localized": "Stress Management"
         },
         "description": {
           "en": "Demonstrated ability to recognize mental, emotional and physical strain, and leverage tools and approaches to mitigate, adapt and address situations of high or ongoing stress.",
-          "fr": "Capacité démontrée à discerner les charges mentales, émotionnelles et physiques, et à tirer parti des outils et des stratégies permettant d'atténuer, de modifier et de résoudre les situations où le stress est élevé ou constant."
+          "fr": "Capacité démontrée à discerner les charges mentales, émotionnelles et physiques, et à tirer parti des outils et des stratégies permettant d'atténuer, de modifier et de résoudre les situations où le stress est élevé ou constant.",
+          "localized": "Demonstrated ability to recognize mental, emotional and physical strain, and leverage tools and approaches to mitigate, adapt and address situations of high or ongoing stress."
         },
         "keywords": {
           "en": ["stress", "management."],
@@ -13372,11 +15004,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -13386,11 +15020,13 @@
         "key": "system_database_administration",
         "name": {
           "en": "System Database Administration",
-          "fr": "Administration des bases de données système"
+          "fr": "Administration des bases de données système",
+          "localized": "System Database Administration"
         },
         "description": {
           "en": "Demonstrated ability to install and configure at least one common Database Management System (DBMS) on one or more operating systems.",
-          "fr": "Capacité démontrée à installer et à configurer au moins un système de gestion de base de données (SGBD) commun sur un ou plusieurs systèmes d'exploitation."
+          "fr": "Capacité démontrée à installer et à configurer au moins un système de gestion de base de données (SGBD) commun sur un ou plusieurs systèmes d'exploitation.",
+          "localized": "Demonstrated ability to install and configure at least one common Database Management System (DBMS) on one or more operating systems."
         },
         "keywords": {
           "en": ["System", "Database", "Administration"],
@@ -13405,11 +15041,13 @@
             "key": "database_design___data_administration",
             "name": {
               "en": "Database Management",
-              "fr": "Gestion des bases de données"
+              "fr": "Gestion des bases de données",
+              "localized": "Database Management"
             },
             "description": {
               "en": "IT generic work stream - Database Management",
-              "fr": "Flux de travail générique de TI - Gestion des bases de données"
+              "fr": "Flux de travail générique de TI - Gestion des bases de données",
+              "localized": "IT generic work stream - Database Management"
             }
           }
         ]
@@ -13419,11 +15057,13 @@
         "key": "systems_interoperability",
         "name": {
           "en": "Systems Interoperability",
-          "fr": "Interopérabilité des systèmes"
+          "fr": "Interopérabilité des systèmes",
+          "localized": "Systems Interoperability"
         },
         "description": {
           "en": "Demonstrated ability to ensure different devices, applications, or components can connect and exchange data.",
-          "fr": "Capacité démontrée à garantir que différents appareils, applications ou composants peuvent se connecter et échanger des données."
+          "fr": "Capacité démontrée à garantir que différents appareils, applications ou composants peuvent se connecter et échanger des données.",
+          "localized": "Demonstrated ability to ensure different devices, applications, or components can connect and exchange data."
         },
         "keywords": {
           "en": null,
@@ -13438,11 +15078,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           }
         ]
@@ -13452,11 +15094,13 @@
         "key": "systems_thinking",
         "name": {
           "en": "Systems Thinking",
-          "fr": "Pensée systémique"
+          "fr": "Pensée systémique",
+          "localized": "Systems Thinking"
         },
         "description": {
           "en": "Demonstrated ability to understand and analyze how all aspects of a service integrate and impact each other, and use that insight to create a clear direction for the service.",
-          "fr": "Capacité démontrée à comprendre et à analyser comment tous les aspects d'un service s'intègrent et s'influencent mutuellement, et à utiliser ces informations pour créer une orientation claire pour le service."
+          "fr": "Capacité démontrée à comprendre et à analyser comment tous les aspects d'un service s'intègrent et s'influencent mutuellement, et à utiliser ces informations pour créer une orientation claire pour le service.",
+          "localized": "Demonstrated ability to understand and analyze how all aspects of a service integrate and impact each other, and use that insight to create a clear direction for the service."
         },
         "keywords": {
           "en": ["Service Integration", "Planning"],
@@ -13471,11 +15115,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -13485,11 +15131,13 @@
         "key": "tableau",
         "name": {
           "en": "Tableau",
-          "fr": "Tableau"
+          "fr": "Tableau",
+          "localized": "Tableau"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this tool to create interactive and dynamic visualizations, dashboards and reports.",
-          "fr": "Capacité démontrée à mettre en profit des connaissances de la plateforme Tableau pour créer des représentations visuelles, des tableaux de bord et des rapports interactifs et dynamiques."
+          "fr": "Capacité démontrée à mettre en profit des connaissances de la plateforme Tableau pour créer des représentations visuelles, des tableaux de bord et des rapports interactifs et dynamiques.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this tool to create interactive and dynamic visualizations, dashboards and reports."
         },
         "keywords": {
           "en": ["Tableau"],
@@ -13504,11 +15152,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           },
           {
@@ -13516,11 +15166,13 @@
             "key": "data_services_data_science",
             "name": {
               "en": "Data Services - Data Science",
-              "fr": "Services de données - Science des données"
+              "fr": "Services de données - Science des données",
+              "localized": "Data Services - Data Science"
             },
             "description": {
               "en": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources.",
-              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses."
+              "fr": "La science des données englobe diverses techniques, notamment le nettoyage des données, l'analyse exploratoire des données, l'apprentissage automatique et la visualisation des données, pour obtenir des informations significatives et exploitables à partir de sources de données vastes et diverses.",
+              "localized": "Data science encompasses various techniques, including data cleaning, exploratory data analysis, machine learning, and data visualization, to derive meaningful and actionable insights from large and diverse data sources."
             }
           },
           {
@@ -13528,11 +15180,13 @@
             "key": "data_services_data_systems",
             "name": {
               "en": "Data Services - Data Systems Operations",
-              "fr": "Services de données - Opérations des systèmes de données"
+              "fr": "Services de données - Opérations des systèmes de données",
+              "localized": "Data Services - Data Systems Operations"
             },
             "description": {
               "en": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes.",
-              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux."
+              "fr": "Les opérations de systèmes de données consistent à développer et à construire des produits et services de données et à les intégrer dans des systèmes et des processus commerciaux.",
+              "localized": "Data Systems operations consists of developing and constructing data products and services and integrates them into systems and business processes."
             }
           }
         ]
@@ -13542,11 +15196,13 @@
         "key": "team_leadership",
         "name": {
           "en": "Team Leadership",
-          "fr": "Direction de l’équipe"
+          "fr": "Direction de l’équipe",
+          "localized": "Team Leadership"
         },
         "description": {
           "en": "Demonstrated ability to support and motivate team members so they may collectively deliver on agreed-upon outcomes.",
-          "fr": "Capacité démontrée à soutenir et à motiver les membres de l'équipe afin qu'ils puissent collectivement atteindre les résultats convenus."
+          "fr": "Capacité démontrée à soutenir et à motiver les membres de l'équipe afin qu'ils puissent collectivement atteindre les résultats convenus.",
+          "localized": "Demonstrated ability to support and motivate team members so they may collectively deliver on agreed-upon outcomes."
         },
         "keywords": {
           "en": ["Managing Teams", "Guiding Teams"],
@@ -13561,11 +15217,13 @@
             "key": "leadership",
             "name": {
               "en": "Leadership - General Behaviours",
-              "fr": "Leadership - Comportements généraux"
+              "fr": "Leadership - Comportements généraux",
+              "localized": "Leadership - General Behaviours"
             },
             "description": {
               "en": "Behavioural - Leadership",
-              "fr": "Comportemental - Leadership"
+              "fr": "Comportemental - Leadership",
+              "localized": "Behavioural - Leadership"
             }
           }
         ]
@@ -13575,11 +15233,13 @@
         "key": "teamwork",
         "name": {
           "en": "Teamwork",
-          "fr": "Travail d’équipe"
+          "fr": "Travail d’équipe",
+          "localized": "Teamwork"
         },
         "description": {
           "en": "Demonstrated ability to work collaboratively with others to achieve common goals and positive results.",
-          "fr": "Capacité avérée à travailler en collaboration avec d'autres personnes pour atteindre des objectifs communs et des résultats positifs."
+          "fr": "Capacité avérée à travailler en collaboration avec d'autres personnes pour atteindre des objectifs communs et des résultats positifs.",
+          "localized": "Demonstrated ability to work collaboratively with others to achieve common goals and positive results."
         },
         "keywords": {
           "en": ["Collaboration", "Cooperation", "Integrity"],
@@ -13594,11 +15254,13 @@
             "key": "interpersonal",
             "name": {
               "en": "Interpersonal Behaviours",
-              "fr": "Comportements interpersonnels"
+              "fr": "Comportements interpersonnels",
+              "localized": "Interpersonal Behaviours"
             },
             "description": {
               "en": "Behavioural - Interpersonal",
-              "fr": "Comportemental - Interpersonnel"
+              "fr": "Comportemental - Interpersonnel",
+              "localized": "Behavioural - Interpersonal"
             }
           }
         ]
@@ -13608,11 +15270,13 @@
         "key": "technical_issue_documentation",
         "name": {
           "en": "Technical issue documentation",
-          "fr": "Documentation sur les problèmes techniques"
+          "fr": "Documentation sur les problèmes techniques",
+          "localized": "Technical issue documentation"
         },
         "description": {
           "en": "Demonstrated ability to express complex technical concepts in a way that is easy for others to follow and action. This includes recording issues and recommending next steps through the appropriate documentation system. Technical documentation may include bug identification, feature descriptions,  detailed instructions, explanations, troubleshooting steps, test cases, defects, and any important notes.",
-          "fr": "Capacité démontrée d’exprimer des concepts techniques complexes d’une manière qui soit facile à suivre et à exécuter par les autres. Il s’agit notamment de consigner les problèmes et de recommander les prochaines étapes à suivre au moyen du système de documentation approprié. La documentation technique peut comprendre le recensement des bogues, la description des fonctionnalités, les instructions détaillées, les explications, les étapes de dépannage, les cas d’essai, les défauts ainsi que toute note importante relative à cet effet."
+          "fr": "Capacité démontrée d’exprimer des concepts techniques complexes d’une manière qui soit facile à suivre et à exécuter par les autres. Il s’agit notamment de consigner les problèmes et de recommander les prochaines étapes à suivre au moyen du système de documentation approprié. La documentation technique peut comprendre le recensement des bogues, la description des fonctionnalités, les instructions détaillées, les explications, les étapes de dépannage, les cas d’essai, les défauts ainsi que toute note importante relative à cet effet.",
+          "localized": "Demonstrated ability to express complex technical concepts in a way that is easy for others to follow and action. This includes recording issues and recommending next steps through the appropriate documentation system. Technical documentation may include bug identification, feature descriptions,  detailed instructions, explanations, troubleshooting steps, test cases, defects, and any important notes."
         },
         "keywords": {
           "en": ["issue", "documentation"],
@@ -13627,11 +15291,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           },
           {
@@ -13639,11 +15305,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           },
           {
@@ -13651,11 +15319,13 @@
             "key": "user_experience_and_interface_design",
             "name": {
               "en": "Software Solutions - Product Design",
-              "fr": "Solutions logicielles - Conception de produits"
+              "fr": "Solutions logicielles - Conception de produits",
+              "localized": "Software Solutions - Product Design"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur",
+              "localized": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design"
             }
           },
           {
@@ -13663,11 +15333,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -13677,11 +15349,13 @@
         "key": "technical_writing",
         "name": {
           "en": "Technical Writing",
-          "fr": "Rédaction technique"
+          "fr": "Rédaction technique",
+          "localized": "Technical Writing"
         },
         "description": {
           "en": "Demonstrated ability to produce written products (such as reports, manuals, technical documentation, and corporate planning and reporting) with respect to digital products and services, including the demonstration of specialized knowledge of IT and the ability to present complex technical concepts in accessible, plain language for use by wide audiences.",
-          "fr": "Capacité démontrée à produire des produits écrits (tels que des rapports, des manuels, de la documentation technique, ainsi que des plans et des rapports d'entreprise) en ce qui concerne les produits et services numériques, y compris la démonstration de connaissances spécialisées en informatique et la capacité de présenter des concepts techniques complexes dans un langage simple et accessible, destiné à être utilisé par un large public."
+          "fr": "Capacité démontrée à produire des produits écrits (tels que des rapports, des manuels, de la documentation technique, ainsi que des plans et des rapports d'entreprise) en ce qui concerne les produits et services numériques, y compris la démonstration de connaissances spécialisées en informatique et la capacité de présenter des concepts techniques complexes dans un langage simple et accessible, destiné à être utilisé par un large public.",
+          "localized": "Demonstrated ability to produce written products (such as reports, manuals, technical documentation, and corporate planning and reporting) with respect to digital products and services, including the demonstration of specialized knowledge of IT and the ability to present complex technical concepts in accessible, plain language for use by wide audiences."
         },
         "keywords": {
           "en": null,
@@ -13696,11 +15370,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           },
           {
@@ -13708,11 +15384,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           },
           {
@@ -13720,11 +15398,13 @@
             "key": "infrastructure_operations",
             "name": {
               "en": "IT Infrastructure Operations",
-              "fr": "Opérations d'infrastructure informatique"
+              "fr": "Opérations d'infrastructure informatique",
+              "localized": "IT Infrastructure Operations"
             },
             "description": {
               "en": "IT generic work stream - Infrastructure Operations",
-              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique"
+              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique",
+              "localized": "IT generic work stream - Infrastructure Operations"
             }
           },
           {
@@ -13732,11 +15412,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           },
           {
@@ -13744,11 +15426,13 @@
             "key": "it_management",
             "name": {
               "en": "Digital Project Portfolio Management",
-              "fr": "Gestion de portefeuille de projets numériques"
+              "fr": "Gestion de portefeuille de projets numériques",
+              "localized": "Digital Project Portfolio Management"
             },
             "description": {
               "en": "IT generic work stream - Digital project portfolio management",
-              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques"
+              "fr": "Flux de travail générique de TI - gestion de portefeuille de projets numériques",
+              "localized": "IT generic work stream - Digital project portfolio management"
             }
           },
           {
@@ -13756,11 +15440,13 @@
             "key": "it_project_management",
             "name": {
               "en": "Digital Business Line Advisory Services",
-              "fr": "Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Services consultatifs auprès des secteurs de la numérique",
+              "localized": "Digital Business Line Advisory Services"
             },
             "description": {
               "en": "IT generic work stream - Business Line Advisory Services",
-              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique"
+              "fr": "Flux de travail générique - Services consultatifs auprès des secteurs de la numérique",
+              "localized": "IT generic work stream - Business Line Advisory Services"
             }
           },
           {
@@ -13768,11 +15454,13 @@
             "key": "it_security",
             "name": {
               "en": "IT Security",
-              "fr": "Sécurité informatique"
+              "fr": "Sécurité informatique",
+              "localized": "IT Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique"
+              "fr": "Flux de travail générique de TI - Sécurité informatique",
+              "localized": "IT generic work stream - IT Security"
             }
           },
           {
@@ -13780,11 +15468,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           },
           {
@@ -13792,11 +15482,13 @@
             "key": "technical_advising",
             "name": {
               "en": "IT Planning and Reporting",
-              "fr": "Planification et établissement de rapports en matière de la numérique"
+              "fr": "Planification et établissement de rapports en matière de la numérique",
+              "localized": "IT Planning and Reporting"
             },
             "description": {
               "en": "IT generic work stream - IT Planning and Reporting",
-              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique"
+              "fr": "Flux de travail générique de TI - Planification et reddition de comptes pour l'informatique",
+              "localized": "IT generic work stream - IT Planning and Reporting"
             }
           },
           {
@@ -13804,11 +15496,13 @@
             "key": "user_experience_and_interface_design",
             "name": {
               "en": "Software Solutions - Product Design",
-              "fr": "Solutions logicielles - Conception de produits"
+              "fr": "Solutions logicielles - Conception de produits",
+              "localized": "Software Solutions - Product Design"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur",
+              "localized": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design"
             }
           },
           {
@@ -13816,11 +15510,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -13830,11 +15526,13 @@
         "key": "telecommunications",
         "name": {
           "en": "Telecommunications",
-          "fr": "Télécommunications"
+          "fr": "Télécommunications",
+          "localized": "Telecommunications"
         },
         "description": {
           "en": "Demonstrated ability to design, implement, or administer telecommunications systems and networks to ensure reliable communication infrastructure and services.",
-          "fr": "Capacité démontrée à concevoir, mettre en œuvre ou administrer des systèmes et réseaux de télécommunications pour garantir une infrastructure et des services de communication fiables."
+          "fr": "Capacité démontrée à concevoir, mettre en œuvre ou administrer des systèmes et réseaux de télécommunications pour garantir une infrastructure et des services de communication fiables.",
+          "localized": "Demonstrated ability to design, implement, or administer telecommunications systems and networks to ensure reliable communication infrastructure and services."
         },
         "keywords": {
           "en": ["Telecommunications"],
@@ -13849,11 +15547,13 @@
             "key": "infrastructure_operations",
             "name": {
               "en": "IT Infrastructure Operations",
-              "fr": "Opérations d'infrastructure informatique"
+              "fr": "Opérations d'infrastructure informatique",
+              "localized": "IT Infrastructure Operations"
             },
             "description": {
               "en": "IT generic work stream - Infrastructure Operations",
-              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique"
+              "fr": "Flux de travail générique de TI - Opérations d'infrastructure informatique",
+              "localized": "IT generic work stream - Infrastructure Operations"
             }
           }
         ]
@@ -13863,11 +15563,13 @@
         "key": "test_documentation",
         "name": {
           "en": "Test Documentation",
-          "fr": "Documentation des tests"
+          "fr": "Documentation des tests",
+          "localized": "Test Documentation"
         },
         "description": {
           "en": "Demonstrated ability to create and manage various test artifacts, such as test plans, test cases, test scripts, test reports, traceability matrices, and defect logs, to ensure thorough quality assurance throughout the software development lifecycle.",
-          "fr": "Capacité démontrée à créer et à gérer divers artefacts de test, tels que des plans de test, des cas de test, des scripts de test, des rapports de test, des matrices de traçabilité et des registres de défauts, afin de garantir une assurance qualité complète tout au long du cycle de développement du logiciel."
+          "fr": "Capacité démontrée à créer et à gérer divers artefacts de test, tels que des plans de test, des cas de test, des scripts de test, des rapports de test, des matrices de traçabilité et des registres de défauts, afin de garantir une assurance qualité complète tout au long du cycle de développement du logiciel.",
+          "localized": "Demonstrated ability to create and manage various test artifacts, such as test plans, test cases, test scripts, test reports, traceability matrices, and defect logs, to ensure thorough quality assurance throughout the software development lifecycle."
         },
         "keywords": {
           "en": ["Test", "Documentation"],
@@ -13882,11 +15584,13 @@
             "key": "data_services_data_analytics",
             "name": {
               "en": "Data Services - Data Analytics",
-              "fr": "Services de données - Analyse de données"
+              "fr": "Services de données - Analyse de données",
+              "localized": "Data Services - Data Analytics"
             },
             "description": {
               "en": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems.",
-              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux."
+              "fr": "L'analyse des données consiste à collecter, organiser et étudier des données pour fournir des informations commerciales, identifier et résoudre des problèmes commerciaux.",
+              "localized": "Data analytics consists collecting, organizing and studying data to provide business insights, identify and solve business problems."
             }
           }
         ]
@@ -13896,11 +15600,13 @@
         "key": "thinking_things_through",
         "name": {
           "en": "Thinking things through",
-          "fr": "Réflexion approfondie"
+          "fr": "Réflexion approfondie",
+          "localized": "Thinking things through"
         },
         "description": {
           "en": "Demonstrated ability to analyze all aspects of a situation, assess risks and potential solutions, and make informed decisions by thoroughly considering all relevant factors.",
-          "fr": "Capacité démontrée à analyser rigoureusement tous les aspects (facteurs pertinents, risques, solutions potentielles) d’une situation donnée pour prendre des décisions éclairées."
+          "fr": "Capacité démontrée à analyser rigoureusement tous les aspects (facteurs pertinents, risques, solutions potentielles) d’une situation donnée pour prendre des décisions éclairées.",
+          "localized": "Demonstrated ability to analyze all aspects of a situation, assess risks and potential solutions, and make informed decisions by thoroughly considering all relevant factors."
         },
         "keywords": {
           "en": ["Thinking", "things", "through"],
@@ -13915,11 +15621,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -13929,11 +15637,13 @@
         "key": "transact_sql__t_sql_",
         "name": {
           "en": "Transact-SQL (T-SQL)",
-          "fr": "Transact-SQL (T-SQL)"
+          "fr": "Transact-SQL (T-SQL)",
+          "localized": "Transact-SQL (T-SQL)"
         },
         "description": {
           "en": "Demonstrated ability to leverage this SQL expansion programming language to manage and manipulate databases.",
-          "fr": "Capacité démontrée à exploiter ce langage de programmation d’expansion SQL pour gérer et manipuler des bases de données."
+          "fr": "Capacité démontrée à exploiter ce langage de programmation d’expansion SQL pour gérer et manipuler des bases de données.",
+          "localized": "Demonstrated ability to leverage this SQL expansion programming language to manage and manipulate databases."
         },
         "keywords": {
           "en": ["T-SQL"],
@@ -13948,11 +15658,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -13962,11 +15674,13 @@
         "key": "typescript",
         "name": {
           "en": "TypeScript",
-          "fr": "TypeScript"
+          "fr": "TypeScript",
+          "localized": "TypeScript"
         },
         "description": {
           "en": "Demonstrated ability to draw on concrete knowledge of this language to advance JavaScript-based products.",
-          "fr": "Capacité démontrée à s’appuyer sur une connaissance concrète de ce langage pour faire progresser les produits basés sur JavaScript."
+          "fr": "Capacité démontrée à s’appuyer sur une connaissance concrète de ce langage pour faire progresser les produits basés sur JavaScript.",
+          "localized": "Demonstrated ability to draw on concrete knowledge of this language to advance JavaScript-based products."
         },
         "keywords": {
           "en": null,
@@ -13981,11 +15695,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -13995,11 +15711,13 @@
         "key": "usability_testing",
         "name": {
           "en": "Usability Testing",
-          "fr": "Tests d'utilisation"
+          "fr": "Tests d'utilisation",
+          "localized": "Usability Testing"
         },
         "description": {
           "en": "Demonstrated ability to assess how users interact with a digital product. This includes conducting user testing, measuring ease of use, and documenting whether or not features and content are producing intended outcomes.",
-          "fr": "Capacité démontrée à évaluer la manière dont les utilisateurs interagissent avec un produit numérique. Cela comprend la réalisation de tests utilisateur, la mesure de la facilité d'utilisation et la documentation indiquant si les fonctionnalités et le contenu produisent ou non les résultats escomptés."
+          "fr": "Capacité démontrée à évaluer la manière dont les utilisateurs interagissent avec un produit numérique. Cela comprend la réalisation de tests utilisateur, la mesure de la facilité d'utilisation et la documentation indiquant si les fonctionnalités et le contenu produisent ou non les résultats escomptés.",
+          "localized": "Demonstrated ability to assess how users interact with a digital product. This includes conducting user testing, measuring ease of use, and documenting whether or not features and content are producing intended outcomes."
         },
         "keywords": {
           "en": null,
@@ -14014,11 +15732,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           },
           {
@@ -14026,11 +15746,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           },
           {
@@ -14038,11 +15760,13 @@
             "key": "user_experience_and_interface_design",
             "name": {
               "en": "Software Solutions - Product Design",
-              "fr": "Solutions logicielles - Conception de produits"
+              "fr": "Solutions logicielles - Conception de produits",
+              "localized": "Software Solutions - Product Design"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur",
+              "localized": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design"
             }
           },
           {
@@ -14050,11 +15774,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -14064,11 +15790,13 @@
         "key": "user_focused_mindset",
         "name": {
           "en": "User-focused mindset",
-          "fr": "État d’esprit centré sur l’utilisateur"
+          "fr": "État d’esprit centré sur l’utilisateur",
+          "localized": "User-focused mindset"
         },
         "description": {
           "en": "Demonstrated ability to empathize with users, understand their needs, and incorporate their feedback into the design and development process.",
-          "fr": "Capacité manifeste à se mettre à la place des utilisateurs, à comprendre leurs besoins et à intégrer leurs commentaires au processus de conception et de développement."
+          "fr": "Capacité manifeste à se mettre à la place des utilisateurs, à comprendre leurs besoins et à intégrer leurs commentaires au processus de conception et de développement.",
+          "localized": "Demonstrated ability to empathize with users, understand their needs, and incorporate their feedback into the design and development process."
         },
         "keywords": {
           "en": ["User-focused", "mindset"],
@@ -14083,11 +15811,13 @@
             "key": "thinking",
             "name": {
               "en": "Thinking Skills",
-              "fr": "Capacités de raisonnement"
+              "fr": "Capacités de raisonnement",
+              "localized": "Thinking Skills"
             },
             "description": {
               "en": "Behavioural - Thinking",
-              "fr": "Comportemental - Réfléchir"
+              "fr": "Comportemental - Réfléchir",
+              "localized": "Behavioural - Thinking"
             }
           }
         ]
@@ -14097,11 +15827,13 @@
         "key": "user_interface_and_interaction_design",
         "name": {
           "en": "User Interface and Interaction Design",
-          "fr": "Conception d'interface utilisateur et d'interaction"
+          "fr": "Conception d'interface utilisateur et d'interaction",
+          "localized": "User Interface and Interaction Design"
         },
         "description": {
           "en": "Demonstrated ability to develop, test, and improve user-facing components and processes for digital products, including creating components based on user research and client requirements, and preparing components for coding and production by development teams.",
-          "fr": "Capacité démontrée à développer, tester et améliorer des composants et des processus destinés aux utilisateurs pour les produits numériques, y compris la création de composants basés sur la recherche des utilisateurs et les exigences des clients, et la préparation des composants pour le codage et la production par les équipes de développement."
+          "fr": "Capacité démontrée à développer, tester et améliorer des composants et des processus destinés aux utilisateurs pour les produits numériques, y compris la création de composants basés sur la recherche des utilisateurs et les exigences des clients, et la préparation des composants pour le codage et la production par les équipes de développement.",
+          "localized": "Demonstrated ability to develop, test, and improve user-facing components and processes for digital products, including creating components based on user research and client requirements, and preparing components for coding and production by development teams."
         },
         "keywords": {
           "en": ["UX", "UI", "design"],
@@ -14116,11 +15848,13 @@
             "key": "user_experience_and_interface_design",
             "name": {
               "en": "Software Solutions - Product Design",
-              "fr": "Solutions logicielles - Conception de produits"
+              "fr": "Solutions logicielles - Conception de produits",
+              "localized": "Software Solutions - Product Design"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur",
+              "localized": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design"
             }
           }
         ]
@@ -14130,11 +15864,13 @@
         "key": "ux_research_methods",
         "name": {
           "en": "UX Research Methods",
-          "fr": "Méthodes de recherche UX"
+          "fr": "Méthodes de recherche UX",
+          "localized": "UX Research Methods"
         },
         "description": {
           "en": "Demonstrated ability to apply recognized methodological approaches (qualitative and quantitative) to gain insights, map journeys, test flows, and develop products and services with users.",
-          "fr": "Capacité démontrée à appliquer des approches méthodologiques reconnues (qualitatives et quantitatives) pour obtenir des informations, cartographier les parcours, tester les flux et développer des produits et services avec les utilisateurs."
+          "fr": "Capacité démontrée à appliquer des approches méthodologiques reconnues (qualitatives et quantitatives) pour obtenir des informations, cartographier les parcours, tester les flux et développer des produits et services avec les utilisateurs.",
+          "localized": "Demonstrated ability to apply recognized methodological approaches (qualitative and quantitative) to gain insights, map journeys, test flows, and develop products and services with users."
         },
         "keywords": {
           "en": null,
@@ -14149,11 +15885,13 @@
             "key": "user_experience_and_interface_design",
             "name": {
               "en": "Software Solutions - Product Design",
-              "fr": "Solutions logicielles - Conception de produits"
+              "fr": "Solutions logicielles - Conception de produits",
+              "localized": "Software Solutions - Product Design"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur",
+              "localized": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design"
             }
           }
         ]
@@ -14163,11 +15901,13 @@
         "key": "verbal_communication",
         "name": {
           "en": "Verbal Communication",
-          "fr": "Communication verbale"
+          "fr": "Communication verbale",
+          "localized": "Verbal Communication"
         },
         "description": {
           "en": "Demonstrated ability to clearly share concepts, coordinate work, and advance goals through discussion or presentations.",
-          "fr": "Capacité démontrée à partager clairement des concepts, à coordonner le travail et à faire progresser les objectifs par le biais de discussions ou de présentations."
+          "fr": "Capacité démontrée à partager clairement des concepts, à coordonner le travail et à faire progresser les objectifs par le biais de discussions ou de présentations.",
+          "localized": "Demonstrated ability to clearly share concepts, coordinate work, and advance goals through discussion or presentations."
         },
         "keywords": {
           "en": [
@@ -14194,11 +15934,13 @@
             "key": "communication",
             "name": {
               "en": "Communication Skills",
-              "fr": "Compétences en communication"
+              "fr": "Compétences en communication",
+              "localized": "Communication Skills"
             },
             "description": {
               "en": "Behavioural - Communication",
-              "fr": "Comportemental - Communication"
+              "fr": "Comportemental - Communication",
+              "localized": "Behavioural - Communication"
             }
           }
         ]
@@ -14208,11 +15950,13 @@
         "key": "version_control",
         "name": {
           "en": "Version Control",
-          "fr": "Contrôle de la version"
+          "fr": "Contrôle de la version",
+          "localized": "Version Control"
         },
         "description": {
           "en": "Demonstrated ability to track and manage changes to software code throughout the life cycle of a product.",
-          "fr": "Capacité démontrée à suivre et à gérer les modifications apportées au code logiciel tout au long du cycle de vie d'un produit."
+          "fr": "Capacité démontrée à suivre et à gérer les modifications apportées au code logiciel tout au long du cycle de vie d'un produit.",
+          "localized": "Demonstrated ability to track and manage changes to software code throughout the life cycle of a product."
         },
         "keywords": {
           "en": null,
@@ -14227,11 +15971,13 @@
             "key": "development_and_programming",
             "name": {
               "en": "Software Solutions - Application Development",
-              "fr": "Solutions logicielles - développement d'applications"
+              "fr": "Solutions logicielles - développement d'applications",
+              "localized": "Software Solutions - Application Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Application Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - Développement d'applications",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Application Development"
             }
           },
           {
@@ -14239,11 +15985,13 @@
             "key": "software_solutions_quality_assurance",
             "name": {
               "en": "Software Solutions - Quality Assurance",
-              "fr": "Solutions logicielles - assurance qualité"
+              "fr": "Solutions logicielles - assurance qualité",
+              "localized": "Software Solutions - Quality Assurance"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance",
-              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité"
+              "fr": "Flux de travail générique de TI - solutions logicielles; sous-flux - assurance qualité",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Quality Assurance"
             }
           }
         ]
@@ -14253,11 +16001,13 @@
         "key": "virtualisation_systems",
         "name": {
           "en": "Virtualisation Systems",
-          "fr": "Systèmes de virtualisation"
+          "fr": "Systèmes de virtualisation",
+          "localized": "Virtualisation Systems"
         },
         "description": {
           "en": "Demonstrated ability to configure Windows and Linux virtual machines using appropriate tools such as, but not limited to, Microsoft Hyper-V, VMware, or Virtualbox.",
-          "fr": "Capacité démontrée à configurer des machines virtuelles Windows et Linux à l'aide d'outils appropriés tels que, sans toutefois s'y limiter, Microsoft Hyper-V, VMware ou Virtualbox."
+          "fr": "Capacité démontrée à configurer des machines virtuelles Windows et Linux à l'aide d'outils appropriés tels que, sans toutefois s'y limiter, Microsoft Hyper-V, VMware ou Virtualbox.",
+          "localized": "Demonstrated ability to configure Windows and Linux virtual machines using appropriate tools such as, but not limited to, Microsoft Hyper-V, VMware, or Virtualbox."
         },
         "keywords": {
           "en": null,
@@ -14272,11 +16022,13 @@
             "key": "it_architecture",
             "name": {
               "en": "Enterprise Architecture",
-              "fr": "Architecture intégrée"
+              "fr": "Architecture intégrée",
+              "localized": "Enterprise Architecture"
             },
             "description": {
               "en": "IT generic work stream - Enterprise Architecture",
-              "fr": "Flux de travail générique  - Architecture intégrée de la numérique"
+              "fr": "Flux de travail générique  - Architecture intégrée de la numérique",
+              "localized": "IT generic work stream - Enterprise Architecture"
             }
           }
         ]
@@ -14286,11 +16038,13 @@
         "key": "visual_communication",
         "name": {
           "en": "Visual Communication",
-          "fr": "Communication visuelle"
+          "fr": "Communication visuelle",
+          "localized": "Visual Communication"
         },
         "description": {
           "en": "Demonstrated ability to create and use visual aids such as diagrams and illustrations to convey information to others.",
-          "fr": "Capacité démontrée à créer et à utiliser des aides visuelles telles que des diagrammes et des illustrations pour transmettre des informations aux autres."
+          "fr": "Capacité démontrée à créer et à utiliser des aides visuelles telles que des diagrammes et des illustrations pour transmettre des informations aux autres.",
+          "localized": "Demonstrated ability to create and use visual aids such as diagrams and illustrations to convey information to others."
         },
         "keywords": {
           "en": ["Video Communication", "Visual Media", "Graphics"],
@@ -14305,11 +16059,13 @@
             "key": "communication",
             "name": {
               "en": "Communication Skills",
-              "fr": "Compétences en communication"
+              "fr": "Compétences en communication",
+              "localized": "Communication Skills"
             },
             "description": {
               "en": "Behavioural - Communication",
-              "fr": "Comportemental - Communication"
+              "fr": "Comportemental - Communication",
+              "localized": "Behavioural - Communication"
             }
           }
         ]
@@ -14319,11 +16075,13 @@
         "key": "visual_design_software",
         "name": {
           "en": "Visual Design Software",
-          "fr": "Logiciel de conception visuelle"
+          "fr": "Logiciel de conception visuelle",
+          "localized": "Visual Design Software"
         },
         "description": {
           "en": "Demonstrated ability to comfortably use common visual design software tools (such as Adobe suite products, Figma, Canva) and have familiarity with additional tools and mark-up languages, as needed.",
-          "fr": "Capacité démontrée à utiliser confortablement les outils logiciels de conception visuelle courants (tels que les produits de la suite Adobe, Figma, Canva) et à être familiarisé avec des outils supplémentaires et des langages de balisage, si nécessaire."
+          "fr": "Capacité démontrée à utiliser confortablement les outils logiciels de conception visuelle courants (tels que les produits de la suite Adobe, Figma, Canva) et à être familiarisé avec des outils supplémentaires et des langages de balisage, si nécessaire.",
+          "localized": "Demonstrated ability to comfortably use common visual design software tools (such as Adobe suite products, Figma, Canva) and have familiarity with additional tools and mark-up languages, as needed."
         },
         "keywords": {
           "en": null,
@@ -14338,11 +16096,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           },
           {
@@ -14350,11 +16110,13 @@
             "key": "user_experience_and_interface_design",
             "name": {
               "en": "Software Solutions - Product Design",
-              "fr": "Solutions logicielles - Conception de produits"
+              "fr": "Solutions logicielles - Conception de produits",
+              "localized": "Software Solutions - Product Design"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - conception de produits numériques et d'interfaces utilisateur",
+              "localized": "IT generic work stream - Software Solutions; sub-stream: Digital Product and User Interface Design"
             }
           }
         ]
@@ -14364,11 +16126,13 @@
         "key": "vue",
         "name": {
           "en": "Vue.js",
-          "fr": "Vue.js"
+          "fr": "Vue.js",
+          "localized": "Vue.js"
         },
         "description": {
           "en": "Demonstrated ability to leverage this framework to develop declarative and component-based user interfaces  with HTML, CSS, and JavaScript.",
-          "fr": "Capacité démontrée à exploiter ce cadre pour développer des interfaces utilisateur déclaratives et basées sur des composants avec HTML, CSS et JavaScript."
+          "fr": "Capacité démontrée à exploiter ce cadre pour développer des interfaces utilisateur déclaratives et basées sur des composants avec HTML, CSS et JavaScript.",
+          "localized": "Demonstrated ability to leverage this framework to develop declarative and component-based user interfaces  with HTML, CSS, and JavaScript."
         },
         "keywords": {
           "en": null,
@@ -14383,11 +16147,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]
@@ -14397,11 +16163,13 @@
         "key": "vulnerability_assessment",
         "name": {
           "en": "Vulnerability Assessment",
-          "fr": "Évaluation de la vulnérabilité"
+          "fr": "Évaluation de la vulnérabilité",
+          "localized": "Vulnerability Assessment"
         },
         "description": {
           "en": "Demonstrated ability to identify, assess, and prioritize security weaknesses within an organization's  systems, networks, and applications.",
-          "fr": "Capacité démontrée de détecter, d’évaluer et de hiérarchiser les faiblesses de sécurité dans les systèmes, les réseaux et les applications d’une organisation."
+          "fr": "Capacité démontrée de détecter, d’évaluer et de hiérarchiser les faiblesses de sécurité dans les systèmes, les réseaux et les applications d’une organisation.",
+          "localized": "Demonstrated ability to identify, assess, and prioritize security weaknesses within an organization's  systems, networks, and applications."
         },
         "keywords": {
           "en": ["Vulnerability", "Assessment"],
@@ -14416,11 +16184,13 @@
             "key": "cyber_security",
             "name": {
               "en": "Cyber Security",
-              "fr": "Cybersécurité"
+              "fr": "Cybersécurité",
+              "localized": "Cyber Security"
             },
             "description": {
               "en": "IT generic work stream - IT Security; sub-stream - Cyber Security",
-              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité"
+              "fr": "Flux de travail générique de TI - Sécurité informatique; sous-flux - cybersécurité",
+              "localized": "IT generic work stream - IT Security; sub-stream - Cyber Security"
             }
           }
         ]
@@ -14430,11 +16200,13 @@
         "key": "web_content_curation",
         "name": {
           "en": "Web Content Curation",
-          "fr": "Curation de contenu web"
+          "fr": "Curation de contenu web",
+          "localized": "Web Content Curation"
         },
         "description": {
           "en": "Demonstrated ability to draft original web content, edit existing content, and audit existing content for consistency across multiple web pages and features. This includes being able to produce content in a variety of tones (instructional, conversational, formal, informal) for a variety of audiences. This also includes working with content management systems and establishing processes to ensure quality and consistency across the totality of product.",
-          "fr": "Capacité démontrée à rédiger du contenu Web original, à modifier du contenu existant et à vérifier la cohérence du contenu existant sur plusieurs pages Web et fonctionnalités. Cela implique d'être capable de produire du contenu dans une variété de tons (instructif, conversationnel, formel, informel) pour une variété de publics. Cela implique également de travailler avec des systèmes de gestion de contenu et d'établir des processus pour garantir la qualité et la cohérence de l'ensemble du produit."
+          "fr": "Capacité démontrée à rédiger du contenu Web original, à modifier du contenu existant et à vérifier la cohérence du contenu existant sur plusieurs pages Web et fonctionnalités. Cela implique d'être capable de produire du contenu dans une variété de tons (instructif, conversationnel, formel, informel) pour une variété de publics. Cela implique également de travailler avec des systèmes de gestion de contenu et d'établir des processus pour garantir la qualité et la cohérence de l'ensemble du produit.",
+          "localized": "Demonstrated ability to draft original web content, edit existing content, and audit existing content for consistency across multiple web pages and features. This includes being able to produce content in a variety of tones (instructional, conversational, formal, informal) for a variety of audiences. This also includes working with content management systems and establishing processes to ensure quality and consistency across the totality of product."
         },
         "keywords": {
           "en": null,
@@ -14449,11 +16221,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -14463,11 +16237,13 @@
         "key": "web_content_development",
         "name": {
           "en": "Web Content Development",
-          "fr": "Développement de contenu Web"
+          "fr": "Développement de contenu Web",
+          "localized": "Web Content Development"
         },
         "description": {
           "en": "Demonstrated ability to develop web content, including transforming requirements into site structure, visual elements, copy and features, as well as testing components and ensuring quality.",
-          "fr": "Capacité démontrée à développer du contenu Web, y compris la transformation des exigences en structure de site, éléments visuels, copie et fonctionnalités, ainsi qu’à tester les composants et à assurer la qualité."
+          "fr": "Capacité démontrée à développer du contenu Web, y compris la transformation des exigences en structure de site, éléments visuels, copie et fonctionnalités, ainsi qu’à tester les composants et à assurer la qualité.",
+          "localized": "Demonstrated ability to develop web content, including transforming requirements into site structure, visual elements, copy and features, as well as testing components and ensuring quality."
         },
         "keywords": {
           "en": null,
@@ -14482,11 +16258,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -14496,11 +16274,13 @@
         "key": "web_development",
         "name": {
           "en": "Web Development",
-          "fr": "Développement Web"
+          "fr": "Développement Web",
+          "localized": "Web Development"
         },
         "description": {
           "en": "Demonstrated ability to build web applications using JavaScript and a server-side language such as, but not limited to, PHP or Python.",
-          "fr": "Capacité démontrée à créer des applications Web à l'aide de JavaScript et d'un langage côté serveur tel que, sans toutefois s'y limiter, PHP ou Python."
+          "fr": "Capacité démontrée à créer des applications Web à l'aide de JavaScript et d'un langage côté serveur tel que, sans toutefois s'y limiter, PHP ou Python.",
+          "localized": "Demonstrated ability to build web applications using JavaScript and a server-side language such as, but not limited to, PHP or Python."
         },
         "keywords": {
           "en": null,
@@ -14515,11 +16295,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -14529,11 +16311,13 @@
         "key": "web_development_languages",
         "name": {
           "en": "Web Development Languages and Tools",
-          "fr": "Langages et outils de développement Web"
+          "fr": "Langages et outils de développement Web",
+          "localized": "Web Development Languages and Tools"
         },
         "description": {
           "en": "Demonstrated ability to comfortably use core web development languages (such as HTML, CSS, Javascript and PHP) and have familiarity with additional frameworks and database languages, as needed.",
-          "fr": "Capacité démontrée à utiliser confortablement les principaux langages de développement Web (tels que HTML, CSS, Javascript et PHP) et à se familiariser avec d’autres frameworks et langages de base de données, au besoin."
+          "fr": "Capacité démontrée à utiliser confortablement les principaux langages de développement Web (tels que HTML, CSS, Javascript et PHP) et à se familiariser avec d’autres frameworks et langages de base de données, au besoin.",
+          "localized": "Demonstrated ability to comfortably use core web development languages (such as HTML, CSS, Javascript and PHP) and have familiarity with additional frameworks and database languages, as needed."
         },
         "keywords": {
           "en": ["Web", "Development", "Languages", "Tools"],
@@ -14548,11 +16332,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -14562,11 +16348,13 @@
         "key": "web_information_architecture",
         "name": {
           "en": "Web Information Architecture",
-          "fr": "Architecture de l’information Web"
+          "fr": "Architecture de l’information Web",
+          "localized": "Web Information Architecture"
         },
         "description": {
           "en": "Demonstrated ability to create, audit, revise, and organize web content in a meaningful way that enables user behaviours and understanding. This includes the demonstrated ability to produce content that is easy to navigate, easy to find, and easily understood.",
-          "fr": "Capacité démontrée de créer, d’auditer, de réviser et d’organiser du contenu Web d’une manière significative qui permet aux utilisateurs de les adopter et de les comprendre. Cela inclut la capacité démontrée à produire du contenu facile à naviguer, facile à trouver et facile à comprendre."
+          "fr": "Capacité démontrée de créer, d’auditer, de réviser et d’organiser du contenu Web d’une manière significative qui permet aux utilisateurs de les adopter et de les comprendre. Cela inclut la capacité démontrée à produire du contenu facile à naviguer, facile à trouver et facile à comprendre.",
+          "localized": "Demonstrated ability to create, audit, revise, and organize web content in a meaningful way that enables user behaviours and understanding. This includes the demonstrated ability to produce content that is easy to navigate, easy to find, and easily understood."
         },
         "keywords": {
           "en": null,
@@ -14581,11 +16369,13 @@
             "key": "ux",
             "name": {
               "en": "Software Solutions - Web Development",
-              "fr": "Solutions logicielles - développement web"
+              "fr": "Solutions logicielles - développement web",
+              "localized": "Software Solutions - Web Development"
             },
             "description": {
               "en": "IT generic work stream - Software Solutions; sub-stream - Web Development",
-              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web"
+              "fr": "Flux de travail générique de TI - Solutions logicielles; sous-flux - développement web",
+              "localized": "IT generic work stream - Software Solutions; sub-stream - Web Development"
             }
           }
         ]
@@ -14595,11 +16385,13 @@
         "key": "working_on_a_distributed_team",
         "name": {
           "en": "Working on a Distributed Team",
-          "fr": "Travailler dans une équipe distribuée"
+          "fr": "Travailler dans une équipe distribuée",
+          "localized": "Working on a Distributed Team"
         },
         "description": {
           "en": "Demonstrated ability to leverage digital resources to communicate, collaborate, and work in a way that engages team members in distributed locations.",
-          "fr": "Capacité démontrée à exploiter les ressources numériques pour communiquer, collaborer et travailler de manière à impliquer les membres de l'équipe dans des emplacements distribués."
+          "fr": "Capacité démontrée à exploiter les ressources numériques pour communiquer, collaborer et travailler de manière à impliquer les membres de l'équipe dans des emplacements distribués.",
+          "localized": "Demonstrated ability to leverage digital resources to communicate, collaborate, and work in a way that engages team members in distributed locations."
         },
         "keywords": {
           "en": ["Remote Work", "Work From Home"],
@@ -14614,11 +16406,13 @@
             "key": "working_in_government",
             "name": {
               "en": "Working in Government",
-              "fr": "Travailler au sein du gouvernement"
+              "fr": "Travailler au sein du gouvernement",
+              "localized": "Working in Government"
             },
             "description": {
               "en": "Technical skills family - Working in Government",
-              "fr": "Groupe de compétences techniques - Travailler au sein du gouvernement"
+              "fr": "Groupe de compétences techniques - Travailler au sein du gouvernement",
+              "localized": "Technical skills family - Working in Government"
             }
           }
         ]
@@ -14628,11 +16422,13 @@
         "key": "workload_management",
         "name": {
           "en": "Workload Management",
-          "fr": "Gestion de la charge de travail"
+          "fr": "Gestion de la charge de travail",
+          "localized": "Workload Management"
         },
         "description": {
           "en": "Demonstrated ability to manage workload in an environment of changing priorities and deadlines.",
-          "fr": "Capacité démontrée de gérer la charge de travail dans un environnement de priorités changeantes et de délais prescrits."
+          "fr": "Capacité démontrée de gérer la charge de travail dans un environnement de priorités changeantes et de délais prescrits.",
+          "localized": "Demonstrated ability to manage workload in an environment of changing priorities and deadlines."
         },
         "keywords": {
           "en": ["workload", "management."],
@@ -14647,11 +16443,13 @@
             "key": "personal",
             "name": {
               "en": "Personal Behaviours",
-              "fr": "Comportements personnels"
+              "fr": "Comportements personnels",
+              "localized": "Personal Behaviours"
             },
             "description": {
               "en": "Behavioural - Personal",
-              "fr": "Comportemental - Personnel"
+              "fr": "Comportemental - Personnel",
+              "localized": "Behavioural - Personal"
             }
           }
         ]
@@ -14661,11 +16459,13 @@
         "key": "written_communication",
         "name": {
           "en": "Written Communication",
-          "fr": "Communication écrite"
+          "fr": "Communication écrite",
+          "localized": "Written Communication"
         },
         "description": {
           "en": "Demonstrated ability to write information in a clear, logical manner that enables readers to understand and use the concepts shared.",
-          "fr": "Capacité démontrée à rédiger de l’information d’une manière claire et logique qui permet aux lecteurs de comprendre et d’utiliser les concepts partagés."
+          "fr": "Capacité démontrée à rédiger de l’information d’une manière claire et logique qui permet aux lecteurs de comprendre et d’utiliser les concepts partagés.",
+          "localized": "Demonstrated ability to write information in a clear, logical manner that enables readers to understand and use the concepts shared."
         },
         "keywords": {
           "en": ["Writing", "Written Information"],
@@ -14680,11 +16480,13 @@
             "key": "communication",
             "name": {
               "en": "Communication Skills",
-              "fr": "Compétences en communication"
+              "fr": "Compétences en communication",
+              "localized": "Communication Skills"
             },
             "description": {
               "en": "Behavioural - Communication",
-              "fr": "Comportemental - Communication"
+              "fr": "Comportemental - Communication",
+              "localized": "Behavioural - Communication"
             }
           }
         ]
@@ -14694,11 +16496,13 @@
         "key": "xml",
         "name": {
           "en": "Extensible Markup Language (XML)",
-          "fr": "Langage de balisage extensible (XML)"
+          "fr": "Langage de balisage extensible (XML)",
+          "localized": "Extensible Markup Language (XML)"
         },
         "description": {
           "en": "Demonstrated ability to apply concrete knowledge of this markup language to develop a variety of projects.",
-          "fr": "Capacité démontrée à appliquer des connaissances concrètes liées à ce langage de balisage afin d’élaborer divers projets."
+          "fr": "Capacité démontrée à appliquer des connaissances concrètes liées à ce langage de balisage afin d’élaborer divers projets.",
+          "localized": "Demonstrated ability to apply concrete knowledge of this markup language to develop a variety of projects."
         },
         "keywords": {
           "en": ["XML"],
@@ -14713,11 +16517,13 @@
             "key": "programming_languages_and_tools",
             "name": {
               "en": "Programming Languages, Frameworks, and Tools",
-              "fr": "Langages de programmation, frameworks et outils"
+              "fr": "Langages de programmation, frameworks et outils",
+              "localized": "Programming Languages, Frameworks, and Tools"
             },
             "description": {
               "en": "IT support stream - Programming Languages and Tools",
-              "fr": "Volet de support informatique - Langages et outils de programmation"
+              "fr": "Volet de support informatique - Langages et outils de programmation",
+              "localized": "IT support stream - Programming Languages and Tools"
             }
           }
         ]


### PR DESCRIPTION
Related: https://github.com/GCTC-NTGC/gc-digital-talent/issues/17227

## 👋 Introduction

Removes full object types for the skils section.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to the following and confirm they still function as expected
    - Skills library
    - Editing experience skills
    - Skill showcase
    - Downloading all skills
    - Create and updates skills and skill families
    - Browsing and addding skills on the talent seaerch page