### PR TITLE
[Fix] Name column alignment on matching candidates table

### DIFF
--- a/apps/web/src/pages/TalentRequests/components/TalentRequestReferralDialogs/TalentRequestAddReferralDialog.tsx
+++ b/apps/web/src/pages/TalentRequests/components/TalentRequestReferralDialogs/TalentRequestAddReferralDialog.tsx
@@ -146,7 +146,11 @@ const TalentRequestAddReferralDialog = ({
   return (
     <Dialog.Root open={isOpen} onOpenChange={setOpen}>
       <Dialog.Trigger>
-        {trigger ?? <Button mode="text">{userName}</Button>}
+        {trigger ?? (
+          <Button mode="text" className="text-left">
+            {userName}
+          </Button>
+        )}
       </Dialog.Trigger>
       <Dialog.Content>
         <ReferralDialogHeader userName={userName} />


### PR DESCRIPTION
🤖 Resolves #17799 

## 👋 Introduction

- Left aligns name column on matching candidates table

## 🧪 Testing

1. Build front-end `pnpm dev:fresh`
2. Login as admin
3. Go to a talent request with matching candidates (or remove filters till you have one)
4. Using the dev tools, inspect the element, and add a very long name (e.g. `Rosaleeeeeeeeeeeeeeeee Kleinnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn`)
5. Ensure name stays aligned to left-side

## 📸 Screenshot

<details><summary>Before</summary>
<p>

<img width="858" height="646" alt="image" src="https://github.com/user-attachments/assets/e22c122d-50ef-44b8-a33a-763cc1182216" />

</p>
</details> 

<details><summary>After</summary>
<p>

<img width="858" height="646" alt="image" src="https://github.com/user-attachments/assets/48edfcdd-cf8f-4a61-846c-6aefdbc4e13c" />

</p>
</details> 


