### PR TITLE
[Copy] Updates Fine print of a note describing that a pool is only open to employees with departmental preference

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -2699,6 +2699,10 @@
     "defaultMessage": "Les personnes candidates peuvent accepter de donner accès à leur profil en utilisant l'outil « Collectivités fonctionnelles » de leur tableau de bord.",
     "description": "Null secondary message for nominee profile"
   },
+  "8t1KYs": {
+    "defaultMessage": "* La préférence sera accordée aux personnes employées par les ministères ou agences (ministère) suivants : {department}.",
+    "description": "Fine print of a note describing that a pool is only open to employees with departmental preference"
+  },
   "8umYON": {
     "defaultMessage": "Prochaines étapes",
     "description": "Title for what to expect section"
@@ -12565,10 +12569,6 @@
   "mnGISd": {
     "defaultMessage": "Intérêt pour les possibilités d'apprentissage",
     "description": "Label for an employee profile career development preference field"
-  },
-  "mnrRuo": {
-    "defaultMessage": "* La préférence sera accordée aux anciens combattants admissibles, aux membres des Forces armées canadiennes admissibles et aux personnes employées par les ministères ou agences (ministère) suivants : {department}.",
-    "description": "Fine print of a note describing that a pool is only open to employees with departmental preference"
   },
   "moB11/": {
     "defaultMessage": "est en mesure d’attribuer les rôles de recruteur de la collectivité et de coordonnateur des talents de la collectivité.",

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/AreaOfSelectionWell.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/AreaOfSelectionWell.tsx
@@ -133,8 +133,8 @@ const deriveAreaOfSelectionMessages = (
         finePrint: intl.formatMessage(
           {
             defaultMessage:
-              "* Preference will be given to eligible veterans, eligible Canadian Armed Forces members, and persons employed with the following departments or agencies: {department}.",
-            id: "mnrRuo",
+              "* Preference will be given to persons employed with the following departments or agencies: {department}.",
+            id: "8t1KYs",
             description:
               "Fine print of a note describing that a pool is only open to employees with departmental preference",
           },
@@ -211,8 +211,8 @@ const deriveAreaOfSelectionMessages = (
         finePrint: intl.formatMessage(
           {
             defaultMessage:
-              "* Preference will be given to eligible veterans, eligible Canadian Armed Forces members, and persons employed with the following departments or agencies: {department}.",
-            id: "mnrRuo",
+              "* Preference will be given to persons employed with the following departments or agencies: {department}.",
+            id: "8t1KYs",
             description:
               "Fine print of a note describing that a pool is only open to employees with departmental preference",
           },

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/components/WhoCanApplyText.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/components/WhoCanApplyText.tsx
@@ -103,8 +103,8 @@ const deriveWhoCanApplyMessages = (
       ? intl.formatMessage(
           {
             defaultMessage:
-              "* Preference will be given to eligible veterans, eligible Canadian Armed Forces members, and persons employed with the following departments or agencies: {department}.",
-            id: "mnrRuo",
+              "* Preference will be given to persons employed with the following departments or agencies: {department}.",
+            id: "8t1KYs",
             description:
               "Fine print of a note describing that a pool is only open to employees with departmental preference",
           },


### PR DESCRIPTION
🤖 Resolves #17506.

## 👋 Introduction

This PR updates Fine print of a note describing that a pool is only open to employees with departmental preference.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to a process advertisement
3. Verify copy in English and French has been changed in both the `AreaOfSelectionWell` and the `WhoCanApplyText` sections

## 📸 Screenshots

### `AreaOfSelectionWell`

<img width="1631" height="830" alt="Screenshot 2026-08-10 at 12 00 25" src="https://github.com/user-attachments/assets/06735a63-2e54-49b3-ad8e-ce388b083925" />
<img width="1649" height="862" alt="Screenshot 2026-08-10 at 12 00 37" src="https://github.com/user-attachments/assets/f88f61bc-3fbc-43c9-af73-8b18fbb23e5d" />

### `WhoCanApplyText`

<img width="1485" height="567" alt="Screenshot 2026-08-10 at 12 08 38" src="https://github.com/user-attachments/assets/4257521c-7d9d-438d-a881-725b1301c44c" />
<img width="1530" height="679" alt="Screenshot 2026-08-10 at 12 08 50" src="https://github.com/user-attachments/assets/04c9dd6d-3050-4130-8d3f-db8b0ce25cce" />