### PR TITLE
Fix candidate bookmark/flag cache issues without causing jumping in table

### DIFF
--- a/apps/web/src/components/CandidateFlag/CandidateFlag.tsx
+++ b/apps/web/src/components/CandidateFlag/CandidateFlag.tsx
@@ -32,16 +32,12 @@ export const PoolCandidate_FlagFragment = graphql(/* GraphQL */ `
 interface CandidateFlagProps {
   candidateQuery: FragmentType<typeof PoolCandidate_FlagFragment>;
   processTitle?: string | null;
-  onFlagChange?: (newIsFlagged: boolean) => void;
-  flagged?: boolean;
   size?: "sm" | "md" | "lg";
 }
 
 const CandidateFlag = ({
   candidateQuery,
   processTitle = null,
-  flagged,
-  onFlagChange,
   size = "md",
 }: CandidateFlagProps) => {
   const intl = useIntl();
@@ -55,8 +51,6 @@ const CandidateFlag = ({
   const [{ isFlagged, isUpdating: isUpdatingFlag }, toggleFlag] =
     useCandidateFlagToggle({
       id: candidate.id,
-      onChange: onFlagChange,
-      value: flagged,
       defaultValue: candidate?.isFlagged ?? false,
       name: candidateName,
       processTitle:

--- a/apps/web/src/hooks/useCandidateBookmarkToggle.test.tsx
+++ b/apps/web/src/hooks/useCandidateBookmarkToggle.test.tsx
@@ -1,0 +1,156 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { Client } from "urql";
+import { Provider as GraphqlProvider, CombinedError } from "urql";
+import { fromValue } from "wonka";
+
+import { Providers } from "@gc-digital-talent/vitest-helpers";
+import { toast } from "@gc-digital-talent/toast";
+
+import useCandidateBookmarkToggle from "./useCandidateBookmarkToggle";
+
+vi.mock("@gc-digital-talent/toast", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+/**
+ * Stub urql client returning a fixed mutation result.
+ * Ref: packages/storybook-helpers/decorators/MockGraphqlDecorator.tsx
+ */
+const mockClient = (result: Record<string, unknown>) =>
+  ({
+    executeMutation: vi.fn(() => fromValue(result)),
+  }) as unknown as Client;
+
+const renderBookmarkToggle = (client: Client, defaultValue = false) =>
+  renderHook(
+    (props: { defaultValue: boolean; id: string }) =>
+      useCandidateBookmarkToggle({
+        id: props.id,
+        defaultValue: props.defaultValue,
+        name: "Test Candidate",
+      }),
+    {
+      initialProps: { defaultValue, id: "candidate-id" },
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <Providers>
+          <GraphqlProvider value={client}>{children}</GraphqlProvider>
+        </Providers>
+      ),
+    },
+  );
+
+describe("useCandidateBookmarkToggle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("bookmarks the candidate and confirms with a toast", async () => {
+    const { result } = renderBookmarkToggle(
+      mockClient({ data: { togglePoolCandidateUserBookmark: true } }),
+    );
+
+    expect(result.current[0].isBookmarked).toBe(false);
+
+    await act(async () => {
+      await result.current[1]();
+    });
+
+    expect(result.current[0].isBookmarked).toBe(true);
+    expect(toast.success).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes the bookmark", async () => {
+    const { result } = renderBookmarkToggle(
+      mockClient({ data: { togglePoolCandidateUserBookmark: false } }),
+      true,
+    );
+
+    await act(async () => {
+      await result.current[1]();
+    });
+
+    expect(result.current[0].isBookmarked).toBe(false);
+    expect(toast.success).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the new bookmark when a stale cached value is re-delivered", async () => {
+    const { result, rerender } = renderBookmarkToggle(
+      mockClient({ data: { togglePoolCandidateUserBookmark: true } }),
+    );
+
+    await act(async () => {
+      await result.current[1]();
+    });
+
+    // The document cache still holds the pre-toggle bookmark list.
+    rerender({ defaultValue: false, id: "candidate-id" });
+    expect(result.current[0].isBookmarked).toBe(true);
+
+    // ... and then the network result catches up.
+    rerender({ defaultValue: true, id: "candidate-id" });
+    expect(result.current[0].isBookmarked).toBe(true);
+  });
+
+  it("adopts a bookmark set elsewhere without a toggle (#16166)", () => {
+    const { result, rerender } = renderBookmarkToggle(
+      mockClient({ data: { togglePoolCandidateUserBookmark: true } }),
+    );
+
+    // Mounted from a stale cached document, then the refetch arrives.
+    expect(result.current[0].isBookmarked).toBe(false);
+    rerender({ defaultValue: true, id: "candidate-id" });
+
+    expect(result.current[0].isBookmarked).toBe(true);
+  });
+
+  it("discards the local bookmark when rendered for a different candidate", async () => {
+    const { result, rerender } = renderBookmarkToggle(
+      mockClient({ data: { togglePoolCandidateUserBookmark: true } }),
+    );
+
+    await act(async () => {
+      await result.current[1]();
+    });
+    expect(result.current[0].isBookmarked).toBe(true);
+
+    // Navigating to an unbookmarked candidate: same server value, different candidate.
+    rerender({ defaultValue: false, id: "other-candidate-id" });
+
+    expect(result.current[0].isBookmarked).toBe(false);
+  });
+
+  it("leaves the bookmark untouched when the mutation fails", async () => {
+    const { result } = renderBookmarkToggle(
+      mockClient({
+        data: null,
+        error: new CombinedError({ graphQLErrors: ["Something went wrong"] }),
+      }),
+    );
+
+    await act(async () => {
+      await result.current[1]();
+    });
+
+    expect(result.current[0].isBookmarked).toBe(false);
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an error when the mutation returns no value", async () => {
+    const { result } = renderBookmarkToggle(
+      mockClient({ data: { togglePoolCandidateUserBookmark: null } }),
+    );
+
+    await act(async () => {
+      await result.current[1]();
+    });
+
+    expect(result.current[0].isBookmarked).toBe(false);
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/hooks/useCandidateBookmarkToggle.ts
+++ b/apps/web/src/hooks/useCandidateBookmarkToggle.ts
@@ -3,7 +3,8 @@ import { useIntl } from "react-intl";
 
 import { graphql } from "@gc-digital-talent/graphql";
 import { toast } from "@gc-digital-talent/toast";
-import { useControllableState } from "@gc-digital-talent/ui";
+
+import useServerSyncedState from "./useServerSyncedState";
 
 const TogglePoolCandidateUserBookmark_Mutation = graphql(/* GraphQL */ `
   mutation TogglePoolCandidateUserBookmark_Mutation($id: UUID!) {
@@ -36,11 +37,11 @@ const useCandidateBookmarkToggle = ({
 }: UseCandidateBookmarkToggleArgs): UseCandidateBookmarkToggleReturn => {
   const intl = useIntl();
 
-  const [isBookmarked, setIsBookmarked] = useControllableState({
-    defaultValue: defaultValue ?? false,
-  });
   const [{ fetching: isUpdating }, executeToggleBookmarkMutation] = useMutation(
     TogglePoolCandidateUserBookmark_Mutation,
+  );
+  const [isBookmarked, setIsBookmarked] = useServerSyncedState(
+    defaultValue ?? false,
   );
 
   const toggleBookmark = async () => {
@@ -95,7 +96,7 @@ const useCandidateBookmarkToggle = ({
     }
   };
 
-  return [{ isBookmarked: isBookmarked ?? false, isUpdating }, toggleBookmark];
+  return [{ isBookmarked, isUpdating }, toggleBookmark];
 };
 
 export default useCandidateBookmarkToggle;

--- a/apps/web/src/hooks/useCandidateBookmarkToggle.ts
+++ b/apps/web/src/hooks/useCandidateBookmarkToggle.ts
@@ -26,7 +26,7 @@ interface CandidateBookmarkResult {
 
 type UseCandidateBookmarkToggleReturn = [
   result: CandidateBookmarkResult,
-  toggle: () => void,
+  toggle: () => Promise<void>,
 ];
 
 const useCandidateBookmarkToggle = ({
@@ -42,46 +42,54 @@ const useCandidateBookmarkToggle = ({
   );
   const [isBookmarked, setIsBookmarked] = useServerSyncedState(
     defaultValue ?? false,
+    id,
   );
 
   const toggleBookmark = async () => {
     if (id) {
       await executeToggleBookmarkMutation({ id })
         .then((res) => {
-          if (!res.error) {
-            const newIsBookmarked =
-              res.data?.togglePoolCandidateUserBookmark === true;
-            if (showToast) {
-              if (newIsBookmarked) {
-                toast.success(
-                  intl.formatMessage(
-                    {
-                      defaultMessage: "You've bookmarked {name} for yourself",
-                      id: "9DJWk4",
-                      description: "Bookmarked a candidate",
-                    },
-                    {
-                      name,
-                    },
-                  ),
-                );
-              } else {
-                toast.success(
-                  intl.formatMessage(
-                    {
-                      defaultMessage: "You've removed the bookmark for {name}.",
-                      id: "UBY4qe",
-                      description: "Un-bookmarked a candidate",
-                    },
-                    {
-                      name,
-                    },
-                  ),
-                );
-              }
-            }
-            setIsBookmarked(newIsBookmarked);
+          // urql resolves rather than rejects on a GraphQL error, so rethrow to reach
+          // the error toast below.
+          if (res.error) throw new Error(res.error.message);
+          const newIsBookmarked = res.data?.togglePoolCandidateUserBookmark;
+          // The mutation returns a nullable Boolean: a missing value means the toggle
+          // did not happen, and must not be reported as a successful un-bookmark.
+          if (typeof newIsBookmarked !== "boolean") {
+            throw new Error("Bookmark toggle returned no value");
           }
+
+          if (showToast) {
+            if (newIsBookmarked) {
+              toast.success(
+                intl.formatMessage(
+                  {
+                    defaultMessage: "You've bookmarked {name} for yourself",
+                    id: "9DJWk4",
+                    description: "Bookmarked a candidate",
+                  },
+                  {
+                    name,
+                  },
+                ),
+              );
+            } else {
+              toast.success(
+                intl.formatMessage(
+                  {
+                    defaultMessage: "You've removed the bookmark for {name}.",
+                    id: "UBY4qe",
+                    description: "Un-bookmarked a candidate",
+                  },
+                  {
+                    name,
+                  },
+                ),
+              );
+            }
+          }
+
+          setIsBookmarked(newIsBookmarked);
         })
         .catch(() => {
           toast.error(

--- a/apps/web/src/hooks/useCandidateFlagToggle.test.tsx
+++ b/apps/web/src/hooks/useCandidateFlagToggle.test.tsx
@@ -1,0 +1,157 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { Client } from "urql";
+import { Provider as GraphqlProvider, CombinedError } from "urql";
+import { fromValue } from "wonka";
+
+import { Providers } from "@gc-digital-talent/vitest-helpers";
+import { toast } from "@gc-digital-talent/toast";
+
+import useCandidateFlagToggle from "./useCandidateFlagToggle";
+
+vi.mock("@gc-digital-talent/toast", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+/**
+ * Stub urql client returning a fixed mutation result.
+ * Ref: packages/storybook-helpers/decorators/MockGraphqlDecorator.tsx
+ */
+const mockClient = (result: Record<string, unknown>) =>
+  ({
+    executeMutation: vi.fn(() => fromValue(result)),
+  }) as unknown as Client;
+
+const renderFlagToggle = (client: Client, defaultValue = false) =>
+  renderHook(
+    (props: { defaultValue: boolean; id: string }) =>
+      useCandidateFlagToggle({
+        id: props.id,
+        defaultValue: props.defaultValue,
+        name: "Test Candidate",
+        processTitle: "Test Process",
+      }),
+    {
+      initialProps: { defaultValue, id: "candidate-id" },
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <Providers>
+          <GraphqlProvider value={client}>{children}</GraphqlProvider>
+        </Providers>
+      ),
+    },
+  );
+
+describe("useCandidateFlagToggle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("flags the candidate and confirms with a toast", async () => {
+    const { result } = renderFlagToggle(
+      mockClient({ data: { togglePoolCandidateFlag: true } }),
+    );
+
+    expect(result.current[0].isFlagged).toBe(false);
+
+    await act(async () => {
+      await result.current[1]();
+    });
+
+    expect(result.current[0].isFlagged).toBe(true);
+    expect(toast.success).toHaveBeenCalledTimes(1);
+  });
+
+  it("un-flags the candidate", async () => {
+    const { result } = renderFlagToggle(
+      mockClient({ data: { togglePoolCandidateFlag: false } }),
+      true,
+    );
+
+    await act(async () => {
+      await result.current[1]();
+    });
+
+    expect(result.current[0].isFlagged).toBe(false);
+    expect(toast.success).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the new flag when a stale cached value is re-delivered", async () => {
+    const { result, rerender } = renderFlagToggle(
+      mockClient({ data: { togglePoolCandidateFlag: true } }),
+    );
+
+    await act(async () => {
+      await result.current[1]();
+    });
+
+    // The document cache still holds the pre-toggle candidate.
+    rerender({ defaultValue: false, id: "candidate-id" });
+    expect(result.current[0].isFlagged).toBe(true);
+
+    // ... and then the network result catches up.
+    rerender({ defaultValue: true, id: "candidate-id" });
+    expect(result.current[0].isFlagged).toBe(true);
+  });
+
+  it("adopts a flag set elsewhere without a toggle (#16166)", () => {
+    const { result, rerender } = renderFlagToggle(
+      mockClient({ data: { togglePoolCandidateFlag: true } }),
+    );
+
+    // Mounted from a stale cached document, then the refetch arrives.
+    expect(result.current[0].isFlagged).toBe(false);
+    rerender({ defaultValue: true, id: "candidate-id" });
+
+    expect(result.current[0].isFlagged).toBe(true);
+  });
+
+  it("discards the local flag when rendered for a different candidate", async () => {
+    const { result, rerender } = renderFlagToggle(
+      mockClient({ data: { togglePoolCandidateFlag: true } }),
+    );
+
+    await act(async () => {
+      await result.current[1]();
+    });
+    expect(result.current[0].isFlagged).toBe(true);
+
+    // Navigating to an unflagged candidate: same server value, different candidate.
+    rerender({ defaultValue: false, id: "other-candidate-id" });
+
+    expect(result.current[0].isFlagged).toBe(false);
+  });
+
+  it("leaves the flag untouched when the mutation fails", async () => {
+    const { result } = renderFlagToggle(
+      mockClient({
+        data: null,
+        error: new CombinedError({ graphQLErrors: ["Something went wrong"] }),
+      }),
+    );
+
+    await act(async () => {
+      await result.current[1]();
+    });
+
+    expect(result.current[0].isFlagged).toBe(false);
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an error when the mutation returns no value", async () => {
+    const { result } = renderFlagToggle(
+      mockClient({ data: { togglePoolCandidateFlag: null } }),
+    );
+
+    await act(async () => {
+      await result.current[1]();
+    });
+
+    expect(result.current[0].isFlagged).toBe(false);
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/hooks/useCandidateFlagToggle.ts
+++ b/apps/web/src/hooks/useCandidateFlagToggle.ts
@@ -3,7 +3,8 @@ import { useIntl } from "react-intl";
 
 import { graphql } from "@gc-digital-talent/graphql";
 import { toast } from "@gc-digital-talent/toast";
-import { useControllableState } from "@gc-digital-talent/ui";
+
+import useServerSyncedState from "./useServerSyncedState";
 
 const PoolCandidate_ToggleFlagMutation = graphql(/* GraphQL */ `
   mutation ToggleFlag_Mutation($id: ID!) {
@@ -14,8 +15,6 @@ const PoolCandidate_ToggleFlagMutation = graphql(/* GraphQL */ `
 interface UseCandidateFlagToggleArgs {
   id: string;
   defaultValue?: boolean;
-  value?: boolean;
-  onChange?: (newIsFlagged: boolean) => void;
   showToast?: boolean;
   name: string;
   processTitle: string;
@@ -34,22 +33,15 @@ type UseCandidateFlagToggleReturn = [
 const useCandidateFlagToggle = ({
   id,
   defaultValue,
-  onChange,
-  value,
   showToast = true,
   name,
   processTitle,
 }: UseCandidateFlagToggleArgs): UseCandidateFlagToggleReturn => {
   const intl = useIntl();
-  const [isFlagged, setIsFlagged] = useControllableState({
-    defaultValue: defaultValue ?? false,
-    controlledProp: value,
-    onChange,
-  });
-
   const [{ fetching: isUpdating }, executeToggleFlagMutation] = useMutation(
     PoolCandidate_ToggleFlagMutation,
   );
+  const [isFlagged, setIsFlagged] = useServerSyncedState(defaultValue ?? false);
 
   const toggleFlag = async () => {
     if (id) {
@@ -111,7 +103,7 @@ const useCandidateFlagToggle = ({
     }
   };
 
-  return [{ isFlagged: isFlagged ?? false, isUpdating }, toggleFlag];
+  return [{ isFlagged, isUpdating }, toggleFlag];
 };
 
 export default useCandidateFlagToggle;

--- a/apps/web/src/hooks/useCandidateFlagToggle.ts
+++ b/apps/web/src/hooks/useCandidateFlagToggle.ts
@@ -27,7 +27,7 @@ interface CandidateFlagResult {
 
 type UseCandidateFlagToggleReturn = [
   result: CandidateFlagResult,
-  toggle: () => void,
+  toggle: () => Promise<void>,
 ];
 
 const useCandidateFlagToggle = ({
@@ -41,7 +41,10 @@ const useCandidateFlagToggle = ({
   const [{ fetching: isUpdating }, executeToggleFlagMutation] = useMutation(
     PoolCandidate_ToggleFlagMutation,
   );
-  const [isFlagged, setIsFlagged] = useServerSyncedState(defaultValue ?? false);
+  const [isFlagged, setIsFlagged] = useServerSyncedState(
+    defaultValue ?? false,
+    id,
+  );
 
   const toggleFlag = async () => {
     if (id) {
@@ -49,46 +52,53 @@ const useCandidateFlagToggle = ({
         id,
       })
         .then((res) => {
-          if (!res.error) {
-            const newIsFlagged = res.data?.togglePoolCandidateFlag === true;
-            if (showToast) {
-              if (newIsFlagged) {
-                toast.success(
-                  intl.formatMessage(
-                    {
-                      defaultMessage:
-                        "You've flagged {candidateName} in {processTitle}. Other authorized users can also view or remove this flag.",
-                      id: "NRX2CA",
-                      description:
-                        "Alert displayed to the user when they mark a candidate as flagged.",
-                    },
-                    {
-                      candidateName: name,
-                      processTitle,
-                    },
-                  ),
-                );
-              } else {
-                toast.success(
-                  intl.formatMessage(
-                    {
-                      defaultMessage:
-                        "You've removed the flag for {candidateName} in {processTitle}.",
-                      id: "idwHJf",
-                      description:
-                        "Alert displayed to the user when they un-flag a candidate.",
-                    },
-                    {
-                      candidateName: name,
-                      processTitle,
-                    },
-                  ),
-                );
-              }
-            }
-
-            setIsFlagged(newIsFlagged);
+          // urql resolves rather than rejects on a GraphQL error, so rethrow to reach
+          // the error toast below.
+          if (res.error) throw new Error(res.error.message);
+          const newIsFlagged = res.data?.togglePoolCandidateFlag;
+          // The mutation returns a nullable Boolean: a missing value means the toggle
+          // did not happen, and must not be reported as a successful un-flag.
+          if (typeof newIsFlagged !== "boolean") {
+            throw new Error("Flag toggle returned no value");
           }
+
+          if (showToast) {
+            if (newIsFlagged) {
+              toast.success(
+                intl.formatMessage(
+                  {
+                    defaultMessage:
+                      "You've flagged {candidateName} in {processTitle}. Other authorized users can also view or remove this flag.",
+                    id: "NRX2CA",
+                    description:
+                      "Alert displayed to the user when they mark a candidate as flagged.",
+                  },
+                  {
+                    candidateName: name,
+                    processTitle,
+                  },
+                ),
+              );
+            } else {
+              toast.success(
+                intl.formatMessage(
+                  {
+                    defaultMessage:
+                      "You've removed the flag for {candidateName} in {processTitle}.",
+                    id: "idwHJf",
+                    description:
+                      "Alert displayed to the user when they un-flag a candidate.",
+                  },
+                  {
+                    candidateName: name,
+                    processTitle,
+                  },
+                ),
+              );
+            }
+          }
+
+          setIsFlagged(newIsFlagged);
         })
         .catch(() => {
           toast.error(

--- a/apps/web/src/hooks/useServerSyncedState.test.ts
+++ b/apps/web/src/hooks/useServerSyncedState.test.ts
@@ -1,0 +1,110 @@
+import { act, renderHook } from "@testing-library/react";
+
+import useServerSyncedState from "./useServerSyncedState";
+
+describe("useServerSyncedState", () => {
+  it("starts at the server value", () => {
+    const { result } = renderHook(() => useServerSyncedState(true));
+
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("adopts a changed server value", () => {
+    const { result, rerender } = renderHook(
+      ({ serverValue }: { serverValue: boolean }) =>
+        useServerSyncedState(serverValue),
+      { initialProps: { serverValue: false } },
+    );
+
+    rerender({ serverValue: true });
+
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("keeps a local value when the same server value is re-delivered", () => {
+    const { result, rerender } = renderHook(
+      ({ serverValue }: { serverValue: boolean }) =>
+        useServerSyncedState(serverValue),
+      { initialProps: { serverValue: false } },
+    );
+
+    const setValue = result.current[1];
+    act(() => {
+      setValue(true);
+    });
+    expect(result.current[0]).toBe(true);
+
+    // A stale cached document arriving again must not undo the local value.
+    rerender({ serverValue: false });
+
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("keeps a local value when the server catches up to it", () => {
+    const { result, rerender } = renderHook(
+      ({ serverValue }: { serverValue: boolean }) =>
+        useServerSyncedState(serverValue),
+      { initialProps: { serverValue: false } },
+    );
+
+    const setValue = result.current[1];
+    act(() => {
+      setValue(true);
+    });
+    rerender({ serverValue: true });
+
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("adopts a later server change that contradicts the local value", () => {
+    const { result, rerender } = renderHook(
+      ({ serverValue }: { serverValue: boolean }) =>
+        useServerSyncedState(serverValue),
+      { initialProps: { serverValue: false } },
+    );
+
+    const setValue = result.current[1];
+    act(() => {
+      setValue(true);
+    });
+    rerender({ serverValue: true });
+    expect(result.current[0]).toBe(true);
+
+    // Someone else removes it: the server is still the authority.
+    rerender({ serverValue: false });
+
+    expect(result.current[0]).toBe(false);
+  });
+
+  it("adopts the server value when the identity changes", () => {
+    const { result, rerender } = renderHook(
+      ({ serverValue, id }: { serverValue: boolean; id: string }) =>
+        useServerSyncedState(serverValue, id),
+      { initialProps: { serverValue: false, id: "a" } },
+    );
+
+    const setValue = result.current[1];
+    act(() => {
+      setValue(true);
+    });
+    expect(result.current[0]).toBe(true);
+
+    // Now showing a different entity that happens to share the old server value: the
+    // local value belongs to the previous entity and must be discarded.
+    rerender({ serverValue: false, id: "b" });
+
+    expect(result.current[0]).toBe(false);
+  });
+
+  it("works with non-boolean values", () => {
+    const { result, rerender } = renderHook(
+      ({ serverValue }: { serverValue: string }) =>
+        useServerSyncedState(serverValue),
+      { initialProps: { serverValue: "a" } },
+    );
+
+    rerender({ serverValue: "b" });
+
+    expect(result.current[0]).toBe("b");
+  });
+});

--- a/apps/web/src/hooks/useServerSyncedState.ts
+++ b/apps/web/src/hooks/useServerSyncedState.ts
@@ -1,0 +1,30 @@
+import { useState } from "react";
+
+/**
+ * Local state seeded from the API that adopts a new server value whenever the
+ * server value actually changes.
+ *
+ * Needed because there are cases where we want to store a specific value from a larger model,
+ * without invalidating the cache for the whole model. See #16166, and flags/bookmarks on
+ * PoolCandidates.
+ * When mutating a bookmark, the component keeps its own copy of the value, but it must still
+ * defer when a fresh (non-stale) server value arrives representing the larger model.
+ *
+ * @param serverValue latest value from the API; may be a stale cached copy
+ */
+const useServerSyncedState = <T>(serverValue: T) => {
+  const [value, setValue] = useState(serverValue);
+  const [lastServerValue, setLastServerValue] = useState(serverValue);
+
+  // Render-phase reconciliation, keyed on a *change* in the server value: after a
+  // toggle the cache still serves the old value, and re-delivering it must not
+  // clobber what the mutation just confirmed.
+  if (serverValue !== lastServerValue) {
+    setLastServerValue(serverValue);
+    setValue(serverValue);
+  }
+
+  return [value, setValue] as const;
+};
+
+export default useServerSyncedState;

--- a/apps/web/src/hooks/useServerSyncedState.ts
+++ b/apps/web/src/hooks/useServerSyncedState.ts
@@ -1,5 +1,7 @@
 import { useState } from "react";
 
+type Primitive = string | number | boolean | null | undefined;
+
 /**
  * Local state seeded from the API that adopts a new server value whenever the
  * server value actually changes.
@@ -7,20 +9,37 @@ import { useState } from "react";
  * Needed because there are cases where we want to store a specific value from a larger model,
  * without invalidating the cache for the whole model. See #16166, and flags/bookmarks on
  * PoolCandidates.
+ *
  * When mutating a bookmark, the component keeps its own copy of the value, but it must still
  * defer when a fresh (non-stale) server value arrives representing the larger model.
  *
+ * `identity` ensures we discard the local value if the hook is now representing a value from a
+ * different entity, eg a different PoolCandidate.
+ *
+ * Note about Primitive type: values are restricted to primitive types to keep comparison simple.
+ * If there is a use case for it, the restriction to Primitive types could be removed, but the method
+ * of comparing serverValue with syncedServer value would need to be refactored - maybe by passing in
+ * a `compare` or `isEqual` function?
+ *
  * @param serverValue latest value from the API; may be a stale cached copy
+ * @param identity identifies which entity the value belongs to; when it changes the local
+ *   value is discarded, even if the server value looks unchanged
  */
-const useServerSyncedState = <T>(serverValue: T) => {
+const useServerSyncedState = <T extends Primitive>(
+  serverValue: T,
+  identity?: Primitive,
+) => {
   const [value, setValue] = useState(serverValue);
-  const [lastServerValue, setLastServerValue] = useState(serverValue);
+  const [synced, setSynced] = useState({ serverValue, identity });
 
-  // Render-phase reconciliation, keyed on a *change* in the server value: after a
-  // toggle the cache still serves the old value, and re-delivering it must not
-  // clobber what the mutation just confirmed.
-  if (serverValue !== lastServerValue) {
-    setLastServerValue(serverValue);
+  // Render-phase reconciliation, keyed on a *change* in the server value.
+  // Assumption is that state will be changed locally with setValue and serverValue will
+  // be temporarily stale. But if serverValue *does* change, we should assume that means a
+  // fresh value from the server, which is more authoritative than our local value.
+  // Alternatively, a change of identity means this instance now represents a
+  // completely different entity, so the local value is meaningless.
+  if (serverValue !== synced.serverValue || identity !== synced.identity) {
+    setSynced({ serverValue, identity });
     setValue(serverValue);
   }
 


### PR DESCRIPTION
🤖 Resolves #16166
Resolves #17704 

## 👋 Introduction
#17704 
This PR attempts to solve one issue without creating another.

#16166 describes an issue where if you view a PoolCandidate as a Community admin, update the flag or bookmark toggle, navigate to a different page, and navigate back, then the flag/toggle appears incorrectly (in the state before you toggled it).

#16167 resolved this issue, but by creating a related one: now toggling the flag/bookmark from a Process/Candidates table could cause rows in the table to jump around. Trying to avoid this in the first place by not refreshing the full cache of PoolCandidates is what led to the somewhat roundabout solution that ultimately caused issue #16166.

This PR resolves the navigate-away-nagivage-back staleness described in #16166 while avoiding jumping rows. It slightly simplifies the CandidateFlag component by removing some unused params, and uses a new hook `useServerSyncedState` which is both simpler than `useControllableState` and more customized for this specific use case.

## 🕵️ Details

How the flags work now:
1. When the page (candidates table or individual candidate) the useSeverSyncedState hook is initialized with the flag value from the overall PoolCandidate query.
2. User clicks a flag/bookmark to toggle it. This triggers a graphql mutation specific to the flag.
3. Button is disabled while mutation is in progress; UI does not update optimistically.
4. The mutation returns the new state of the flag itself, instead of the entire PoolCandidate object. If the mutation was successful, the hook saves the new value locally and displays it; local state now differs from serverValue.
5. If you navigate away and come back, the hook will be initialized with the flag value from the overallPoolCandidate query again - but that value will be stale, coming from the cache, while a new query is kicked off.
6. When the query returns, serverValue will differ from cached serverValue, and useServerSyncedState will adopt it as a new local value.

> [!NOTE]
> Why does the flag/bookmark mutation return only the new state of the boolean, not the entire PoolCandidate object?
> Returning the whole object would cause URQL's document cache to invalidate its cache for all PoolCandidates. This would immediately trigger a new query if you're on the Pool/Candidates table. This would result in re-ordered results, with newly flagged candidates appearing at the top and unflagged candidates moving later, and this re-ordering of table rows is what we want to avoid. 

### Downsides to this solution

1. When you navigate to a new page and navigate back after toggling a flag, it will briefly appear with the stale state before being updated by the new query.
2. The code for handling this specific case of this specific cache implementation still feels rather convoluted.

### Alternative solution

The code would be a lot simpler if we could rely on the normal operation of the cache. The main reason not to is the reordering of the table. So instead of working around the cache, we could consider working around the ordering behaviour:
1. When PoolCandidates query is first completed, we save the ordering of ids in local state
2. We then use that ordering to order the table rows, instead of whatever is returned by the api.
3. But... then we have to be really careful about when we invalidate the cached order. We'd want to maintain the cached order when running mutations on PoolCandidates, but we'd want to invalidate that cache any time the PoolCandidates query is modified (updated sort order or filters or pagination).

## 🧪 Testing

### navigate-away-navigate-back
1. Access to GC digital portal using a community role
2. Navigate to any pool candidate
3. Mark that candidate as flagged or bookmarked from Candidate application page
4. Navigate to processes or talent requests or any pages from that page
5. Use browser back button to navigate back to the candidate application page
6. Verify that the flag appears in the correct state you left it in (you may briefly see it in stale state)

### jumping-rows
1. Access GC digital portal using a community role
2. Navigate to a Pool/Process
3. Navigate to Candidates table
4. Scroll down to a candidate that is not flagged or bookmarked, and does not appear at top of table
5. Mark candidate as bookmarked. Bookmark should be displayed, but candidate row should not move.
6. Change filters. Candidate should move to top of table, bookmark still showing.
7. Flag another candidate lower in the table.
8. Navigate to another page, then navigate back to candidates table. After a brief flash of stale state, flagged candidate should appear at top of table.