### PR TITLE
[Fix] Incorrect talent request community

### DIFF
--- a/apps/web/src/pages/SearchRequests/SearchPage/components/CommunityResultCard.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/CommunityResultCard.tsx
@@ -99,7 +99,6 @@ const CommunityResultCard = ({
         color="secondary"
         type="submit"
         {...communitySubmitProps}
-        value={community.id}
         onClick={() => {
           setValue("pool", "");
           setValue("communityId", community.id);

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/NoResults.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/NoResults.tsx
@@ -55,6 +55,7 @@ const NoResults = () => {
         value=""
         onClick={() => {
           setValue("pool", "");
+          setValue("communityId", "");
           setValue("count", 0);
         }}
       >

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/ResultCards.test.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/ResultCards.test.tsx
@@ -49,6 +49,29 @@ describe("result cards", () => {
     onSubmit.mockReset();
   });
 
+  it("sets communityId when the community result card is submitted", async () => {
+    renderWithProviders(
+      <Harness>
+        <CommunityResultCard
+          community={community}
+          qualifiedInPoolCount={5}
+          atLevelCount={0}
+          count={5}
+          showQualifiedInPool
+          showAtLevel={false}
+        />
+      </Harness>,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /request all matching candidates/i }),
+    );
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ communityId: community.id }),
+    );
+  });
+
   it("leaves communityId unset while a community result card is rendered", async () => {
     renderWithProviders(
       <Harness>
@@ -64,6 +87,22 @@ describe("result cards", () => {
     );
 
     expect((await submitFromElsewhere()).communityId).toBeFalsy();
+  });
+
+  it("sets pool when the process result card is submitted", async () => {
+    renderWithProviders(
+      <Harness>
+        <SearchResultCard candidateCount={5} pool={pool} />
+      </Harness>,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /request candidates/i }),
+    );
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ pool: pool.id }),
+    );
   });
 
   it("leaves pool unset while a process result card is rendered", async () => {

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/ResultCards.test.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/ResultCards.test.tsx
@@ -69,6 +69,7 @@ describe("result cards", () => {
 
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({ communityId: community.id }),
+      expect.anything(),
     );
   });
 
@@ -102,6 +103,7 @@ describe("result cards", () => {
 
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({ pool: pool.id }),
+      expect.anything(),
     );
   });
 

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/ResultCards.test.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/ResultCards.test.tsx
@@ -1,0 +1,78 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { vi } from "vitest";
+
+import { renderWithProviders } from "@gc-digital-talent/vitest-helpers";
+import type { SearchResultCard_PoolFragment } from "@gc-digital-talent/graphql";
+
+import type { FormValues } from "~/types/talentRequestForm";
+
+import CommunityResultCard from "./CommunityResultCard";
+import SearchResultCard from "./SearchResultCard";
+
+const community = { id: "privacy-community", name: { localized: "Privacy" } };
+
+const pool: SearchResultCard_PoolFragment = {
+  id: "privacy-pool",
+  name: { en: "Privacy analyst", fr: "Analyste de la confidentialité" },
+  community,
+  poolSkills: [],
+};
+
+const onSubmit = vi.fn<(values: FormValues) => void>();
+
+const Harness = ({ children }: { children: ReactNode }) => {
+  const methods = useForm<FormValues>();
+
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={methods.handleSubmit(onSubmit)}>
+        {children}
+        <button type="submit">Submit from elsewhere</button>
+      </form>
+    </FormProvider>
+  );
+};
+
+const submitFromElsewhere = async () => {
+  await userEvent.click(
+    screen.getByRole("button", { name: "Submit from elsewhere" }),
+  );
+
+  return onSubmit.mock.calls[0][0];
+};
+
+describe("result cards", () => {
+  beforeEach(() => {
+    onSubmit.mockReset();
+  });
+
+  it("leaves communityId unset while a community result card is rendered", async () => {
+    renderWithProviders(
+      <Harness>
+        <CommunityResultCard
+          community={community}
+          qualifiedInPoolCount={5}
+          atLevelCount={0}
+          count={5}
+          showQualifiedInPool
+          showAtLevel={false}
+        />
+      </Harness>,
+    );
+
+    expect((await submitFromElsewhere()).communityId).toBeFalsy();
+  });
+
+  it("leaves pool unset while a process result card is rendered", async () => {
+    renderWithProviders(
+      <Harness>
+        <SearchResultCard candidateCount={5} pool={pool} />
+      </Harness>,
+    );
+
+    expect((await submitFromElsewhere()).pool).toBeFalsy();
+  });
+});

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.test.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.test.tsx
@@ -1,0 +1,96 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider as GraphqlProvider } from "urql";
+import { fromValue } from "wonka";
+
+import { renderWithProviders } from "@gc-digital-talent/vitest-helpers";
+import {
+  fakeClassifications,
+  fakeWorkStreams,
+} from "@gc-digital-talent/fake-data";
+import { WorkRegion } from "@gc-digital-talent/graphql";
+import { setInSessionStorage } from "@gc-digital-talent/storage";
+
+import { TALENT_REQUEST_STATE_KEY } from "../hooks";
+import { SearchForm } from "./SearchForm";
+
+const classifications = fakeClassifications();
+const workStreams = fakeWorkStreams(1);
+const community = { id: "privacy-community", name: { localized: "Privacy" } };
+
+const matches = {
+  countTalentRequestMatches: 5,
+  countTalentRequestMatchesByPool: [],
+  countTalentRequestMatchesByCommunity: [
+    { community, qualifiedInPoolCount: 5, atLevelCount: 0, count: 5 },
+  ],
+};
+
+const noMatches = {
+  countTalentRequestMatches: 0,
+  countTalentRequestMatchesByPool: [],
+  countTalentRequestMatchesByCommunity: [],
+};
+
+interface Variables {
+  where?: {
+    applicantFilter?: {
+      qualifiedInClassifications?: { level?: number }[] | null;
+    } | null;
+  } | null;
+}
+
+// IT-01 returns the community card, IT-04 returns the no-results card.
+const mockClient = {
+  executeQuery: ({ variables }: { variables?: Variables }) =>
+    fromValue({
+      data:
+        variables?.where?.applicantFilter?.qualifiedInClassifications?.[0]
+          ?.level === 4
+          ? noMatches
+          : matches,
+    }),
+};
+
+describe("SearchForm", () => {
+  beforeEach(() => {
+    setInSessionStorage(TALENT_REQUEST_STATE_KEY, {
+      applicantFilter: {
+        qualifiedInClassifications: [{ group: "IT", level: 1 }],
+        qualifiedInWorkStreams: [{ id: workStreams[0].id }],
+        locationPreferences: [WorkRegion.Ontario],
+      },
+      candidateCount: 0,
+    });
+  });
+
+  it("stores no community when the results empty out before submitting", async () => {
+    renderWithProviders(
+      <GraphqlProvider value={mockClient}>
+        <SearchForm
+          classifications={classifications}
+          skills={[]}
+          workStreams={workStreams}
+        />
+      </GraphqlProvider>,
+    );
+
+    expect(
+      await screen.findByRole("article", { name: "Privacy" }),
+    ).toBeInTheDocument();
+
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: /classification/i }),
+      "IT-04",
+    );
+    await userEvent.click(
+      await screen.findByRole("button", { name: /request candidates/i }),
+    );
+
+    const stored = JSON.parse(
+      window.sessionStorage.getItem(TALENT_REQUEST_STATE_KEY) ?? "null",
+    ) as { applicantFilter?: { community?: { id: string } } };
+
+    expect(stored.applicantFilter?.community).toBeUndefined();
+  });
+});

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchResultCard.tsx
@@ -194,7 +194,6 @@ const SearchResultCard = ({ candidateCount, pool }: SearchResultCardProps) => {
           type="submit"
           mode="inline"
           {...poolSubmitProps}
-          value={pool.id}
           onClick={() => {
             setValue("pool", pool.id);
             setValue("communityId", "");

--- a/apps/web/src/pages/TalentRequests/Details.tsx
+++ b/apps/web/src/pages/TalentRequests/Details.tsx
@@ -127,7 +127,13 @@ const TalentRequestDetailsPage = () => {
 };
 
 export const Component = () => (
-  <RequireAuth roles={[ROLE_NAME.CommunityRecruiter, ROLE_NAME.CommunityAdmin]}>
+  <RequireAuth
+    roles={[
+      ROLE_NAME.CommunityRecruiter,
+      ROLE_NAME.CommunityAdmin,
+      ROLE_NAME.PlatformAdmin,
+    ]}
+  >
     <TalentRequestDetailsPage />
   </RequireAuth>
 );

--- a/apps/web/src/pages/TalentRequests/Layout.tsx
+++ b/apps/web/src/pages/TalentRequests/Layout.tsx
@@ -160,7 +160,11 @@ const TalentRequestLayout = () => {
 export const Component = () => {
   return (
     <RequireAuth
-      roles={[ROLE_NAME.CommunityRecruiter, ROLE_NAME.CommunityAdmin]}
+      roles={[
+        ROLE_NAME.CommunityRecruiter,
+        ROLE_NAME.CommunityAdmin,
+        ROLE_NAME.PlatformAdmin,
+      ]}
     >
       <TalentRequestLayout />
     </RequireAuth>

--- a/apps/web/src/pages/TalentRequests/Tracking.tsx
+++ b/apps/web/src/pages/TalentRequests/Tracking.tsx
@@ -69,7 +69,13 @@ const Tracking = () => {
 };
 
 export const Component = () => (
-  <RequireAuth roles={[ROLE_NAME.CommunityRecruiter, ROLE_NAME.CommunityAdmin]}>
+  <RequireAuth
+    roles={[
+      ROLE_NAME.CommunityRecruiter,
+      ROLE_NAME.CommunityAdmin,
+      ROLE_NAME.PlatformAdmin,
+    ]}
+  >
     <Tracking />
   </RequireAuth>
 );


### PR DESCRIPTION
🤖 Resolves #17717 

## 👋 Introduction

Fixes an issue where talent requests were being assigned to an incorrect community.

## 🕵️ Details

We were using submit buttons that set the community when selecting a specific community. Ubfortuantly, `react-hook-form` automatically sets the value when registering the button, not when it is clicked.

What was happening was, when the cards rendered, they registered the new field for `communityId` with the cards ID as the value. so, when submitting a talent request, the community ID was already unintentinally set by the community cards rendering. This was overriding the automatic selection based on both pools or work streams.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Clear all session storage
3. Navigate to `/search`
4. Subimt a request to each options
    - Empty
    - All
    - Specific process
    - Specific community
5. Confirm the commuinity of the request was either:
    - The specific ciommunity selected
    - The community of a process selected
    - The commuity of the work stream selected