### PR TITLE
[Fix] Allow unauthenticated job poster template download

### DIFF
--- a/api/app/Console/Commands/PruneUserGeneratedFiles.php
+++ b/api/app/Console/Commands/PruneUserGeneratedFiles.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Support\FilePath;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
@@ -29,16 +30,15 @@ class PruneUserGeneratedFiles extends Command
     {
         $this->info('Pruning old user generated files');
         $now = Carbon::now();
-        $disk = Storage::disk('user_generated');
-        $allDirectories = $disk->allDirectories();
-        foreach ($allDirectories as $directory) {
-            $allFiles = $disk->allFiles($directory);
-            foreach ($allFiles as $file) {
+        $diskNames = [FilePath::GUARDED_DISK, FilePath::PUBLIC_DISK];
+        foreach ($diskNames as $diskName) {
+            $disk = Storage::disk($diskName);
+            foreach ($disk->allFiles() as $file) {
                 $lastModified = Carbon::createFromTimestamp($disk->lastModified($file));
                 $hoursOld = $now->diffInHours($lastModified);
                 $shouldDelete = $hoursOld > 24;
                 if ($shouldDelete) {
-                    $this->info("Deleting $file - $hoursOld hours old");
+                    $this->info("Deleting $diskName/$file - $hoursOld hours old");
                     $disk->delete($file);
                 }
             }

--- a/api/app/Generators/FileGenerator.php
+++ b/api/app/Generators/FileGenerator.php
@@ -2,6 +2,7 @@
 
 namespace App\Generators;
 
+use App\Support\FilePath;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
@@ -13,6 +14,8 @@ class FileGenerator
     protected ?string $authenticatedUserId;
 
     protected string $extension = '';
+
+    protected string $diskName = FilePath::GUARDED_DISK;
 
     public function __construct(protected string $fileName, protected ?string $dir) {}
 
@@ -41,7 +44,7 @@ class FileGenerator
      *
      * @param  ?string  $diskName  Name of the disk we want to save file to
      */
-    public function getPath(?string $diskName = 'user_generated'): string
+    public function getPath(?string $diskName = null): string
     {
         $disk = $this->getDisk($diskName);
 
@@ -53,7 +56,7 @@ class FileGenerator
      *
      * @param  ?string  $diskName  Name of the disk we want to save file to
      */
-    public function getDisk(?string $diskName = 'user_generated'): FilesystemAdapter
+    public function getDisk(?string $diskName = null): FilesystemAdapter
     {
         /**
          * We don't actually put the file with
@@ -62,7 +65,7 @@ class FileGenerator
          * so we need to manually create the directory if
          * it doesn't exist
          */
-        $disk = Storage::disk($diskName);
+        $disk = Storage::disk($diskName ?? $this->diskName);
         if ($this->dir && ! $disk->exists($this->dir)) {
             File::makeDirectory($disk->path($this->dir));
         }
@@ -106,6 +109,18 @@ class FileGenerator
     public function setAuthenticatedUserId(string $authenticatedUserId)
     {
         $this->authenticatedUserId = $authenticatedUserId;
+
+        return $this;
+    }
+
+    /**
+     * Set the disk the file is written to and read from
+     *
+     * @param  string  $diskName  Name of the disk
+     */
+    public function setDiskName(string $diskName)
+    {
+        $this->diskName = $diskName;
 
         return $this;
     }

--- a/api/app/Generators/FileGeneratorInterface.php
+++ b/api/app/Generators/FileGeneratorInterface.php
@@ -16,5 +16,5 @@ interface FileGeneratorInterface
 
     public function setFileName(string $name): void;
 
-    public function getPath(?string $disk = 'user_generated'): string;
+    public function getPath(?string $disk = null): string;
 }

--- a/api/app/GraphQL/Mutations/DownloadJobPosterTemplateDoc.php
+++ b/api/app/GraphQL/Mutations/DownloadJobPosterTemplateDoc.php
@@ -19,9 +19,11 @@ final readonly class DownloadJobPosterTemplateDoc
             $targetPoster = JobPosterTemplate::findOrFail($args['id']);
             $generator = new JobPosterTemplateGenerator(
                 jobPoster: $targetPoster,
-                dir: FilePath::PUBLIC_PATH,
+                dir: null,
                 lang: App::getLocale(),
             );
+
+            $generator->setDiskName(FilePath::PUBLIC_DISK);
 
             $generator->generate()->write();
 

--- a/api/app/GraphQL/Mutations/DownloadJobPosterTemplateDoc.php
+++ b/api/app/GraphQL/Mutations/DownloadJobPosterTemplateDoc.php
@@ -6,28 +6,22 @@ namespace App\GraphQL\Mutations;
 
 use App\Generators\JobPosterTemplateGenerator;
 use App\Models\JobPosterTemplate;
+use App\Support\FilePath;
 use Illuminate\Support\Facades\App;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Validation\UnauthorizedException;
 
 final readonly class DownloadJobPosterTemplateDoc
 {
     /** @param  array{id: string|null}  $args */
     public function __invoke(null $_, array $args)
     {
-        $user = Auth::user();
-        throw_unless(is_string($user?->id), UnauthorizedException::class);
-
         try {
             $targetPoster = JobPosterTemplate::findOrFail($args['id']);
             $generator = new JobPosterTemplateGenerator(
                 jobPoster: $targetPoster,
-                dir: $user->id,
+                dir: FilePath::PUBLIC_PATH,
                 lang: App::getLocale(),
             );
-
-            $generator->setAuthenticatedUserId($user->id);
 
             $generator->generate()->write();
 

--- a/api/app/Http/Controllers/UserGeneratedFilesController.php
+++ b/api/app/Http/Controllers/UserGeneratedFilesController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Support\FilePath;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -36,13 +35,6 @@ class UserGeneratedFilesController extends Controller
     {
         $safeFileName = FilePath::sanitize($fileName, true);
         $filePath = $parentDir.DIRECTORY_SEPARATOR.$safeFileName;
-
-        Log::debug([
-            'fileName' => $fileName,
-            'safeFileName' => $safeFileName,
-            'parentdir' => $parentDir,
-            'path' => $filePath,
-        ]);
 
         throw_unless(Storage::disk('user_generated')->exists($filePath), NotFoundHttpException::class);
 

--- a/api/app/Http/Controllers/UserGeneratedFilesController.php
+++ b/api/app/Http/Controllers/UserGeneratedFilesController.php
@@ -4,20 +4,45 @@ namespace App\Http\Controllers;
 
 use App\Support\FilePath;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class UserGeneratedFilesController extends Controller
 {
-    public function getFile(string $fileName)
+    /**
+     * Streams a public file that does not require authentication
+     *
+     * @param  string  $fileName  The name of the file to be streamed
+     * @return void
+     */
+    public function getPublicFile(string $fileName): StreamedResponse
+    {
+        return $this->streamFile(FilePath::PUBLIC_PATH, $fileName);
+    }
+
+    public function getGuardedFile(string $fileName): StreamedResponse
     {
         // https://laravel.com/docs/10.x/authentication#accessing-specific-guard-instances
         $userId = Auth::guard('api')->id();
         throw_unless(is_string($userId) && ! empty($userId), UnauthorizedHttpException::class);
 
+        return $this->streamFile($userId, $fileName);
+    }
+
+    private function streamFile(string $parentDir, string $fileName): StreamedResponse
+    {
         $safeFileName = FilePath::sanitize($fileName, true);
-        $filePath = $userId.'/'.$safeFileName;
+        $filePath = $parentDir.DIRECTORY_SEPARATOR.$safeFileName;
+
+        Log::debug([
+            'fileName' => $fileName,
+            'safeFileName' => $safeFileName,
+            'parentdir' => $parentDir,
+            'path' => $filePath,
+        ]);
 
         throw_unless(Storage::disk('user_generated')->exists($filePath), NotFoundHttpException::class);
 
@@ -44,6 +69,5 @@ class UserGeneratedFilesController extends Controller
                 }
             }
         }, $safeFileName, ['Content-Type' => $contentType]);
-
     }
 }

--- a/api/app/Http/Controllers/UserGeneratedFilesController.php
+++ b/api/app/Http/Controllers/UserGeneratedFilesController.php
@@ -15,11 +15,10 @@ class UserGeneratedFilesController extends Controller
      * Streams a public file that does not require authentication
      *
      * @param  string  $fileName  The name of the file to be streamed
-     * @return void
      */
     public function getPublicFile(string $fileName): StreamedResponse
     {
-        return $this->streamFile(FilePath::PUBLIC_PATH, $fileName);
+        return $this->streamFile(FilePath::PUBLIC_DISK, null, $fileName);
     }
 
     public function getGuardedFile(string $fileName): StreamedResponse
@@ -28,15 +27,16 @@ class UserGeneratedFilesController extends Controller
         $userId = Auth::guard('api')->id();
         throw_unless(is_string($userId) && ! empty($userId), UnauthorizedHttpException::class);
 
-        return $this->streamFile($userId, $fileName);
+        return $this->streamFile(FilePath::GUARDED_DISK, $userId, $fileName);
     }
 
-    private function streamFile(string $parentDir, string $fileName): StreamedResponse
+    private function streamFile(string $diskName, ?string $parentDir, string $fileName): StreamedResponse
     {
         $safeFileName = FilePath::sanitize($fileName, true);
-        $filePath = $parentDir.DIRECTORY_SEPARATOR.$safeFileName;
+        $filePath = $parentDir ? $parentDir.DIRECTORY_SEPARATOR.$safeFileName : $safeFileName;
+        $disk = Storage::disk($diskName);
 
-        throw_unless(Storage::disk('user_generated')->exists($filePath), NotFoundHttpException::class);
+        throw_unless($disk->exists($filePath), NotFoundHttpException::class);
 
         $extension = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
 
@@ -51,8 +51,8 @@ class UserGeneratedFilesController extends Controller
         };
 
         /* buffered response */
-        return response()->streamDownload(function () use ($filePath) {
-            $handle = Storage::disk('user_generated')->readStream($filePath);
+        return response()->streamDownload(function () use ($disk, $filePath) {
+            $handle = $disk->readStream($filePath);
             if ($handle) {
                 fpassthru($handle);
                 // Check to avoid warnings if the handle is already closed or invalid

--- a/api/app/Support/FilePath.php
+++ b/api/app/Support/FilePath.php
@@ -29,7 +29,7 @@ class FilePath
 
         // Keep French letters, numbers, spaces, and dashes
         // Extension requires \.
-        $allowedPattern = $preserveExtension ? '/[^\p{L}\p{N}\s\-\_\.]/u' : '/[^\p{L}\p{N}\s\-\_]/u';
+        $allowedPattern = $preserveExtension ? '/[^\p{L}\p{N}\s\-\_\.\'’]/u' : '/[^\p{L}\p{N}\s\-\_\'’]/u';
         $name = preg_replace($allowedPattern, '', $name);
 
         // Normalize whitespace and trim

--- a/api/app/Support/FilePath.php
+++ b/api/app/Support/FilePath.php
@@ -4,6 +4,8 @@ namespace App\Support;
 
 class FilePath
 {
+    public const PUBLIC_PATH = 'public';
+
     /**
      * Normalizes a string into a safe, cross-platform file name.
      * Preserves French characters while stripping path separators and dots.

--- a/api/app/Support/FilePath.php
+++ b/api/app/Support/FilePath.php
@@ -6,6 +6,10 @@ class FilePath
 {
     public const PUBLIC_PATH = 'public';
 
+    public const PUBLIC_DISK = 'public_generated';
+
+    public const GUARDED_DISK = 'user_generated';
+
     /**
      * Normalizes a string into a safe, cross-platform file name.
      * Preserves French characters while stripping path separators and dots.

--- a/api/config/filesystems.php
+++ b/api/config/filesystems.php
@@ -40,6 +40,11 @@ return [
             'root' => storage_path('app/user_generated'),
         ],
 
+        'public_generated' => [
+            'driver' => 'local',
+            'root' => storage_path('app/public_generated'),
+        ],
+
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -4185,6 +4185,7 @@ type Mutation {
     @canFind(ability: "view", find: "id", model: "PoolCandidate")
   downloadJobPosterTemplateDoc(id: UUID!): String
     @canFind(ability: "view", find: "id", model: "JobPosterTemplate")
+    @throttle(maxAttempts: 20)
   downloadNominationDoc(id: UUID!): String
     @guard
     @canFind(ability: "view", find: "id", model: "TalentNominationGroup")

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -4185,7 +4185,6 @@ type Mutation {
     @canFind(ability: "view", find: "id", model: "PoolCandidate")
   downloadJobPosterTemplateDoc(id: UUID!): String
     @canFind(ability: "view", find: "id", model: "JobPosterTemplate")
-    @throttle(maxAttempts: 20)
   downloadNominationDoc(id: UUID!): String
     @guard
     @canFind(ability: "view", find: "id", model: "TalentNominationGroup")

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -4184,7 +4184,6 @@ type Mutation {
     @guard
     @canFind(ability: "view", find: "id", model: "PoolCandidate")
   downloadJobPosterTemplateDoc(id: UUID!): String
-    @guard
     @canFind(ability: "view", find: "id", model: "JobPosterTemplate")
   downloadNominationDoc(id: UUID!): String
     @guard

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\CspReportController;
 use App\Http\Controllers\SupportController;
 use App\Http\Controllers\UserGeneratedFilesController;
+use App\Support\FilePath;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -21,9 +22,10 @@ Route::prefix('support')->controller(SupportController::class)->group(function (
 
 Route::prefix('user-generated-files')
     ->controller(UserGeneratedFilesController::class)->group(function () {
-        Route::get('/{fileName}', 'getFile')
-        // api/config/auth.php
-            ->middleware('auth:api');
+        // Unauthenticated files
+        Route::get('/'.FilePath::PUBLIC_PATH.'/{fileName}', 'getPublicFile');
+        // Authentication required files
+        Route::get('/{fileName}', 'getGuardedFile')->middleware('auth:api');
     });
 
 Route::post('csp-report', [CspReportController::class, 'report'])

--- a/api/tests/Feature/UserGeneratedFilesTest.php
+++ b/api/tests/Feature/UserGeneratedFilesTest.php
@@ -2,16 +2,25 @@
 
 namespace Tests\Feature;
 
+use App\Models\Classification;
+use App\Models\JobPosterTemplate;
 use App\Models\User;
+use App\Models\WorkStream;
 use App\Support\FilePath;
 use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Storage;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+use Nuwave\Lighthouse\Testing\RefreshesSchemaCache;
 use Tests\TestCase;
+use Tests\UsesUnprotectedGraphqlEndpoint;
 
 class UserGeneratedFilesTest extends TestCase
 {
+    use MakesGraphQLRequests;
     use RefreshDatabase;
+    use RefreshesSchemaCache;
+    use UsesUnprotectedGraphqlEndpoint;
 
     private User $user;
 
@@ -21,15 +30,15 @@ class UserGeneratedFilesTest extends TestCase
 
         $this->seed(RolePermissionSeeder::class);
 
-        Storage::fake('user_generated');
+        Storage::fake(FilePath::GUARDED_DISK);
+        Storage::fake(FilePath::PUBLIC_DISK);
 
         $this->user = User::factory()->create();
     }
 
     public function testPublicFileIsStreamedWithoutAuthentication(): void
     {
-        Storage::disk('user_generated')
-            ->put(FilePath::PUBLIC_PATH.'/template.docx', 'template contents');
+        Storage::disk(FilePath::PUBLIC_DISK)->put('template.docx', 'template contents');
 
         $response = $this->getJson('/api/user-generated-files/'.FilePath::PUBLIC_PATH.'/template.docx');
 
@@ -48,9 +57,19 @@ class UserGeneratedFilesTest extends TestCase
         $response->assertNotFound();
     }
 
+    public function testPublicRouteDoesNotStreamFilesFromTheGuardedDisk(): void
+    {
+        Storage::disk(FilePath::GUARDED_DISK)->put('report.docx', 'report contents');
+        Storage::disk(FilePath::GUARDED_DISK)->put($this->user->id.'/report.docx', 'report contents');
+
+        $response = $this->getJson('/api/user-generated-files/'.FilePath::PUBLIC_PATH.'/report.docx');
+
+        $response->assertNotFound();
+    }
+
     public function testGuardedFileRejectsUnauthenticatedRequest(): void
     {
-        Storage::disk('user_generated')->put($this->user->id.'/report.docx', 'report contents');
+        Storage::disk(FilePath::GUARDED_DISK)->put($this->user->id.'/report.docx', 'report contents');
 
         $response = $this->getJson('/api/user-generated-files/report.docx');
 
@@ -59,7 +78,7 @@ class UserGeneratedFilesTest extends TestCase
 
     public function testGuardedFileIsStreamedFromAuthenticatedUserDirectory(): void
     {
-        Storage::disk('user_generated')->put($this->user->id.'/report.docx', 'report contents');
+        Storage::disk(FilePath::GUARDED_DISK)->put($this->user->id.'/report.docx', 'report contents');
 
         $response = $this->actingAs($this->user, 'api')
             ->getJson('/api/user-generated-files/report.docx');
@@ -68,14 +87,36 @@ class UserGeneratedFilesTest extends TestCase
         $this->assertSame('report contents', $response->streamedContent());
     }
 
-    public function testGuardedFileDoesNotServeFilesFromAnotherDirectory(): void
+    public function testGuardedRouteDoesNotStreamFilesFromThePublicDisk(): void
     {
-        Storage::disk('user_generated')
-            ->put(FilePath::PUBLIC_PATH.'/template.docx', 'template contents');
+        Storage::disk(FilePath::PUBLIC_DISK)->put('template.docx', 'template contents');
 
         $response = $this->actingAs($this->user, 'api')
             ->getJson('/api/user-generated-files/template.docx');
 
         $response->assertNotFound();
+    }
+
+    public function testUnauthenticatedUserCanGenerateAndDownloadAJobPosterTemplate(): void
+    {
+        Classification::factory()->create();
+        WorkStream::factory()->create();
+        $template = JobPosterTemplate::factory()->withSkills()->create();
+
+        $mutation = $this->graphQL(
+            /** @lang GraphQL */
+            'mutation Download($id: UUID!) {
+                downloadJobPosterTemplateDoc(id: $id)
+            }',
+            ['id' => $template->id]
+        );
+
+        $fileName = $mutation->json('data.downloadJobPosterTemplateDoc');
+        $this->assertIsString($fileName);
+        Storage::disk(FilePath::PUBLIC_DISK)->assertExists($fileName);
+
+        $download = $this->getJson('/api/user-generated-files/'.FilePath::PUBLIC_PATH.'/'.$fileName);
+
+        $download->assertOk();
     }
 }

--- a/api/tests/Feature/UserGeneratedFilesTest.php
+++ b/api/tests/Feature/UserGeneratedFilesTest.php
@@ -119,4 +119,15 @@ class UserGeneratedFilesTest extends TestCase
 
         $download->assertOk();
     }
+
+    public function testPublicFileWithAnApostropheIsStreamed(): void
+    {
+        $fileName = 'Modèle d’offre d’emploi.docx';
+        Storage::disk(FilePath::PUBLIC_DISK)->put($fileName, 'template contents');
+
+        $response = $this->getJson('/api/user-generated-files/'.FilePath::PUBLIC_PATH.'/'.$fileName);
+
+        $response->assertOk();
+        $this->assertSame('template contents', $response->streamedContent());
+    }
 }

--- a/api/tests/Feature/UserGeneratedFilesTest.php
+++ b/api/tests/Feature/UserGeneratedFilesTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Support\FilePath;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class UserGeneratedFilesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(RolePermissionSeeder::class);
+
+        Storage::fake('user_generated');
+
+        $this->user = User::factory()->create();
+    }
+
+    public function testPublicFileIsStreamedWithoutAuthentication(): void
+    {
+        Storage::disk('user_generated')
+            ->put(FilePath::PUBLIC_PATH.'/template.docx', 'template contents');
+
+        $response = $this->getJson('/api/user-generated-files/'.FilePath::PUBLIC_PATH.'/template.docx');
+
+        $response->assertOk();
+        $response->assertHeader(
+            'Content-Type',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        );
+        $this->assertSame('template contents', $response->streamedContent());
+    }
+
+    public function testAbsentPublicFileIsNotFound(): void
+    {
+        $response = $this->getJson('/api/user-generated-files/'.FilePath::PUBLIC_PATH.'/absent.docx');
+
+        $response->assertNotFound();
+    }
+
+    public function testGuardedFileRejectsUnauthenticatedRequest(): void
+    {
+        Storage::disk('user_generated')->put($this->user->id.'/report.docx', 'report contents');
+
+        $response = $this->getJson('/api/user-generated-files/report.docx');
+
+        $response->assertUnauthorized();
+    }
+
+    public function testGuardedFileIsStreamedFromAuthenticatedUserDirectory(): void
+    {
+        Storage::disk('user_generated')->put($this->user->id.'/report.docx', 'report contents');
+
+        $response = $this->actingAs($this->user, 'api')
+            ->getJson('/api/user-generated-files/report.docx');
+
+        $response->assertOk();
+        $this->assertSame('report contents', $response->streamedContent());
+    }
+
+    public function testGuardedFileDoesNotServeFilesFromAnotherDirectory(): void
+    {
+        Storage::disk('user_generated')
+            ->put(FilePath::PUBLIC_PATH.'/template.docx', 'template contents');
+
+        $response = $this->actingAs($this->user, 'api')
+            ->getJson('/api/user-generated-files/template.docx');
+
+        $response->assertNotFound();
+    }
+}

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatePage/components/JobPosterDownloadButton.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatePage/components/JobPosterDownloadButton.tsx
@@ -42,7 +42,9 @@ const JobPosterDownloadButton = ({ id }: JobPosterDownloadButtonProps) => {
       .then((res) => {
         if (res?.data?.downloadJobPosterTemplateDoc) {
           executeAsyncDownload({
-            url: paths.userGeneratedFile(res.data.downloadJobPosterTemplateDoc),
+            url: paths.userGeneratedPublicFile(
+              res.data.downloadJobPosterTemplateDoc,
+            ),
             fileName: res.data.downloadJobPosterTemplateDoc,
           }).catch(handleDownloadError);
         } else {

--- a/infrastructure/bin/post_deployment.sh
+++ b/infrastructure/bin/post_deployment.sh
@@ -63,6 +63,7 @@ if
      mkdir --parents \
         /var/site/storage/app/public \
         /var/site/storage/app/user_generated \
+        /var/site/storage/app/public_generated \
         /var/site/storage/framework/cache/data \
         /var/site/storage/framework/sessions \
         /var/site/storage/framework/testing \

--- a/packages/auth/src/hooks/useApiRoutes.ts
+++ b/packages/auth/src/hooks/useApiRoutes.ts
@@ -1,9 +1,3 @@
-interface ApiRoutes {
-  login: (from?: string, locale?: string) => string;
-  refreshAccessToken: () => string;
-  userGeneratedFile: (fileName: string) => string;
-}
-
 const isDevServer =
   typeof IS_DEV_SERVER !== "undefined" ? IS_DEV_SERVER : false;
 
@@ -43,6 +37,6 @@ export default apiRoutes;
  * A hook version of loginRoutes which gets the locale from the intl context.
  * @returns LoginRoutes
  */
-export const useApiRoutes = (): ApiRoutes => {
+export const useApiRoutes = () => {
   return apiRoutes;
 };

--- a/packages/auth/src/hooks/useApiRoutes.ts
+++ b/packages/auth/src/hooks/useApiRoutes.ts
@@ -32,6 +32,10 @@ const apiRoutes = {
     const filePath = `api/user-generated-files/${fileName}`;
     return apiHost ? new URL(filePath, apiHost).toString() : `/${filePath}`;
   },
+  userGeneratedPublicFile: (fileName: string): string => {
+    const filePath = `api/user-generated-files/public/${fileName}`;
+    return apiHost ? new URL(filePath, apiHost).toString() : `/${filePath}`;
+  },
 };
 export default apiRoutes;
 


### PR DESCRIPTION
🤖 Resolves #17356 

## 👋 Introduction

Fixes an issue where unauthenticated users could not download job poster templates.

## 🕵️ Details

We have added a public folder than anyone can read from. We allow unautenticated users to read from this folder. Since job postr templates do not contain sensitive information, we allow them to read these and download them.

This adds a separate disk for public files to make it less likely to leak guarded/unguarded files.

## 🧪 Testing

1. Refresh `make refresh-api`
2. Ensure you aere not logged in
3. Navigate to `/job-templates`
4. Go to one of the templates
5. Attempt to download it
6. Confirm the download works