### PR TITLE
[Feature] Make end_session visit non-optional

### DIFF
--- a/packages/auth/src/utils/authenticationState.ts
+++ b/packages/auth/src/utils/authenticationState.ts
@@ -81,14 +81,6 @@ function getAuthenticationState({
           logoutUri,
           postLogoutRedirectUri,
           logoutReason: "session-expired",
-          /**
-           * Failure prevents redirect when possible or,
-           * returns user to the page they were on to continue.
-           *
-           * Allows router to handle errors and either load page
-           * or restart auth flow if necessary.
-           */
-          preventRedirect: true,
           from: window.location.href,
         });
       }

--- a/packages/auth/src/utils/authenticationState.ts
+++ b/packages/auth/src/utils/authenticationState.ts
@@ -81,14 +81,6 @@ function getAuthenticationState({
           logoutUri,
           postLogoutRedirectUri,
           logoutReason: "session-expired",
-          /**
-           * Failure prevents redirect when possible or,
-           * returns user to the page they were on to continue.
-           *
-           * Allows router to handle errors and either load page
-           * or restart auth flow if necessary.
-           */
-          allowRedirect: false,
           from: window.location.href,
         });
       }

--- a/packages/auth/src/utils/authenticationState.ts
+++ b/packages/auth/src/utils/authenticationState.ts
@@ -81,6 +81,14 @@ function getAuthenticationState({
           logoutUri,
           postLogoutRedirectUri,
           logoutReason: "session-expired",
+          /**
+           * Failure prevents redirect when possible or,
+           * returns user to the page they were on to continue.
+           *
+           * Allows router to handle errors and either load page
+           * or restart auth flow if necessary.
+           */
+          allowRedirect: false,
           from: window.location.href,
         });
       }

--- a/packages/auth/src/utils/logout.ts
+++ b/packages/auth/src/utils/logout.ts
@@ -1,6 +1,3 @@
-import type { JwtPayload } from "jwt-decode";
-import { jwtDecode } from "jwt-decode";
-
 import type { Locales } from "@gc-digital-talent/i18n";
 import { getRuntimeVariableNotNull } from "@gc-digital-talent/env";
 import { defaultLogger } from "@gc-digital-talent/logger";
@@ -41,8 +38,6 @@ interface LogoutAndRefreshPageParameters {
   broadcastLogoutMessage?: () => void;
   // the reason for the logout
   logoutReason?: LogoutReason;
-  // whether or not to prevent the redirect when completing
-  preventRedirect?: boolean;
   // URL user came from and should be returned to after a full logout
   from?: string;
 }
@@ -53,12 +48,10 @@ function logoutAndRefreshPage({
   postLogoutOverridePath,
   broadcastLogoutMessage,
   logoutReason,
-  preventRedirect = false,
   from,
 }: LogoutAndRefreshPageParameters): void {
   defaultLogger.notice("Logging out and refreshing the page");
   // capture tokens before they are removed
-  const accessToken = localStorage.getItem(ACCESS_TOKEN);
   const idToken = localStorage.getItem(ID_TOKEN);
 
   // remove tokens from local storage
@@ -101,34 +94,31 @@ function logoutAndRefreshPage({
       },
     );
   }
-  let authSessionIsCurrentlyActive = false; // assume false unless we can prove it below
-
-  if (accessToken) {
-    const decodedAccessToken = jwtDecode<JwtPayload>(accessToken);
-    if (decodedAccessToken.exp)
-      authSessionIsCurrentlyActive = Date.now() < decodedAccessToken.exp * 1000; // JWT expiry date in seconds, not milliseconds
-  }
 
   // Post a logout message to the broadcast channel
   // so they know to logout as well
   broadcastLogoutMessage?.();
 
-  let nextLocation = postLogoutRedirectUri;
-  if (from) {
-    const searchParams = new URLSearchParams();
-    searchParams.append("from", window.location.href);
-    nextLocation = `${nextLocation}?${searchParams.toString()}`;
+  // what is the the full end_session URL we are about to go to first?
+  const endSessionUrl = new URL(logoutUri);
+
+  // what URL are we redirecting back to after the session is ended?
+  if (postLogoutRedirectUri) {
+    const nextLocation = new URL(postLogoutRedirectUri);
+    if (from) {
+      nextLocation.searchParams.set("from", window.location.href);
+    }
+    endSessionUrl.searchParams.set(
+      "post_logout_redirect_uri",
+      nextLocation.toString(),
+    );
   }
 
-  if (idToken && authSessionIsCurrentlyActive) {
-    // CanadaLogin logout will error out unless there is actually an active session
-    window.location.href = `${logoutUri}?post_logout_redirect_uri=${encodeURIComponent(nextLocation)}&id_token_hint=${idToken}`;
-  } else if (!preventRedirect) {
-    // at least a hard refresh to URI to restart react app
-    window.location.href = nextLocation;
-  } else {
-    window.location.reload();
+  if (idToken) {
+    endSessionUrl.searchParams.set("id_token_hint", idToken);
   }
+
+  window.location.href = endSessionUrl.toString();
 }
 
 export default logoutAndRefreshPage;

--- a/packages/auth/src/utils/logout.ts
+++ b/packages/auth/src/utils/logout.ts
@@ -38,6 +38,8 @@ interface LogoutAndRefreshPageParameters {
   broadcastLogoutMessage?: () => void;
   // the reason for the logout
   logoutReason?: LogoutReason;
+  // whether or not to allow the redirect when completing
+  allowRedirect?: boolean;
   // URL user came from and should be returned to after a full logout
   from?: string;
 }
@@ -48,6 +50,7 @@ function logoutAndRefreshPage({
   postLogoutOverridePath,
   broadcastLogoutMessage,
   logoutReason,
+  allowRedirect = true,
   from,
 }: LogoutAndRefreshPageParameters): void {
   defaultLogger.notice("Logging out and refreshing the page");
@@ -99,26 +102,34 @@ function logoutAndRefreshPage({
   // so they know to logout as well
   broadcastLogoutMessage?.();
 
-  // what is the the full end_session URL we are about to go to first?
-  const endSessionUrl = new URL(logoutUri);
-
   // what URL are we redirecting back to after the session is ended?
-  if (postLogoutRedirectUri) {
-    const nextLocation = new URL(postLogoutRedirectUri);
-    if (from) {
-      nextLocation.searchParams.set("from", window.location.href);
-    }
-    endSessionUrl.searchParams.set(
-      "post_logout_redirect_uri",
-      nextLocation.toString(),
-    );
+  const nextLocation = new URL(postLogoutRedirectUri);
+  if (from) {
+    nextLocation.searchParams.set("from", window.location.href);
   }
+
+  // what is the end_session URL we are about to go to first?
+  const endSessionUrl = new URL(logoutUri);
+  endSessionUrl.searchParams.set(
+    "post_logout_redirect_uri",
+    nextLocation.toString(),
+  );
 
   if (idToken) {
     endSessionUrl.searchParams.set("id_token_hint", idToken);
   }
 
-  window.location.href = endSessionUrl.toString();
+  // OK to visit if the session was already ended.  The only known requirement is that we pass an id token.
+  const canVisitEndSessionUrl = endSessionUrl.searchParams.has("id_token_hint");
+
+  if (canVisitEndSessionUrl) {
+    window.location.href = endSessionUrl.toString();
+  } else if (allowRedirect) {
+    // at least a hard refresh to URI to restart react app
+    window.location.href = nextLocation.toString();
+  } else {
+    window.location.reload();
+  }
 }
 
 export default logoutAndRefreshPage;

--- a/packages/auth/src/utils/logout.ts
+++ b/packages/auth/src/utils/logout.ts
@@ -38,8 +38,6 @@ interface LogoutAndRefreshPageParameters {
   broadcastLogoutMessage?: () => void;
   // the reason for the logout
   logoutReason?: LogoutReason;
-  // whether or not to allow the redirect when completing
-  allowRedirect?: boolean;
   // URL user came from and should be returned to after a full logout
   from?: string;
 }
@@ -50,7 +48,6 @@ function logoutAndRefreshPage({
   postLogoutOverridePath,
   broadcastLogoutMessage,
   logoutReason,
-  allowRedirect = true,
   from,
 }: LogoutAndRefreshPageParameters): void {
   defaultLogger.notice("Logging out and refreshing the page");
@@ -124,11 +121,9 @@ function logoutAndRefreshPage({
 
   if (canVisitEndSessionUrl) {
     window.location.href = endSessionUrl.toString();
-  } else if (allowRedirect) {
+  } else {
     // at least a hard refresh to URI to restart react app
     window.location.href = nextLocation.toString();
-  } else {
-    window.location.reload();
   }
 }
 


### PR DESCRIPTION
🤖 Resolves #17582 

## 👋 Introduction

Makes visiting the end_session endpoint non-optional on logout.

## 🕵️ Details

CanadaLogin will not error out if we try to end the session when it's already ended.  Therefore, we can safely send our users there on every logout. This simplifies the code and increases security.

I also removed the "prevent redirect" logic from https://github.com/GCTC-NTGC/gc-digital-talent/pull/14876 as I think it's no longer necessary.

## 🧪 Testing

1. Configure your environment for CanadaLogin
2. For easier testing, set OAUTH_INTROSPECTION_CACHE_TIME to 1
3. Rebuild the app.

### Simple Case

1. Log in
2. Log out

- [ ] End session was visited
- [ ] No errors
- [ ] Ended up on /logged-out

### Multiple tabs

1. Log in
2. Open multiple tabs
3. Log out in one tab

- [ ] End session was visited on first tab
- [ ] No errors
- [ ] Ended up on /logged-out
- [ ] All other tabs logged out as well

* all other tabs will not visit end_session - that is expected


### Logout when session was already ended

1. Log in
2. Open the "Manage CanadaLogin" app in a new tab from the "Your account" menu and choose "Sign out" from the "Menu" menu.
3. Go back to the first tab and sign out from our app

- [ ] End session was visited
- [ ] No errors
- [ ] Ended up on /logged-out

### Redirect for public page when session was already ended
Check for regressions from https://github.com/GCTC-NTGC/gc-digital-talent/pull/14876

1. Log in
2. Open the "Manage CanadaLogin" app in a new tab from the "Your account" menu and choose "Sign out" from the "Menu" menu.
3. Open a third tab and visit a public page like "http://localhost:8000/en/jobs"

- [ ] End session was visited
- [ ] No errors
- [ ] Ended up on the public page

### Redirect for private page when session was already ended
Check for regressions from https://github.com/GCTC-NTGC/gc-digital-talent/pull/14876

1. Log in
2. Open the "Manage CanadaLogin" app in a new tab from the "Your account" menu and choose "Sign out" from the "Menu" menu.
3. Open a third tab and visit a private page like "http://localhost:8000/en/applicant"

- [ ] End session was visited
- [ ] No errors
- [ ] Ended up on the public page
