### PR TITLE
[Bug] Add missing community consent check in nominations excel

### DIFF
--- a/api/app/Traits/Generator/GeneratesCommunityInterestSheet.php
+++ b/api/app/Traits/Generator/GeneratesCommunityInterestSheet.php
@@ -111,7 +111,10 @@ trait GeneratesCommunityInterestSheet
             ->chunk(200, function ($interests) use ($developmentProgramIds, $communityProgramIdsMap) {
                 foreach ($interests as $interest) {
                     $this->writer->addRow($this->row(
-                        $this->buildCommunityInterestRow($interest, $developmentProgramIds, $communityProgramIdsMap)
+                        $this->applyConsentToRow(
+                            $this->buildCommunityInterestRow($interest, $developmentProgramIds, $communityProgramIdsMap),
+                            $interest->user->id
+                        )
                     ));
                 }
             });


### PR DESCRIPTION
🤖 Resolves #17462

## 👋 Introduction

In the Nominations Excel download the Community Interest sheet was missing the `applyConsentToRow` check that every other tab uses. This PR adds the missing check 

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `talent-coordinator@test.com`
3. Navigate to `/admin/talent-events` and select an event with several nominees:
    - one nominee with a functional community (digital community)
    - one nominee with a functional community (financial management)
    - one nominee with no functional communities
4. In a second terminal run `make queue-work`
5. Download the excel file and confirm:
    - [ ] File downloads
 - In the Community Interest Tab
    - [ ] Verify nominees who have consented share their profile data are visible (as Talent Coordinator, you should see nominees with Digital Community)
    - [ ] Verify nominees who have not consented to share their profile no data with is visible.

## 📸 Screenshot

[TestTalentNominationEventactiveEN4_nominations.xlsx](https://github.com/user-attachments/files/31197492/TestTalentNominationEventactiveEN4_nominations.xlsx)

