### PR TITLE
[Fix] Classifications not displaying in snapshotted experiences

### DIFF
--- a/apps/web/src/components/ExperienceCard/WorkContent/GovContent.tsx
+++ b/apps/web/src/components/ExperienceCard/WorkContent/GovContent.tsx
@@ -43,6 +43,13 @@ const GovContent = ({
   const intl = useIntl();
   const experienceFormLabels = getExperienceFormLabels(intl);
 
+  const group = classification?.group;
+  const level = classification?.level;
+  const groupAndLevel =
+    group && level
+      ? group + "-" + (level < 10 ? "0" : "") + level
+      : intl.formatMessage(commonMessages.notAvailable);
+
   if (govEmploymentType?.value === GovEmployeeType.Student) {
     return (
       <>
@@ -85,10 +92,7 @@ const GovContent = ({
           <ClassificationSection
             title={experienceFormLabels.classification}
             headingLevel={headingLevel}
-            content={
-              classification?.groupAndLevel ??
-              intl.formatMessage(commonMessages.notAvailable)
-            }
+            content={groupAndLevel}
           />
         </div>
       </>
@@ -122,10 +126,7 @@ const GovContent = ({
           <ClassificationSection
             title={experienceFormLabels.classification}
             headingLevel={headingLevel}
-            content={
-              classification?.groupAndLevel ??
-              intl.formatMessage(commonMessages.notAvailable)
-            }
+            content={groupAndLevel}
           />
         </div>
       </>
@@ -152,10 +153,7 @@ const GovContent = ({
           <ClassificationSection
             title={experienceFormLabels.classification}
             headingLevel={headingLevel}
-            content={
-              classification?.groupAndLevel ??
-              intl.formatMessage(commonMessages.notAvailable)
-            }
+            content={groupAndLevel}
           />
         </div>
       </>


### PR DESCRIPTION
🤖 Resolves #17711.

## 👋 Introduction

Makes classifications appear properly in experiences on the application page.

## 🧪 Testing

1. Find or create an application with a casual/term/indeterminate government work experience
2. Navigate to view that application in admin
3. Confirm the classification appears in the experience

## 📸 Screenshot

<img width="1243" height="691" alt="image" src="https://github.com/user-attachments/assets/638d5e08-27ed-4a9f-9407-00abcdd86656" />