### PR TITLE
[Fix] Missing referral options on details page

### DIFF
--- a/apps/web/src/pages/TalentRequests/Details.tsx
+++ b/apps/web/src/pages/TalentRequests/Details.tsx
@@ -43,8 +43,8 @@ const TalentRequestDetails_Fragment = graphql(/** GraphQL */ `
 
 interface DetailsProps {
   query: FragmentType<typeof TalentRequestDetails_Fragment>;
-  optionsQuery?: FragmentType<typeof TalentRequestSourceOptions_Fragment>;
-  referralOptionsQuery?: TalentRequestReferralDialogOptions;
+  optionsQuery: FragmentType<typeof TalentRequestSourceOptions_Fragment>;
+  referralOptionsQuery: TalentRequestReferralDialogOptions;
 }
 
 const Details = ({
@@ -118,7 +118,11 @@ const TalentRequestDetailsPage = () => {
   return (
     <Pending fetching={fetching} error={error}>
       {data?.talentRequest ? (
-        <Details query={data.talentRequest} optionsQuery={data} />
+        <Details
+          query={data.talentRequest}
+          optionsQuery={data}
+          referralOptionsQuery={data}
+        />
       ) : (
         <ThrowNotFound />
       )}


### PR DESCRIPTION
🤖 Resolves #17764 

## 👋 Introduction

Fixes an issue where referral options were not present on the talent request details page.

## 🕵️ Details

This ocurred due to the refactor of moving the matching candidates table to the details page. It required the options were passed in as a prop but, that prop was optional. So, the prop never got passed and never failed any type checks or linting.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate tot a talent request in the admin side
4. Scroll to the matching candidates table
5. Open the referral dialog from a users name button in the table
6. Confirm the options for referral apppear
7. Confirm you can successfully set the referral status