### PR TITLE
[Feature] Remove preselected flexible work locations in search form

### DIFF
--- a/apps/playwright/tests/admin/talent-requests-validation.spec.ts
+++ b/apps/playwright/tests/admin/talent-requests-validation.spec.ts
@@ -107,7 +107,10 @@ test.describe("Talent search", () => {
             OperationalRequirement.OvertimeOccasional,
           ],
           locationPreferences: [WorkRegion.Ontario],
-          flexibleWorkLocations: [FlexibleWorkLocation.Hybrid],
+          flexibleWorkLocations: [
+            FlexibleWorkLocation.Onsite,
+            FlexibleWorkLocation.Hybrid,
+          ],
           personalExperiences: {
             create: [
               {

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -18,11 +18,7 @@ import type {
   Skill,
   WorkStream,
 } from "@gc-digital-talent/graphql";
-import {
-  graphql,
-  FlexibleWorkLocation,
-  TalentRequestSource,
-} from "@gc-digital-talent/graphql";
+import { graphql, TalentRequestSource } from "@gc-digital-talent/graphql";
 import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
 
 import type { FormValues } from "~/types/talentRequestForm";

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -70,20 +70,12 @@ export const SearchForm = ({
   const defaultValuesAdjusted = {
     ...defaultValues,
     talentSources: [TalentRequestSource.QualifiedInPool],
-    flexibleWorkLocations: [
-      FlexibleWorkLocation.Remote,
-      FlexibleWorkLocation.Hybrid,
-    ],
   } satisfies FormValues;
 
   // set some fields to a desired default (query)
   const initialFiltersAdjusted = {
     ...initialFilters,
     talentSources: [TalentRequestSource.QualifiedInPool],
-    flexibleWorkLocations: [
-      FlexibleWorkLocation.Remote,
-      FlexibleWorkLocation.Hybrid,
-    ],
   } satisfies ApplicantFilterInput;
 
   const [applicantFilter, setApplicantFilter] = useState<ApplicantFilterInput>(


### PR DESCRIPTION
🤖 Resolves #17675 

## 👋 Introduction

- Removes preselected options (Remote, Hybrid) from flexible work locations checklist on the SearchForm

## 🧪 Testing

1. Build front-end `pnpm dev:fresh`
2. Go to "Find talent" page
3. Scroll to "Flexible work location options" section
4. Ensure that both items are not selected

## 📸 Screenshot

<img width="1870" height="940" alt="image" src="https://github.com/user-attachments/assets/77682903-d36d-405d-a6f1-a43f9bbd1a46" />