### PR TITLE
[Feature] Nomination warnings for non-employees

### DIFF
--- a/api/app/GraphQL/Directives/NullUnlessDirective.php
+++ b/api/app/GraphQL/Directives/NullUnlessDirective.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\GraphQL\Directives;
+
+use Illuminate\Database\Eloquent\Model;
+use Nuwave\Lighthouse\Execution\ResolveInfo;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Nuwave\Lighthouse\Schema\Values\FieldValue;
+use Nuwave\Lighthouse\Support\Contracts\FieldMiddleware;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+
+final class NullUnlessDirective extends BaseDirective implements FieldMiddleware
+{
+    public static function definition(): string
+    {
+        return
+            /** @lang GraphQL */
+            <<<'GRAPHQL'
+"""
+Resolve the field to null unless the given attribute on the parent model is truthy.
+Wraps whatever resolver would otherwise run, so it can be combined with directives
+like @belongsTo to short-circuit before the underlying relation is even queried.
+"""
+directive @nullUnless(
+    """
+    The attribute (or accessor) to check truthiness of on the parent model.
+    """
+    attribute: String!
+) on FIELD_DEFINITION
+GRAPHQL;
+    }
+
+    public function handleField(FieldValue $fieldValue): void
+    {
+        $attribute = $this->directiveArgValue('attribute');
+
+        $fieldValue->wrapResolver(
+            fn (callable $previousResolver): \Closure => function (Model $root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) use ($previousResolver, $attribute) {
+                if (! $root->{$attribute}) {
+                    return null;
+                }
+
+                return $previousResolver($root, $args, $context, $resolveInfo);
+            }
+        );
+    }
+}

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -418,10 +418,18 @@ type BasicGovEmployeeProfile @model(class: "\\App\\Models\\User") {
   workEmail: Email @rename(attribute: "work_email")
   firstName: String @rename(attribute: "first_name")
   lastName: String @rename(attribute: "last_name")
-  preferredLang: LocalizedLanguage @rename(attribute: "preferred_lang")
-  role: String @rename(attribute: "computed_gov_role")
-  department: Department @belongsTo
-  classification: Classification @belongsTo(relation: "currentClassification")
+  preferredLang: LocalizedLanguage
+    @rename(attribute: "preferred_lang")
+    @nullUnless(attribute: "computed_is_gov_employee")
+  role: String
+    @rename(attribute: "computed_gov_role")
+    @nullUnless(attribute: "computed_is_gov_employee")
+  department: Department
+    @belongsTo
+    @nullUnless(attribute: "computed_is_gov_employee")
+  classification: Classification
+    @belongsTo(relation: "currentClassification")
+    @nullUnless(attribute: "computed_is_gov_employee")
 }
 
 # Mini type to support search by work email

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -420,16 +420,16 @@ type BasicGovEmployeeProfile @model(class: "\\App\\Models\\User") {
   lastName: String @rename(attribute: "last_name")
   preferredLang: LocalizedLanguage
     @rename(attribute: "preferred_lang")
-    @nullUnless(attribute: "computed_is_gov_employee")
+    @nullUnless(attribute: "isVerifiedGovEmployee")
   role: String
     @rename(attribute: "computed_gov_role")
-    @nullUnless(attribute: "computed_is_gov_employee")
+    @nullUnless(attribute: "isVerifiedGovEmployee")
   department: Department
     @belongsTo
-    @nullUnless(attribute: "computed_is_gov_employee")
+    @nullUnless(attribute: "isVerifiedGovEmployee")
   classification: Classification
     @belongsTo(relation: "currentClassification")
-    @nullUnless(attribute: "computed_is_gov_employee")
+    @nullUnless(attribute: "isVerifiedGovEmployee")
 }
 
 # Mini type to support search by work email

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -418,6 +418,7 @@ type BasicGovEmployeeProfile @model(class: "\\App\\Models\\User") {
   workEmail: Email @rename(attribute: "work_email")
   firstName: String @rename(attribute: "first_name")
   lastName: String @rename(attribute: "last_name")
+  isVerifiedGovEmployee: Boolean
   preferredLang: LocalizedLanguage
     @rename(attribute: "preferred_lang")
     @nullUnless(attribute: "isVerifiedGovEmployee")

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -419,6 +419,19 @@ type BasicGovEmployeeProfile @model(class: "\\App\\Models\\User") {
   firstName: String @rename(attribute: "first_name")
   lastName: String @rename(attribute: "last_name")
   isVerifiedGovEmployee: Boolean
+  preferredLang: LocalizedLanguage @rename(attribute: "preferred_lang")
+  role: String @rename(attribute: "computed_gov_role")
+  department: Department @belongsTo
+  classification: Classification @belongsTo(relation: "currentClassification")
+}
+
+# Like BasicGovEmployeeProfile but it masks fields when the user isn't a verified employee
+type BasicGovEmployeeProfileMasked @model(class: "\\App\\Models\\User") {
+  id: ID!
+  workEmail: Email @rename(attribute: "work_email")
+  firstName: String @rename(attribute: "first_name")
+  lastName: String @rename(attribute: "last_name")
+  isVerifiedGovEmployee: Boolean
   preferredLang: LocalizedLanguage
     @rename(attribute: "preferred_lang")
     @nullUnless(attribute: "isVerifiedGovEmployee")
@@ -924,14 +937,14 @@ type TalentNomination {
   createdAt: DateTime @rename(attribute: "created_at")
   updatedAt: DateTime @rename(attribute: "updated_at")
   submittedAt: DateTime @rename(attribute: "submitted_at")
-  submitter: BasicGovEmployeeProfile
+  submitter: BasicGovEmployeeProfileMasked
     @belongsTo
     @canModel(ability: "viewAnyBasicGovEmployeeProfile", model: "User")
   submitterRelationshipToNominator: LocalizedTalentNominationSubmitterRelationshipToNominator
     @rename(attribute: "submitter_relationship_to_nominator")
   submitterRelationshipToNominatorOther: String
     @rename(attribute: "submitter_relationship_to_nominator_other")
-  nominator: BasicGovEmployeeProfile
+  nominator: BasicGovEmployeeProfileMasked
     @belongsTo
     @canModel(ability: "viewAnyBasicGovEmployeeProfile", model: "User")
   nominatorFallbackWorkEmail: String
@@ -941,7 +954,7 @@ type TalentNomination {
   nominatorFallbackDepartment: Department @belongsTo
   nominatorReview: LocalizedTalentNominationUserReview
     @rename(attribute: "nominator_review")
-  nominee: BasicGovEmployeeProfile
+  nominee: BasicGovEmployeeProfileMasked
     @belongsTo
     @canModel(ability: "viewAnyBasicGovEmployeeProfile", model: "User")
   nomineeReview: LocalizedTalentNominationUserReview
@@ -957,7 +970,7 @@ type TalentNomination {
   nominateForDevelopmentPrograms: Boolean
     @rename(attribute: "nominate_for_development_programs")
 
-  advancementReference: BasicGovEmployeeProfile
+  advancementReference: BasicGovEmployeeProfileMasked
     @belongsTo
     @canModel(ability: "viewAnyBasicGovEmployeeProfile", model: "User")
   advancementReferenceReview: LocalizedTalentNominationUserReview
@@ -992,7 +1005,7 @@ type TalentNomination {
 type TalentNominationGroup {
   id: UUID!
   createdAt: DateTime @rename(attribute: "created_at")
-  nominee: BasicGovEmployeeProfile
+  nominee: BasicGovEmployeeProfileMasked
     @belongsTo
     @canModel(ability: "viewAnyBasicGovEmployeeProfile", model: "User")
   nominations: [TalentNomination!]

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -418,7 +418,6 @@ type BasicGovEmployeeProfile @model(class: "\\App\\Models\\User") {
   workEmail: Email @rename(attribute: "work_email")
   firstName: String @rename(attribute: "first_name")
   lastName: String @rename(attribute: "last_name")
-  isVerifiedGovEmployee: Boolean
   preferredLang: LocalizedLanguage @rename(attribute: "preferred_lang")
   role: String @rename(attribute: "computed_gov_role")
   department: Department @belongsTo

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1083,6 +1083,7 @@ type BasicGovEmployeeProfile {
   workEmail: Email
   firstName: String
   lastName: String
+  isVerifiedGovEmployee: Boolean
   preferredLang: LocalizedLanguage
   role: String
   department: Department

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1083,6 +1083,17 @@ type BasicGovEmployeeProfile {
   workEmail: Email
   firstName: String
   lastName: String
+  preferredLang: LocalizedLanguage
+  role: String
+  department: Department
+  classification: Classification
+}
+
+type BasicGovEmployeeProfileMasked {
+  id: ID!
+  workEmail: Email
+  firstName: String
+  lastName: String
   isVerifiedGovEmployee: Boolean
   preferredLang: LocalizedLanguage
   role: String
@@ -1470,23 +1481,23 @@ type TalentNomination {
   createdAt: DateTime
   updatedAt: DateTime
   submittedAt: DateTime
-  submitter: BasicGovEmployeeProfile
+  submitter: BasicGovEmployeeProfileMasked
   submitterRelationshipToNominator: LocalizedTalentNominationSubmitterRelationshipToNominator
   submitterRelationshipToNominatorOther: String
-  nominator: BasicGovEmployeeProfile
+  nominator: BasicGovEmployeeProfileMasked
   nominatorFallbackWorkEmail: String
   nominatorFallbackName: String
   nominatorFallbackClassification: Classification
   nominatorFallbackDepartment: Department
   nominatorReview: LocalizedTalentNominationUserReview
-  nominee: BasicGovEmployeeProfile
+  nominee: BasicGovEmployeeProfileMasked
   nomineeReview: LocalizedTalentNominationUserReview
   nomineeRelationshipToNominator: LocalizedTalentNominationNomineeRelationshipToNominator
   nomineeRelationshipToNominatorOther: String
   nominateForAdvancement: Boolean
   nominateForLateralMovement: Boolean
   nominateForDevelopmentPrograms: Boolean
-  advancementReference: BasicGovEmployeeProfile
+  advancementReference: BasicGovEmployeeProfileMasked
   advancementReferenceReview: LocalizedTalentNominationUserReview
   advancementReferenceFallbackWorkEmail: String
   advancementReferenceFallbackName: String
@@ -1509,7 +1520,7 @@ type TalentNomination {
 type TalentNominationGroup {
   id: UUID!
   createdAt: DateTime
-  nominee: BasicGovEmployeeProfile
+  nominee: BasicGovEmployeeProfileMasked
   nominations: [TalentNomination!]
   talentNominationEvent: TalentNominationEvent!
   advancementNominationCount: Int

--- a/api/tests/Feature/TalentNominationGroupTest.php
+++ b/api/tests/Feature/TalentNominationGroupTest.php
@@ -735,4 +735,68 @@ class TalentNominationGroupTest extends TestCase
 
         $this->assertDatabaseEmpty('classification_talent_nomination_group_advancement');
     }
+
+    public function testNomineeClassificationHiddenWhenNotCurrentlyGovEmployee()
+    {
+        // TalentNominationGroup::nominee() has no whereIsVerifiedGovEmployee() scope
+        // (nominees need not be employees), so stale computed_classification data
+        // must be hidden by the BasicGovEmployeeProfile type itself.
+        $community = Community::factory()->create();
+        $talentNominationEvent = TalentNominationEvent::factory()
+            ->for($community)
+            ->create();
+
+        $nominator = $this->makeEmployee('nominator');
+        $nominee = $this->makeEmployee('nominee');
+        $staleClassification = Classification::factory()->create();
+        $nominee->update([
+            'computed_is_gov_employee' => false,
+            'computed_classification' => $staleClassification->id,
+        ]);
+
+        $coordinator = User::factory()
+            ->asApplicant()
+            ->asCommunityTalentCoordinator($community->id)
+            ->create([
+                'email' => 'coordinator@test.com',
+                'computed_is_gov_employee' => true,
+                'work_email' => 'coordinator@gc.ca',
+                'work_email_verified_at' => now(),
+            ]);
+
+        TalentNomination::factory()
+            ->submittedReviewAndSubmit()
+            ->create([
+                'talent_nomination_event_id' => $talentNominationEvent->id,
+                'submitter_id' => $nominator->id,
+                'nominator_id' => $nominator->id,
+                'nominee_id' => $nominee->id,
+            ]);
+
+        $query = <<<'GRAPHQL'
+            query TalentNominationGroupsWithNomineeClassification($talentNominationEventId: UUID!) {
+                talentNominationEvent(id: $talentNominationEventId) {
+                    talentNominationGroups {
+                        nominee {
+                            id
+                            classification { id }
+                        }
+                    }
+                }
+            }
+        GRAPHQL;
+
+        $response = $this->actingAs($coordinator, 'api')
+            ->graphQL($query, [
+                'talentNominationEventId' => $talentNominationEvent->id,
+            ]);
+
+        $response->assertGraphQLErrorFree();
+        $response->assertJsonFragment([
+            'nominee' => [
+                'id' => $nominee->id,
+                'classification' => null,
+            ],
+        ]);
+    }
 }

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
@@ -78,7 +78,7 @@ const DetailsFieldsOptions_Fragment = graphql(/* GraphQL */ `
 `);
 
 const DetailsEmployee_Fragment = graphql(/* GraphQL */ `
-  fragment DetailsEmployee on BasicGovEmployeeProfile {
+  fragment DetailsEmployee on BasicGovEmployeeProfileMasked {
     ...EmployeeSearchResult
   }
 `);

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
@@ -79,7 +79,16 @@ const DetailsFieldsOptions_Fragment = graphql(/* GraphQL */ `
 
 const DetailsEmployee_Fragment = graphql(/* GraphQL */ `
   fragment DetailsEmployee on BasicGovEmployeeProfileMasked {
-    ...EmployeeSearchResult
+    id
+    workEmail
+    firstName
+    lastName
+    role
+    department {
+      name {
+        localized
+      }
+    }
   }
 `);
 

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Nominator.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Nominator.tsx
@@ -58,7 +58,16 @@ interface FormValues extends BaseFormValues {
 
 const NominatorEmployee_Fragment = graphql(/* GraphQL */ `
   fragment NominatorEmployee on BasicGovEmployeeProfileMasked {
-    ...EmployeeSearchResult
+    id
+    workEmail
+    firstName
+    lastName
+    role
+    department {
+      name {
+        localized
+      }
+    }
   }
 `);
 

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Nominator.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Nominator.tsx
@@ -57,7 +57,7 @@ interface FormValues extends BaseFormValues {
 }
 
 const NominatorEmployee_Fragment = graphql(/* GraphQL */ `
-  fragment NominatorEmployee on BasicGovEmployeeProfile {
+  fragment NominatorEmployee on BasicGovEmployeeProfileMasked {
     ...EmployeeSearchResult
   }
 `);

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Nominee.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Nominee.tsx
@@ -160,7 +160,15 @@ const NominateTalentNominee_Fragment = graphql(/* GraphQL */ `
     id
     nominee {
       id
-      ...EmployeeSearchResult
+      workEmail
+      firstName
+      lastName
+      role
+      department {
+        name {
+          localized
+        }
+      }
     }
     nomineeReview {
       value

--- a/apps/web/src/pages/TalentNominations/NominationGroup/CareerExperience.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/CareerExperience.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "urql";
+import type { ComponentProps } from "react";
 
 import type { FragmentType } from "@gc-digital-talent/graphql";
 import { getFragment, graphql } from "@gc-digital-talent/graphql";
@@ -11,6 +12,7 @@ import permissionConstants from "~/constants/permissionConstants";
 import type { RouteParams } from "./types";
 import CurrentPositionExperiences from "./components/CurrentPositionExperiences";
 import FullCareerExperiences from "./components/FullCareerExperiences";
+import type ErrorNotice from "./components/ErrorNotice";
 
 const TalentNominationGroupCareerExperience_Fragment = graphql(/* GraphQL */ `
   fragment TalentNominationGroupCareerExperience on TalentNominationGroup {
@@ -30,7 +32,7 @@ const NomineeExperiences_Query = graphql(/* GraphQL */ `
 
 interface TalentNominationGroupCareerExperienceProps {
   nomineeId: string;
-  shareProfile?: boolean;
+  contentHiddenReason?: null | ComponentProps<typeof ErrorNotice>["reason"];
   talentNominationGroupQuery: FragmentType<
     typeof TalentNominationGroupCareerExperience_Fragment
   >;
@@ -38,13 +40,14 @@ interface TalentNominationGroupCareerExperienceProps {
 
 const TalentNominationGroupCareerExperience = ({
   nomineeId,
-  shareProfile,
+  contentHiddenReason,
   talentNominationGroupQuery,
 }: TalentNominationGroupCareerExperienceProps) => {
+  const contentIsVisible = !contentHiddenReason;
   const [{ data: nomineeData, fetching, error }] = useQuery({
     query: NomineeExperiences_Query,
     variables: { nomineeId },
-    pause: !shareProfile,
+    pause: !contentIsVisible,
   });
 
   const talentNominationGroup = getFragment(
@@ -57,14 +60,14 @@ const TalentNominationGroupCareerExperience = ({
       <Card space="lg" className="mb-6">
         <CurrentPositionExperiences
           query={nomineeData?.user}
-          shareProfile={shareProfile}
+          contentHiddenReason={contentHiddenReason}
         />
       </Card>
       <Card space="lg">
         <FullCareerExperiences
           userQuery={nomineeData?.user}
           talentNominationGroupQuery={talentNominationGroup}
-          shareProfile={shareProfile}
+          contentHiddenReason={contentHiddenReason}
         />
       </Card>
     </Pending>
@@ -78,6 +81,7 @@ const TalentNominationGroupCareerExperience_Query = graphql(/* GraphQL */ `
       consentToShareProfile
       nominee {
         id
+        isVerifiedGovEmployee
       }
     }
   }
@@ -93,14 +97,23 @@ const TalentNominationGroupCareerExperiencePage = () => {
   });
 
   const nomineeId = data?.talentNominationGroup?.nominee?.id;
-  const shareProfile = data?.talentNominationGroup?.consentToShareProfile;
+
+  let contentHiddenReason: ComponentProps<
+    typeof TalentNominationGroupCareerExperience
+  >["contentHiddenReason"] = null;
+  if (!data?.talentNominationGroup?.consentToShareProfile) {
+    contentHiddenReason = "not-shared-with-community";
+  }
+  if (!data?.talentNominationGroup?.nominee?.isVerifiedGovEmployee) {
+    contentHiddenReason = "not-verified-gov-employee";
+  }
 
   return (
     <Pending fetching={fetching} error={error}>
-      {data?.talentNominationGroup && nomineeId && shareProfile !== null ? (
+      {data?.talentNominationGroup && nomineeId ? (
         <TalentNominationGroupCareerExperience
           nomineeId={nomineeId}
-          shareProfile={shareProfile}
+          contentHiddenReason={contentHiddenReason}
           talentNominationGroupQuery={data.talentNominationGroup}
         />
       ) : (

--- a/apps/web/src/pages/TalentNominations/NominationGroup/Profile.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/Profile.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "urql";
-import { useState } from "react";
+import { useState, type ComponentProps } from "react";
 import { useIntl } from "react-intl";
 import UserCircleIcon from "@heroicons/react/24/outline/UserCircleIcon";
 
@@ -12,7 +12,9 @@ import {
   Pending,
   ThrowNotFound,
   Notice,
+  Ul,
 } from "@gc-digital-talent/ui";
+import { assertUnreachable } from "@gc-digital-talent/helpers";
 
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import BasicInformation from "~/components/BasicInformation/BasicInformation";
@@ -45,24 +47,103 @@ const Nominee_Query = graphql(/* GraphQL */ `
   }
 `);
 
+interface ErrorNoticeProps {
+  reason: "not-shared-with-community" | "not-verified-gov-employee";
+}
+
+const ErrorNotice = ({ reason }: ErrorNoticeProps) => {
+  const intl = useIntl();
+
+  if (reason == "not-shared-with-community") {
+    return (
+      <Notice.Root color="error" className="mt-9">
+        <Notice.Title>
+          {intl.formatMessage({
+            defaultMessage:
+              "This nominee has not agreed to share their information with your community",
+            id: "4ujr5X",
+            description: "Null message for nominee profile",
+          })}
+        </Notice.Title>
+        <Notice.Content>
+          <p>
+            {intl.formatMessage({
+              defaultMessage:
+                "Nominees can agree to provide access to their profile using the “Functional communities” tool on their dashboard.",
+              id: "8plD42",
+              description: "Null secondary message for nominee profile",
+            })}
+          </p>
+        </Notice.Content>
+      </Notice.Root>
+    );
+  }
+
+  if (reason == "not-verified-gov-employee") {
+    return (
+      <Notice.Root color="error" className="mt-9">
+        <Notice.Title>
+          {intl.formatMessage({
+            defaultMessage:
+              "The nominee is no longer a verified Government of Canada employee",
+            id: "PbTf7L",
+            description: "Null message for nominee profile",
+          })}
+        </Notice.Title>
+        <Notice.Content>
+          <p className="mb-3">
+            {intl.formatMessage({
+              defaultMessage:
+                "In order to view the nominee’s profile information and career experience, please reach out to the nominator and have them contact the nominee to confirm whether the nominee is still an employee.",
+              id: "FcINAB",
+              description: "Null secondary message for nominee profile",
+            })}
+          </p>
+          <Ul space="md">
+            <li>
+              {intl.formatMessage({
+                defaultMessage:
+                  "If they are, have them verify their employee status by confirming their work email and adding current Government of Canada work experience.",
+                id: "1mNea9",
+                description: "Null secondary message for nominee profile",
+              })}
+            </li>
+            <li>
+              {intl.formatMessage({
+                defaultMessage:
+                  "If they aren’t, mark this nomination as “Not supported”.",
+                id: "hOiaIL",
+                description: "Null secondary message for nominee profile",
+              })}
+            </li>
+          </Ul>
+        </Notice.Content>
+      </Notice.Root>
+    );
+  }
+
+  return assertUnreachable(reason);
+};
+
 interface TalentNominationGroupProfileProps {
   nomineeId: string;
   communityId: string;
-  shareProfile?: boolean;
+  contentHiddenReason?: null | ErrorNoticeProps["reason"];
   defaultOpen?: boolean;
 }
 
 const TalentNominationGroupProfile = ({
   nomineeId,
-  shareProfile,
+  contentHiddenReason,
   defaultOpen = false,
   communityId,
 }: TalentNominationGroupProfileProps) => {
   const intl = useIntl();
+  const contentIsVisible = !contentHiddenReason;
   const [{ data, fetching, error }] = useQuery({
     query: Nominee_Query,
     variables: { nomineeId },
-    pause: !shareProfile,
+    pause: !contentIsVisible,
   });
 
   const [openSections, setOpenSections] = useState<string[]>(
@@ -101,7 +182,7 @@ const TalentNominationGroupProfile = ({
                 "Heading for nominee profile page accordion sections",
             })}
           </Heading>
-          {shareProfile && (
+          {contentIsVisible && (
             <Button mode="inline" color="primary" onClick={toggleSections}>
               {hasOpenSections
                 ? intl.formatMessage({
@@ -131,28 +212,7 @@ const TalentNominationGroupProfile = ({
           })}
         </p>
         <Card.Separator className="mt-9" />
-        {!shareProfile && (
-          <Notice.Root color="error" className="mt-9">
-            <Notice.Title>
-              {intl.formatMessage({
-                defaultMessage:
-                  "This nominee has not agreed to share their information with your community",
-                id: "4ujr5X",
-                description: "Null message for nominee profile",
-              })}
-            </Notice.Title>
-            <Notice.Content>
-              <p>
-                {intl.formatMessage({
-                  defaultMessage:
-                    "Nominees can agree to provide access to their profile using the “Functional communities” tool on their dashboard.",
-                  id: "8plD42",
-                  description: "Null secondary message for nominee profile",
-                })}
-              </p>
-            </Notice.Content>
-          </Notice.Root>
-        )}
+        {!contentIsVisible && <ErrorNotice reason={contentHiddenReason} />}
       </Card>
       {data?.user?.employeeProfile ? (
         <Accordion.Root
@@ -204,6 +264,7 @@ const TalentNominationGroupProfile_Query = graphql(/* GraphQL */ `
       consentToShareProfile
       nominee {
         id
+        isVerifiedGovEmployee
       }
       talentNominationEvent {
         community {
@@ -224,19 +285,25 @@ const TalentNominationGroupProfilePage = () => {
   });
 
   const nomineeId = data?.talentNominationGroup?.nominee?.id;
-  const shareProfile = data?.talentNominationGroup?.consentToShareProfile;
   const communityId =
     data?.talentNominationGroup?.talentNominationEvent?.community?.id;
 
+  let contentHiddenReason: ComponentProps<
+    typeof TalentNominationGroupProfile
+  >["contentHiddenReason"] = null;
+  if (!data?.talentNominationGroup?.consentToShareProfile) {
+    contentHiddenReason = "not-shared-with-community";
+  }
+  if (!data?.talentNominationGroup?.nominee?.isVerifiedGovEmployee) {
+    contentHiddenReason = "not-verified-gov-employee";
+  }
+
   return (
     <Pending fetching={fetching} error={error}>
-      {data?.talentNominationGroup &&
-      nomineeId &&
-      shareProfile !== null &&
-      communityId ? (
+      {data?.talentNominationGroup && nomineeId && communityId ? (
         <TalentNominationGroupProfile
           nomineeId={nomineeId}
-          shareProfile={shareProfile}
+          contentHiddenReason={contentHiddenReason}
           communityId={communityId}
         />
       ) : (

--- a/apps/web/src/pages/TalentNominations/NominationGroup/Profile.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/Profile.tsx
@@ -11,10 +11,7 @@ import {
   Heading,
   Pending,
   ThrowNotFound,
-  Notice,
-  Ul,
 } from "@gc-digital-talent/ui";
-import { assertUnreachable } from "@gc-digital-talent/helpers";
 
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
 import BasicInformation from "~/components/BasicInformation/BasicInformation";
@@ -28,6 +25,7 @@ import permissionConstants from "~/constants/permissionConstants";
 
 import type { RouteParams } from "./types";
 import { SECTION_KEY } from "./types";
+import ErrorNotice from "./components/ErrorNotice";
 
 const Nominee_Query = graphql(/* GraphQL */ `
   query Nominee($nomineeId: UUID!) {
@@ -47,88 +45,10 @@ const Nominee_Query = graphql(/* GraphQL */ `
   }
 `);
 
-interface ErrorNoticeProps {
-  reason: "not-shared-with-community" | "not-verified-gov-employee";
-}
-
-const ErrorNotice = ({ reason }: ErrorNoticeProps) => {
-  const intl = useIntl();
-
-  if (reason == "not-shared-with-community") {
-    return (
-      <Notice.Root color="error" className="mt-9">
-        <Notice.Title>
-          {intl.formatMessage({
-            defaultMessage:
-              "This nominee has not agreed to share their information with your community",
-            id: "4ujr5X",
-            description: "Null message for nominee profile",
-          })}
-        </Notice.Title>
-        <Notice.Content>
-          <p>
-            {intl.formatMessage({
-              defaultMessage:
-                "Nominees can agree to provide access to their profile using the “Functional communities” tool on their dashboard.",
-              id: "8plD42",
-              description: "Null secondary message for nominee profile",
-            })}
-          </p>
-        </Notice.Content>
-      </Notice.Root>
-    );
-  }
-
-  if (reason == "not-verified-gov-employee") {
-    return (
-      <Notice.Root color="error" className="mt-9">
-        <Notice.Title>
-          {intl.formatMessage({
-            defaultMessage:
-              "The nominee is no longer a verified Government of Canada employee",
-            id: "PbTf7L",
-            description: "Null message for nominee profile",
-          })}
-        </Notice.Title>
-        <Notice.Content>
-          <p className="mb-3">
-            {intl.formatMessage({
-              defaultMessage:
-                "In order to view the nominee’s profile information and career experience, please reach out to the nominator and have them contact the nominee to confirm whether the nominee is still an employee.",
-              id: "FcINAB",
-              description: "Null secondary message for nominee profile",
-            })}
-          </p>
-          <Ul space="md">
-            <li>
-              {intl.formatMessage({
-                defaultMessage:
-                  "If they are, have them verify their employee status by confirming their work email and adding current Government of Canada work experience.",
-                id: "1mNea9",
-                description: "Null secondary message for nominee profile",
-              })}
-            </li>
-            <li>
-              {intl.formatMessage({
-                defaultMessage:
-                  "If they aren’t, mark this nomination as “Not supported”.",
-                id: "hOiaIL",
-                description: "Null secondary message for nominee profile",
-              })}
-            </li>
-          </Ul>
-        </Notice.Content>
-      </Notice.Root>
-    );
-  }
-
-  return assertUnreachable(reason);
-};
-
 interface TalentNominationGroupProfileProps {
   nomineeId: string;
   communityId: string;
-  contentHiddenReason?: null | ErrorNoticeProps["reason"];
+  contentHiddenReason?: null | ComponentProps<typeof ErrorNotice>["reason"];
   defaultOpen?: boolean;
 }
 

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/CurrentPositionExperiences.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/CurrentPositionExperiences.tsx
@@ -1,6 +1,7 @@
 import FlagIcon from "@heroicons/react/24/outline/FlagIcon";
 import { useIntl } from "react-intl";
 import { Fragment } from "react/jsx-runtime";
+import type { ComponentProps } from "react";
 
 import type { FragmentType, GovPositionType } from "@gc-digital-talent/graphql";
 import { getFragment, graphql } from "@gc-digital-talent/graphql";
@@ -20,6 +21,8 @@ import {
   getGovernmentPositionTypeLabel,
   isGovWorkExperience,
 } from "~/utils/experienceUtils";
+
+import ErrorNotice from "./ErrorNotice";
 
 const CurrentPositionExperiences_Fragment = graphql(/* GraphQL */ `
   fragment CurrentPositionExperiences on User {
@@ -57,13 +60,14 @@ const isCurrentExperience = (endDate?: string | null): boolean => {
 interface CurrentPositionExperiencesProps {
   query:
     FragmentType<typeof CurrentPositionExperiences_Fragment> | null | undefined;
-  shareProfile?: boolean;
+  contentHiddenReason?: null | ComponentProps<typeof ErrorNotice>["reason"];
 }
 
 const CurrentPositionExperiences = ({
   query,
-  shareProfile,
+  contentHiddenReason,
 }: CurrentPositionExperiencesProps) => {
+  const contentIsVisible = !contentHiddenReason;
   const intl = useIntl();
   const data = getFragment(CurrentPositionExperiences_Fragment, query);
 
@@ -118,7 +122,7 @@ const CurrentPositionExperiences = ({
       </p>
       <Card.Separator className="my-9" />
 
-      {shareProfile && !empty(data) && (
+      {contentIsVisible && !empty(data) && (
         <div>
           <div className="flex flex-col gap-y-3">
             {Object.keys(currentWorkExperiencesByGovPositionType).length ===
@@ -207,30 +211,9 @@ const CurrentPositionExperiences = ({
           </div>
         </div>
       )}
-      {!shareProfile && (
-        <Notice.Root color="error">
-          <Notice.Title>
-            {intl.formatMessage({
-              defaultMessage:
-                "This nominee has not agreed to share their information with your community",
-              id: "4ujr5X",
-              description: "Null message for nominee profile",
-            })}
-          </Notice.Title>
-          <Notice.Content>
-            <p>
-              {intl.formatMessage({
-                defaultMessage:
-                  "Nominees can agree to provide access to their profile using the “Functional communities” tool on their dashboard.",
-                id: "8plD42",
-                description: "Null secondary message for nominee profile",
-              })}
-            </p>
-          </Notice.Content>
-        </Notice.Root>
-      )}
-      {shareProfile && <Card.Separator className="my-9" />}
-      {shareProfile && (
+      {!contentIsVisible && <ErrorNotice reason={contentHiddenReason} />}
+      {contentIsVisible && <Card.Separator className="my-9" />}
+      {contentIsVisible && (
         <p className="text-gray-600 dark:text-gray-200">
           {intl.formatMessage(
             {

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/ErrorNotice.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/ErrorNotice.tsx
@@ -12,7 +12,7 @@ const ErrorNotice = ({ reason }: ErrorNoticeProps) => {
 
   if (reason == "not-shared-with-community") {
     return (
-      <Notice.Root color="error" className="mt-9">
+      <Notice.Root color="error">
         <Notice.Title>
           {intl.formatMessage({
             defaultMessage:

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/ErrorNotice.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/ErrorNotice.tsx
@@ -10,75 +10,74 @@ interface ErrorNoticeProps {
 const ErrorNotice = ({ reason }: ErrorNoticeProps) => {
   const intl = useIntl();
 
-  if (reason == "not-shared-with-community") {
-    return (
-      <Notice.Root color="error">
-        <Notice.Title>
-          {intl.formatMessage({
-            defaultMessage:
-              "This nominee has not agreed to share their information with your community",
-            id: "4ujr5X",
-            description: "Null message for nominee profile",
-          })}
-        </Notice.Title>
-        <Notice.Content>
-          <p>
+  switch (reason) {
+    case "not-shared-with-community":
+      return (
+        <Notice.Root color="error">
+          <Notice.Title>
             {intl.formatMessage({
               defaultMessage:
-                "Nominees can agree to provide access to their profile using the “Functional communities” tool on their dashboard.",
-              id: "8plD42",
-              description: "Null secondary message for nominee profile",
+                "This nominee has not agreed to share their information with your community",
+              id: "4ujr5X",
+              description: "Null message for nominee profile",
             })}
-          </p>
-        </Notice.Content>
-      </Notice.Root>
-    );
-  }
-
-  if (reason == "not-verified-gov-employee") {
-    return (
-      <Notice.Root color="error" className="mt-9">
-        <Notice.Title>
-          {intl.formatMessage({
-            defaultMessage:
-              "The nominee is no longer a verified Government of Canada employee",
-            id: "PbTf7L",
-            description: "Null message for nominee profile",
-          })}
-        </Notice.Title>
-        <Notice.Content>
-          <p className="mb-3">
+          </Notice.Title>
+          <Notice.Content>
+            <p>
+              {intl.formatMessage({
+                defaultMessage:
+                  "Nominees can agree to provide access to their profile using the “Functional communities” tool on their dashboard.",
+                id: "8plD42",
+                description: "Null secondary message for nominee profile",
+              })}
+            </p>
+          </Notice.Content>
+        </Notice.Root>
+      );
+    case "not-verified-gov-employee":
+      return (
+        <Notice.Root color="error" className="mt-9">
+          <Notice.Title>
             {intl.formatMessage({
               defaultMessage:
-                "In order to view the nominee’s profile information and career experience, please reach out to the nominator and have them contact the nominee to confirm whether the nominee is still an employee.",
-              id: "FcINAB",
-              description: "Null secondary message for nominee profile",
+                "The nominee is no longer a verified Government of Canada employee",
+              id: "PbTf7L",
+              description: "Null message for nominee profile",
             })}
-          </p>
-          <Ul space="md">
-            <li>
+          </Notice.Title>
+          <Notice.Content>
+            <p className="mb-3">
               {intl.formatMessage({
                 defaultMessage:
-                  "If they are, have them verify their employee status by confirming their work email and adding current Government of Canada work experience.",
-                id: "1mNea9",
+                  "In order to view the nominee’s profile information and career experience, please reach out to the nominator and have them contact the nominee to confirm whether the nominee is still an employee.",
+                id: "FcINAB",
                 description: "Null secondary message for nominee profile",
               })}
-            </li>
-            <li>
-              {intl.formatMessage({
-                defaultMessage:
-                  "If they aren’t, mark this nomination as “Not supported”.",
-                id: "hOiaIL",
-                description: "Null secondary message for nominee profile",
-              })}
-            </li>
-          </Ul>
-        </Notice.Content>
-      </Notice.Root>
-    );
+            </p>
+            <Ul space="md">
+              <li>
+                {intl.formatMessage({
+                  defaultMessage:
+                    "If they are, have them verify their employee status by confirming their work email and adding current Government of Canada work experience.",
+                  id: "1mNea9",
+                  description: "Null secondary message for nominee profile",
+                })}
+              </li>
+              <li>
+                {intl.formatMessage({
+                  defaultMessage:
+                    "If they aren’t, mark this nomination as “Not supported”.",
+                  id: "hOiaIL",
+                  description: "Null secondary message for nominee profile",
+                })}
+              </li>
+            </Ul>
+          </Notice.Content>
+        </Notice.Root>
+      );
+    default:
+      return assertUnreachable(reason);
   }
-
-  return assertUnreachable(reason);
 };
 
 export default ErrorNotice;

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/ErrorNotice.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/ErrorNotice.tsx
@@ -1,0 +1,84 @@
+import { useIntl } from "react-intl";
+
+import { assertUnreachable } from "@gc-digital-talent/helpers";
+import { Notice, Ul } from "@gc-digital-talent/ui";
+
+interface ErrorNoticeProps {
+  reason: "not-shared-with-community" | "not-verified-gov-employee";
+}
+
+const ErrorNotice = ({ reason }: ErrorNoticeProps) => {
+  const intl = useIntl();
+
+  if (reason == "not-shared-with-community") {
+    return (
+      <Notice.Root color="error" className="mt-9">
+        <Notice.Title>
+          {intl.formatMessage({
+            defaultMessage:
+              "This nominee has not agreed to share their information with your community",
+            id: "4ujr5X",
+            description: "Null message for nominee profile",
+          })}
+        </Notice.Title>
+        <Notice.Content>
+          <p>
+            {intl.formatMessage({
+              defaultMessage:
+                "Nominees can agree to provide access to their profile using the “Functional communities” tool on their dashboard.",
+              id: "8plD42",
+              description: "Null secondary message for nominee profile",
+            })}
+          </p>
+        </Notice.Content>
+      </Notice.Root>
+    );
+  }
+
+  if (reason == "not-verified-gov-employee") {
+    return (
+      <Notice.Root color="error" className="mt-9">
+        <Notice.Title>
+          {intl.formatMessage({
+            defaultMessage:
+              "The nominee is no longer a verified Government of Canada employee",
+            id: "PbTf7L",
+            description: "Null message for nominee profile",
+          })}
+        </Notice.Title>
+        <Notice.Content>
+          <p className="mb-3">
+            {intl.formatMessage({
+              defaultMessage:
+                "In order to view the nominee’s profile information and career experience, please reach out to the nominator and have them contact the nominee to confirm whether the nominee is still an employee.",
+              id: "FcINAB",
+              description: "Null secondary message for nominee profile",
+            })}
+          </p>
+          <Ul space="md">
+            <li>
+              {intl.formatMessage({
+                defaultMessage:
+                  "If they are, have them verify their employee status by confirming their work email and adding current Government of Canada work experience.",
+                id: "1mNea9",
+                description: "Null secondary message for nominee profile",
+              })}
+            </li>
+            <li>
+              {intl.formatMessage({
+                defaultMessage:
+                  "If they aren’t, mark this nomination as “Not supported”.",
+                id: "hOiaIL",
+                description: "Null secondary message for nominee profile",
+              })}
+            </li>
+          </Ul>
+        </Notice.Content>
+      </Notice.Root>
+    );
+  }
+
+  return assertUnreachable(reason);
+};
+
+export default ErrorNotice;

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/FullCareerExperiences.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/FullCareerExperiences.tsx
@@ -8,7 +8,6 @@ import {
   Button,
   Heading,
   Ul,
-  Notice,
   wrapParens,
   Card,
 } from "@gc-digital-talent/ui";

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/FullCareerExperiences.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/FullCareerExperiences.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { ComponentProps, ReactNode } from "react";
 import { useId, useState } from "react";
 import { useIntl } from "react-intl";
 import NewspaperIcon from "@heroicons/react/24/outline/NewspaperIcon";
@@ -30,6 +30,7 @@ import {
   buildExperienceByTypeData,
   buildExperienceByWorkStreamData,
 } from "./fullCareerExperiencesUtils";
+import ErrorNotice from "./ErrorNotice";
 
 const FullCareerExperiencesUser_Fragment = graphql(/* GraphQL */ `
   fragment FullCareerExperiencesUser on User {
@@ -92,16 +93,17 @@ interface FullCareerExperiencesProps {
     | FragmentType<typeof FullCareerExperiencesTalentNominationGroup_Fragment>
     | null
     | undefined;
-  shareProfile?: boolean;
+  contentHiddenReason?: null | ComponentProps<typeof ErrorNotice>["reason"];
   defaultOpen?: boolean;
 }
 
 const FullCareerExperiences = ({
   userQuery,
   talentNominationGroupQuery,
-  shareProfile,
+  contentHiddenReason,
   defaultOpen = false,
 }: FullCareerExperiencesProps) => {
+  const contentIsVisible = !contentHiddenReason;
   const intl = useIntl();
   const showExperienceByLabelId = useId();
   const user = getFragment(FullCareerExperiencesUser_Fragment, userQuery);
@@ -182,7 +184,7 @@ const FullCareerExperiences = ({
             description: "Heading for career experience",
           })}
         </Heading>
-        {shareProfile && (
+        {contentIsVisible && (
           <Button
             type="button"
             mode="inline"
@@ -209,7 +211,7 @@ const FullCareerExperiences = ({
 
       <Card.Separator className="my-9" />
 
-      {shareProfile ? (
+      {contentIsVisible ? (
         <>
           <div className="mb-3 flex items-center gap-6">
             <p id={showExperienceByLabelId}>
@@ -292,26 +294,7 @@ const FullCareerExperiences = ({
           ) : null}
         </>
       ) : (
-        <Notice.Root color="error">
-          <Notice.Title>
-            {intl.formatMessage({
-              defaultMessage:
-                "This nominee has not agreed to share their information with your community",
-              id: "4ujr5X",
-              description: "Null message for nominee profile",
-            })}
-          </Notice.Title>
-          <Notice.Content>
-            <p>
-              {intl.formatMessage({
-                defaultMessage:
-                  "Nominees can agree to provide access to their profile using the “Functional communities” tool on their dashboard.",
-                id: "8plD42",
-                description: "Null secondary message for nominee profile",
-              })}
-            </p>
-          </Notice.Content>
-        </Notice.Root>
+        <ErrorNotice reason={contentHiddenReason} />
       )}
     </>
   );

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/NominationGroupSidebar.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/NominationGroupSidebar.tsx
@@ -6,6 +6,7 @@ import type { FragmentType } from "@gc-digital-talent/graphql";
 import { getFragment, graphql } from "@gc-digital-talent/graphql";
 import { commonMessages } from "@gc-digital-talent/i18n";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
+import richTextElements from "@gc-digital-talent/rich-text-elements";
 
 import { getFullNameLabel } from "~/utils/nameUtils";
 import FieldDisplay from "~/components/FieldDisplay/FieldDisplay";
@@ -90,7 +91,9 @@ const NominationGroupSidebar = ({
         <div className="flex justify-between">
           <p className="mb-1.5 text-sm text-gray-600 dark:text-gray-200">
             {talentNominationGroup.nominee?.classification?.groupAndLevel ??
-              intl.formatMessage(commonMessages.notProvided)}
+              richTextElements.red(
+                intl.formatMessage(commonMessages.noClassification),
+              )}
           </p>
           <DownloadNominationDocxButton
             id={talentNominationGroup.id}
@@ -107,7 +110,9 @@ const NominationGroupSidebar = ({
         </Heading>
         <p className="mb-6">
           {talentNominationGroup.nominee?.department?.name?.localized ??
-            intl.formatMessage(commonMessages.notProvided)}
+            richTextElements.red(
+              intl.formatMessage(commonMessages.noDepartment),
+            )}
         </p>
         <div className="w-full self-start">
           <NominationGroupEvaluationDialog query={talentNominationGroup} />

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -646,6 +646,16 @@ const commonMessages = defineMessages({
     id: "96yWSc",
     description: "Special application label",
   },
+  noClassification: {
+    defaultMessage: "No classification",
+    id: "xuxKpE",
+    description: "Placeholder for when the classification can not be displayed",
+  },
+  noDepartment: {
+    defaultMessage: "No organization",
+    id: "x2TbMe",
+    description: "Placeholder for when the classification can not be displayed",
+  },
 });
 
 export default commonMessages;

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -653,8 +653,8 @@ const commonMessages = defineMessages({
   },
   noDepartment: {
     defaultMessage: "No organization",
-    id: "x2TbMe",
-    description: "Placeholder for when the classification can not be displayed",
+    id: "wpNvbg",
+    description: "Placeholder for when the department can not be displayed",
   },
 });
 


### PR DESCRIPTION
🤖 Resolves #17638 

## 👋 Introduction

Adds warning placeholders in the nomination tabs if the nominee is not a verified gov employee.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

1. Rebuild app
2. Log in as community@test.com

- [ ] When the nominee has the community interest and is a verified gov employee then all content is visible (unchanged)
- [ ] When the nominee does not have the  community interest then the consent warning is displayed (unchanged)
- [ ] When the nominee is not a verified gov employee then the employee warning is 
displayed and the classification and department are hidden


## 📸 Screenshot

<img width="1300" height="725" alt="image" src="https://github.com/user-attachments/assets/0337c40c-11bd-4083-8802-a64357286a7c" />
