### PR TITLE
[Refactor] Moves `rolesAndPermissions` from administration section to resources section

### DIFF
--- a/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
+++ b/apps/web/src/pages/AdminDashboardPage/AdminDashboardPage.tsx
@@ -138,6 +138,16 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
       href: adminRoutes.jobPosterTemplates(),
       roles: [],
     },
+    {
+      label: intl.formatMessage(adminMessages.rolesAndPermissions),
+      href: adminRoutes.rolesAndPermissions(),
+      roles: [
+        ROLE_NAME.PlatformAdmin,
+        ROLE_NAME.CommunityTalentCoordinator,
+        ROLE_NAME.CommunityRecruiter,
+        ROLE_NAME.CommunityAdmin,
+      ],
+    },
   ];
   const resourcesCollectionFiltered = resourcesCollection.filter((item) =>
     hasRolesHandleNoRolesRequired(item.roles, roleAssignments),
@@ -167,16 +177,6 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
       label: intl.formatMessage(adminMessages.developmentPrograms),
       href: adminRoutes.developmentProgramTable(),
       roles: [ROLE_NAME.PlatformAdmin],
-    },
-    {
-      label: intl.formatMessage(adminMessages.rolesAndPermissions),
-      href: adminRoutes.rolesAndPermissions(),
-      roles: [
-        ROLE_NAME.PlatformAdmin,
-        ROLE_NAME.CommunityTalentCoordinator,
-        ROLE_NAME.CommunityRecruiter,
-        ROLE_NAME.CommunityAdmin,
-      ],
     },
     {
       label: intl.formatMessage(navigationMessages.skills),

--- a/apps/web/src/pages/CommunityDashboardPage/CommunityDashboardPage.tsx
+++ b/apps/web/src/pages/CommunityDashboardPage/CommunityDashboardPage.tsx
@@ -138,6 +138,16 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
       href: adminRoutes.jobPosterTemplates(),
       roles: [],
     },
+    {
+      label: intl.formatMessage(adminMessages.rolesAndPermissions),
+      href: adminRoutes.rolesAndPermissions(),
+      roles: [
+        ROLE_NAME.PlatformAdmin,
+        ROLE_NAME.CommunityTalentCoordinator,
+        ROLE_NAME.CommunityRecruiter,
+        ROLE_NAME.CommunityAdmin,
+      ],
+    },
   ];
   const resourcesCollectionFiltered = resourcesCollection.filter((item) =>
     hasRolesHandleNoRolesRequired(item.roles, roleAssignments),
@@ -162,16 +172,6 @@ export const DashboardPage = ({ currentUser }: DashboardPageProps) => {
       label: intl.formatMessage(adminMessages.departments),
       href: adminRoutes.departmentTable(),
       roles: [ROLE_NAME.PlatformAdmin],
-    },
-    {
-      label: intl.formatMessage(adminMessages.rolesAndPermissions),
-      href: adminRoutes.rolesAndPermissions(),
-      roles: [
-        ROLE_NAME.PlatformAdmin,
-        ROLE_NAME.CommunityTalentCoordinator,
-        ROLE_NAME.CommunityRecruiter,
-        ROLE_NAME.CommunityAdmin,
-      ],
     },
     {
       label: intl.formatMessage(navigationMessages.skills),


### PR DESCRIPTION
🤖 Resolves #15898.

## 👋 Introduction

This PR moves `rolesAndPermissions` from administration section to resources section.

## 🧪 Testing

1. `pnpm build`
2. Navigate to http://localhost:8000/en/admin as admin@test.com
3. Switch to admin view
4. Verify `rolesAndPermissions` item is not in administration section but is in resources section
5. Navigate to http://localhost:8000/en/community as admin@test.com
6. Switch to community view
7. Verify `rolesAndPermissions` item is not in administration section but is in resources section

## 📸 Screenshots

<img width="1308" height="939" alt="Screenshot 2026-08-19 at 14 46 05" src="https://github.com/user-attachments/assets/db8675f1-2324-417d-9eff-07873298d81f" />

<img width="1319" height="864" alt="Screenshot 2026-08-19 at 14 45 52" src="https://github.com/user-attachments/assets/8dddaf97-52e0-4940-b277-8ec1de9fb30b" />