### PR TITLE
Code quality finding -Array.prototype.sort mutates the original array in place

### DIFF
--- a/apps/web/src/utils/skillUtils.ts
+++ b/apps/web/src/utils/skillUtils.ts
@@ -231,7 +231,7 @@ const categoryOrder = [SkillCategory.Technical, SkillCategory.Behavioural];
 export const sortPoolSkillsBySkillCategory = <T extends PoolSkill[]>(
   poolSkills: T,
 ) => {
-  return poolSkills.sort((poolSkillA, poolSkillB) => {
+  return [...poolSkills].sort((poolSkillA, poolSkillB) => {
     if (poolSkillA?.skill?.category && poolSkillB?.skill?.category) {
       return (
         categoryOrder.indexOf(


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/GCTC-NTGC/gc-digital-talent/security/quality/ai-findings)._

`Array.prototype.sort` mutates the original array in place. Since `poolSkills` is a parameter passed in, this will mutate the caller's array unexpectedly. Consider creating a shallow copy before sorting, e.g. `[...poolSkills].sort(...)`.