### PR TITLE
Fix stale bookmark/flag state on the candidate application page

### DIFF
--- a/apps/web/src/components/CandidateFlag/CandidateFlag.tsx
+++ b/apps/web/src/components/CandidateFlag/CandidateFlag.tsx
@@ -52,24 +52,22 @@ const CandidateFlag = ({
     intl,
   );
 
-  const [{ isFlagged, isUpdating: isUpdatingFlag }, toggleFlag] =
-    useCandidateFlagToggle({
-      id: candidate.id,
-      onChange: onFlagChange,
-      value: flagged,
-      defaultValue: candidate?.isFlagged ?? false,
-      name: candidateName,
-      processTitle:
-        processTitle ??
-        candidate.pool.displayName?.display.localized ??
-        intl.formatMessage(commonMessages.notAvailable),
-    });
+  const [{ isFlagged }, toggleFlag] = useCandidateFlagToggle({
+    id: candidate.id,
+    onChange: onFlagChange,
+    value: flagged,
+    defaultValue: candidate?.isFlagged ?? false,
+    name: candidateName,
+    processTitle:
+      processTitle ??
+      candidate.pool.displayName?.display.localized ??
+      intl.formatMessage(commonMessages.notAvailable),
+  });
 
   return (
     <IconButton
       color={isFlagged ? "warning" : "black"}
       onClick={toggleFlag}
-      disabled={isUpdatingFlag}
       icon={isFlagged ? FlagIconSolid : FlagIconOutline}
       size={size}
       label={

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidateBookmark.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidateBookmark.tsx
@@ -40,18 +40,16 @@ const PoolCandidateBookmark = ({
   );
   const poolCandidateName = getFullNameLabel(firstName, lastName, intl);
 
-  const [{ isBookmarked, isUpdating: isUpdatingBookmark }, toggleBookmark] =
-    useCandidateBookmarkToggle({
-      id: poolCandidateId,
-      defaultValue: isBookmarkedDefaultValue,
-      name: poolCandidateName,
-    });
+  const [{ isBookmarked }, toggleBookmark] = useCandidateBookmarkToggle({
+    id: poolCandidateId,
+    defaultValue: isBookmarkedDefaultValue,
+    name: poolCandidateName,
+  });
 
   return (
     <IconButton
       color={isBookmarked ? "secondary" : "black"}
       onClick={toggleBookmark}
-      disabled={isUpdatingBookmark}
       icon={isBookmarked ? BookmarkIconSolid : BookmarkIconOutline}
       size={size}
       label={

--- a/apps/web/src/hooks/useCandidateBookmarkToggle.ts
+++ b/apps/web/src/hooks/useCandidateBookmarkToggle.ts
@@ -44,7 +44,8 @@ const useCandidateBookmarkToggle = ({
   );
 
   const toggleBookmark = async () => {
-    if (id) {
+    // Ignores calls made while a previous toggle is still in flight
+    if (id && !isUpdating) {
       await executeToggleBookmarkMutation({ id })
         .then((res) => {
           if (!res.error) {

--- a/apps/web/src/hooks/useCandidateBookmarkToggle.ts
+++ b/apps/web/src/hooks/useCandidateBookmarkToggle.ts
@@ -46,44 +46,57 @@ const useCandidateBookmarkToggle = ({
   const toggleBookmark = async () => {
     // Ignores calls made while a previous toggle is still in flight
     if (id && !isUpdating) {
+      const previousIsBookmarked = isBookmarked ?? false;
+
+      // Flip immediately so the button responds to the click, then reconcile below with
+      // the value the server actually stored.
+      setIsBookmarked(!previousIsBookmarked);
+
       await executeToggleBookmarkMutation({ id })
         .then((res) => {
-          if (!res.error) {
-            const newIsBookmarked =
-              res.data?.togglePoolCandidateUserBookmark === true;
-            if (showToast) {
-              if (newIsBookmarked) {
-                toast.success(
-                  intl.formatMessage(
-                    {
-                      defaultMessage: "You've bookmarked {name} for yourself",
-                      id: "9DJWk4",
-                      description: "Bookmarked a candidate",
-                    },
-                    {
-                      name,
-                    },
-                  ),
-                );
-              } else {
-                toast.success(
-                  intl.formatMessage(
-                    {
-                      defaultMessage: "You've removed the bookmark for {name}.",
-                      id: "UBY4qe",
-                      description: "Un-bookmarked a candidate",
-                    },
-                    {
-                      name,
-                    },
-                  ),
-                );
-              }
-            }
-            setIsBookmarked(newIsBookmarked);
+          // urql resolves with an error rather than rejecting, so failures surface here:
+          // an authorization denial, expired session, or network error.
+          if (!res.data || res.error) {
+            throw new Error();
           }
+
+          // Bookmark could come back null, treat that as false
+          const newIsBookmarked =
+            res.data.togglePoolCandidateUserBookmark === true;
+          if (showToast) {
+            if (newIsBookmarked) {
+              toast.success(
+                intl.formatMessage(
+                  {
+                    defaultMessage: "You've bookmarked {name} for yourself",
+                    id: "9DJWk4",
+                    description: "Bookmarked a candidate",
+                  },
+                  {
+                    name,
+                  },
+                ),
+              );
+            } else {
+              toast.success(
+                intl.formatMessage(
+                  {
+                    defaultMessage: "You've removed the bookmark for {name}.",
+                    id: "UBY4qe",
+                    description: "Un-bookmarked a candidate",
+                  },
+                  {
+                    name,
+                  },
+                ),
+              );
+            }
+          }
+
+          setIsBookmarked(newIsBookmarked);
         })
         .catch(() => {
+          setIsBookmarked(previousIsBookmarked); // undo optimistic update
           toast.error(
             intl.formatMessage({
               defaultMessage: "Error: failed to update a candidate's bookmark.",

--- a/apps/web/src/hooks/useCandidateBookmarkToggle.ts
+++ b/apps/web/src/hooks/useCandidateBookmarkToggle.ts
@@ -48,14 +48,11 @@ const useCandidateBookmarkToggle = ({
     if (id && !isUpdating) {
       const previousIsBookmarked = isBookmarked ?? false;
 
-      // Flip immediately so the button responds to the click, then reconcile below with
-      // the value the server actually stored.
+      // Update flag optimistically. Reconcile when mutation returns.
       setIsBookmarked(!previousIsBookmarked);
 
       await executeToggleBookmarkMutation({ id })
         .then((res) => {
-          // urql resolves with an error rather than rejecting, so failures surface here:
-          // an authorization denial, expired session, or network error.
           if (!res.data || res.error) {
             throw new Error();
           }

--- a/apps/web/src/hooks/useCandidateFlagToggle.ts
+++ b/apps/web/src/hooks/useCandidateFlagToggle.ts
@@ -56,16 +56,13 @@ const useCandidateFlagToggle = ({
     if (id && !isUpdating) {
       const previousIsFlagged = isFlagged ?? false;
 
-      // Flip immediately so the button responds to the click, then reconcile below with
-      // the value the server actually stored.
+      // Update flag optimistically. Reconcile when mutation returns.
       setIsFlagged(!previousIsFlagged);
 
       await executeToggleFlagMutation({
         id,
       })
         .then((res) => {
-          // urql resolves with an error rather than rejecting, so failures surface here:
-          // an authorization denial, expired session, or network error.
           if (!res.data || res.error) {
             throw new Error();
           }

--- a/apps/web/src/hooks/useCandidateFlagToggle.ts
+++ b/apps/web/src/hooks/useCandidateFlagToggle.ts
@@ -52,7 +52,8 @@ const useCandidateFlagToggle = ({
   );
 
   const toggleFlag = async () => {
-    if (id) {
+    // Ignores calls made while a previous toggle is still in flight
+    if (id && !isUpdating) {
       await executeToggleFlagMutation({
         id,
       })

--- a/apps/web/src/hooks/useCandidateFlagToggle.ts
+++ b/apps/web/src/hooks/useCandidateFlagToggle.ts
@@ -54,52 +54,64 @@ const useCandidateFlagToggle = ({
   const toggleFlag = async () => {
     // Ignores calls made while a previous toggle is still in flight
     if (id && !isUpdating) {
+      const previousIsFlagged = isFlagged ?? false;
+
+      // Flip immediately so the button responds to the click, then reconcile below with
+      // the value the server actually stored.
+      setIsFlagged(!previousIsFlagged);
+
       await executeToggleFlagMutation({
         id,
       })
         .then((res) => {
-          if (!res.error) {
-            const newIsFlagged = res.data?.togglePoolCandidateFlag === true;
-            if (showToast) {
-              if (newIsFlagged) {
-                toast.success(
-                  intl.formatMessage(
-                    {
-                      defaultMessage:
-                        "You've flagged {candidateName} in {processTitle}. Other authorized users can also view or remove this flag.",
-                      id: "NRX2CA",
-                      description:
-                        "Alert displayed to the user when they mark a candidate as flagged.",
-                    },
-                    {
-                      candidateName: name,
-                      processTitle,
-                    },
-                  ),
-                );
-              } else {
-                toast.success(
-                  intl.formatMessage(
-                    {
-                      defaultMessage:
-                        "You've removed the flag for {candidateName} in {processTitle}.",
-                      id: "idwHJf",
-                      description:
-                        "Alert displayed to the user when they un-flag a candidate.",
-                    },
-                    {
-                      candidateName: name,
-                      processTitle,
-                    },
-                  ),
-                );
-              }
-            }
-
-            setIsFlagged(newIsFlagged);
+          // urql resolves with an error rather than rejecting, so failures surface here:
+          // an authorization denial, expired session, or network error.
+          if (!res.data || res.error) {
+            throw new Error();
           }
+
+          // flag could come back null, treat that as false
+          const newIsFlagged = res.data.togglePoolCandidateFlag === true;
+          if (showToast) {
+            if (newIsFlagged) {
+              toast.success(
+                intl.formatMessage(
+                  {
+                    defaultMessage:
+                      "You've flagged {candidateName} in {processTitle}. Other authorized users can also view or remove this flag.",
+                    id: "NRX2CA",
+                    description:
+                      "Alert displayed to the user when they mark a candidate as flagged.",
+                  },
+                  {
+                    candidateName: name,
+                    processTitle,
+                  },
+                ),
+              );
+            } else {
+              toast.success(
+                intl.formatMessage(
+                  {
+                    defaultMessage:
+                      "You've removed the flag for {candidateName} in {processTitle}.",
+                    id: "idwHJf",
+                    description:
+                      "Alert displayed to the user when they un-flag a candidate.",
+                  },
+                  {
+                    candidateName: name,
+                    processTitle,
+                  },
+                ),
+              );
+            }
+          }
+
+          setIsFlagged(newIsFlagged);
         })
         .catch(() => {
+          setIsFlagged(previousIsFlagged); // undo optimistic update
           toast.error(
             intl.formatMessage({
               defaultMessage: "Error: failed to update a candidate's flag.",

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/Sidebar/ApplicationBookmarkFlag.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/Sidebar/ApplicationBookmarkFlag.tsx
@@ -7,7 +7,7 @@ import BookmarkIconOutline from "@heroicons/react/24/outline/BookmarkIcon";
 import BookmarkIconSolid from "@heroicons/react/24/solid/BookmarkIcon";
 
 import type { ButtonProps } from "@gc-digital-talent/ui";
-import { Button } from "@gc-digital-talent/ui";
+import { Button, Pending } from "@gc-digital-talent/ui";
 import type { FragmentType } from "@gc-digital-talent/graphql";
 import { getFragment, graphql } from "@gc-digital-talent/graphql";
 import { commonMessages } from "@gc-digital-talent/i18n";
@@ -58,37 +58,50 @@ const networkOnlyRequest: Partial<OperationContext> = {
   requestPolicy: "network-only",
 };
 
-const noop = () => {
-  // Placeholder handler for the buttons while their state is still unknown.
-};
-
 interface BookmarkFlagButtonsProps {
+  id: string;
+  name: string;
+  processTitle: string;
   isBookmarked: boolean;
   isFlagged: boolean;
-  bookmarkDisabled?: boolean;
-  flagDisabled?: boolean;
-  onToggleBookmark: () => void;
-  onToggleFlag: () => void;
 }
 
-/** Presentational bookmark and flag buttons, with no knowledge of where their state comes from. */
+/**
+ * Bookmark and flag buttons, owning the toggle mutations and seeded with freshly fetched
+ * server state.
+ *
+ * The toggle hooks only read their `defaultValue` on mount, so this must not be rendered
+ * until the real values are known.
+ */
 const BookmarkFlagButtons = ({
-  isBookmarked,
-  isFlagged,
-  bookmarkDisabled = false,
-  flagDisabled = false,
-  onToggleBookmark,
-  onToggleFlag,
+  id,
+  name,
+  processTitle,
+  isBookmarked: initialIsBookmarked,
+  isFlagged: initialIsFlagged,
 }: BookmarkFlagButtonsProps) => {
   const intl = useIntl();
+  const [{ isFlagged, isUpdating: isUpdatingFlag }, toggleFlag] =
+    useCandidateFlagToggle({
+      id,
+      defaultValue: initialIsFlagged,
+      name,
+      processTitle,
+    });
+  const [{ isBookmarked, isUpdating: isUpdatingBookmark }, toggleBookmark] =
+    useCandidateBookmarkToggle({
+      id,
+      defaultValue: initialIsBookmarked,
+      name,
+    });
 
   return (
     <div className="flex flex-col gap-y-4.5">
       <Button
         {...commonProps}
         icon={isBookmarked ? BookmarkIconSolid : BookmarkIconOutline}
-        disabled={bookmarkDisabled}
-        onClick={onToggleBookmark}
+        disabled={isUpdatingBookmark}
+        onClick={toggleBookmark}
       >
         {isBookmarked
           ? intl.formatMessage({
@@ -106,8 +119,8 @@ const BookmarkFlagButtons = ({
       <Button
         {...commonProps}
         icon={isFlagged ? FlagIconSolid : FlagIconOutline}
-        disabled={flagDisabled}
-        onClick={onToggleFlag}
+        disabled={isUpdatingFlag}
+        onClick={toggleFlag}
       >
         {isFlagged
           ? intl.formatMessage({
@@ -125,53 +138,6 @@ const BookmarkFlagButtons = ({
   );
 };
 
-interface LoadedBookmarkFlagProps {
-  id: string;
-  name: string;
-  processTitle: string;
-  isBookmarked: boolean;
-  isFlagged: boolean;
-}
-
-/**
- * Owns the toggle mutations, seeded with freshly fetched server state.
- *
- * The toggle hooks only read their `defaultValue` on mount, so this is deliberately kept as a
- * separate component: it is not rendered until the real values are known.
- */
-const LoadedBookmarkFlag = ({
-  id,
-  name,
-  processTitle,
-  isBookmarked: initialIsBookmarked,
-  isFlagged: initialIsFlagged,
-}: LoadedBookmarkFlagProps) => {
-  const [{ isFlagged, isUpdating: isUpdatingFlag }, toggleFlag] =
-    useCandidateFlagToggle({
-      id,
-      defaultValue: initialIsFlagged,
-      name,
-      processTitle,
-    });
-  const [{ isBookmarked, isUpdating: isUpdatingBookmark }, toggleBookmark] =
-    useCandidateBookmarkToggle({
-      id,
-      defaultValue: initialIsBookmarked,
-      name,
-    });
-
-  return (
-    <BookmarkFlagButtons
-      isBookmarked={isBookmarked}
-      isFlagged={isFlagged}
-      bookmarkDisabled={isUpdatingBookmark}
-      flagDisabled={isUpdatingFlag}
-      onToggleBookmark={toggleBookmark}
-      onToggleFlag={toggleFlag}
-    />
-  );
-};
-
 interface ApplicationBookmarkFlagProps {
   query: FragmentType<typeof ApplicationBookmarkFlag_Fragment>;
 }
@@ -181,7 +147,7 @@ const ApplicationBookmarkFlag = ({ query }: ApplicationBookmarkFlagProps) => {
   const application = getFragment(ApplicationBookmarkFlag_Fragment, query);
 
   // This query is run separately without a cache policy, to avoid rendering stale values.
-  const [{ data, fetching }] = useQuery({
+  const [{ data, fetching, error }] = useQuery({
     query: ApplicationBookmarkFlagState_Query,
     variables: { id: application.id },
     context: networkOnlyRequest,
@@ -189,37 +155,27 @@ const ApplicationBookmarkFlag = ({ query }: ApplicationBookmarkFlagProps) => {
 
   const candidate = data?.poolCandidate;
 
-  // Until the current state is known, render the buttons as inert rather than risk showing a
-  // stale value from the cache. The same applies if the query failed: an enabled button in an
-  // unverified state is worse than one that does nothing.
-  if (fetching || !candidate) {
-    return (
-      <BookmarkFlagButtons
-        isBookmarked={false}
-        isFlagged={false}
-        bookmarkDisabled
-        flagDisabled
-        onToggleBookmark={noop}
-        onToggleFlag={noop}
-      />
-    );
-  }
-
+  // A spinner stands in until the current state is known, rather than risk showing a stale
+  // value from the cache.
   return (
-    <LoadedBookmarkFlag
-      id={application.id}
-      name={getFullNameLabel(
-        application.user.firstName,
-        application.user.lastName,
-        intl,
-      )}
-      processTitle={
-        application.pool.displayName?.display.localized ??
-        intl.formatMessage(commonMessages.notAvailable)
-      }
-      isBookmarked={candidate.isBookmarked ?? false}
-      isFlagged={candidate.applicationAssessmentData?.isFlagged ?? false}
-    />
+    <Pending fetching={fetching} error={error} inline>
+      {candidate ? (
+        <BookmarkFlagButtons
+          id={application.id}
+          name={getFullNameLabel(
+            application.user.firstName,
+            application.user.lastName,
+            intl,
+          )}
+          processTitle={
+            application.pool.displayName?.display.localized ??
+            intl.formatMessage(commonMessages.notAvailable)
+          }
+          isBookmarked={candidate.isBookmarked ?? false}
+          isFlagged={candidate.applicationAssessmentData?.isFlagged ?? false}
+        />
+      ) : null}
+    </Pending>
   );
 };
 

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/Sidebar/ApplicationBookmarkFlag.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/Sidebar/ApplicationBookmarkFlag.tsx
@@ -81,26 +81,23 @@ const BookmarkFlagButtons = ({
   isFlagged: initialIsFlagged,
 }: BookmarkFlagButtonsProps) => {
   const intl = useIntl();
-  const [{ isFlagged, isUpdating: isUpdatingFlag }, toggleFlag] =
-    useCandidateFlagToggle({
-      id,
-      defaultValue: initialIsFlagged,
-      name,
-      processTitle,
-    });
-  const [{ isBookmarked, isUpdating: isUpdatingBookmark }, toggleBookmark] =
-    useCandidateBookmarkToggle({
-      id,
-      defaultValue: initialIsBookmarked,
-      name,
-    });
+  const [{ isFlagged }, toggleFlag] = useCandidateFlagToggle({
+    id,
+    defaultValue: initialIsFlagged,
+    name,
+    processTitle,
+  });
+  const [{ isBookmarked }, toggleBookmark] = useCandidateBookmarkToggle({
+    id,
+    defaultValue: initialIsBookmarked,
+    name,
+  });
 
   return (
     <div className="flex flex-col gap-y-4.5">
       <Button
         {...commonProps}
         icon={isBookmarked ? BookmarkIconSolid : BookmarkIconOutline}
-        disabled={isUpdatingBookmark}
         onClick={toggleBookmark}
       >
         {isBookmarked
@@ -119,7 +116,6 @@ const BookmarkFlagButtons = ({
       <Button
         {...commonProps}
         icon={isFlagged ? FlagIconSolid : FlagIconOutline}
-        disabled={isUpdatingFlag}
         onClick={toggleFlag}
       >
         {isFlagged

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/Sidebar/ApplicationBookmarkFlag.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/Sidebar/ApplicationBookmarkFlag.tsx
@@ -1,4 +1,6 @@
 import { useIntl } from "react-intl";
+import { useQuery } from "urql";
+import type { OperationContext } from "urql";
 import FlagIconOutline from "@heroicons/react/24/outline/FlagIcon";
 import FlagIconSolid from "@heroicons/react/24/solid/FlagIcon";
 import BookmarkIconOutline from "@heroicons/react/24/outline/BookmarkIcon";
@@ -35,47 +37,58 @@ const ApplicationBookmarkFlag_Fragment = graphql(/** GraphQL */ `
         }
       }
     }
-    applicationAssessmentData {
-      isFlagged
-    }
-    isBookmarked
   }
 `);
 
-interface ApplicationBookmarkFlagProps {
-  query: FragmentType<typeof ApplicationBookmarkFlag_Fragment>;
+const ApplicationBookmarkFlagState_Query = graphql(/** GraphQL */ `
+  query ApplicationBookmarkFlagState($id: UUID!) {
+    poolCandidate(id: $id) {
+      id
+      isBookmarked
+      applicationAssessmentData {
+        isFlagged
+      }
+    }
+  }
+`);
+
+// The cached page snapshot can be stale after a toggle followed by a back-navigation (#16166),
+// so the toggle state is always re-fetched from the network rather than seeded from cache.
+const networkOnlyRequest: Partial<OperationContext> = {
+  requestPolicy: "network-only",
+};
+
+const noop = () => {
+  // Placeholder handler for the buttons while their state is still unknown.
+};
+
+interface BookmarkFlagButtonsProps {
+  isBookmarked: boolean;
+  isFlagged: boolean;
+  bookmarkDisabled?: boolean;
+  flagDisabled?: boolean;
+  onToggleBookmark: () => void;
+  onToggleFlag: () => void;
 }
 
-const ApplicationBookmarkFlag = ({ query }: ApplicationBookmarkFlagProps) => {
+/** Presentational bookmark and flag buttons, with no knowledge of where their state comes from. */
+const BookmarkFlagButtons = ({
+  isBookmarked,
+  isFlagged,
+  bookmarkDisabled = false,
+  flagDisabled = false,
+  onToggleBookmark,
+  onToggleFlag,
+}: BookmarkFlagButtonsProps) => {
   const intl = useIntl();
-  const application = getFragment(ApplicationBookmarkFlag_Fragment, query);
-
-  const name = getFullNameLabel(
-    application.user.firstName,
-    application.user.lastName,
-    intl,
-  );
-
-  const [{ isFlagged }, toggleFlag] = useCandidateFlagToggle({
-    id: application.id,
-    defaultValue: application.applicationAssessmentData?.isFlagged ?? false,
-    name,
-    processTitle:
-      application.pool.displayName?.display.localized ??
-      intl.formatMessage(commonMessages.notAvailable),
-  });
-  const [{ isBookmarked }, toggleBookmark] = useCandidateBookmarkToggle({
-    id: application.id,
-    defaultValue: application.isBookmarked ?? false,
-    name,
-  });
 
   return (
     <div className="flex flex-col gap-y-4.5">
       <Button
         {...commonProps}
         icon={isBookmarked ? BookmarkIconSolid : BookmarkIconOutline}
-        onClick={toggleBookmark}
+        disabled={bookmarkDisabled}
+        onClick={onToggleBookmark}
       >
         {isBookmarked
           ? intl.formatMessage({
@@ -93,7 +106,8 @@ const ApplicationBookmarkFlag = ({ query }: ApplicationBookmarkFlagProps) => {
       <Button
         {...commonProps}
         icon={isFlagged ? FlagIconSolid : FlagIconOutline}
-        onClick={toggleFlag}
+        disabled={flagDisabled}
+        onClick={onToggleFlag}
       >
         {isFlagged
           ? intl.formatMessage({
@@ -108,6 +122,104 @@ const ApplicationBookmarkFlag = ({ query }: ApplicationBookmarkFlagProps) => {
             })}
       </Button>
     </div>
+  );
+};
+
+interface LoadedBookmarkFlagProps {
+  id: string;
+  name: string;
+  processTitle: string;
+  isBookmarked: boolean;
+  isFlagged: boolean;
+}
+
+/**
+ * Owns the toggle mutations, seeded with freshly fetched server state.
+ *
+ * The toggle hooks only read their `defaultValue` on mount, so this is deliberately kept as a
+ * separate component: it is not rendered until the real values are known.
+ */
+const LoadedBookmarkFlag = ({
+  id,
+  name,
+  processTitle,
+  isBookmarked: initialIsBookmarked,
+  isFlagged: initialIsFlagged,
+}: LoadedBookmarkFlagProps) => {
+  const [{ isFlagged, isUpdating: isUpdatingFlag }, toggleFlag] =
+    useCandidateFlagToggle({
+      id,
+      defaultValue: initialIsFlagged,
+      name,
+      processTitle,
+    });
+  const [{ isBookmarked, isUpdating: isUpdatingBookmark }, toggleBookmark] =
+    useCandidateBookmarkToggle({
+      id,
+      defaultValue: initialIsBookmarked,
+      name,
+    });
+
+  return (
+    <BookmarkFlagButtons
+      isBookmarked={isBookmarked}
+      isFlagged={isFlagged}
+      bookmarkDisabled={isUpdatingBookmark}
+      flagDisabled={isUpdatingFlag}
+      onToggleBookmark={toggleBookmark}
+      onToggleFlag={toggleFlag}
+    />
+  );
+};
+
+interface ApplicationBookmarkFlagProps {
+  query: FragmentType<typeof ApplicationBookmarkFlag_Fragment>;
+}
+
+const ApplicationBookmarkFlag = ({ query }: ApplicationBookmarkFlagProps) => {
+  const intl = useIntl();
+  const application = getFragment(ApplicationBookmarkFlag_Fragment, query);
+
+  // This query is run separately without a cache policy, to avoid rendering stale values.
+  const [{ data, fetching }] = useQuery({
+    query: ApplicationBookmarkFlagState_Query,
+    variables: { id: application.id },
+    context: networkOnlyRequest,
+  });
+
+  const candidate = data?.poolCandidate;
+
+  // Until the current state is known, render the buttons as inert rather than risk showing a
+  // stale value from the cache. The same applies if the query failed: an enabled button in an
+  // unverified state is worse than one that does nothing.
+  if (fetching || !candidate) {
+    return (
+      <BookmarkFlagButtons
+        isBookmarked={false}
+        isFlagged={false}
+        bookmarkDisabled
+        flagDisabled
+        onToggleBookmark={noop}
+        onToggleFlag={noop}
+      />
+    );
+  }
+
+  return (
+    <LoadedBookmarkFlag
+      id={application.id}
+      name={getFullNameLabel(
+        application.user.firstName,
+        application.user.lastName,
+        intl,
+      )}
+      processTitle={
+        application.pool.displayName?.display.localized ??
+        intl.formatMessage(commonMessages.notAvailable)
+      }
+      isBookmarked={candidate.isBookmarked ?? false}
+      isFlagged={candidate.applicationAssessmentData?.isFlagged ?? false}
+    />
   );
 };
 

--- a/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/Sidebar/ApplicationSidebar.stories.tsx
+++ b/apps/web/src/pages/PoolCandidates/ViewPoolCandidatePage/components/Sidebar/ApplicationSidebar.stories.tsx
@@ -94,6 +94,17 @@ const meta = {
           },
         },
       },
+      ApplicationBookmarkFlagState: {
+        data: {
+          poolCandidate: {
+            id: application.id,
+            isBookmarked: application.isBookmarked ?? false,
+            applicationAssessmentData: {
+              isFlagged: application.applicationAssessmentData?.isFlagged,
+            },
+          },
+        },
+      },
       ApplicationStatusFormOptions: {
         data: {
           statuses: fakeLocalizedEnum(ApplicationStatus).map((value) => ({


### PR DESCRIPTION
🤖 Resolves #16166
~~Resolves #17704~~ unable to reproduce #17704

## 👋 Introduction

An alternative to #17771, taking the approach suggested in [this review comment](https://github.com/GCTC-NTGC/gc-digital-talent/pull/17771#issuecomment-5296298496).

#16166 describes the bookmark/flag buttons on the candidate application page reverting to their pre-toggle state after you navigate away and come back. The buttons are seeded from the page's `PoolCandidateSnapshot` query, and `defaultValue` on the toggle hooks is only read once at mount — so on back-navigation they latch onto the stale cached document and never pick up the network result that follows.

Rather than teach the hooks to adopt a later server value (the `useServerSyncedState` approach in #17771), this PR simply asks the server for the current state in a dedicated `network-only` query, and doesn't render the real buttons until that answer arrives.

## 🕵️ Details

`ApplicationBookmarkFlag.tsx` now uses a `<Pending>` component to render a spinner until fresh data comes in from the server. This avoids initializing the flag and bookmark with stale cache data.

`isBookmarked` and `applicationAssessmentData { isFlagged }` were dropped from `ApplicationBookmarkFlag_Fragment` — they were the stale values, and nothing else on the page reads them.

Nothing about the candidates table changes. The toggle mutations still return a bare `Boolean` rather than a `PoolCandidate`, so URQL's document cache is not invalidated and rows still don't jump around (#16167).

The bookmark and flag buttons in PoolCandidateTable were slightly modified to avoid disabling buttons while the mutation is in progress. Instead, `useCandidateFlagToggle` and `useCandidateBookmarkToggle` avoid triggering a new mutation if one is in progress already. Thus, the behaviour of the table buttons now matches what was already in the sidebar.

### Trade-offs

- One extra small query per candidate page load. That's the cost of the approach, and it's cheap.
- After clicking a flag/bookmark button, there is no user feedback while the mutation is running. This is how it already worked on the sidebar, and the mutation runs fast enough on UAT that users haven't seemed bothered.

## 🧪 Testing

### navigate-away-navigate-back (#16166)

1. Sign in with a community role.
2. Open any pool candidate's application page.
3. Toggle the flag and the bookmark on.
4. Navigate to Processes, or any other page.
5. Use the browser back button to return to the application page.
6. A spinner should briefly replace the flag and bookmark buttons, and when they appear they should be in the correct state.

### jumping-rows no-regression (#16167)

1. Sign in with a community role, open a process and its Candidates table.
2. Scroll to a candidate that is neither flagged nor bookmarked and is not near the top.
3. Bookmark it. The icon fills and the row does **not** move.
4. Flag another candidate lower down. Same.
5. Change a filter. Rows re-order as expected, with the bookmark/flag states preserved.
6. Toggle a bookmark or flag, then click a link to go to another page.
7. Navigate back. After a brief moment when a query refresh is happening, the latest toggled flag should appear correctly.

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

---

*Description generated by Claude Code.*
