### PR TITLE
 code quality finding : The GovEmployeeType.Contractor uses grid-cols-3 without the sm: responsive prefix

### DIFF
--- a/apps/web/src/components/ExperienceCard/WorkContent/GovContent.tsx
+++ b/apps/web/src/components/ExperienceCard/WorkContent/GovContent.tsx
@@ -169,7 +169,7 @@ const GovContent = ({
           {division ?? intl.formatMessage(commonMessages.notAvailable)}
         </ContentSection>
         <Separator space="sm" decorative />
-        <div className="grid grid-cols-3 gap-6">
+        <div className="grid gap-6 sm:grid-cols-3">
           <ContentSection
             title={experienceFormLabels.govEmploymentType}
             headingLevel={headingLevel}


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/GCTC-NTGC/gc-digital-talent/security/quality/ai-findings)._

The `GovEmployeeType.Contractor` branch uses `grid-cols-3` without the `sm:` responsive prefix, unlike the other branches which use `sm:grid-cols-2` and `sm:grid-cols-3`. This means the three-column layout is applied at all screen sizes, which may cause layout issues on small screens. It should be `sm:grid-cols-3` to be consistent with the other branches.