### PR TITLE
[Fix] Flaky nomination test

### DIFF
--- a/apps/playwright/tests/admin/talent-nomination.spec.ts
+++ b/apps/playwright/tests/admin/talent-nomination.spec.ts
@@ -215,6 +215,7 @@ test.describe("Talent nomination management", () => {
       .getByRole("button", { name: /submit nomination/i })
       .click();
     await appPage.waitForGraphqlResponse("NominateTalentSubmit");
+    await appPage.waitForGraphqlResponse("NominateTalent");
     await expect(
       appPage.page.getByRole("heading", {
         name: /We’ve received your nomination/i,


### PR DESCRIPTION
🤖 Resolves #17644 

## 👋 Introduction

Fixes an issue where the talent nomination e2e test spec was flaky.

## 🕵️ Details

We were only waiting that the submit request completed. However, the query for the success step was in-flight when we expected the success heading to appear. This adds another wait for the success query before checking for the heading which should make this test more reliable.

## 🧪 Testing

1. Run the test multiple times
2. Confirm it passess consistently