### PR TITLE
[Fix] Employee profile move spacing element within conditional

### DIFF
--- a/apps/web/src/pages/EmployeeProfile/CareerPlanningPage.tsx
+++ b/apps/web/src/pages/EmployeeProfile/CareerPlanningPage.tsx
@@ -211,11 +211,11 @@ export const CareerPlanning = ({
           <SharedTocLinks />
         </TableOfContents.Navigation>
         <TableOfContents.Content>
-          <div className="mb-6">
-            {noticeIsVisible ? (
+          {noticeIsVisible ? (
+            <div className="mb-6">
               <NewFeatureMessage onDismiss={() => setNoticeIsVisible(false)} />
-            ) : null}
-          </div>
+            </div>
+          ) : null}
           <div className="flex flex-col gap-y-18">
             <TableOfContents.Section id={SECTION_ID.CAREER_PLANNING}>
               <Heading

--- a/apps/web/src/pages/EmployeeProfile/EmployeeVerificationPage.tsx
+++ b/apps/web/src/pages/EmployeeProfile/EmployeeVerificationPage.tsx
@@ -71,11 +71,11 @@ export const EmployeeVerification = ({
           <SharedTocLinks />
         </TableOfContents.Navigation>
         <TableOfContents.Content>
-          <div className="mb-6">
-            {noticeIsVisible ? (
+          {noticeIsVisible ? (
+            <div className="mb-6">
               <NewFeatureMessage onDismiss={() => setNoticeIsVisible(false)} />
-            ) : null}
-          </div>
+            </div>
+          ) : null}
           <div className="flex flex-col gap-y-18">
             <TableOfContents.Section id={SECTION_ID.EMPLOYEE_VERIFICATION}>
               <EmployeeVerificationSection


### PR DESCRIPTION
🤖 Resolves #17728.

## 👋 Introduction

This PR nests the spacing element within conditional so when the `NewFeatureMessage` is dismissed, there is no empty div left over with unnecessary bottom margin.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to http://localhost:8000/en/employee
3. Close **Your employee profile has expanded!** message
4. Verify element with `mb-6` is no longer rendered
5. Clear `new_feature_employee_profile` from local storage
6. Navigate to http://localhost:8000/en/employee/career-planning
7. Close **Your employee profile has expanded!** message
8. Verify element with `mb-6` is no longer rendered

## 📸 Screenshots

<img width="1069" height="616" alt="Screenshot 2026-08-13 at 08 11 25" src="https://github.com/user-attachments/assets/ced6879e-49af-48e1-af03-ff12b232b558" />
<img width="1060" height="491" alt="Screenshot 2026-08-13 at 08 12 13" src="https://github.com/user-attachments/assets/bf2bd8dc-3b41-46a8-8129-cdf7fcd87017" />