### PR TITLE
[Refactor] Fix markup defects and mistakes

### DIFF
--- a/apps/web/src/components/DevelopmentProgramCard/DevelopmentProgramCard.tsx
+++ b/apps/web/src/components/DevelopmentProgramCard/DevelopmentProgramCard.tsx
@@ -76,7 +76,7 @@ const DevelopmentProgramCard = ({
           </DropdownMenu.Root>
         )}
         <div className="flex flex-col items-start gap-3">
-          <span>
+          <div>
             <Heading
               level={headingAs}
               size="h6"
@@ -85,10 +85,10 @@ const DevelopmentProgramCard = ({
               {title}
             </Heading>
             {description && <p>{description}</p>}
-          </span>
+          </div>
 
           {classificationRestrictions?.length ? (
-            <span className="flex gap-1.5">
+            <div className="flex gap-1.5">
               <p>
                 {intl.formatMessage({
                   defaultMessage: "Restricted to",
@@ -105,7 +105,7 @@ const DevelopmentProgramCard = ({
                   </Chip>
                 ))}
               </Chips>
-            </span>
+            </div>
           ) : null}
         </div>
       </div>

--- a/apps/web/src/components/NextRoleAndCareerObjective/NextRoleAndCareerObjective.tsx
+++ b/apps/web/src/components/NextRoleAndCareerObjective/NextRoleAndCareerObjective.tsx
@@ -73,38 +73,42 @@ const NextRoleAndCareerObjective = ({
           <PreviewList.Root>
             {/* If the employee hasn't filled out this section then display null message */}
             {hasAllEmptyFieldsNextRole({ ...nextRole }) ? (
-              <Notice.Root className="my-6">
-                <Notice.Content>
-                  <p>
-                    {intl.formatMessage({
-                      defaultMessage:
-                        "The nominee has not provided information about the next role they’d like to achieve.",
-                      id: "wYka/g",
-                      description:
-                        "Message displayed if nominee hasn't filled out next role info",
-                    })}
-                  </p>
-                </Notice.Content>
-              </Notice.Root>
+              <li>
+                <Notice.Root className="my-6">
+                  <Notice.Content>
+                    <p>
+                      {intl.formatMessage({
+                        defaultMessage:
+                          "The nominee has not provided information about the next role they’d like to achieve.",
+                        id: "wYka/g",
+                        description:
+                          "Message displayed if nominee hasn't filled out next role info",
+                      })}
+                    </p>
+                  </Notice.Content>
+                </Notice.Root>
+              </li>
             ) : (
               <NextRolePreview
                 nextRolePreviewQuery={nextRoleAndCareerObjective}
               />
             )}
             {hasAllEmptyFieldsCareerObjective({ ...careerObjective }) ? (
-              <Notice.Root className="my-6">
-                <Notice.Content>
-                  <p>
-                    {intl.formatMessage({
-                      defaultMessage:
-                        "The nominee has not provided information about their ultimate career objective.",
-                      id: "wL95nl",
-                      description:
-                        "Message displayed if nominee hasn't filled out career objective info",
-                    })}
-                  </p>
-                </Notice.Content>
-              </Notice.Root>
+              <li>
+                <Notice.Root className="my-6">
+                  <Notice.Content>
+                    <p>
+                      {intl.formatMessage({
+                        defaultMessage:
+                          "The nominee has not provided information about their ultimate career objective.",
+                        id: "wL95nl",
+                        description:
+                          "Message displayed if nominee hasn't filled out career objective info",
+                      })}
+                    </p>
+                  </Notice.Content>
+                </Notice.Root>
+              </li>
             ) : (
               <CareerObjectivePreview
                 careerObjectivePreviewQuery={nextRoleAndCareerObjective}

--- a/apps/web/src/components/RecruitmentProcesses/RecruitmentProcessesPreviewList.tsx
+++ b/apps/web/src/components/RecruitmentProcesses/RecruitmentProcessesPreviewList.tsx
@@ -177,20 +177,20 @@ const RecruitmentProcessPreviewList = ({
             description: "Off-platform section information",
           })}
         </p>
-        <p className="mb-6">
-          {offPlatformRecruitmentProcesses?.length ? (
-            <OffPlatformRecruitmentProcessList
-              processesQuery={offPlatformRecruitmentProcesses}
-            />
-          ) : (
-            intl.formatMessage({
+        {offPlatformRecruitmentProcesses?.length ? (
+          <OffPlatformRecruitmentProcessList
+            processesQuery={offPlatformRecruitmentProcesses}
+          />
+        ) : (
+          <p className="mb-6">
+            {intl.formatMessage({
               defaultMessage:
                 "The nominee has not added any off-platform processes.",
               id: "4NtC0R",
               description: "Null state for off-platform section",
-            })
-          )}
-        </p>
+            })}
+          </p>
+        )}
       </div>
     </>
   );

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialogForm.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialogForm.tsx
@@ -24,14 +24,16 @@ const TEXT_AREA_MAX_WORDS = 200;
 
 interface ContextBlockProps {
   messages: string[];
-  key: string;
+  idPrefix: string;
 }
 
-const ContextBlock = ({ messages, key }: ContextBlockProps) => (
+// NOTE: not named `key` — React strips that before props reach a component,
+// so it would always arrive undefined.
+const ContextBlock = ({ messages, idPrefix }: ContextBlockProps) => (
   <div className="mb-3">
     {messages.map((message, index) => (
       <div
-        key={`${key}-${index + 1}`}
+        key={`${idPrefix}-${index + 1}`}
         className="mb-3 flex justify-start gap-3"
       >
         <CheckIcon className="size-6" />
@@ -175,7 +177,7 @@ const ScreeningDecisionDialogForm = ({
                     educationContext ? (
                       <ContextBlock
                         messages={educationContext.messages}
-                        key={educationContext.key}
+                        idPrefix={educationContext.key}
                       />
                     ) : null
                   }

--- a/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialogForm.tsx
+++ b/apps/web/src/components/ScreeningDecisions/ScreeningDecisionDialogForm.tsx
@@ -30,13 +30,13 @@ interface ContextBlockProps {
 const ContextBlock = ({ messages, key }: ContextBlockProps) => (
   <div className="mb-3">
     {messages.map((message, index) => (
-      <span
+      <div
         key={`${key}-${index + 1}`}
         className="mb-3 flex justify-start gap-3"
       >
         <CheckIcon className="size-6" />
         <p>{message}</p>
-      </span>
+      </div>
     ))}
   </div>
 );

--- a/apps/web/src/pages/CommunityDashboardPage/CommunityDashboardPage.tsx
+++ b/apps/web/src/pages/CommunityDashboardPage/CommunityDashboardPage.tsx
@@ -332,12 +332,7 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
           )}
         </div>
         <div className="mt-18 mb-12">
-          <Heading
-            size="h4"
-            icon={CogIcon}
-            color="warning"
-            className="m-t0 mb-6"
-          >
+          <Heading size="h4" icon={CogIcon} color="warning" className="mb-6">
             {intl.formatMessage({
               defaultMessage: "Your roles",
               id: "IJlJF1",

--- a/apps/web/src/pages/Home/IAPManagerHomePage/IAPManagerHomePage.tsx
+++ b/apps/web/src/pages/Home/IAPManagerHomePage/IAPManagerHomePage.tsx
@@ -475,7 +475,7 @@ export const Component = () => {
                     "Paragraph 1 for the 'Indigenous talent ready for IT apprenticeships' section",
                 })}
               </p>
-              <p className="m-y3">
+              <p>
                 {intl.formatMessage({
                   defaultMessage: "You will receive candidates who have:",
                   id: "SeJ1eB",

--- a/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentStepCard.tsx
+++ b/apps/web/src/pages/Pools/AssessmentPlanBuilderPage/components/AssessmentStepCard.tsx
@@ -1,4 +1,3 @@
-import { Fragment } from "react";
 import { useIntl } from "react-intl";
 
 import { unpackMaybes } from "@gc-digital-talent/helpers";
@@ -176,14 +175,15 @@ const AssessmentStepCard = ({
             </li>
           )}
           {skillNames.map((skillName, skillIndex) => (
-            <Fragment key={skillName}>
+            <li className="inline pl-0" key={skillName}>
+              {/* The separator lives inside the item: a <ul> only accepts <li>. */}
               {skillIndex !== 0 || isApplicationScreening ? (
                 <span className="mx-3" aria-hidden>
                   {UNICODE_CHAR.BULLET}
                 </span>
               ) : null}
-              <li className="inline pl-0">{skillName}</li>
-            </Fragment>
+              {skillName}
+            </li>
           ))}
         </ul>
       ) : (

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -1176,7 +1176,7 @@ export const PoolPoster = ({
                     })}
                   </Accordion.Trigger>
                   <Accordion.Content>
-                    <Text className="m-y0">
+                    <Text>
                       {intl.formatMessage(
                         {
                           defaultMessage:

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -933,7 +933,7 @@ export const PoolPoster = ({
                     size="h3"
                     icon={QuestionMarkCircleIcon}
                     color="success"
-                    className="m-t18 mb-0"
+                    className="mb-0"
                   >
                     {sections.moreInfo.title}
                   </TableOfContents.Heading>

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -1056,24 +1056,24 @@ export const PoolPoster = ({
                             internalLink(paths.register(), chunks),
                         },
                       )}
-                      <Text>
-                        {intl.formatMessage({
-                          defaultMessage:
-                            "First-time users report spending between 2 to 3 hours on average on their first application. The second time you apply, it should take significantly less time since we'll reuse most of your information. Return users spend on average between 30 minutes to 1 hour on each application.",
-                          id: "adaiV0",
-                          description:
-                            "Text explaining the average time spent on applications",
-                        })}
-                      </Text>
-                      <Text>
-                        {intl.formatMessage({
-                          defaultMessage:
-                            "Applying early also allows hiring managers to review your application sooner. They can begin assessing your application as soon as you submit it, even if the deadline hasn't passed yet.",
-                          id: "ay8mcT",
-                          description:
-                            "Text explaining the benefits of applying early",
-                        })}
-                      </Text>
+                    </Text>
+                    <Text>
+                      {intl.formatMessage({
+                        defaultMessage:
+                          "First-time users report spending between 2 to 3 hours on average on their first application. The second time you apply, it should take significantly less time since we'll reuse most of your information. Return users spend on average between 30 minutes to 1 hour on each application.",
+                        id: "adaiV0",
+                        description:
+                          "Text explaining the average time spent on applications",
+                      })}
+                    </Text>
+                    <Text>
+                      {intl.formatMessage({
+                        defaultMessage:
+                          "Applying early also allows hiring managers to review your application sooner. They can begin assessing your application as soon as you submit it, even if the deadline hasn't passed yet.",
+                        id: "ay8mcT",
+                        description:
+                          "Text explaining the benefits of applying early",
+                      })}
                     </Text>
                   </Accordion.Content>
                 </Accordion.Item>
@@ -1144,24 +1144,24 @@ export const PoolPoster = ({
                             internalLink(paths.support(), chunks),
                         },
                       )}
-                      <Text>
-                        {intl.formatMessage({
-                          defaultMessage:
-                            "We review tickets during business hours. If you report an issue late at night, right before a job advertisement deadline, expect a response within 2 business days. To avoid last-minute issues, we encourage you to submit your application as early as possible.",
-                          id: "b9gGFH",
-                          description:
-                            "Text explaining the average time spent on applications",
-                        })}
-                      </Text>
-                      <Text>
-                        {intl.formatMessage({
-                          defaultMessage:
-                            "If you submit your ticket after the application deadline has passed, we won't be able to assist you, and your application won't be accepted.",
-                          id: "4DfNUW",
-                          description:
-                            "Text explaining the benefits of applying early",
-                        })}
-                      </Text>
+                    </Text>
+                    <Text>
+                      {intl.formatMessage({
+                        defaultMessage:
+                          "We review tickets during business hours. If you report an issue late at night, right before a job advertisement deadline, expect a response within 2 business days. To avoid last-minute issues, we encourage you to submit your application as early as possible.",
+                        id: "b9gGFH",
+                        description:
+                          "Text explaining the average time spent on applications",
+                      })}
+                    </Text>
+                    <Text>
+                      {intl.formatMessage({
+                        defaultMessage:
+                          "If you submit your ticket after the application deadline has passed, we won't be able to assist you, and your application won't be accepted.",
+                        id: "4DfNUW",
+                        description:
+                          "Text explaining the benefits of applying early",
+                      })}
                     </Text>
                   </Accordion.Content>
                 </Accordion.Item>

--- a/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
+++ b/apps/web/src/pages/Pools/PoolAdvertisementPage/PoolAdvertisementPage.tsx
@@ -1176,7 +1176,7 @@ export const PoolPoster = ({
                     })}
                   </Accordion.Trigger>
                   <Accordion.Content>
-                    <Text>
+                    <Text className="my-0">
                       {intl.formatMessage(
                         {
                           defaultMessage:

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/CurrentPositionExperiences.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/CurrentPositionExperiences.tsx
@@ -144,36 +144,36 @@ const CurrentPositionExperiences = ({
                       description:
                         "Description for the message displayed when there is no government experience for the current position",
                     })}
-                    <p className="my-3">
+                  </p>
+                  <p className="my-3">
+                    {intl.formatMessage({
+                      defaultMessage:
+                        "Contact the nominator or submitter so they can follow up with the nominee:",
+                      id: "4Ect9u",
+                      description:
+                        "Instruction to contact nominator or submitter for follow up",
+                    })}
+                  </p>
+                  <Ul>
+                    <li>
                       {intl.formatMessage({
                         defaultMessage:
-                          "Contact the nominator or submitter so they can follow up with the nominee:",
-                        id: "4Ect9u",
+                          "If the nominee is still a Government of Canada employee, they’ll need to update their career experience on the platform.",
+                        id: "e0M7vj",
                         description:
-                          "Instruction to contact nominator or submitter for follow up",
+                          "Instruction if nominee is still a Government of Canada employee",
                       })}
-                    </p>
-                    <Ul>
-                      <li>
-                        {intl.formatMessage({
-                          defaultMessage:
-                            "If the nominee is still a Government of Canada employee, they’ll need to update their career experience on the platform.",
-                          id: "e0M7vj",
-                          description:
-                            "Instruction if nominee is still a Government of Canada employee",
-                        })}
-                      </li>
-                      <li>
-                        {intl.formatMessage({
-                          defaultMessage:
-                            "If the nominee is no longer an employee, this nomination should be marked as “Not supported”.",
-                          id: "0P591/",
-                          description:
-                            "Instruction if nominee is no longer a Government of Canada employee",
-                        })}
-                      </li>
-                    </Ul>
-                  </p>
+                    </li>
+                    <li>
+                      {intl.formatMessage({
+                        defaultMessage:
+                          "If the nominee is no longer an employee, this nomination should be marked as “Not supported”.",
+                        id: "0P591/",
+                        description:
+                          "Instruction if nominee is no longer a Government of Canada employee",
+                      })}
+                    </li>
+                  </Ul>
                 </Notice.Content>
               </Notice.Root>
             )}

--- a/apps/web/src/pages/TalentRequests/components/TalentRequestReferralDialogs/ChangeStatusDialog.tsx
+++ b/apps/web/src/pages/TalentRequests/components/TalentRequestReferralDialogs/ChangeStatusDialog.tsx
@@ -63,8 +63,8 @@ const ChangeStatusDialog = ({
           {intl.formatMessage(talentRequestMessages.markAs, { status })}
         </Dialog.Header>
         <Dialog.Body>
-          <p className="mb-6 flex flex-col gap-3">
-            <span>
+          <div className="mb-6 flex flex-col gap-3">
+            <p>
               {intl.formatMessage(
                 {
                   defaultMessage:
@@ -76,11 +76,9 @@ const ChangeStatusDialog = ({
                 { numOfSelectedCandidates },
               )}
               {intl.formatMessage(commonMessages.dividingColon)}
-            </span>
-            <span>
-              <IconLabel label={status} icon={icon} />
-            </span>
-          </p>
+            </p>
+            <IconLabel label={status} icon={icon} />
+          </div>
           {onUpdate ? (
             <ChangeStatusForm
               reasonType={reasonType ?? "notSelected"}

--- a/apps/web/src/pages/TalentRequests/components/TalentRequestTrackedUsersInbox/dialogs/StatusDialogLayout.tsx
+++ b/apps/web/src/pages/TalentRequests/components/TalentRequestTrackedUsersInbox/dialogs/StatusDialogLayout.tsx
@@ -44,8 +44,8 @@ const StatusDialogLayout = ({
           })}
         </Dialog.Header>
         <Dialog.Body>
-          <p className="mb-6 flex flex-col gap-3">
-            <span>
+          <div className="mb-6 flex flex-col gap-3">
+            <p>
               {intl.formatMessage(
                 {
                   defaultMessage:
@@ -57,11 +57,9 @@ const StatusDialogLayout = ({
                 { count: selectedCount },
               )}
               {intl.formatMessage(commonMessages.dividingColon)}
-            </span>
-            <span>
-              <IconLabel label={statusLabel} icon={icon} />
-            </span>
-          </p>
+            </p>
+            <IconLabel label={statusLabel} icon={icon} />
+          </div>
           {children}
         </Dialog.Body>
       </Dialog.Content>

--- a/apps/web/src/pages/Users/UserEmployeeInformationPage/components/NextRoleAndCareerObjective.tsx
+++ b/apps/web/src/pages/Users/UserEmployeeInformationPage/components/NextRoleAndCareerObjective.tsx
@@ -2,7 +2,7 @@ import { useIntl } from "react-intl";
 
 import type { FragmentType } from "@gc-digital-talent/graphql";
 import { getFragment } from "@gc-digital-talent/graphql";
-import { Notice } from "@gc-digital-talent/ui";
+import { Notice, PreviewList } from "@gc-digital-talent/ui";
 
 import { hasAllEmptyFields as hasAllEmptyFieldsNextRole } from "~/validators/employeeProfile/nextRole";
 import { hasAllEmptyFields as hasAllEmptyFieldsCareerObjective } from "~/validators/employeeProfile/careerObjective";
@@ -67,26 +67,28 @@ const NextRoleAndCareerObjective = ({
     );
   }
   return (
-    <div className="space-y-6">
+    <PreviewList.Root>
       {hasNextRole ? (
         <NextRolePreview
           nextRolePreviewQuery={nextRoleAndCareerObjective}
           dialogSubtitle={nextRoleDialogSubtitle}
         />
       ) : (
-        <Notice.Root>
-          <Notice.Content>
-            <p>
-              {intl.formatMessage({
-                defaultMessage:
-                  "The employee has not provided information about the next role they'd like to achieve.",
-                id: "U5plJQ",
-                description:
-                  "Message displayed if employee hasn't filled out next role",
-              })}
-            </p>
-          </Notice.Content>
-        </Notice.Root>
+        <li>
+          <Notice.Root className="my-6">
+            <Notice.Content>
+              <p>
+                {intl.formatMessage({
+                  defaultMessage:
+                    "The employee has not provided information about the next role they'd like to achieve.",
+                  id: "U5plJQ",
+                  description:
+                    "Message displayed if employee hasn't filled out next role",
+                })}
+              </p>
+            </Notice.Content>
+          </Notice.Root>
+        </li>
       )}
 
       {/* Career Objective Section */}
@@ -97,21 +99,23 @@ const NextRoleAndCareerObjective = ({
           dialogSubtitle={dialogSubtitle}
         />
       ) : (
-        <Notice.Root>
-          <Notice.Content>
-            <p>
-              {intl.formatMessage({
-                defaultMessage:
-                  "The employee has not provided information about their ultimate career objective.",
-                id: "ZhccbH",
-                description:
-                  "Message displayed if employee hasn't filled out career objective",
-              })}
-            </p>
-          </Notice.Content>
-        </Notice.Root>
+        <li>
+          <Notice.Root className="my-6">
+            <Notice.Content>
+              <p>
+                {intl.formatMessage({
+                  defaultMessage:
+                    "The employee has not provided information about their ultimate career objective.",
+                  id: "ZhccbH",
+                  description:
+                    "Message displayed if employee hasn't filled out career objective",
+                })}
+              </p>
+            </Notice.Content>
+          </Notice.Root>
+        </li>
       )}
-    </div>
+    </PreviewList.Root>
   );
 };
 

--- a/packages/ui/src/components/Accordion/Accordion.test.tsx
+++ b/packages/ui/src/components/Accordion/Accordion.test.tsx
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker/locale/en";
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import type { ComponentPropsWithoutRef } from "react";
 
@@ -61,6 +61,36 @@ describe("Accordion", () => {
       children: <DefaultChildren />,
     });
     await expectNoAccessibilityErrors(container);
+  });
+
+  // A heading is flow content, which is invalid inside <button>, so the heading
+  // has to wrap the trigger rather than sit within it.
+  it.each([
+    ["h2" as const, 2],
+    ["h3" as const, 3],
+    ["h4" as const, 4],
+  ])("should render an %s around the trigger, not inside it", (as, level) => {
+    renderAccordion({
+      type: "single",
+      children: (
+        <Accordion.Item value="one">
+          <Accordion.Trigger as={as} subtitle="Accordion subtitle" context="12">
+            Accordion One
+          </Accordion.Trigger>
+          <Accordion.Content>
+            <Text />
+          </Accordion.Content>
+        </Accordion.Item>
+      ),
+    });
+
+    const trigger = screen.getByRole("button", { name: /accordion one/i });
+    expect(within(trigger).queryByRole("heading")).toBeNull();
+
+    const heading = screen.getByRole("heading", { level });
+    expect(heading).toContainElement(trigger);
+    // The context is a sibling of the heading, so it stays out of its text.
+    expect(heading).not.toHaveTextContent("12");
   });
 
   it("should only open one when single", async () => {

--- a/packages/ui/src/components/Accordion/Accordion.tsx
+++ b/packages/ui/src/components/Accordion/Accordion.tsx
@@ -220,38 +220,43 @@ const Trigger = forwardRef<
     });
 
     return (
-      <AccordionPrimitive.Header asChild>
-        <div className={header()} {...titleProps}>
-          <AccordionPrimitive.Trigger
-            ref={forwardedRef}
-            className={btn()}
-            {...rest}
-          >
-            <span className="-mt-0.5 rounded-full p-1 transition-colors duration-150 group-focus-visible/btn:bg-focus group-focus-visible/btn:text-black">
-              <ChevronRightIcon
-                className={iconSize({
-                  class:
-                    "rotate-0 transform leading-none transition-transform duration-150 group-data-[state=open]/btn:rotate-90",
-                })}
-              />
-            </span>
-            <span className="flex grow flex-col">
-              <Heading className={heading()}>{children}</Heading>
-              {subtitle && (
-                <span className="dark:text-gray-200m mt-1 text-sm">
-                  {subtitle}
-                </span>
-              )}
-            </span>
-          </AccordionPrimitive.Trigger>
-          {(!!Icon || !!context) && (
-            <span className={ctx()}>
-              {context && <span>{context}</span>}
-              {Icon && <Icon className={iconSize()} />}
-            </span>
-          )}
-        </div>
-      </AccordionPrimitive.Header>
+      <div className={header()}>
+        {/* NOTE: The heading wraps the trigger rather than sitting inside it.
+        A heading is flow content, which is invalid inside <button>. The icon and
+        context stay outside the heading so they don't join its text content. */}
+        <AccordionPrimitive.Header asChild>
+          <Heading className="flex grow" {...titleProps}>
+            <AccordionPrimitive.Trigger
+              ref={forwardedRef}
+              className={btn()}
+              {...rest}
+            >
+              <span className="-mt-0.5 rounded-full p-1 transition-colors duration-150 group-focus-visible/btn:bg-focus group-focus-visible/btn:text-black">
+                <ChevronRightIcon
+                  className={iconSize({
+                    class:
+                      "rotate-0 transform leading-none transition-transform duration-150 group-data-[state=open]/btn:rotate-90",
+                  })}
+                />
+              </span>
+              <span className="flex grow flex-col">
+                <span className={heading()}>{children}</span>
+                {subtitle && (
+                  <span className="dark:text-gray-200m mt-1 text-sm">
+                    {subtitle}
+                  </span>
+                )}
+              </span>
+            </AccordionPrimitive.Trigger>
+          </Heading>
+        </AccordionPrimitive.Header>
+        {(!!Icon || !!context) && (
+          <span className={ctx()}>
+            {context && <span>{context}</span>}
+            {Icon && <Icon className={iconSize()} />}
+          </span>
+        )}
+      </div>
     );
   },
 );

--- a/packages/ui/src/components/Stepper/Step.tsx
+++ b/packages/ui/src/components/Stepper/Step.tsx
@@ -90,7 +90,7 @@ const Step = ({
         className={link()}
         aria-label={ariaLabel}
       >
-        <span className="absolute -top-0.5 left-0 h-full w-9">
+        <div className="absolute -top-0.5 left-0 h-full w-9">
           {!last && <div className={tail()} />}
 
           <span className={icon()}>
@@ -101,7 +101,7 @@ const Step = ({
               <span className="absolute top-1/2 left-1/2 size-5 -translate-1/2 transform rounded-full border-3 border-white dark:border-gray-700" />
             )}
           </span>
-        </span>
+        </div>
         <span className={text()}>{label}</span>
       </StepLink>
     </li>


### PR DESCRIPTION
🤖 Resolves #17596

## 👋 Introduction

To attempt to play to the bot's strength I had it try and analyze to find markup problems. Something easier to do with such tooling rather than stumbling upon with the console open by chance

## 🕵️ Details

It did some extensive probing, with me pestering for double-checks and refinements. This resulted in the connected issue being fairly extensive and involved. Gathering the findings, proposing fixes, and plenty of justification or rationale. Making for a harder to parse issue.

So why not let the bot try to handle what it found and see if it makes sense?
Judging by the diff size, it wasn't all that much editing required

### Explanation of the fixes

Nesting elements inside other elements that you aren't supposed to.
Component key that was ending up undefined
Accordion header markup fix, was technically invalid but threw no problems due to implementation's leniency
Tailwind classes that were invalid (likely typos)

> **Invalid HTML nesting — the class React reports as errors (9 sites, 5 files)**
>
> Paragraphs were wrapping content that can't legally live inside a paragraph: bulleted lists, other paragraphs, and components rooted at a list. Browsers tolerate this today only because the app renders client-side; if any of it is ever server-rendered or prerendered, the parser closes the paragraph early and the structure genuinely changes.
> Two status dialogs had a second layer of the same fault that the ticket's proposed fix would have missed — an inner span also holding a paragraph. Re-tagging only the outer element would have moved the problem rather than solved it.
>
>**Accordion heading nested inside the trigger button (affects every accordion in the app)**
>
>The heading element sat inside the `<button>`. A heading is flow content, which is invalid inside a button, and ARIA marks a button's children as presentational — so a conforming assistive technology is permitted to drop the heading entirely. In practice the accessibility tree on main does expose it at the correct level, so there's no observed loss today; the markup was relying on lenient implementation rather than on the spec. The heading now wraps the button, matching the ARIA APG accordion pattern and Radix's own Accordion.Header default. The rendered DOM is otherwise byte-identical, with no class gained or lost.
>
>
>**Lists that weren't lists (5 sites, 3 files)**
>
>Two near-duplicate components had opposite faults: one put non-list content directly inside a `<ul>`, the other rendered list items with no list around them at all. The second had a visible consequence — Tailwind's preflight resets list-style on ul/ol but not on li, and list-style-type is inherited, so `<li>`s adrift in a `<div>` fall back to disc and rendered stray bullets.
>A third placed decorative bullet separators as siblings of the list items rather than inside them, so the `<ul>` had five children where only three were items.
>
> **`<span>` used as a layout container (5 sites, 3 files)**
>
> Five spans were holding headings, paragraphs and a list, where only inline content is allowed. All five were already flex containers or flex items, so the swap to div changes nothing visually.
>
> **Styling that never did anything (4 sites)**
>
> Four Tailwind classes were misspelled in a way that matches no utility (m-y0, m-t18, m-t0, m-y3), so they had never applied. Deleted rather than corrected — these pages passed design review as they actually render, so making the classes work would have silently changed approved layouts.
>
> **A prop React silently discards (1 site)**
>
> A component took its list-key prefix in a prop named key. React strips key before props reach a component, so it always arrived undefined and every generated key came out as "undefined-1", "undefined-2". Renamed to idPrefix.

~ Claude 

## 🧪 Testing

1. Manual exercise of pages
2. Observe Chromatic diff

Places where I manually checked include:

- PoolAdvertisementPage 
- Stepper / Step
- UserEmployeeInformationPage → NextRoleAndCareerObjective 
- Accordion with a subtitle
- CommunityDashboardPage
- AssessmentStepCard
- NextRoleAndCareerObjective — nomination group → Profile tab
- RecruitmentProcessesPreviewList
- CurrentPositionExperiences
- ChangeStatusDialog — talent request → Details tab
- StatusDialogLayout — talent request → Tracking tab

## 📸 Screenshot

One place with changes, but I'd contend that it would be fixing existing problems

#### MAIN

<img width="1247" height="629" alt="image" src="https://github.com/user-attachments/assets/d9d672ad-f2e3-407d-bbd0-9127b4f1cb08" />

#### BRANCH

<img width="1255" height="576" alt="image" src="https://github.com/user-attachments/assets/7335d9f4-91cb-42a8-b55e-32752b8aa503" />

#### RELATED
I would contend this resolved a visual bug. As it now is in sync with

<img width="1228" height="550" alt="image" src="https://github.com/user-attachments/assets/52fe4815-c91e-44bc-a9d2-a86138cf1d14" />

