### PR TITLE
[Copy] Removes possessive pronoun from search your skills

### DIFF
--- a/apps/web/src/components/SkillsPortfolioTable/SkillPortfolioTable.tsx
+++ b/apps/web/src/components/SkillsPortfolioTable/SkillPortfolioTable.tsx
@@ -282,8 +282,8 @@ const SkillPortfolioTable = ({
       }
       search={{
         label: intl.formatMessage({
-          defaultMessage: "Search your skills",
-          id: "bBIZ3a",
+          defaultMessage: "Search skills",
+          id: "r8mT7a",
           description: "Label for the skill library table search input",
         }),
         internal: true,

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -9582,10 +9582,6 @@
     "defaultMessage": "Nous traitons les billets pendant les heures normales de travail. Si vous signalez un problème tard le soir, juste avant la date limite d’une annonce d’emploi, attendez vous à une réponse dans les deux jours ouvrables. Pour éviter les problèmes de dernière minute, nous vous encourageons à soumettre votre demande le plus tôt possible.",
     "description": "Text explaining the average time spent on applications"
   },
-  "bBIZ3a": {
-    "defaultMessage": "Recherchez vos compétences",
-    "description": "Label for the skill library table search input"
-  },
   "bDmp5T": {
     "defaultMessage": "Vous élaborez votre parcours professionnel en décrivant <strong>vos expériences professionnelles</strong>, <strong>vos études</strong>, <strong>votre participation à la vie communautaire</strong>, <strong>votre apprentissage personnel</strong>, et <strong>les récompenses </strong> que vous avez reçues. Dans une étape ultérieure, vous utiliserez ces expériences pour mettre en valeur vos compétences. Vous pouvez commencer à ajouter des expériences à votre parcours professionnel en sélectionnant le lien « <strong>Ajouter une nouvelle expérience</strong> ».",
     "description": "Application step to begin working on career timeline, paragraph two"
@@ -9641,10 +9637,6 @@
   "bSFeLf": {
     "defaultMessage": "Processus fermé avec succès!",
     "description": "Message displayed to user after pool is closed"
-  },
-  "bShedV": {
-    "defaultMessage": "Veuillez ajouter au moins une possibilité de perfectionnement parmi lesquelles les personnes proposant des nominations pourront faire un choix.",
-    "description": "Message to add at least one development opportunity"
   },
   "bTkYfa": {
     "defaultMessage": "80 612 $ à 102 712 $ · (classification AS ou équivalente)",
@@ -13665,6 +13657,10 @@
   "r7lf0k": {
     "defaultMessage": "Aucun nom de famille fourni",
     "description": "Fallback for last name value"
+  },
+  "r8mT7a": {
+    "defaultMessage": "Rechercher les compétences",
+    "description": "Label for the skill library table search input"
   },
   "rAK3Dh": {
     "defaultMessage": "La mise à jour des informations sur le compte a échoué.",


### PR DESCRIPTION
🤖 Resolves #16346.

## 👋 Introduction

This PR removes the possessive pronoun your from the string Search your skills.

## 🧪 Testing

1. `pnpm build:fresh`
2. Navigate to a user as admin@test.com
3. Navigate to the Skills tab
4. Verify label for the Skills portfolio search input is Search skills

## 📸 Screenshots

<img width="1350" height="927" alt="Screenshot 2026-08-18 at 10 32 31" src="https://github.com/user-attachments/assets/fc90cddc-ebef-4b73-aea3-25154af8a801" />

<img width="1345" height="930" alt="Screenshot 2026-08-18 at 10 32 16" src="https://github.com/user-attachments/assets/e4315dcb-0947-44f0-932a-f94b82ccc986" />