### PR TITLE
[Fix] Set department on test candidate in TalentRequestMatchesTest

### DIFF
--- a/api/tests/Feature/TalentRequestMatchesTest.php
+++ b/api/tests/Feature/TalentRequestMatchesTest.php
@@ -465,6 +465,9 @@ class TalentRequestMatchesTest extends TestCase
         $department = Department::factory()->create();
         $pool = Pool::factory()->candidatesAvailableInSearch()->create();
         $inDepartment = $this->matchingUser($pool, [], true);
+        $inDepartmentWorkExperience = $inDepartment->currentGovWorkExperience()->firstOrFail();
+        $inDepartmentWorkExperience->department_id = $department->id;
+        $inDepartmentWorkExperience->save();
         $this->matchingUser($pool, [], false);
 
         $this->runMatches(['departments' => [$department->id]])


### PR DESCRIPTION
## Introduction
Sets `department_id` on the in-department test candidate's work experience so `testFiltersByDepartments` actually exercises the department filter instead of relying on unset factory data.

## Testing
`php artisan test --filter TalentRequestMatchesTest`