### PR TITLE
[Fix] CSP nonce hydration error

### DIFF
--- a/apps/web/src/root.tsx
+++ b/apps/web/src/root.tsx
@@ -9,6 +9,7 @@ import "~/assets/css/tailwind.css";
 
 import type { Route } from "./+types/root";
 import RootErrorBoundary from "./components/Layout/RouteErrorBoundary/RootErrorBoundary";
+import { getDocumentNonce } from "./utils/csp";
 import { makeServerConfigJS } from "./utils/runtime";
 // eslint-disable-next-line import/extensions
 import initTheme from "./utils/initTheme.js?raw";
@@ -125,14 +126,13 @@ interface LayoutProps {
 }
 
 export function Layout({ children }: LayoutProps) {
+  const nonce = getDocumentNonce();
+
   return (
     // Suppress hydration warning coming from `initTheme.js` when running watch mode
     <html lang="en" suppressHydrationWarning>
       <head>
-        <script
-          nonce="**CSP_NONCE**"
-          dangerouslySetInnerHTML={{ __html: initTheme }}
-        />
+        <script nonce={nonce} dangerouslySetInnerHTML={{ __html: initTheme }} />
         <meta charSet="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="msapplication-TileColor" content="#9747FF" />
@@ -144,13 +144,13 @@ export function Layout({ children }: LayoutProps) {
           content="$APP_URL/images/digital-talent/banner.jpg"
         />
         <Meta />
-        <Links nonce="**CSP_NONCE**" />
+        <Links nonce={nonce} />
       </head>
       <body className="bg-[#EEF1F9] font-sans text-black dark:bg-gray-700 dark:text-white">
         <div className="isolate">{children}</div>
 
         <ScrollRestoration
-          nonce="**CSP_NONCE**"
+          nonce={nonce}
           getKey={(location) => {
             // if there's a hash then use default behavior since the ScrollToLink will be handling scrolling
             if (location.hash) {
@@ -160,10 +160,10 @@ export function Layout({ children }: LayoutProps) {
             return location.pathname;
           }}
         />
-        <Scripts nonce="**CSP_NONCE**" />
+        <Scripts nonce={nonce} />
 
         <script
-          nonce="**CSP_NONCE**"
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: `
               const filterUnusable = (value) => !value.startsWith("$") && value.length > 0 ? value : undefined;

--- a/apps/web/src/utils/csp.test.ts
+++ b/apps/web/src/utils/csp.test.ts
@@ -1,6 +1,6 @@
 import { getNonce, setNonce } from "get-nonce";
 
-import { applyCspNonce } from "./csp";
+import { applyCspNonce, getDocumentNonce } from "./csp";
 
 /**
  * Limitation: jsdom has no CSP, so it never blanks the `nonce` content
@@ -34,5 +34,27 @@ describe("applyCspNonce", () => {
     applyCspNonce();
 
     expect(getNonce()).toBeUndefined();
+  });
+});
+
+describe("getDocumentNonce", () => {
+  beforeEach(() => {
+    document.head.innerHTML = "";
+  });
+
+  it("returns the document nonce", () => {
+    addElementWithNonce("abc123");
+
+    expect(getDocumentNonce()).toBe("abc123");
+  });
+
+  it("returns an empty string once a browser has blanked the attribute", () => {
+    addElementWithNonce("");
+
+    expect(getDocumentNonce()).toBe("");
+  });
+
+  it("returns the placeholder when no element has a nonce", () => {
+    expect(getDocumentNonce()).toBe("**CSP_NONCE**");
   });
 });

--- a/apps/web/src/utils/csp.ts
+++ b/apps/web/src/utils/csp.ts
@@ -7,6 +7,14 @@ import { setNonce } from "get-nonce";
  */
 const NONCE_PLACEHOLDER = "**CSP_NONCE**";
 
+const getNonceElement = (): HTMLElement | null => {
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  return document.querySelector<HTMLElement>("[nonce]");
+};
+
 /**
  * Hand the nonce to `react-style-singleton`, which `react-remove-scroll` uses
  * to inject its scroll-lock `<style>` tag when a modal Radix dialog opens.
@@ -18,9 +26,12 @@ const NONCE_PLACEHOLDER = "**CSP_NONCE**";
  * property keeps the real value.
  */
 export const applyCspNonce = (): void => {
-  const nonce = document.querySelector<HTMLElement>("[nonce]")?.nonce;
+  const nonce = getNonceElement()?.nonce;
 
   if (nonce && nonce !== NONCE_PLACEHOLDER) {
     setNonce(nonce);
   }
 };
+
+export const getDocumentNonce = (): string =>
+  getNonceElement()?.getAttribute("nonce") ?? NONCE_PLACEHOLDER;


### PR DESCRIPTION
🤖 Resolves #17634 

## 👋 Introduction

Fixes a hydration error in react the CSP nonce placeholder value.

## 🕵️ Details

We had the placeholder hardcoded into both the built HTML and the JS files. When nginx sent the HTML with the substituted value, it did not match the placeholder value in the JS bundle when react was hydrating it which lead to the error.

This now keeps the placeholder since `document` is not defined in the build so it still contains the placeholder in the HTML for nginx to replace. However, it should no longet be in the JS bundle since it just has code that executes to get the nonce from the HTML. So, there is no longer anything to be mistmatched when react hydrates.

## 🧪 Testing

1. Run the dev sever `pnpm watch`
2. Navigate to any page
3. Confirm no hydration error appears in the console