### PR TITLE
[Fix] Exclude community-less pools from talent search results and estimated count

### DIFF
--- a/api/app/Builders/PoolCandidateBuilder.php
+++ b/api/app/Builders/PoolCandidateBuilder.php
@@ -46,6 +46,16 @@ class PoolCandidateBuilder extends Builder implements TalentRequestMatchable
     }
 
     /**
+     * Scopes the query to exclude PoolCandidates in a pool that isn't attached to a community
+     */
+    public function whereHasCommunity(): self
+    {
+        return $this->whereHas('pool', function ($query) {
+            $query->whereNotNull('community_id');
+        });
+    }
+
+    /**
      * Scopes the query to return PoolCandidates in a pool with one of the specified classifications.
      * If $classifications is empty, this scope will be ignored.
      *
@@ -141,6 +151,7 @@ class PoolCandidateBuilder extends Builder implements TalentRequestMatchable
         // so its id is pulled out first.
         return $this->whereAvailable()
             ->whereInTalentSearchablePublishingGroup()
+            ->whereHasCommunity()
             ->whereAppliedClassificationsIn($filters['qualifiedInClassifications'] ?? null)
             ->whereWorkStreamsIn(array_column($filters['qualifiedInWorkStreams'] ?? [], 'id'))
             ->whereInCommunity($filters['community'] ?? null)

--- a/api/tests/Feature/TalentRequestMatchesTest.php
+++ b/api/tests/Feature/TalentRequestMatchesTest.php
@@ -709,6 +709,49 @@ class TalentRequestMatchesTest extends TestCase
         ]);
     }
 
+    public function testCommunitylessPoolExcludedFromCountsAndTotal(): void
+    {
+        $classification = Classification::factory()->create();
+        $community = Community::factory()->create();
+
+        $pool = Pool::factory()->candidatesAvailableInSearch()->create([
+            'classification_id' => $classification->id,
+            'community_id' => $community->id,
+        ]);
+        $this->matchingUser($pool);
+
+        // matches every other filter, but its pool has no community attached
+        $communitylessPool = Pool::factory()->candidatesAvailableInSearch()->create([
+            'classification_id' => $classification->id,
+        ]);
+        $communitylessPool->forceFill(['community_id' => null])->save();
+        $this->matchingUser($communitylessPool);
+
+        $where = [
+            'applicantFilter' => [
+                'qualifiedInClassifications' => [['group' => $classification->group, 'level' => $classification->level]],
+            ],
+        ];
+
+        // total excludes the communityless pool's candidate
+        $this->runCountMatches($where)
+            ->assertJson(['data' => ['countTalentRequestMatches' => 1]]);
+
+        // by-pool breakdown only lists the community-attached pool
+        $this->runCountByPool($where)->assertExactJson([
+            'data' => [
+                'countTalentRequestMatchesByPool' => [
+                    ['pool' => ['id' => $pool->id], 'count' => 1],
+                ],
+            ],
+        ]);
+
+        // by-community breakdown is unaffected and matches the total
+        $this->runCountByCommunity($where)
+            ->assertJsonPath('data.countTalentRequestMatchesByCommunity.0.community.id', $community->id)
+            ->assertJsonPath('data.countTalentRequestMatchesByCommunity.0.count', 1);
+    }
+
     public function testCountByCommunityCountsBreakdownAndDedupesTotal(): void
     {
         $classification = Classification::factory()->create();


### PR DESCRIPTION
🤖 Resolves #17732 

## 👋 Introduction

Pools without a community attached were still showing up as cards on the talent search page, and were being counted in the "estimated candidates" total even though they were already excluded from the by-community breakdown. This PR excludes community-less pools from talent request matching entirely, so the search results and the estimated count agree.

## 🕵️ Details

 - Added a `whereHasCommunity()` scope to `PoolCandidateBuilder`
 - Wired it into the shared `whereMatchesTalentRequest()` scope, since the by-pool count, by-community count, and overall total all route through it.

## 🧪 Testing

1. Run `php artisan test --filter=TalentRequestMatchesTest`
2. On the search page, confirm a pool with no community attached does not appear as a card and isn't reflected in the estimated candidate count
