### PR TITLE
[Refactor] Remove full graphql object types 11

### DIFF
--- a/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -9,7 +9,6 @@ import { Chip, Chips, Ul } from "@gc-digital-talent/ui";
 import {
   getEmploymentDuration,
   getOperationalRequirement,
-  getLocale,
   commonMessages,
   getLocalizedName,
 } from "@gc-digital-talent/i18n";
@@ -41,7 +40,6 @@ const ApplicantFilters = ({
   flexibleWorkLocationOptions: LocalizedEnumString[];
 }) => {
   const intl = useIntl();
-  const locale = getLocale(intl);
 
   const classifications = applicantFilter?.qualifiedInClassifications ?? [];
   const classificationsFromApplicantFilter = classifications
@@ -50,7 +48,7 @@ const ApplicantFilters = ({
 
   const skills: string[] | undefined = applicantFilter?.skills?.map((skill) => {
     return (
-      skill?.name[locale] ??
+      skill?.name?.localized ??
       intl.formatMessage({
         defaultMessage: "Error: skill name not found",
         id: "0T3NB0",

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/ApplicationCareerTimelineEditPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelineEditPage/ApplicationCareerTimelineEditPage.tsx
@@ -2,7 +2,6 @@ import { useIntl } from "react-intl";
 import StarIcon from "@heroicons/react/20/solid/StarIcon";
 
 import { Heading, ThrowNotFound } from "@gc-digital-talent/ui";
-import type { Experience } from "@gc-digital-talent/graphql";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 
 import useRoutes from "~/hooks/useRoutes";
@@ -122,9 +121,7 @@ export const Component = () => {
     true,
   );
 
-  const experiences: Omit<Experience, "user">[] = unpackMaybes(
-    application.user?.experiences,
-  );
+  const experiences = unpackMaybes(application.user?.experiences);
   const experience = experiences?.find((exp) => exp?.id === experienceId);
 
   return application && experience ? (

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
@@ -16,7 +16,6 @@ import {
 import { toast } from "@gc-digital-talent/toast";
 import { ErrorMessage, Field, HiddenInput } from "@gc-digital-talent/forms";
 import { groupBy, notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
-import type { Experience } from "@gc-digital-talent/graphql";
 import { ApplicationStep, makeFragmentData } from "@gc-digital-talent/graphql";
 import { commonMessages } from "@gc-digital-talent/i18n";
 
@@ -435,9 +434,7 @@ export const ApplicationCareerTimeline = ({
 export const Component = () => {
   const { application } = useApplication();
 
-  const experiences: Omit<Experience, "user">[] = unpackMaybes(
-    application.user.experiences,
-  );
+  const experiences = unpackMaybes(application.user.experiences);
 
   return application ? (
     <ApplicationCareerTimeline

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
@@ -12,7 +12,6 @@ import { toast } from "@gc-digital-talent/toast";
 import { RadioGroup } from "@gc-digital-talent/forms";
 import { errorMessages, getLocale } from "@gc-digital-talent/i18n";
 import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
-import type { Experience } from "@gc-digital-talent/graphql";
 import {
   ApplicationStep,
   EducationRequirementOption,
@@ -406,9 +405,7 @@ const ApplicationEducation = ({
 export const Component = () => {
   const { application } = useApplication();
 
-  const experiences: Omit<Experience, "user">[] = unpackMaybes(
-    application.user.experiences,
-  );
+  const experiences = unpackMaybes(application.user.experiences);
 
   return application?.pool ? (
     <ApplicationEducation application={application} experiences={experiences} />

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/LinkCareerTimeline.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/LinkCareerTimeline.tsx
@@ -7,7 +7,6 @@ import type { CheckboxOption } from "@gc-digital-talent/forms";
 import { Checklist } from "@gc-digital-talent/forms";
 import { errorMessages } from "@gc-digital-talent/i18n";
 import { Heading, Link, Ul, Notice } from "@gc-digital-talent/ui";
-import type { Classification } from "@gc-digital-talent/graphql";
 import { EducationRequirementOption } from "@gc-digital-talent/graphql";
 
 import type { SimpleAnyExperience } from "~/utils/experienceUtils";
@@ -78,7 +77,7 @@ interface ExperienceItems {
 }
 
 interface CheckListSectionProps {
-  group?: Classification["group"];
+  group?: string;
   experiences: ExperienceItems;
   path: string;
 }

--- a/apps/web/src/pages/Applications/ApplicationQuestionsPage/ApplicationQuestionsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsPage/ApplicationQuestionsPage.tsx
@@ -173,7 +173,11 @@ const ApplicationQuestions = ({ application }: ApplicationPageProps) => {
                 type="hidden"
                 name={`screeningAnswers.${index}.questionId`}
               />
-              <AnswerInput index={index} question={question} />
+              <AnswerInput
+                index={index}
+                question={question}
+                answerPrefix="screeningAnswers"
+              />
             </Fragment>
           ))}
         </div>
@@ -224,7 +228,11 @@ const ApplicationQuestions = ({ application }: ApplicationPageProps) => {
                 type="hidden"
                 name={`generalAnswers.${index}.questionId`}
               />
-              <AnswerInput index={index} question={question} />
+              <AnswerInput
+                index={index}
+                question={question}
+                answerPrefix="generalAnswers"
+              />
             </Fragment>
           ))}
         </>

--- a/apps/web/src/pages/Applications/ApplicationQuestionsPage/components/AnswerInput.tsx
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsPage/components/AnswerInput.tsx
@@ -7,26 +7,23 @@ import {
   getLocale,
   getLocalizedName,
 } from "@gc-digital-talent/i18n";
-import type {
-  GeneralQuestion,
-  ScreeningQuestion,
-} from "@gc-digital-talent/graphql";
 
 import { FRENCH_WORDS_PER_ENGLISH_WORD } from "~/constants/talentSearchConstants";
+
+import type { AnswerPrefix, ApplicationQuestion } from "../types";
 
 const TEXT_AREA_ROWS = 3;
 const TEXT_AREA_MAX_WORDS_EN = 500;
 
 interface AnswerInputProps {
   index: number;
-  question: ScreeningQuestion | GeneralQuestion;
+  question: ApplicationQuestion;
+  answerPrefix: AnswerPrefix;
 }
 
-const AnswerInput = ({ index, question }: AnswerInputProps) => {
+const AnswerInput = ({ index, question, answerPrefix }: AnswerInputProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
-  const isScreening = question.__typename === "ScreeningQuestion";
-  const answerPrefix = isScreening ? "screeningAnswers" : "generalAnswers";
   const questionId = `${answerPrefix}.${index}.question`;
 
   const wordCountLimits: Record<Locales, number> = {

--- a/apps/web/src/pages/Applications/ApplicationQuestionsPage/types.ts
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsPage/types.ts
@@ -1,3 +1,5 @@
+import type { LocalizedString } from "@gc-digital-talent/graphql";
+
 interface QuestionResponse {
   id: string;
   questionId: string;
@@ -8,4 +10,27 @@ export interface FormValues {
   screeningAnswers: QuestionResponse[];
   generalAnswers: QuestionResponse[];
   action: "continue" | "cancel";
+}
+
+export type AnswerPrefix = "screeningAnswers" | "generalAnswers";
+
+export interface ApplicationQuestion {
+  id: string;
+  question?: LocalizedString | null;
+}
+
+interface ApplicationQuestionRef {
+  id: string;
+}
+
+export interface ApplicationScreeningQuestionResponse {
+  id: string;
+  answer?: string | null;
+  screeningQuestion?: ApplicationQuestionRef | null;
+}
+
+export interface ApplicationGeneralQuestionResponse {
+  id: string;
+  answer?: string | null;
+  generalQuestion?: ApplicationQuestionRef | null;
 }

--- a/apps/web/src/pages/Applications/ApplicationQuestionsPage/utils.ts
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsPage/utils.ts
@@ -1,21 +1,22 @@
 import type {
   CreateGeneralQuestionResponseInput,
-  GeneralQuestion,
-  GeneralQuestionResponse,
-  ScreeningQuestion,
-  ScreeningQuestionResponse,
   UpdateGeneralQuestionResponseInput,
   CreateScreeningQuestionResponseInput,
   UpdateScreeningQuestionResponseInput,
 } from "@gc-digital-talent/graphql";
 
-import type { FormValues } from "./types";
+import type {
+  ApplicationGeneralQuestionResponse,
+  ApplicationQuestion,
+  ApplicationScreeningQuestionResponse,
+  FormValues,
+} from "./types";
 
 export const dataToFormValues = (
-  screeningQuestions: ScreeningQuestion[],
-  screeningResponses: ScreeningQuestionResponse[],
-  generalQuestions: GeneralQuestion[],
-  generalResponses: GeneralQuestionResponse[],
+  screeningQuestions: ApplicationQuestion[],
+  screeningResponses: ApplicationScreeningQuestionResponse[],
+  generalQuestions: ApplicationQuestion[],
+  generalResponses: ApplicationGeneralQuestionResponse[],
 ): FormValues => {
   return {
     action: "continue",
@@ -46,8 +47,8 @@ export const dataToFormValues = (
 
 export const formValuesToSubmitData = (
   formValues: FormValues,
-  existingScreeningResponses: ScreeningQuestionResponse[],
-  existingGeneralResponses: GeneralQuestionResponse[],
+  existingScreeningResponses: ApplicationScreeningQuestionResponse[],
+  existingGeneralResponses: ApplicationGeneralQuestionResponse[],
 ) => {
   let screeningCreate: CreateScreeningQuestionResponseInput[] = [];
   let screeningUpdate: UpdateScreeningQuestionResponseInput[] = [];

--- a/apps/web/src/pages/Applications/ApplicationSkillsPage/components/SkillDescriptionAccordion.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsPage/components/SkillDescriptionAccordion.tsx
@@ -2,10 +2,16 @@ import { useIntl } from "react-intl";
 
 import { Accordion } from "@gc-digital-talent/ui";
 import { getLocalizedName } from "@gc-digital-talent/i18n";
-import type { Skill } from "@gc-digital-talent/graphql";
+import type { LocalizedString } from "@gc-digital-talent/graphql";
+
+interface AccordionSkill {
+  id: string;
+  name: LocalizedString;
+  description?: LocalizedString | null;
+}
 
 interface SkillDescriptionAccordionProps {
-  skills: Skill[];
+  skills: AccordionSkill[];
 }
 
 const SkillDescriptionAccordion = ({

--- a/apps/web/src/pages/Applications/educationStep/educationStepValidation.tsx
+++ b/apps/web/src/pages/Applications/educationStep/educationStepValidation.tsx
@@ -1,15 +1,13 @@
-import type {
-  Pool,
-  Application_PoolCandidateFragment as ApplicationPoolCandidateFragmentType,
-} from "@gc-digital-talent/graphql";
+import type { Application_PoolCandidateFragment as ApplicationPoolCandidateFragmentType } from "@gc-digital-talent/graphql";
 import { EducationRequirementOption } from "@gc-digital-talent/graphql";
 
+import type { ApplicationStepPool } from "~/types/applicationStep";
 import type { ExperienceForDate } from "~/types/experience";
 import { isEducationExperience } from "~/utils/experienceUtils";
 
 const stepHasError = (
   _user: ApplicationPoolCandidateFragmentType["user"],
-  _pool: Omit<Pool, "activities" | "teamId" | "wasClosedEarly">,
+  _pool: ApplicationStepPool,
   application: ApplicationPoolCandidateFragmentType,
 ) => {
   return (

--- a/apps/web/src/pages/Applications/profileStep/profileStepValidation.tsx
+++ b/apps/web/src/pages/Applications/profileStep/profileStepValidation.tsx
@@ -1,9 +1,9 @@
-import type {
-  Application_PoolCandidateFragment,
-  Pool,
-} from "@gc-digital-talent/graphql";
+import type { Application_PoolCandidateFragment } from "@gc-digital-talent/graphql";
 
-import type { ApplicationBrowserState } from "~/types/applicationStep";
+import type {
+  ApplicationBrowserState,
+  ApplicationStepPool,
+} from "~/types/applicationStep";
 import type {
   PartialUserAbout,
   PartialUserDei,
@@ -30,7 +30,7 @@ interface PartialUser
 
 const stepHasError = (
   user: PartialUser,
-  pool: Omit<Pool, "activities" | "teamId" | "wasClosedEarly">,
+  pool: ApplicationStepPool,
   _application: Application_PoolCandidateFragment | null | undefined,
   browserState: ApplicationBrowserState | null | undefined,
 ) => {

--- a/apps/web/src/pages/Applications/questionsStep/questionsStepValidation.tsx
+++ b/apps/web/src/pages/Applications/questionsStep/questionsStepValidation.tsx
@@ -1,8 +1,6 @@
-import type {
-  Pool,
-  Application_PoolCandidateFragment as ApplicationPoolCandidateFragmentType,
-} from "@gc-digital-talent/graphql";
+import type { Application_PoolCandidateFragment as ApplicationPoolCandidateFragmentType } from "@gc-digital-talent/graphql";
 
+import type { ApplicationStepPool } from "~/types/applicationStep";
 import {
   generalQuestionsSectionHasMissingResponses,
   screeningQuestionsSectionHasMissingResponses,
@@ -10,7 +8,7 @@ import {
 
 const stepHasError = (
   _user: ApplicationPoolCandidateFragmentType["user"],
-  pool: Omit<Pool, "activities" | "teamId" | "wasClosedEarly">,
+  pool: ApplicationStepPool,
   application: ApplicationPoolCandidateFragmentType,
 ) => {
   return (

--- a/apps/web/src/pages/Applications/reviewStep/reviewStepValidation.tsx
+++ b/apps/web/src/pages/Applications/reviewStep/reviewStepValidation.tsx
@@ -1,11 +1,10 @@
-import type {
-  Pool,
-  Application_PoolCandidateFragment as ApplicationPoolCandidateFragmentType,
-} from "@gc-digital-talent/graphql";
+import type { Application_PoolCandidateFragment as ApplicationPoolCandidateFragmentType } from "@gc-digital-talent/graphql";
+
+import type { ApplicationStepPool } from "~/types/applicationStep";
 
 const stepHasError = (
   _user: ApplicationPoolCandidateFragmentType["user"],
-  _pool: Omit<Pool, "activities" | "teamId" | "wasClosedEarly">,
+  _pool: ApplicationStepPool,
   application: ApplicationPoolCandidateFragmentType,
 ) => {
   return !application.signature;

--- a/apps/web/src/pages/Applications/skillsStep/skillsStepValidation.tsx
+++ b/apps/web/src/pages/Applications/skillsStep/skillsStepValidation.tsx
@@ -1,18 +1,14 @@
-import type {
-  Pool,
-  Experience,
-  Application_PoolCandidateFragment as ApplicationPoolCandidateFragmentType,
-} from "@gc-digital-talent/graphql";
+import type { Application_PoolCandidateFragment as ApplicationPoolCandidateFragmentType } from "@gc-digital-talent/graphql";
 import { notEmpty } from "@gc-digital-talent/helpers";
 
+import type { ApplicationStepPool } from "~/types/applicationStep";
 import { skillRequirementsIsIncomplete } from "~/validators/profile";
 
 const stepHasError = (
   user: ApplicationPoolCandidateFragmentType["user"],
-  pool: Omit<Pool, "activities" | "teamId" | "wasClosedEarly">,
+  pool: ApplicationStepPool,
 ) => {
-  const applicantExperiences: Omit<Experience, "user">[] | undefined =
-    user?.experiences?.filter(notEmpty);
+  const applicantExperiences = user?.experiences?.filter(notEmpty);
   return skillRequirementsIsIncomplete(applicantExperiences, pool);
 };
 

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.stories.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.stories.tsx
@@ -29,6 +29,7 @@ import {
   RequestForm,
   RequestFormClassification_Fragment,
   RequestFormDepartment_Fragment,
+  RequestFormSkill_Fragment,
 } from "./RequestForm";
 
 const classifications = fakeClassifications();
@@ -45,6 +46,10 @@ const classificationFragments = classifications.map((classification) =>
   makeFragmentData(classification, RequestFormClassification_Fragment),
 );
 
+const skillFragments = skills.map((skill) =>
+  makeFragmentData(skill, RequestFormSkill_Fragment),
+);
+
 const [applicantFilter] = applicantFilters;
 applicantFilter.skills = [skills[0], skills[1]];
 applicantFilter.pools = [pools[0]];
@@ -58,7 +63,7 @@ export default {
     classificationsQuery: classificationFragments,
     applicantFilter,
     pools,
-    skills,
+    skills: skillFragments,
     candidateCount: 10,
     handleCreateTalentRequest: async (data: CreateTalentRequestInput) => {
       await new Promise((resolve) => {

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.test.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.test.tsx
@@ -20,6 +20,7 @@ import {
   RequestForm,
   RequestFormClassification_Fragment,
   RequestFormDepartment_Fragment,
+  RequestFormSkill_Fragment,
 } from "./RequestForm";
 
 const mockClient = {
@@ -34,6 +35,9 @@ const departmentsQuery = fakeDepartments().map((department) =>
 const classificationsQuery = fakeClassifications().map((classification) =>
   makeFragmentData(classification, RequestFormClassification_Fragment),
 );
+const skillsQuery = fakeSkills().map((skill) =>
+  makeFragmentData(skill, RequestFormSkill_Fragment),
+);
 
 const renderRequestForm = () => {
   const router = createMemoryRouter(
@@ -45,7 +49,7 @@ const renderRequestForm = () => {
             departmentsQuery={departmentsQuery}
             classificationsQuery={classificationsQuery}
             communitiesQuery={[]}
-            skills={fakeSkills()}
+            skills={skillsQuery}
             handleCreateTalentRequest={vi.fn()}
           />
         ),

--- a/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
+++ b/apps/web/src/pages/SearchRequests/RequestPage/components/RequestForm.tsx
@@ -35,14 +35,6 @@ import {
 } from "@gc-digital-talent/graphql";
 import type {
   TalentRequestReason,
-  EquitySelections,
-  DepartmentBelongsTo,
-  Classification,
-  OperationalRequirement,
-  Pool,
-  Skill,
-  ApplicantFilter,
-  ApplicantFilterInput,
   FragmentType,
   CreateTalentRequestMutation,
   CreateTalentRequestInput,
@@ -78,26 +70,7 @@ interface FormValues {
   reason: TalentRequestReason;
   additionalComments?: string;
   hrAdvisorEmail?: string;
-  applicantFilter?: {
-    qualifiedInClassifications?: {
-      sync?: (Classification["id"] | null)[];
-    };
-    qualifiedInworkStreams?: ApplicantFilterInput["qualifiedInWorkStreams"];
-    skills?: {
-      sync?: (Skill["id"] | null)[];
-    };
-    hasDiploma?: ApplicantFilterInput["hasDiploma"];
-    positionDuration?: ApplicantFilterInput["positionDuration"];
-    equity?: EquitySelections;
-    languageAbility?: ApplicantFilter["languageAbility"];
-    operationalRequirements?: (OperationalRequirement | null)[];
-    pools?: {
-      sync?: (Pool["id"] | null)[];
-    };
-    locationPreferences?: ApplicantFilterInput["locationPreferences"];
-    flexibleWorkLocations?: ApplicantFilterInput["flexibleWorkLocations"];
-  };
-  department?: DepartmentBelongsTo["connect"];
+  department?: string;
 }
 
 export const RequestFormClassification_Fragment = graphql(/* GraphQL */ `
@@ -107,6 +80,15 @@ export const RequestFormClassification_Fragment = graphql(/* GraphQL */ `
     level
     groupAndLevel
     displayName
+  }
+`);
+
+export const RequestFormSkill_Fragment = graphql(/* GraphQL */ `
+  fragment RequestFormSkill on Skill {
+    id
+    name {
+      localized
+    }
   }
 `);
 
@@ -239,7 +221,7 @@ const RequestOptions_Query = graphql(/* GraphQL */ `
 
 export interface RequestFormProps {
   departmentsQuery: FragmentType<typeof RequestFormDepartment_Fragment>[];
-  skills: Skill[];
+  skills: FragmentType<typeof RequestFormSkill_Fragment>[];
   classificationsQuery: FragmentType<
     typeof RequestFormClassification_Fragment
   >[];
@@ -253,7 +235,7 @@ export interface RequestFormProps {
 
 export const RequestForm = ({
   departmentsQuery,
-  skills,
+  skills: skillsQuery,
   classificationsQuery,
   communitiesQuery,
   defaultUserQuery,
@@ -272,6 +254,7 @@ export const RequestForm = ({
       includeIds: unpackMaybes(applicantFilter?.pools).map(({ id }) => id),
     },
   });
+  const skills = getFragment(RequestFormSkill_Fragment, skillsQuery);
   const classifications = getFragment(
     RequestFormClassification_Fragment,
     classificationsQuery,
@@ -766,19 +749,7 @@ const RequestForm_SearchRequestDataQuery = graphql(/* GraphQL */ `
       ...RequestFormDepartment
     }
     skills {
-      id
-      key
-      name {
-        en
-        fr
-      }
-      category {
-        value
-        label {
-          en
-          fr
-        }
-      }
+      ...RequestFormSkill
     }
     classifications {
       ...RequestFormClassification
@@ -797,8 +768,6 @@ const RequestFormApi = () => {
   const [{ data: lookupData, fetching, error }] = useQuery({
     query: RequestForm_SearchRequestDataQuery,
   });
-
-  const skills: Skill[] = unpackMaybes(lookupData?.skills);
 
   const [, executeTalentRequestMutation] = useMutation(
     CreateTalentRequest_Mutation,
@@ -826,7 +795,7 @@ const RequestFormApi = () => {
           classificationsQuery={unpackMaybes(lookupData?.classifications)}
           departmentsQuery={unpackMaybes(lookupData?.departments)}
           communitiesQuery={unpackMaybes(lookupData?.communities)}
-          skills={skills}
+          skills={unpackMaybes(lookupData?.skills)}
           handleCreateTalentRequest={handleCreateTalentRequest}
           defaultUserQuery={lookupData?.me ?? {}}
         />

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/FormFields.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/FormFields.tsx
@@ -15,15 +15,10 @@ import {
   commonMessages,
   errorMessages,
   getEmploymentEquityGroup,
-  getLocalizedName,
   sortFlexibleWorkLocations,
   sortWorkRegion,
 } from "@gc-digital-talent/i18n";
-import type {
-  Classification,
-  FragmentType,
-  WorkStream,
-} from "@gc-digital-talent/graphql";
+import type { FragmentType } from "@gc-digital-talent/graphql";
 import {
   FlexibleWorkLocation,
   WorkRegion,
@@ -32,6 +27,10 @@ import {
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 import { Link } from "@gc-digital-talent/ui";
 
+import type {
+  TalentRequestClassification,
+  TalentRequestWorkStream,
+} from "~/types/talentRequestForm";
 import { NullSelection } from "~/types/talentRequestForm";
 import SkillBrowser from "~/components/SkillBrowser/SkillBrowser";
 import type { SkillBrowserSkill_Fragment } from "~/components/SkillBrowser/SkillSelection";
@@ -80,9 +79,9 @@ const SearchRequestOptions_Query = graphql(/* GraphQL */ `
 `);
 
 interface FormFieldsProps {
-  classifications: Classification[];
+  classifications: TalentRequestClassification[];
   skills: FragmentType<typeof SkillBrowserSkill_Fragment>[];
-  workStreams: WorkStream[];
+  workStreams: TalentRequestWorkStream[];
 }
 
 const internalLink = (href: string, chunks: ReactNode) => (
@@ -108,7 +107,9 @@ const FormFields = ({
 
   const workStreamOptions = workStreams.map((workStream) => ({
     value: workStream.id,
-    label: getLocalizedName(workStream.name, intl),
+    label:
+      workStream.name?.localized ??
+      intl.formatMessage(commonMessages.notAvailable),
   }));
 
   const languageAbilityOptions = localizedEnumToOptions(

--- a/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
+++ b/apps/web/src/pages/SearchRequests/SearchPage/components/SearchForm.tsx
@@ -13,15 +13,17 @@ import {
 } from "@gc-digital-talent/ui";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
 import type {
-  Classification,
   ApplicantFilterInput,
   FragmentType,
-  WorkStream,
 } from "@gc-digital-talent/graphql";
 import { graphql, TalentRequestSource } from "@gc-digital-talent/graphql";
-import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
+import { commonMessages } from "@gc-digital-talent/i18n";
 
-import type { FormValues } from "~/types/talentRequestForm";
+import type {
+  FormValues,
+  TalentRequestClassification,
+  TalentRequestWorkStream,
+} from "~/types/talentRequestForm";
 import useRoutes from "~/hooks/useRoutes";
 import type { SkillBrowserSkill_Fragment } from "~/components/SkillBrowser/SkillSelection";
 
@@ -51,9 +53,9 @@ const submitOnlyFields: string[] = [
 ] satisfies (keyof FormValues)[];
 
 interface SearchFormProps {
-  classifications: Classification[];
+  classifications: TalentRequestClassification[];
   skills: FragmentType<typeof SkillBrowserSkill_Fragment>[];
-  workStreams: WorkStream[];
+  workStreams: TalentRequestWorkStream[];
 }
 
 export const SearchForm = ({
@@ -129,7 +131,8 @@ export const SearchForm = ({
       workStream.id === applicantFilter?.qualifiedInWorkStreams?.[0]?.id,
   );
   const selectedWorkStreamName = selectedWorkStream
-    ? getLocalizedName(selectedWorkStream.name, intl)
+    ? (selectedWorkStream.name?.localized ??
+      intl.formatMessage(commonMessages.notAvailable))
     : undefined;
 
   const handleSubmit = async (values: FormValues) => {
@@ -296,8 +299,7 @@ const SearchForm_Query = graphql(/* GraphQL */ `
     workStreams(talentSearchable: true) {
       id
       name {
-        en
-        fr
+        localized
       }
     }
     skills {

--- a/apps/web/src/pages/SearchRequests/SearchPage/hooks.ts
+++ b/apps/web/src/pages/SearchRequests/SearchPage/hooks.ts
@@ -5,14 +5,16 @@ import { useQuery } from "urql";
 import { useAnnouncer } from "@gc-digital-talent/ui";
 import type {
   ApplicantFilterInput,
-  Classification,
   CountTalentRequestMatchesQuery,
   SearchResultCard_PoolFragment,
 } from "@gc-digital-talent/graphql";
 import { graphql } from "@gc-digital-talent/graphql";
 import { useSessionStorage } from "@gc-digital-talent/storage";
 
-import type { FormValues } from "~/types/talentRequestForm";
+import type {
+  FormValues,
+  TalentRequestClassification,
+} from "~/types/talentRequestForm";
 
 import { applicantFilterToQueryArgs, dataToFormValues } from "./utils";
 
@@ -38,7 +40,7 @@ interface UseInitialState {
 }
 
 export const useInitialFilters = (
-  classifications: Pick<Classification, "group" | "level" | "groupAndLevel">[],
+  classifications: TalentRequestClassification[],
 ): UseInitialState => {
   const [{ applicantFilter }] = useTalentRequestState();
 

--- a/apps/web/src/pages/SearchRequests/SearchPage/utils.ts
+++ b/apps/web/src/pages/SearchRequests/SearchPage/utils.ts
@@ -5,16 +5,16 @@ import {
   emptyToNull,
 } from "@gc-digital-talent/helpers";
 import { EmploymentDuration } from "@gc-digital-talent/i18n";
-import type {
-  ApplicantFilterInput,
-  Classification,
-} from "@gc-digital-talent/graphql";
+import type { ApplicantFilterInput } from "@gc-digital-talent/graphql";
 import {
   PositionDuration,
   FlexibleWorkLocation,
 } from "@gc-digital-talent/graphql";
 
-import type { FormValues } from "~/types/talentRequestForm";
+import type {
+  FormValues,
+  TalentRequestClassification,
+} from "~/types/talentRequestForm";
 import { NullSelection } from "~/types/talentRequestForm";
 import { formatClassificationAriaString } from "~/utils/poolUtils";
 import { positionDurationToEmploymentDuration } from "~/utils/talentRequestUtils";
@@ -23,7 +23,7 @@ export const getClassificationAriaLabel = ({
   group,
   level,
   name: genericName,
-}: Pick<Classification, "group" | "level" | "name">) => {
+}: TalentRequestClassification) => {
   const groupAndLevel = formatClassificationAriaString({ group, level });
   const separator = " ";
   const name = emptyToNull(genericName?.localized);
@@ -103,7 +103,7 @@ export const applicantFilterToQueryArgs = (
  */
 export const dataToFormValues = (
   data: ApplicantFilterInput,
-  classifications: Pick<Classification, "group" | "level" | "groupAndLevel">[],
+  classifications: TalentRequestClassification[],
 ): FormValues => {
   const stream = data?.qualifiedInWorkStreams?.find(notEmpty);
   const selected = data?.qualifiedInClassifications?.find(notEmpty);
@@ -147,7 +147,7 @@ export const dataToFormValues = (
  */
 export const formValuesToData = (
   values: FormValues,
-  classifications: Pick<Classification, "group" | "level" | "groupAndLevel">[],
+  classifications: TalentRequestClassification[],
 ): ApplicantFilterInput => {
   const selectedClassification = classifications.find(({ groupAndLevel }) => {
     return groupAndLevel === values.classification;

--- a/apps/web/src/types/applicationStep.ts
+++ b/apps/web/src/types/applicationStep.ts
@@ -2,9 +2,15 @@ import type { IntlShape } from "react-intl";
 
 import type {
   ApplicationStep,
-  Pool,
+  LocalizedString,
+  PoolAreaOfSelection,
+  PoolLanguage,
+  PoolSkillType,
+  PublishingGroup,
+  SkillCategory,
   Application_PoolCandidateFragment as ApplicationPoolCandidateFragmentType,
 } from "@gc-digital-talent/graphql";
+import type { GenericLocalizedEnum } from "@gc-digital-talent/i18n";
 
 import type useRoutes from "~/hooks/useRoutes";
 
@@ -16,6 +22,30 @@ interface GetApplicationStepInfoArgs {
   resourceId?: string;
   intl: IntlShape;
   stepOrdinal?: number;
+}
+
+interface ApplicationStepSkill {
+  id: string;
+  key: string;
+  name: LocalizedString;
+  category: GenericLocalizedEnum<SkillCategory>;
+  description?: LocalizedString | null;
+}
+
+interface ApplicationStepPoolSkill {
+  id: string;
+  type?: GenericLocalizedEnum<PoolSkillType> | null;
+  skill?: ApplicationStepSkill | null;
+}
+
+export interface ApplicationStepPool {
+  id: string;
+  areaOfSelection?: GenericLocalizedEnum<PoolAreaOfSelection> | null;
+  publishingGroup?: GenericLocalizedEnum<PublishingGroup> | null;
+  language?: GenericLocalizedEnum<PoolLanguage> | null;
+  poolSkills?: (ApplicationStepPoolSkill | null)[] | null;
+  generalQuestions?: ({ id: string } | null)[] | null;
+  screeningQuestions?: ({ id: string } | null)[] | null;
 }
 
 export interface ApplicationBrowserState {
@@ -38,7 +68,7 @@ export interface ApplicationStepInfo {
   // Is the applicant valid as far as this step is concerned?
   hasError?: (
     user: ApplicationPoolCandidateFragmentType["user"],
-    pool: Omit<Pool, "activities" | "teamId" | "wasClosedEarly">,
+    pool: ApplicationStepPool,
     application: ApplicationPoolCandidateFragmentType,
     browserState: ApplicationBrowserState | undefined,
   ) => boolean;

--- a/apps/web/src/types/applicationStep.ts
+++ b/apps/web/src/types/applicationStep.ts
@@ -38,14 +38,18 @@ interface ApplicationStepPoolSkill {
   skill?: ApplicationStepSkill | null;
 }
 
+interface ApplicationStepQuestion {
+  id: string;
+}
+
 export interface ApplicationStepPool {
   id: string;
   areaOfSelection?: GenericLocalizedEnum<PoolAreaOfSelection> | null;
   publishingGroup?: GenericLocalizedEnum<PublishingGroup> | null;
   language?: GenericLocalizedEnum<PoolLanguage> | null;
   poolSkills?: (ApplicationStepPoolSkill | null)[] | null;
-  generalQuestions?: ({ id: string } | null)[] | null;
-  screeningQuestions?: ({ id: string } | null)[] | null;
+  generalQuestions?: (ApplicationStepQuestion | null)[] | null;
+  screeningQuestions?: (ApplicationStepQuestion | null)[] | null;
 }
 
 export interface ApplicationBrowserState {

--- a/apps/web/src/types/talentRequestForm.ts
+++ b/apps/web/src/types/talentRequestForm.ts
@@ -1,13 +1,31 @@
 import type {
   ApplicantFilterInput,
+  FlexibleWorkLocation,
   LanguageAbility,
+  LocalizedString,
+  OperationalRequirement,
+  PositionDuration,
+  PublishingGroup,
+  TalentRequestSource,
   UserPoolFilterInput,
-  Classification,
-  ApplicantFilter,
-  Pool,
+  WorkRegion,
 } from "@gc-digital-talent/graphql";
+import type { GenericLocalizedEnum } from "@gc-digital-talent/i18n";
 
 export const NullSelection = "NULL_SELECTION";
+
+export interface TalentRequestClassification {
+  group: string;
+  level: number;
+  groupAndLevel: string;
+  displayName: string;
+  name?: LocalizedString | null;
+}
+
+export interface TalentRequestWorkStream {
+  id: string;
+  name?: LocalizedString | null;
+}
 
 export type FormValues = Pick<
   ApplicantFilterInput,
@@ -26,14 +44,46 @@ export type FormValues = Pick<
   poolCandidates?: UserPoolFilterInput;
   pool?: string;
   communityId?: string;
-  selectedClassifications?: Pick<
-    Classification,
-    "group" | "level" | "groupAndLevel"
-  >[];
+  selectedClassifications?: TalentRequestClassification[];
   count?: number;
 };
 
-export type PartialApplicantFilter = Omit<ApplicantFilter, "pools"> & {
-  pools?:
-    (Omit<Pool, "activities" | "teamId" | "wasClosedEarly"> | null)[] | null;
-};
+interface PartialApplicantFilterSkill {
+  id: string;
+  name?: LocalizedString | null;
+}
+
+interface PartialApplicantFilterPool {
+  id: string;
+  name?: LocalizedString | null;
+  publishingGroup?: GenericLocalizedEnum<PublishingGroup> | null;
+  workStream?: TalentRequestWorkStream | null;
+  classification?: { groupAndLevel: string } | null;
+}
+
+interface PartialApplicantFilterEquity {
+  hasDisability?: boolean | null;
+  isIndigenous?: boolean | null;
+  isVisibleMinority?: boolean | null;
+  isWoman?: boolean | null;
+}
+
+export interface PartialApplicantFilter {
+  __typename?: "ApplicantFilter";
+  id: string;
+  community?: { name?: LocalizedString | null } | null;
+  equity?: PartialApplicantFilterEquity | null;
+  flexibleWorkLocations?:
+    (GenericLocalizedEnum<FlexibleWorkLocation> | null)[] | null;
+  hasDiploma?: boolean | null;
+  languageAbility?: GenericLocalizedEnum<LanguageAbility> | null;
+  locationPreferences?: (GenericLocalizedEnum<WorkRegion> | null)[] | null;
+  operationalRequirements?:
+    (GenericLocalizedEnum<OperationalRequirement> | null)[] | null;
+  pools?: (PartialApplicantFilterPool | null)[] | null;
+  positionDuration?: (PositionDuration | null)[] | null;
+  qualifiedInClassifications?: (TalentRequestClassification | null)[] | null;
+  qualifiedInWorkStreams?: TalentRequestWorkStream[] | null;
+  skills?: (PartialApplicantFilterSkill | null)[] | null;
+  talentSources?: GenericLocalizedEnum<TalentRequestSource>[] | null;
+}

--- a/apps/web/src/validators/profile/about.ts
+++ b/apps/web/src/validators/profile/about.ts
@@ -1,30 +1,41 @@
 import { empty } from "@gc-digital-talent/helpers";
 import type {
-  LocalizedArmedForcesStatus,
-  LocalizedCitizenshipStatus,
-  LocalizedLanguage,
-  Pool,
-  User,
+  ArmedForcesStatus,
+  CitizenshipStatus,
+  Language,
 } from "@gc-digital-talent/graphql";
 import { PoolAreaOfSelection } from "@gc-digital-talent/graphql";
+import type { GenericLocalizedEnum } from "@gc-digital-talent/i18n";
 
-type PartialLanguage = Pick<LocalizedLanguage, "value"> | null;
+interface AboutPool {
+  areaOfSelection?: GenericLocalizedEnum<PoolAreaOfSelection> | null;
+}
 
-export interface PartialUser extends Pick<
-  User,
-  | "firstName"
-  | "lastName"
-  | "email"
-  | "telephone"
-  | "isEmailVerified"
-  | "workEmail"
-  | "isWorkEmailVerified"
-> {
-  preferredLang?: PartialLanguage;
-  preferredLanguageForInterview?: PartialLanguage;
-  preferredLanguageForExam?: PartialLanguage;
-  citizenship?: Pick<LocalizedCitizenshipStatus, "value"> | null;
-  armedForcesStatus?: Pick<LocalizedArmedForcesStatus, "value"> | null;
+interface PartialLanguage {
+  value: Language;
+}
+
+interface PartialCitizenship {
+  value: CitizenshipStatus;
+}
+
+interface PartialArmedForcesStatus {
+  value: ArmedForcesStatus;
+}
+
+export interface PartialUser {
+  firstName?: string | null;
+  lastName?: string | null;
+  email?: string | null;
+  telephone?: string | null;
+  isEmailVerified?: boolean | null;
+  workEmail?: string | null;
+  isWorkEmailVerified?: boolean | null;
+  preferredLang?: PartialLanguage | null;
+  preferredLanguageForInterview?: PartialLanguage | null;
+  preferredLanguageForExam?: PartialLanguage | null;
+  citizenship?: PartialCitizenship | null;
+  armedForcesStatus?: PartialArmedForcesStatus | null;
 }
 
 export function hasAllEmptyFields({
@@ -49,7 +60,7 @@ export function hasAllEmptyFields({
 
 export function hasEmptyRequiredFields(
   applicant: PartialUser,
-  pool?: Pick<Pool, "areaOfSelection"> | null,
+  pool?: AboutPool | null,
   isSpecialApplication?: boolean | null,
 ): boolean {
   let isWorkEmailVerifiedForInternalJobs: boolean | undefined | null = true;

--- a/apps/web/src/validators/profile/about.ts
+++ b/apps/web/src/validators/profile/about.ts
@@ -5,22 +5,13 @@ import type {
   Language,
 } from "@gc-digital-talent/graphql";
 import { PoolAreaOfSelection } from "@gc-digital-talent/graphql";
-import type { GenericLocalizedEnum } from "@gc-digital-talent/i18n";
+import type {
+  GenericLocalizedEnum,
+  LocalizedEnumValue,
+} from "@gc-digital-talent/i18n";
 
 interface AboutPool {
   areaOfSelection?: GenericLocalizedEnum<PoolAreaOfSelection> | null;
-}
-
-interface PartialLanguage {
-  value: Language;
-}
-
-interface PartialCitizenship {
-  value: CitizenshipStatus;
-}
-
-interface PartialArmedForcesStatus {
-  value: ArmedForcesStatus;
 }
 
 export interface PartialUser {
@@ -31,11 +22,11 @@ export interface PartialUser {
   isEmailVerified?: boolean | null;
   workEmail?: string | null;
   isWorkEmailVerified?: boolean | null;
-  preferredLang?: PartialLanguage | null;
-  preferredLanguageForInterview?: PartialLanguage | null;
-  preferredLanguageForExam?: PartialLanguage | null;
-  citizenship?: PartialCitizenship | null;
-  armedForcesStatus?: PartialArmedForcesStatus | null;
+  preferredLang?: LocalizedEnumValue<Language> | null;
+  preferredLanguageForInterview?: LocalizedEnumValue<Language> | null;
+  preferredLanguageForExam?: LocalizedEnumValue<Language> | null;
+  citizenship?: LocalizedEnumValue<CitizenshipStatus> | null;
+  armedForcesStatus?: LocalizedEnumValue<ArmedForcesStatus> | null;
 }
 
 export function hasAllEmptyFields({

--- a/apps/web/src/validators/profile/careerTimeline.ts
+++ b/apps/web/src/validators/profile/careerTimeline.ts
@@ -1,6 +1,8 @@
-import type { Experience } from "@gc-digital-talent/graphql";
+interface Experience {
+  id: string;
+}
 
-type Experiences = Pick<Experience, "id">[] | undefined | null;
+type Experiences = Experience[] | undefined | null;
 
 export function isIncomplete(experiences: Experiences): boolean {
   return !experiences?.length;

--- a/apps/web/src/validators/profile/citizenVeteranPriority.ts
+++ b/apps/web/src/validators/profile/citizenVeteranPriority.ts
@@ -1,17 +1,23 @@
 import { empty } from "@gc-digital-talent/helpers";
 import type {
-  LocalizedArmedForcesStatus,
-  LocalizedCitizenshipStatus,
-  User,
+  ArmedForcesStatus,
+  CitizenshipStatus,
 } from "@gc-digital-talent/graphql";
 
-export type PartialUser = Pick<
-  User,
-  "hasPriorityEntitlement" | "priorityNumber"
-> & {
-  citizenship?: Pick<LocalizedCitizenshipStatus, "value"> | null;
-  armedForcesStatus?: Pick<LocalizedArmedForcesStatus, "value"> | null;
-};
+interface PartialCitizenship {
+  value: CitizenshipStatus;
+}
+
+interface PartialArmedForcesStatus {
+  value: ArmedForcesStatus;
+}
+
+export interface PartialUser {
+  hasPriorityEntitlement?: boolean | null;
+  priorityNumber?: string | null;
+  citizenship?: PartialCitizenship | null;
+  armedForcesStatus?: PartialArmedForcesStatus | null;
+}
 
 export function hasAllEmptyFields({
   hasPriorityEntitlement,

--- a/apps/web/src/validators/profile/citizenVeteranPriority.ts
+++ b/apps/web/src/validators/profile/citizenVeteranPriority.ts
@@ -3,20 +3,13 @@ import type {
   ArmedForcesStatus,
   CitizenshipStatus,
 } from "@gc-digital-talent/graphql";
-
-interface PartialCitizenship {
-  value: CitizenshipStatus;
-}
-
-interface PartialArmedForcesStatus {
-  value: ArmedForcesStatus;
-}
+import type { LocalizedEnumValue } from "@gc-digital-talent/i18n";
 
 export interface PartialUser {
   hasPriorityEntitlement?: boolean | null;
   priorityNumber?: string | null;
-  citizenship?: PartialCitizenship | null;
-  armedForcesStatus?: PartialArmedForcesStatus | null;
+  citizenship?: LocalizedEnumValue<CitizenshipStatus> | null;
+  armedForcesStatus?: LocalizedEnumValue<ArmedForcesStatus> | null;
 }
 
 export function hasAllEmptyFields({

--- a/apps/web/src/validators/profile/diversityEquityInclusion.ts
+++ b/apps/web/src/validators/profile/diversityEquityInclusion.ts
@@ -1,21 +1,26 @@
-import type {
-  User,
-  Pool,
-  LocalizedIndigenousCommunity,
-} from "@gc-digital-talent/graphql";
+import type { IndigenousCommunity } from "@gc-digital-talent/graphql";
 import { PublishingGroup } from "@gc-digital-talent/graphql";
+import type { GenericLocalizedEnum } from "@gc-digital-talent/i18n";
 
-export interface PartialUser extends Pick<
-  User,
-  "isWoman" | "hasDisability" | "isVisibleMinority"
-> {
+interface DiversityEquityInclusionPool {
+  publishingGroup?: GenericLocalizedEnum<PublishingGroup> | null;
+}
+
+interface PartialIndigenousCommunity {
+  value: IndigenousCommunity;
+}
+
+export interface PartialUser {
+  isWoman?: boolean | null;
+  hasDisability?: boolean | null;
+  isVisibleMinority?: boolean | null;
   indigenousCommunities?:
-    (Pick<LocalizedIndigenousCommunity, "value"> | null | undefined)[] | null;
+    (PartialIndigenousCommunity | null | undefined)[] | null;
 }
 
 export function hasEmptyRequiredFields(
   applicant: PartialUser,
-  pool?: Pick<Pool, "publishingGroup"> | null,
+  pool?: DiversityEquityInclusionPool | null,
 ): boolean {
   if (!(pool?.publishingGroup?.value === PublishingGroup.Iap)) {
     return false;

--- a/apps/web/src/validators/profile/diversityEquityInclusion.ts
+++ b/apps/web/src/validators/profile/diversityEquityInclusion.ts
@@ -1,13 +1,12 @@
 import type { IndigenousCommunity } from "@gc-digital-talent/graphql";
 import { PublishingGroup } from "@gc-digital-talent/graphql";
-import type { GenericLocalizedEnum } from "@gc-digital-talent/i18n";
+import type {
+  GenericLocalizedEnum,
+  LocalizedEnumValue,
+} from "@gc-digital-talent/i18n";
 
 interface DiversityEquityInclusionPool {
   publishingGroup?: GenericLocalizedEnum<PublishingGroup> | null;
-}
-
-interface PartialIndigenousCommunity {
-  value: IndigenousCommunity;
 }
 
 export interface PartialUser {
@@ -15,7 +14,7 @@ export interface PartialUser {
   hasDisability?: boolean | null;
   isVisibleMinority?: boolean | null;
   indigenousCommunities?:
-    (PartialIndigenousCommunity | null | undefined)[] | null;
+    (LocalizedEnumValue<IndigenousCommunity> | null | undefined)[] | null;
 }
 
 export function hasEmptyRequiredFields(

--- a/apps/web/src/validators/profile/generalQuestions.ts
+++ b/apps/web/src/validators/profile/generalQuestions.ts
@@ -1,11 +1,24 @@
 import { notEmpty } from "@gc-digital-talent/helpers";
-import type { Pool, PoolCandidate } from "@gc-digital-talent/graphql";
 
-type PartialPoolCandidate = Pick<PoolCandidate, "generalQuestionResponses">;
+interface GeneralQuestion {
+  id: string;
+}
+
+interface GeneralQuestionResponse {
+  generalQuestion?: GeneralQuestion | null;
+}
+
+interface PartialPoolCandidate {
+  generalQuestionResponses?: (GeneralQuestionResponse | null)[] | null;
+}
+
+interface GeneralQuestionsPool {
+  generalQuestions?: (GeneralQuestion | null)[] | null;
+}
 
 export function hasMissingResponses(
   poolCandidate: PartialPoolCandidate,
-  pool: Omit<Pool, "activities" | "teamId" | "wasClosedEarly"> | null,
+  pool: GeneralQuestionsPool | null,
 ): boolean {
   const poolQuestionIds =
     pool?.generalQuestions

--- a/apps/web/src/validators/profile/languageInformation.ts
+++ b/apps/web/src/validators/profile/languageInformation.ts
@@ -6,24 +6,15 @@ import type {
   Language,
   PoolLanguage,
 } from "@gc-digital-talent/graphql";
-import type { GenericLocalizedEnum } from "@gc-digital-talent/i18n";
+import type {
+  GenericLocalizedEnum,
+  LocalizedEnumValue,
+} from "@gc-digital-talent/i18n";
 
 import { getMissingLanguageRequirements } from "~/utils/languageUtils";
 
 interface LanguageInformationPool {
   language?: GenericLocalizedEnum<PoolLanguage> | null;
-}
-
-interface PartialLanguage {
-  value: Language;
-}
-
-interface PartialEvaluatedLanguage {
-  value: EvaluatedLanguageAbility;
-}
-
-interface PartialEstimatedLanguage {
-  value: EstimatedLanguageAbility;
 }
 
 export interface PartialUser {
@@ -32,13 +23,13 @@ export interface PartialUser {
   lookingForBilingual?: boolean | null;
   secondLanguageExamCompleted?: boolean | null;
   secondLanguageExamValidity?: boolean | null;
-  firstOfficialLanguage?: PartialLanguage | null;
-  estimatedLanguageAbility?: PartialEstimatedLanguage | null;
-  writtenLevel?: PartialEvaluatedLanguage | null;
-  comprehensionLevel?: PartialEvaluatedLanguage | null;
-  verbalLevel?: PartialEvaluatedLanguage | null;
-  preferredLanguageForInterview?: PartialLanguage | null;
-  preferredLanguageForExam?: PartialLanguage | null;
+  firstOfficialLanguage?: LocalizedEnumValue<Language> | null;
+  estimatedLanguageAbility?: LocalizedEnumValue<EstimatedLanguageAbility> | null;
+  writtenLevel?: LocalizedEnumValue<EvaluatedLanguageAbility> | null;
+  comprehensionLevel?: LocalizedEnumValue<EvaluatedLanguageAbility> | null;
+  verbalLevel?: LocalizedEnumValue<EvaluatedLanguageAbility> | null;
+  preferredLanguageForInterview?: LocalizedEnumValue<Language> | null;
+  preferredLanguageForExam?: LocalizedEnumValue<Language> | null;
 }
 
 export function hasAllEmptyFields({

--- a/apps/web/src/validators/profile/languageInformation.ts
+++ b/apps/web/src/validators/profile/languageInformation.ts
@@ -1,39 +1,44 @@
 import isEmpty from "lodash/isEmpty";
 
 import type {
-  User,
-  Pool,
-  LocalizedLanguage,
-  LocalizedEstimatedLanguageAbility,
-  LocalizedEvaluatedLanguageAbility,
+  EstimatedLanguageAbility,
+  EvaluatedLanguageAbility,
+  Language,
+  PoolLanguage,
 } from "@gc-digital-talent/graphql";
+import type { GenericLocalizedEnum } from "@gc-digital-talent/i18n";
 
 import { getMissingLanguageRequirements } from "~/utils/languageUtils";
 
-type PartialLanguage = Pick<LocalizedLanguage, "value"> | null;
-type PartialEvaluatedLanguage = Pick<
-  LocalizedEvaluatedLanguageAbility,
-  "value"
-> | null;
+interface LanguageInformationPool {
+  language?: GenericLocalizedEnum<PoolLanguage> | null;
+}
 
-export interface PartialUser extends Pick<
-  User,
-  | "lookingForEnglish"
-  | "lookingForFrench"
-  | "lookingForBilingual"
-  | "secondLanguageExamCompleted"
-  | "secondLanguageExamValidity"
-> {
-  firstOfficialLanguage?: PartialLanguage;
-  estimatedLanguageAbility?: Pick<
-    LocalizedEstimatedLanguageAbility,
-    "value"
-  > | null;
-  writtenLevel?: PartialEvaluatedLanguage;
-  comprehensionLevel?: PartialEvaluatedLanguage;
-  verbalLevel?: PartialEvaluatedLanguage;
-  preferredLanguageForInterview?: PartialLanguage;
-  preferredLanguageForExam?: PartialLanguage;
+interface PartialLanguage {
+  value: Language;
+}
+
+interface PartialEvaluatedLanguage {
+  value: EvaluatedLanguageAbility;
+}
+
+interface PartialEstimatedLanguage {
+  value: EstimatedLanguageAbility;
+}
+
+export interface PartialUser {
+  lookingForEnglish?: boolean | null;
+  lookingForFrench?: boolean | null;
+  lookingForBilingual?: boolean | null;
+  secondLanguageExamCompleted?: boolean | null;
+  secondLanguageExamValidity?: boolean | null;
+  firstOfficialLanguage?: PartialLanguage | null;
+  estimatedLanguageAbility?: PartialEstimatedLanguage | null;
+  writtenLevel?: PartialEvaluatedLanguage | null;
+  comprehensionLevel?: PartialEvaluatedLanguage | null;
+  verbalLevel?: PartialEvaluatedLanguage | null;
+  preferredLanguageForInterview?: PartialLanguage | null;
+  preferredLanguageForExam?: PartialLanguage | null;
 }
 
 export function hasAllEmptyFields({
@@ -83,7 +88,7 @@ export function hasEmptyRequiredFields({
 
 export function hasUnsatisfiedRequirements(
   user: PartialUser,
-  pool: Pick<Pool, "language"> | null,
+  pool: LanguageInformationPool | null,
 ): boolean {
   return (
     getMissingLanguageRequirements(user, {

--- a/apps/web/src/validators/profile/screeningQuestions.ts
+++ b/apps/web/src/validators/profile/screeningQuestions.ts
@@ -1,11 +1,24 @@
 import { notEmpty } from "@gc-digital-talent/helpers";
-import type { Pool, PoolCandidate } from "@gc-digital-talent/graphql";
 
-type PartialPoolCandidate = Pick<PoolCandidate, "screeningQuestionResponses">;
+interface ScreeningQuestion {
+  id: string;
+}
+
+interface ScreeningQuestionResponse {
+  screeningQuestion?: ScreeningQuestion | null;
+}
+
+interface PartialPoolCandidate {
+  screeningQuestionResponses?: (ScreeningQuestionResponse | null)[] | null;
+}
+
+interface ScreeningQuestionsPool {
+  screeningQuestions?: (ScreeningQuestion | null)[] | null;
+}
 
 export function hasMissingResponses(
   poolCandidate: PartialPoolCandidate,
-  pool: Omit<Pool, "activities" | "teamId" | "wasClosedEarly"> | null,
+  pool: ScreeningQuestionsPool | null,
 ): boolean {
   const poolQuestionIds =
     pool?.screeningQuestions

--- a/apps/web/src/validators/profile/skillRequirements.ts
+++ b/apps/web/src/validators/profile/skillRequirements.ts
@@ -1,6 +1,7 @@
 import { notEmpty } from "@gc-digital-talent/helpers";
-import type { Pool } from "@gc-digital-talent/graphql";
+import type { LocalizedString } from "@gc-digital-talent/graphql";
 import { SkillCategory, PoolSkillType } from "@gc-digital-talent/graphql";
+import type { GenericLocalizedEnum } from "@gc-digital-talent/i18n";
 
 import type { AddedSkill } from "~/utils/skillUtils";
 import {
@@ -14,9 +15,26 @@ interface ApplicantExperience {
   skills?: AddedSkill[] | null;
 }
 
+interface RequiredSkill {
+  id: string;
+  key: string;
+  name: LocalizedString;
+  category: GenericLocalizedEnum<SkillCategory>;
+}
+
+interface RequiredPoolSkill {
+  id: string;
+  type?: GenericLocalizedEnum<PoolSkillType> | null;
+  skill?: RequiredSkill | null;
+}
+
+interface SkillRequirementPool {
+  poolSkills?: (RequiredPoolSkill | null)[] | null;
+}
+
 export function isIncomplete(
   applicantExperiences: ApplicantExperience[] | null | undefined,
-  pool: Omit<Pool, "activities" | "teamId" | "wasClosedEarly">,
+  pool: SkillRequirementPool,
 ): boolean {
   const poolEssentialTechnicalSkills = filterSkillsByCategory(
     filterPoolSkillsByType(pool.poolSkills, PoolSkillType.Essential),

--- a/apps/web/src/validators/profile/skillRequirements.ts
+++ b/apps/web/src/validators/profile/skillRequirements.ts
@@ -10,6 +10,7 @@ import {
 } from "~/utils/skillUtils";
 
 interface ApplicantExperience {
+  id: string;
   skills?: AddedSkill[] | null;
 }
 

--- a/apps/web/src/validators/profile/workPreferences.ts
+++ b/apps/web/src/validators/profile/workPreferences.ts
@@ -6,27 +6,17 @@ import type {
   WorkRegion,
 } from "@gc-digital-talent/graphql";
 import { FlexibleWorkLocation } from "@gc-digital-talent/graphql";
-
-interface PartialWorkRegion {
-  value: WorkRegion;
-}
-
-interface PartialFlexibleWorkLocation {
-  value: FlexibleWorkLocation;
-}
-
-interface PartialProvinceOrTerritory {
-  value: ProvinceOrTerritory;
-}
+import type { LocalizedEnumValue } from "@gc-digital-talent/i18n";
 
 export interface PartialUser {
   positionDuration?: (PositionDuration | null)[] | null;
   locationExemptions?: string | null;
   currentCity?: string | null;
-  locationPreferences?: (PartialWorkRegion | null | undefined)[] | null;
+  locationPreferences?:
+    (LocalizedEnumValue<WorkRegion> | null | undefined)[] | null;
   flexibleWorkLocations?:
-    (PartialFlexibleWorkLocation | null | undefined)[] | null;
-  currentProvince?: PartialProvinceOrTerritory | null;
+    (LocalizedEnumValue<FlexibleWorkLocation> | null | undefined)[] | null;
+  currentProvince?: LocalizedEnumValue<ProvinceOrTerritory> | null;
 }
 
 export function hasAllEmptyFields({

--- a/apps/web/src/validators/profile/workPreferences.ts
+++ b/apps/web/src/validators/profile/workPreferences.ts
@@ -1,22 +1,32 @@
 import isEmpty from "lodash/isEmpty";
 
 import type {
-  LocalizedFlexibleWorkLocation,
-  LocalizedProvinceOrTerritory,
-  LocalizedWorkRegion,
-  User,
+  PositionDuration,
+  ProvinceOrTerritory,
+  WorkRegion,
 } from "@gc-digital-talent/graphql";
 import { FlexibleWorkLocation } from "@gc-digital-talent/graphql";
 
-export interface PartialUser extends Pick<
-  User,
-  "positionDuration" | "locationExemptions" | "currentCity"
-> {
-  locationPreferences?:
-    (Pick<LocalizedWorkRegion, "value"> | null | undefined)[] | null;
+interface PartialWorkRegion {
+  value: WorkRegion;
+}
+
+interface PartialFlexibleWorkLocation {
+  value: FlexibleWorkLocation;
+}
+
+interface PartialProvinceOrTerritory {
+  value: ProvinceOrTerritory;
+}
+
+export interface PartialUser {
+  positionDuration?: (PositionDuration | null)[] | null;
+  locationExemptions?: string | null;
+  currentCity?: string | null;
+  locationPreferences?: (PartialWorkRegion | null | undefined)[] | null;
   flexibleWorkLocations?:
-    (Pick<LocalizedFlexibleWorkLocation, "value"> | null | undefined)[] | null;
-  currentProvince?: Pick<LocalizedProvinceOrTerritory, "value"> | null;
+    (PartialFlexibleWorkLocation | null | undefined)[] | null;
+  currentProvince?: PartialProvinceOrTerritory | null;
 }
 
 export function hasAllEmptyFields({

--- a/packages/i18n/src/index.tsx
+++ b/packages/i18n/src/index.tsx
@@ -62,6 +62,7 @@ import {
 import {
   type MaybeLocalizedEnums,
   type GenericLocalizedEnum,
+  type LocalizedEnumValue,
   enumInputToLocalizedEnum,
   getLocalizedEnumByValue,
   getLocalizedEnumStringByValue,
@@ -174,6 +175,7 @@ export type {
   Messages,
   MaybeLocalizedEnums,
   GenericLocalizedEnum,
+  LocalizedEnumValue,
   TEmploymentDuration,
 };
 export { fr };

--- a/packages/i18n/src/utils/enum.ts
+++ b/packages/i18n/src/utils/enum.ts
@@ -38,6 +38,8 @@ export interface GenericLocalizedEnum<T> {
   label: LocalizedString;
 }
 
+export type LocalizedEnumValue<T> = Pick<GenericLocalizedEnum<T>, "value">;
+
 /**
  * Retrieve the full localized enum from an array
  * of them based of a value


### PR DESCRIPTION
Related: #17227 

## 👋 Introduction

Removes full object types from the applicaitons and talent request sections.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as any user
3. Confirm no regressions in submitting an application
4. Confirm no regression in submitting a talent request