### PR TITLE
[Fix] Do not refetch on submit field being set

### DIFF
--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -42,6 +42,13 @@ const defaultRequestState = {
   candidateCount: 0,
 };
 
+// Fields the result cards set on click to describe the submission, not the filters.
+const submitOnlyFields: string[] = [
+  "pool",
+  "communityId",
+  "count",
+] satisfies (keyof FormValues)[];
+
 interface SearchFormProps {
   classifications: Classification[];
   skills: Skill[];
@@ -89,7 +96,11 @@ export const SearchForm = ({
   const { watch } = methods;
 
   useEffect(() => {
-    const subscription = watch((newValues) => {
+    const subscription = watch((newValues, { name }) => {
+      if (name && submitOnlyFields.includes(name)) {
+        return;
+      }
+
       const newFilters = formValuesToData(
         newValues as FormValues,
         classifications,


### PR DESCRIPTION
🤖 Resolves #17731 

## 👋 Introduction

Addreses an issue where, when submitting the search form, the page would re-run the search query.

## 🕵️ Details

This was ocurring due to the submit buttons setting values. When the values were set, the subscription updated the filters being applied which lead to the query params going stale and triggering a refetch in urql.

This fixes that but ignoring the submit only fields in that logic.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Navigate to `/search`
3. Scroll to the bottom of the page
4. Submit the form with a pool or community
5. Confirm you see no loading spinners and are taken to the first error