### PR TITLE
[Refactor] Remove full graphql object types 12

### DIFF
--- a/apps/web/src/pages/EmployeeProfile/components/CareerDevelopmentSection/CareerDevelopmentSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerDevelopmentSection/CareerDevelopmentSection.tsx
@@ -30,11 +30,11 @@ import {
   getLearningOpportunitiesInterest,
   getMentorshipInterest,
   getMentorshipStatus,
+  localizedEnumArrayToInput,
   MentorshipStatus,
 } from "@gc-digital-talent/i18n";
 import type {
   FragmentType,
-  EmployeeProfile,
   UpdateEmployeeProfileInput,
   TimeFrame,
   OrganizationTypeInterest,
@@ -81,41 +81,6 @@ const UpdateEmployeeProfileCareerDevelopment_Mutation = graphql(/* GraphQL */ `
     }
   }
 `);
-
-const dataToFormValues = ({
-  lateralMoveInterest,
-  lateralMoveTimeFrame,
-  lateralMoveOrganizationType,
-  promotionMoveInterest,
-  promotionMoveTimeFrame,
-  promotionMoveOrganizationType,
-  learningOpportunitiesInterest,
-  eligibleRetirementYearKnown,
-  eligibleRetirementYear,
-  mentorshipStatus,
-  mentorshipInterest,
-  execInterest,
-  execCoachingStatus,
-  execCoachingInterest,
-}: EmployeeProfile): FormValues => ({
-  lateralMoveInterest: boolToYesNo(lateralMoveInterest),
-  lateralMoveTimeFrame: lateralMoveTimeFrame?.value,
-  lateralMoveOrganizationType:
-    lateralMoveOrganizationType?.map((x) => x.value) ?? [],
-  promotionMoveInterest: boolToYesNo(promotionMoveInterest),
-  promotionMoveTimeFrame: promotionMoveTimeFrame?.value,
-  promotionMoveOrganizationType:
-    promotionMoveOrganizationType?.map((x) => x.value) ?? [],
-  learningOpportunitiesInterest:
-    learningOpportunitiesInterest?.map((x) => x.value) ?? [],
-  eligibleRetirementYearKnown: boolToYesNo(eligibleRetirementYearKnown),
-  eligibleRetirementYear: eligibleRetirementYear ?? null,
-  mentorshipStatus: mentorshipStatusToFormValues(mentorshipStatus),
-  mentorshipInterest: mentorshipInterest?.map((x) => x.value) ?? [],
-  execInterest: boolToYesNo(execInterest),
-  execCoachingStatus: execCoachingStatusToFormValues(execCoachingStatus),
-  execCoachingInterest: execCoachingInterest?.map((x) => x.value) ?? [],
-});
 
 export interface FormValues extends Pick<
   UpdateEmployeeProfileInput,
@@ -197,7 +162,38 @@ const CareerDevelopmentSection = ({
   };
 
   const methods = useForm<FormValues>({
-    defaultValues: dataToFormValues(employeeProfile),
+    defaultValues: {
+      lateralMoveInterest: boolToYesNo(employeeProfile.lateralMoveInterest),
+      lateralMoveTimeFrame: employeeProfile.lateralMoveTimeFrame?.value,
+      lateralMoveOrganizationType: localizedEnumArrayToInput(
+        employeeProfile.lateralMoveOrganizationType,
+      ),
+      promotionMoveInterest: boolToYesNo(employeeProfile.promotionMoveInterest),
+      promotionMoveTimeFrame: employeeProfile.promotionMoveTimeFrame?.value,
+      promotionMoveOrganizationType: localizedEnumArrayToInput(
+        employeeProfile.promotionMoveOrganizationType,
+      ),
+      learningOpportunitiesInterest: localizedEnumArrayToInput(
+        employeeProfile.learningOpportunitiesInterest,
+      ),
+      eligibleRetirementYearKnown: boolToYesNo(
+        employeeProfile.eligibleRetirementYearKnown,
+      ),
+      eligibleRetirementYear: employeeProfile.eligibleRetirementYear ?? null,
+      mentorshipStatus: mentorshipStatusToFormValues(
+        employeeProfile.mentorshipStatus,
+      ),
+      mentorshipInterest: localizedEnumArrayToInput(
+        employeeProfile.mentorshipInterest,
+      ),
+      execInterest: boolToYesNo(employeeProfile.execInterest),
+      execCoachingStatus: execCoachingStatusToFormValues(
+        employeeProfile.execCoachingStatus,
+      ),
+      execCoachingInterest: localizedEnumArrayToInput(
+        employeeProfile.execCoachingInterest,
+      ),
+    },
   });
   const { watch, resetField, handleSubmit } = methods;
 

--- a/apps/web/src/pages/EmployeeProfile/components/CareerDevelopmentSection/utils.ts
+++ b/apps/web/src/pages/EmployeeProfile/components/CareerDevelopmentSection/utils.ts
@@ -1,8 +1,6 @@
-import type {
-  EmployeeProfile,
-  UpdateEmployeeProfileInput,
-} from "@gc-digital-talent/graphql";
+import type { UpdateEmployeeProfileInput } from "@gc-digital-talent/graphql";
 import { ExecCoaching, graphql, Mentorship } from "@gc-digital-talent/graphql";
+import type { LocalizedEnumValue } from "@gc-digital-talent/i18n";
 import { ExecCoachingStatus, MentorshipStatus } from "@gc-digital-talent/i18n";
 
 import type { FormValues } from "./CareerDevelopmentSection";
@@ -123,7 +121,7 @@ export const EmployeeProfileCareerDevelopment_Fragment = graphql(/* GraphQL */ `
 `);
 
 export const mentorshipStatusToFormValues = (
-  mentorshipStatus: EmployeeProfile["mentorshipStatus"],
+  mentorshipStatus?: LocalizedEnumValue<Mentorship>[] | null,
 ) => {
   if (!mentorshipStatus) return null;
 
@@ -169,7 +167,7 @@ export const mentorshipStatusToData = (
 };
 
 export const execCoachingStatusToFormValues = (
-  execCoachingStatus: EmployeeProfile["execCoachingStatus"],
+  execCoachingStatus?: LocalizedEnumValue<ExecCoaching>[] | null,
 ) => {
   if (!execCoachingStatus) return null;
 

--- a/apps/web/src/pages/EmployeeProfile/components/GoalsWorkStyleSection/GoalsWorkStyleSection.tsx
+++ b/apps/web/src/pages/EmployeeProfile/components/GoalsWorkStyleSection/GoalsWorkStyleSection.tsx
@@ -17,7 +17,7 @@ import {
   formMessages,
   getLocale,
 } from "@gc-digital-talent/i18n";
-import type { FragmentType, EmployeeProfile } from "@gc-digital-talent/graphql";
+import type { FragmentType } from "@gc-digital-talent/graphql";
 import { graphql, getFragment } from "@gc-digital-talent/graphql";
 import { toast } from "@gc-digital-talent/toast";
 import { useAuthorization } from "@gc-digital-talent/auth";
@@ -117,14 +117,12 @@ const GoalsWorkStyleSection = ({
     );
   };
 
-  const dataToFormValues = (initialData: EmployeeProfile): FormValues => ({
-    aboutYou: initialData.aboutYou ?? "",
-    learningGoals: initialData.learningGoals ?? "",
-    workStyle: initialData.workStyle ?? "",
-  });
-
   const methods = useForm<FormValues>({
-    defaultValues: dataToFormValues(employeeProfile),
+    defaultValues: {
+      aboutYou: employeeProfile.aboutYou ?? "",
+      learningGoals: employeeProfile.learningGoals ?? "",
+      workStyle: employeeProfile.workStyle ?? "",
+    },
   });
   const { handleSubmit } = methods;
 

--- a/apps/web/src/pages/JobPosterTemplateAdminPages/components/JobDetailsForm.tsx
+++ b/apps/web/src/pages/JobPosterTemplateAdminPages/components/JobDetailsForm.tsx
@@ -12,7 +12,7 @@ import {
 import type { Locales } from "@gc-digital-talent/i18n";
 import { errorMessages, uiMessages } from "@gc-digital-talent/i18n";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
-import type { Classification, FragmentType } from "@gc-digital-talent/graphql";
+import type { FragmentType } from "@gc-digital-talent/graphql";
 import { getFragment, graphql } from "@gc-digital-talent/graphql";
 
 import { FRENCH_WORDS_PER_ENGLISH_WORD } from "~/constants/talentSearchConstants";
@@ -58,8 +58,8 @@ export interface FormValues {
   keywordsEn: string | null;
   keywordsFr: string | null;
   classification: string | null;
-  classificationGroup: Classification["group"] | null;
-  classificationLevel: Classification["level"] | null;
+  classificationGroup: string | null;
+  classificationLevel: number | null;
   referenceId: string | null;
 }
 

--- a/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
+++ b/apps/web/src/pages/JobPosterTemplates/JobPosterTemplatesPage/JobPosterTemplatesPage.tsx
@@ -21,9 +21,8 @@ import {
   type PreviewMetaData,
 } from "@gc-digital-talent/ui";
 import type {
-  Classification,
+  LocalizedString,
   SupervisoryStatus,
-  WorkStream,
 } from "@gc-digital-talent/graphql";
 import { graphql } from "@gc-digital-talent/graphql";
 import {
@@ -127,10 +126,20 @@ function assertIncludes(haystack: string[], needle?: string | null): boolean {
   return false;
 }
 
+interface PreviewClassification {
+  id: string;
+  groupAndLevel: string;
+}
+
+interface PreviewWorkStream {
+  id: string;
+  name?: LocalizedString | null;
+}
+
 function previewMetaData(
   intl: IntlShape,
-  classification?: Classification | null,
-  workStream?: WorkStream | null,
+  classification?: PreviewClassification | null,
+  workStream?: PreviewWorkStream | null,
 ): PreviewMetaData[] {
   const metaData = [];
   if (classification) {

--- a/packages/i18n/src/utils/enum.ts
+++ b/packages/i18n/src/utils/enum.ts
@@ -150,7 +150,7 @@ export function localizedEnumToInput<T>(
  */
 export function localizedEnumArrayToInput<T>(
   localizedEnumArray?: (GenericLocalizedEnum<T> | null | undefined)[] | null,
-): (T | null | undefined)[] | undefined {
+): T[] {
   return unpackMaybes(
     localizedEnumArray?.map((localizedEnum) =>
       localizedEnumToInput(localizedEnum),


### PR DESCRIPTION
Related: #17227 

## 👋 Introduction

Removes the full graphql object types from the employee profile and job poster templates section of the site.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navcigate to `/employee` and confirm everything functions
4. Navigate to `/job-templates` and confirm everything functions
5. Navigate to `/admin/settings/job-templates` and confirm everytihng functions