### PR TITLE
[Fix] Stale search filters after sign out

### DIFF
--- a/apps/web/src/constants/storageKeys.ts
+++ b/apps/web/src/constants/storageKeys.ts
@@ -3,3 +3,6 @@ export const KEY_NEW_USER_LANGUAGE_PRESET = "new_user_language_preset";
 
 // new feature messages
 export const KEY_NEW_FEATURE_EMPLOYEE_PROFILE = "new_feature_employee_profile";
+
+// talent request search state, persisted across the search and request pages
+export const TALENT_REQUEST_STATE_KEY = "talentRequestState";

--- a/apps/web/src/pages/Auth/SignedOutPage/SignedOutPage.test.tsx
+++ b/apps/web/src/pages/Auth/SignedOutPage/SignedOutPage.test.tsx
@@ -1,0 +1,34 @@
+import { setInSessionStorage } from "@gc-digital-talent/storage";
+
+import { TALENT_REQUEST_STATE_KEY } from "~/constants/storageKeys";
+
+import { clientLoader } from "./SignedOutPage";
+
+const callClientLoader = (url: string) =>
+  clientLoader({
+    request: new Request(url),
+  } as Parameters<typeof clientLoader>[0]);
+
+describe("SignedOutPage clientLoader", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+  });
+
+  it("clears the stored talent request state on logout", async () => {
+    setInSessionStorage(TALENT_REQUEST_STATE_KEY, {
+      applicantFilter: {},
+      candidateCount: 5,
+    });
+
+    await callClientLoader("https://talent.canada.ca/en/logged-out");
+
+    expect(window.sessionStorage.getItem(TALENT_REQUEST_STATE_KEY)).toBeNull();
+  });
+
+  it("does not error when there is no stored talent request state", async () => {
+    await callClientLoader("https://talent.canada.ca/en/logged-out");
+
+    expect(window.sessionStorage.getItem(TALENT_REQUEST_STATE_KEY)).toBeNull();
+  });
+});

--- a/apps/web/src/pages/Auth/SignedOutPage/SignedOutPage.tsx
+++ b/apps/web/src/pages/Auth/SignedOutPage/SignedOutPage.tsx
@@ -20,6 +20,7 @@ import {
 } from "@gc-digital-talent/auth";
 import { commonMessages } from "@gc-digital-talent/i18n";
 import { getLogger } from "@gc-digital-talent/logger";
+import { removeFromSessionStorage } from "@gc-digital-talent/storage";
 
 import Hero from "~/components/Hero";
 import SEO from "~/components/SEO/SEO";
@@ -28,6 +29,7 @@ import useBreadcrumbs from "~/hooks/useBreadcrumbs";
 import authMessages from "~/messages/authMessages";
 import useReturnPath from "~/hooks/useReturnPath";
 import { urlMatchesAppHostName } from "~/utils/utils";
+import { TALENT_REQUEST_STATE_KEY } from "~/constants/storageKeys";
 
 const supportLink = (chunks: ReactNode, path: string) => (
   <Link href={path} state={{ referrer: window.location.href }} color="black">
@@ -37,6 +39,9 @@ const supportLink = (chunks: ReactNode, path: string) => (
 
 export const clientLoader: ClientLoaderFunction = ({ request }) => {
   const logger = getLogger();
+
+  removeFromSessionStorage(TALENT_REQUEST_STATE_KEY);
+
   const url = new URL(request.url);
   const from = url.searchParams.get("from");
   if (from && (urlMatchesAppHostName(from) || from.startsWith("/"))) {

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.test.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.test.tsx
@@ -15,7 +15,8 @@ import { makeFragmentData } from "@gc-digital-talent/graphql";
 import richTextElements from "@gc-digital-talent/rich-text-elements";
 import { setInSessionStorage } from "@gc-digital-talent/storage";
 
-import { TALENT_REQUEST_STATE_KEY } from "../../SearchPage/hooks";
+import { TALENT_REQUEST_STATE_KEY } from "~/constants/storageKeys";
+
 import {
   RequestForm,
   RequestFormClassification_Fragment,

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -57,11 +57,9 @@ import type {
 } from "~/types/talentRequestForm";
 import talentRequestMessages from "~/messages/talentRequestMessages";
 import { getBasicFullNameLabel } from "~/utils/nameUtils";
+import { TALENT_REQUEST_STATE_KEY } from "~/constants/storageKeys";
 
-import {
-  TALENT_REQUEST_STATE_KEY,
-  useTalentRequestState,
-} from "../../SearchPage/hooks";
+import { useTalentRequestState } from "../../SearchPage/hooks";
 
 const directiveLink = (chunks: ReactNode, href: string) => (
   <Link href={href} newTab>

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.test.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.test.tsx
@@ -11,7 +11,8 @@ import {
 import { WorkRegion } from "@gc-digital-talent/graphql";
 import { setInSessionStorage } from "@gc-digital-talent/storage";
 
-import { TALENT_REQUEST_STATE_KEY } from "../hooks";
+import { TALENT_REQUEST_STATE_KEY } from "~/constants/storageKeys";
+
 import { SearchForm } from "./SearchForm";
 
 const classifications = fakeClassifications();

--- a/apps/web/src/pages/SearchRequests/SearchPage/hooks.ts
+++ b/apps/web/src/pages/SearchRequests/SearchPage/hooks.ts
@@ -13,10 +13,9 @@ import { graphql } from "@gc-digital-talent/graphql";
 import { useSessionStorage } from "@gc-digital-talent/storage";
 
 import type { FormValues } from "~/types/talentRequestForm";
+import { TALENT_REQUEST_STATE_KEY } from "~/constants/storageKeys";
 
 import { applicantFilterToQueryArgs, dataToFormValues } from "./utils";
-
-export const TALENT_REQUEST_STATE_KEY = "talentRequestState";
 
 interface TalentRequestState {
   applicantFilter?: ApplicantFilterInput;


### PR DESCRIPTION
🤖 Resolves #17723 

## 👋 Introduction

- Removes talent request state session storage on sign out

## 🧪 Testing

1. Build front-end `pnpm dev:fresh`
2. Build a request, but don't submit it. Instead, go back to search page and sign out.
3. Then sign back in.
4. Ensure the search filters are empty.
