### PR TITLE
[Feature] Nomination warnings for non-employees

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -422,6 +422,7 @@ type BasicGovEmployeeProfile @model(class: "\\App\\Models\\User") {
   role: String @rename(attribute: "computed_gov_role")
   department: Department @belongsTo
   classification: Classification @belongsTo(relation: "currentClassification")
+  isVerifiedGovEmployee: Boolean
 }
 
 # Mini type to support search by work email

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1087,6 +1087,7 @@ type BasicGovEmployeeProfile {
   role: String
   department: Department
   classification: Classification
+  isVerifiedGovEmployee: Boolean
 }
 
 type UserWorkEmail {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -999,6 +999,10 @@
     "defaultMessage": "Le fonds vise à compléter les budgets ministériels de formation en offrant des possibilités de formation supplémentaires, uniformes et de grande qualité qui permettent :",
     "description": "title for a list of fund objectives"
   },
+  "1mNea9": {
+    "defaultMessage": "Si c’est le cas, demandez-lui de faire confirmer son statut d’emploi en vérifiant son adresse courriel professionnelle et en ajoutant son expérience de travail actuelle au gouvernement du Canada.",
+    "description": "Null secondary message for nominee profile"
+  },
   "1mYPEx": {
     "defaultMessage": "Je ne suis <strong>pas disponible</strong> et je ne veux pas que l’on communique avec moi au sujet de possibilités découlant de ce processus de recrutement.",
     "description": "Radio button label for not available for opportunities option"
@@ -4387,6 +4391,10 @@
     "defaultMessage": "J'ai confirmé l'admissibilité de la candidate ou du candidat en contactant la référence secondaire fournie par le nominateur ou la nominatrice.",
     "description": "Statement of confirmation for reference check"
   },
+  "FcINAB": {
+    "defaultMessage": "Pour consulter les renseignements du profil et l’expérience professionnelle du nominé ou de la nominée, veuillez communiquer avec le nominateur ou la nominatrice et lui demander de contacter la personne nominée afin de confirmer si elle est toujours à l’emploi du gouvernement du Canada.",
+    "description": "Null secondary message for nominee profile"
+  },
   "FclnNa": {
     "defaultMessage": "Le Corps d’innovation",
     "description": "Heading for innovation corps"
@@ -6870,6 +6878,10 @@
   "PbLJnr": {
     "defaultMessage": "Grade en économie, en sociologie ou en statistique",
     "description": "Heading for the `just education` option for EC education requirements"
+  },
+  "PbTf7L": {
+    "defaultMessage": "Le statut d’emploi du nominé ou de la nominée au gouvernement du Canada n’est plus vérifié",
+    "description": "Null message for nominee profile"
   },
   "PbUHEk": {
     "defaultMessage": "Sélectionner une expérience d’études ou de certification",
@@ -11261,6 +11273,10 @@
   "hNIQyO": {
     "defaultMessage": "Événement de mise en candidature {eventId} introuvable.",
     "description": "Message displayed for talent nomination event not found."
+  },
+  "hOiaIL": {
+    "defaultMessage": "Si ce n’est pas le cas, indiquez que cette mise en candidature est « Non appuyée ».",
+    "description": "Null secondary message for nominee profile"
   },
   "hOnqmx": {
     "defaultMessage": "Le candidat n’a pas réussi une évaluation requise",

--- a/apps/web/src/pages/TalentNominations/NominationGroup/CareerExperience.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/CareerExperience.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "urql";
+import type { ComponentProps } from "react";
 
 import type { FragmentType } from "@gc-digital-talent/graphql";
 import { getFragment, graphql } from "@gc-digital-talent/graphql";
@@ -11,6 +12,7 @@ import permissionConstants from "~/constants/permissionConstants";
 import type { RouteParams } from "./types";
 import CurrentPositionExperiences from "./components/CurrentPositionExperiences";
 import FullCareerExperiences from "./components/FullCareerExperiences";
+import type ErrorNotice from "./components/ErrorNotice";
 
 const TalentNominationGroupCareerExperience_Fragment = graphql(/* GraphQL */ `
   fragment TalentNominationGroupCareerExperience on TalentNominationGroup {
@@ -30,7 +32,7 @@ const NomineeExperiences_Query = graphql(/* GraphQL */ `
 
 interface TalentNominationGroupCareerExperienceProps {
   nomineeId: string;
-  shareProfile?: boolean;
+  contentHiddenReason?: null | ComponentProps<typeof ErrorNotice>["reason"];
   talentNominationGroupQuery: FragmentType<
     typeof TalentNominationGroupCareerExperience_Fragment
   >;
@@ -38,13 +40,14 @@ interface TalentNominationGroupCareerExperienceProps {
 
 const TalentNominationGroupCareerExperience = ({
   nomineeId,
-  shareProfile,
+  contentHiddenReason,
   talentNominationGroupQuery,
 }: TalentNominationGroupCareerExperienceProps) => {
+  const contentIsVisible = !contentHiddenReason;
   const [{ data: nomineeData, fetching, error }] = useQuery({
     query: NomineeExperiences_Query,
     variables: { nomineeId },
-    pause: !shareProfile,
+    pause: !contentIsVisible,
   });
 
   const talentNominationGroup = getFragment(
@@ -57,14 +60,14 @@ const TalentNominationGroupCareerExperience = ({
       <Card space="lg" className="mb-6">
         <CurrentPositionExperiences
           query={nomineeData?.user}
-          shareProfile={shareProfile}
+          contentHiddenReason={contentHiddenReason}
         />
       </Card>
       <Card space="lg">
         <FullCareerExperiences
           userQuery={nomineeData?.user}
           talentNominationGroupQuery={talentNominationGroup}
-          shareProfile={shareProfile}
+          contentHiddenReason={contentHiddenReason}
         />
       </Card>
     </Pending>
@@ -78,6 +81,7 @@ const TalentNominationGroupCareerExperience_Query = graphql(/* GraphQL */ `
       consentToShareProfile
       nominee {
         id
+        isVerifiedGovEmployee
       }
     }
   }
@@ -93,14 +97,23 @@ const TalentNominationGroupCareerExperiencePage = () => {
   });
 
   const nomineeId = data?.talentNominationGroup?.nominee?.id;
-  const shareProfile = data?.talentNominationGroup?.consentToShareProfile;
+
+  let contentHiddenReason: ComponentProps<
+    typeof TalentNominationGroupCareerExperience
+  >["contentHiddenReason"] = null;
+  if (!data?.talentNominationGroup?.consentToShareProfile) {
+    contentHiddenReason = "not-shared-with-community";
+  }
+  if (!data?.talentNominationGroup?.nominee?.isVerifiedGovEmployee) {
+    contentHiddenReason = "not-verified-gov-employee";
+  }
 
   return (
     <Pending fetching={fetching} error={error}>
-      {data?.talentNominationGroup && nomineeId && shareProfile !== null ? (
+      {data?.talentNominationGroup && nomineeId ? (
         <TalentNominationGroupCareerExperience
           nomineeId={nomineeId}
-          shareProfile={shareProfile}
+          contentHiddenReason={contentHiddenReason}
           talentNominationGroupQuery={data.talentNominationGroup}
         />
       ) : (

--- a/apps/web/src/pages/TalentNominations/NominationGroup/Profile.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/Profile.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "urql";
-import { useState } from "react";
+import { useState, type ComponentProps } from "react";
 import { useIntl } from "react-intl";
 import UserCircleIcon from "@heroicons/react/24/outline/UserCircleIcon";
 
@@ -11,7 +11,6 @@ import {
   Heading,
   Pending,
   ThrowNotFound,
-  Notice,
 } from "@gc-digital-talent/ui";
 
 import RequireAuth from "~/components/RequireAuth/RequireAuth";
@@ -26,6 +25,7 @@ import permissionConstants from "~/constants/permissionConstants";
 
 import type { RouteParams } from "./types";
 import { SECTION_KEY } from "./types";
+import ErrorNotice from "./components/ErrorNotice";
 
 const Nominee_Query = graphql(/* GraphQL */ `
   query Nominee($nomineeId: UUID!) {
@@ -48,21 +48,22 @@ const Nominee_Query = graphql(/* GraphQL */ `
 interface TalentNominationGroupProfileProps {
   nomineeId: string;
   communityId: string;
-  shareProfile?: boolean;
+  contentHiddenReason?: null | ComponentProps<typeof ErrorNotice>["reason"];
   defaultOpen?: boolean;
 }
 
 const TalentNominationGroupProfile = ({
   nomineeId,
-  shareProfile,
+  contentHiddenReason,
   defaultOpen = false,
   communityId,
 }: TalentNominationGroupProfileProps) => {
   const intl = useIntl();
+  const contentIsVisible = !contentHiddenReason;
   const [{ data, fetching, error }] = useQuery({
     query: Nominee_Query,
     variables: { nomineeId },
-    pause: !shareProfile,
+    pause: !contentIsVisible,
   });
 
   const [openSections, setOpenSections] = useState<string[]>(
@@ -101,7 +102,7 @@ const TalentNominationGroupProfile = ({
                 "Heading for nominee profile page accordion sections",
             })}
           </Heading>
-          {shareProfile && (
+          {contentIsVisible && (
             <Button mode="inline" color="primary" onClick={toggleSections}>
               {hasOpenSections
                 ? intl.formatMessage({
@@ -131,28 +132,7 @@ const TalentNominationGroupProfile = ({
           })}
         </p>
         <Card.Separator className="mt-9" />
-        {!shareProfile && (
-          <Notice.Root color="error" className="mt-9">
-            <Notice.Title>
-              {intl.formatMessage({
-                defaultMessage:
-                  "This nominee has not agreed to share their information with your community",
-                id: "4ujr5X",
-                description: "Null message for nominee profile",
-              })}
-            </Notice.Title>
-            <Notice.Content>
-              <p>
-                {intl.formatMessage({
-                  defaultMessage:
-                    "Nominees can agree to provide access to their profile using the “Functional communities” tool on their dashboard.",
-                  id: "8plD42",
-                  description: "Null secondary message for nominee profile",
-                })}
-              </p>
-            </Notice.Content>
-          </Notice.Root>
-        )}
+        {!contentIsVisible && <ErrorNotice reason={contentHiddenReason} />}
       </Card>
       {data?.user?.employeeProfile ? (
         <Accordion.Root
@@ -204,6 +184,7 @@ const TalentNominationGroupProfile_Query = graphql(/* GraphQL */ `
       consentToShareProfile
       nominee {
         id
+        isVerifiedGovEmployee
       }
       talentNominationEvent {
         community {
@@ -224,19 +205,25 @@ const TalentNominationGroupProfilePage = () => {
   });
 
   const nomineeId = data?.talentNominationGroup?.nominee?.id;
-  const shareProfile = data?.talentNominationGroup?.consentToShareProfile;
   const communityId =
     data?.talentNominationGroup?.talentNominationEvent?.community?.id;
 
+  let contentHiddenReason: ComponentProps<
+    typeof TalentNominationGroupProfile
+  >["contentHiddenReason"] = null;
+  if (!data?.talentNominationGroup?.consentToShareProfile) {
+    contentHiddenReason = "not-shared-with-community";
+  }
+  if (!data?.talentNominationGroup?.nominee?.isVerifiedGovEmployee) {
+    contentHiddenReason = "not-verified-gov-employee";
+  }
+
   return (
     <Pending fetching={fetching} error={error}>
-      {data?.talentNominationGroup &&
-      nomineeId &&
-      shareProfile !== null &&
-      communityId ? (
+      {data?.talentNominationGroup && nomineeId && communityId ? (
         <TalentNominationGroupProfile
           nomineeId={nomineeId}
-          shareProfile={shareProfile}
+          contentHiddenReason={contentHiddenReason}
           communityId={communityId}
         />
       ) : (

--- a/apps/web/src/pages/TalentNominations/NominationGroup/Profile.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/Profile.tsx
@@ -132,7 +132,11 @@ const TalentNominationGroupProfile = ({
           })}
         </p>
         <Card.Separator className="mt-9" />
-        {!contentIsVisible && <ErrorNotice reason={contentHiddenReason} />}
+        {!contentIsVisible && (
+          <div className="mt-9">
+            <ErrorNotice reason={contentHiddenReason} />
+          </div>
+        )}
       </Card>
       {data?.user?.employeeProfile ? (
         <Accordion.Root

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/CurrentPositionExperiences.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/CurrentPositionExperiences.tsx
@@ -1,6 +1,7 @@
 import FlagIcon from "@heroicons/react/24/outline/FlagIcon";
 import { useIntl } from "react-intl";
 import { Fragment } from "react/jsx-runtime";
+import type { ComponentProps } from "react";
 
 import type { FragmentType, GovPositionType } from "@gc-digital-talent/graphql";
 import { getFragment, graphql } from "@gc-digital-talent/graphql";
@@ -20,6 +21,8 @@ import {
   getGovernmentPositionTypeLabel,
   isGovWorkExperience,
 } from "~/utils/experienceUtils";
+
+import ErrorNotice from "./ErrorNotice";
 
 const CurrentPositionExperiences_Fragment = graphql(/* GraphQL */ `
   fragment CurrentPositionExperiences on User {
@@ -57,13 +60,14 @@ const isCurrentExperience = (endDate?: string | null): boolean => {
 interface CurrentPositionExperiencesProps {
   query:
     FragmentType<typeof CurrentPositionExperiences_Fragment> | null | undefined;
-  shareProfile?: boolean;
+  contentHiddenReason?: null | ComponentProps<typeof ErrorNotice>["reason"];
 }
 
 const CurrentPositionExperiences = ({
   query,
-  shareProfile,
+  contentHiddenReason,
 }: CurrentPositionExperiencesProps) => {
+  const contentIsVisible = !contentHiddenReason;
   const intl = useIntl();
   const data = getFragment(CurrentPositionExperiences_Fragment, query);
 
@@ -118,7 +122,7 @@ const CurrentPositionExperiences = ({
       </p>
       <Card.Separator className="my-9" />
 
-      {shareProfile && !empty(data) && (
+      {contentIsVisible && !empty(data) && (
         <div>
           <div className="flex flex-col gap-y-3">
             {Object.keys(currentWorkExperiencesByGovPositionType).length ===
@@ -207,30 +211,9 @@ const CurrentPositionExperiences = ({
           </div>
         </div>
       )}
-      {!shareProfile && (
-        <Notice.Root color="error">
-          <Notice.Title>
-            {intl.formatMessage({
-              defaultMessage:
-                "This nominee has not agreed to share their information with your community",
-              id: "4ujr5X",
-              description: "Null message for nominee profile",
-            })}
-          </Notice.Title>
-          <Notice.Content>
-            <p>
-              {intl.formatMessage({
-                defaultMessage:
-                  "Nominees can agree to provide access to their profile using the “Functional communities” tool on their dashboard.",
-                id: "8plD42",
-                description: "Null secondary message for nominee profile",
-              })}
-            </p>
-          </Notice.Content>
-        </Notice.Root>
-      )}
-      {shareProfile && <Card.Separator className="my-9" />}
-      {shareProfile && (
+      {!contentIsVisible && <ErrorNotice reason={contentHiddenReason} />}
+      {contentIsVisible && <Card.Separator className="my-9" />}
+      {contentIsVisible && (
         <p className="text-gray-600 dark:text-gray-200">
           {intl.formatMessage(
             {

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/ErrorNotice.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/ErrorNotice.tsx
@@ -1,0 +1,83 @@
+import { useIntl } from "react-intl";
+
+import { assertUnreachable } from "@gc-digital-talent/helpers";
+import { Notice, Ul } from "@gc-digital-talent/ui";
+
+interface ErrorNoticeProps {
+  reason: "not-shared-with-community" | "not-verified-gov-employee";
+}
+
+const ErrorNotice = ({ reason }: ErrorNoticeProps) => {
+  const intl = useIntl();
+
+  switch (reason) {
+    case "not-shared-with-community":
+      return (
+        <Notice.Root color="error">
+          <Notice.Title>
+            {intl.formatMessage({
+              defaultMessage:
+                "This nominee has not agreed to share their information with your community",
+              id: "4ujr5X",
+              description: "Null message for nominee profile",
+            })}
+          </Notice.Title>
+          <Notice.Content>
+            <p>
+              {intl.formatMessage({
+                defaultMessage:
+                  "Nominees can agree to provide access to their profile using the “Functional communities” tool on their dashboard.",
+                id: "8plD42",
+                description: "Null secondary message for nominee profile",
+              })}
+            </p>
+          </Notice.Content>
+        </Notice.Root>
+      );
+    case "not-verified-gov-employee":
+      return (
+        <Notice.Root color="error" className="mt-9">
+          <Notice.Title>
+            {intl.formatMessage({
+              defaultMessage:
+                "The nominee is no longer a verified Government of Canada employee",
+              id: "PbTf7L",
+              description: "Null message for nominee profile",
+            })}
+          </Notice.Title>
+          <Notice.Content>
+            <p className="mb-3">
+              {intl.formatMessage({
+                defaultMessage:
+                  "In order to view the nominee’s profile information and career experience, please reach out to the nominator and have them contact the nominee to confirm whether the nominee is still an employee.",
+                id: "FcINAB",
+                description: "Null secondary message for nominee profile",
+              })}
+            </p>
+            <Ul space="md">
+              <li>
+                {intl.formatMessage({
+                  defaultMessage:
+                    "If they are, have them verify their employee status by confirming their work email and adding current Government of Canada work experience.",
+                  id: "1mNea9",
+                  description: "Null secondary message for nominee profile",
+                })}
+              </li>
+              <li>
+                {intl.formatMessage({
+                  defaultMessage:
+                    "If they aren’t, mark this nomination as “Not supported”.",
+                  id: "hOiaIL",
+                  description: "Null secondary message for nominee profile",
+                })}
+              </li>
+            </Ul>
+          </Notice.Content>
+        </Notice.Root>
+      );
+    default:
+      return assertUnreachable(reason);
+  }
+};
+
+export default ErrorNotice;

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/FullCareerExperiences.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/FullCareerExperiences.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { ComponentProps, ReactNode } from "react";
 import { useId, useState } from "react";
 import { useIntl } from "react-intl";
 import NewspaperIcon from "@heroicons/react/24/outline/NewspaperIcon";
@@ -8,7 +8,6 @@ import {
   Button,
   Heading,
   Ul,
-  Notice,
   wrapParens,
   Card,
 } from "@gc-digital-talent/ui";
@@ -30,6 +29,7 @@ import {
   buildExperienceByTypeData,
   buildExperienceByWorkStreamData,
 } from "./fullCareerExperiencesUtils";
+import ErrorNotice from "./ErrorNotice";
 
 const FullCareerExperiencesUser_Fragment = graphql(/* GraphQL */ `
   fragment FullCareerExperiencesUser on User {
@@ -92,16 +92,17 @@ interface FullCareerExperiencesProps {
     | FragmentType<typeof FullCareerExperiencesTalentNominationGroup_Fragment>
     | null
     | undefined;
-  shareProfile?: boolean;
+  contentHiddenReason?: null | ComponentProps<typeof ErrorNotice>["reason"];
   defaultOpen?: boolean;
 }
 
 const FullCareerExperiences = ({
   userQuery,
   talentNominationGroupQuery,
-  shareProfile,
+  contentHiddenReason,
   defaultOpen = false,
 }: FullCareerExperiencesProps) => {
+  const contentIsVisible = !contentHiddenReason;
   const intl = useIntl();
   const showExperienceByLabelId = useId();
   const user = getFragment(FullCareerExperiencesUser_Fragment, userQuery);
@@ -182,7 +183,7 @@ const FullCareerExperiences = ({
             description: "Heading for career experience",
           })}
         </Heading>
-        {shareProfile && (
+        {contentIsVisible && (
           <Button
             type="button"
             mode="inline"
@@ -209,7 +210,7 @@ const FullCareerExperiences = ({
 
       <Card.Separator className="my-9" />
 
-      {shareProfile ? (
+      {contentIsVisible ? (
         <>
           <div className="mb-3 flex items-center gap-6">
             <p id={showExperienceByLabelId}>
@@ -292,26 +293,7 @@ const FullCareerExperiences = ({
           ) : null}
         </>
       ) : (
-        <Notice.Root color="error">
-          <Notice.Title>
-            {intl.formatMessage({
-              defaultMessage:
-                "This nominee has not agreed to share their information with your community",
-              id: "4ujr5X",
-              description: "Null message for nominee profile",
-            })}
-          </Notice.Title>
-          <Notice.Content>
-            <p>
-              {intl.formatMessage({
-                defaultMessage:
-                  "Nominees can agree to provide access to their profile using the “Functional communities” tool on their dashboard.",
-                id: "8plD42",
-                description: "Null secondary message for nominee profile",
-              })}
-            </p>
-          </Notice.Content>
-        </Notice.Root>
+        <ErrorNotice reason={contentHiddenReason} />
       )}
     </>
   );

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/NominationGroupSidebar.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/NominationGroupSidebar.tsx
@@ -37,11 +37,11 @@ const MaskedDisplay = ({
   const intl = useIntl();
 
   if (!canShow) {
-    return intl.formatMessage(maskedMessage);
+    return richTextElements.red(intl.formatMessage(maskedMessage));
   }
 
   if (!value) {
-    return richTextElements.red(intl.formatMessage(defaultMessage));
+    return intl.formatMessage(defaultMessage);
   }
 
   return value;

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/NominationGroupSidebar.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/NominationGroupSidebar.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
-import { useIntl } from "react-intl";
+import { useIntl, type MessageDescriptor } from "react-intl";
 
 import { Accordion, Card, Heading } from "@gc-digital-talent/ui";
 import type { FragmentType } from "@gc-digital-talent/graphql";
 import { getFragment, graphql } from "@gc-digital-talent/graphql";
 import { commonMessages } from "@gc-digital-talent/i18n";
 import { unpackMaybes } from "@gc-digital-talent/helpers";
+import richTextElements from "@gc-digital-talent/rich-text-elements";
 
 import { getFullNameLabel } from "~/utils/nameUtils";
 import FieldDisplay from "~/components/FieldDisplay/FieldDisplay";
@@ -20,6 +21,32 @@ import NominationGroupEvaluationDialog from "../../NominationGroupEvaluationDial
 
 type AccordionStates = "nominee-contact-information" | "comments" | "";
 
+interface MaskedDisplayProps {
+  value: string | null | undefined;
+  canShow: boolean | null | undefined;
+  maskedMessage: MessageDescriptor;
+  defaultMessage: MessageDescriptor;
+}
+
+const MaskedDisplay = ({
+  value,
+  canShow,
+  maskedMessage,
+  defaultMessage,
+}: MaskedDisplayProps) => {
+  const intl = useIntl();
+
+  if (!canShow) {
+    return intl.formatMessage(maskedMessage);
+  }
+
+  if (!value) {
+    return richTextElements.red(intl.formatMessage(defaultMessage));
+  }
+
+  return value;
+};
+
 export const NominationGroupSidebar_Fragment = graphql(/* GraphQL */ `
   fragment NominationGroupSidebar on TalentNominationGroup {
     id
@@ -33,6 +60,7 @@ export const NominationGroupSidebar_Fragment = graphql(/* GraphQL */ `
     }
     nominee {
       id
+      isVerifiedGovEmployee
       workEmail
       firstName
       lastName
@@ -89,8 +117,14 @@ const NominationGroupSidebar = ({
       <Card className="mb-3 flex flex-col justify-center pb-3">
         <div className="flex justify-between">
           <p className="mb-1.5 text-sm text-gray-600 dark:text-gray-200">
-            {talentNominationGroup.nominee?.classification?.groupAndLevel ??
-              intl.formatMessage(commonMessages.notProvided)}
+            <MaskedDisplay
+              value={
+                talentNominationGroup.nominee?.classification?.groupAndLevel
+              }
+              canShow={talentNominationGroup.nominee?.isVerifiedGovEmployee}
+              maskedMessage={commonMessages.noClassification}
+              defaultMessage={commonMessages.notProvided}
+            />
           </p>
           <DownloadNominationDocxButton
             id={talentNominationGroup.id}
@@ -106,8 +140,12 @@ const NominationGroupSidebar = ({
           )}
         </Heading>
         <p className="mb-6">
-          {talentNominationGroup.nominee?.department?.name?.localized ??
-            intl.formatMessage(commonMessages.notProvided)}
+          <MaskedDisplay
+            value={talentNominationGroup.nominee?.department?.name?.localized}
+            canShow={talentNominationGroup.nominee?.isVerifiedGovEmployee}
+            maskedMessage={commonMessages.noDepartment}
+            defaultMessage={commonMessages.notProvided}
+          />
         </p>
         <div className="w-full self-start">
           <NominationGroupEvaluationDialog query={talentNominationGroup} />

--- a/packages/i18n/src/lang/fr.json
+++ b/packages/i18n/src/lang/fr.json
@@ -1855,6 +1855,10 @@
     "defaultMessage": "La date doit être égale ou postérieure à la {label}",
     "description": "Error message when a date was entered that is less than the minimum required, referencing an associated input label"
   },
+  "wpNvbg": {
+    "defaultMessage": "Aucune organisation",
+    "description": "Placeholder for when the department can not be displayed"
+  },
   "wqBryV": {
     "defaultMessage": "Tableau de bord du (de la) candidat(e)",
     "description": "Name of applicant dashboard page"
@@ -1906,6 +1910,10 @@
   "xmzq/b": {
     "defaultMessage": "Un champ obligatoire est vide : Votre contribution (anglais)",
     "description": "Error message that Your Impact in English must be filled"
+  },
+  "xuxKpE": {
+    "defaultMessage": "Aucune classification",
+    "description": "Placeholder for when the classification can not be displayed"
   },
   "y4oBW4": {
     "defaultMessage": "Décembre",

--- a/packages/i18n/src/messages/commonMessages.ts
+++ b/packages/i18n/src/messages/commonMessages.ts
@@ -646,6 +646,16 @@ const commonMessages = defineMessages({
     id: "96yWSc",
     description: "Special application label",
   },
+  noClassification: {
+    defaultMessage: "No classification",
+    id: "xuxKpE",
+    description: "Placeholder for when the classification can not be displayed",
+  },
+  noDepartment: {
+    defaultMessage: "No organization",
+    id: "wpNvbg",
+    description: "Placeholder for when the department can not be displayed",
+  },
 });
 
 export default commonMessages;


### PR DESCRIPTION
🤖 Resolves #17638 

## 👋 Introduction

Adds warning placeholders in the nomination tabs if the nominee is not a verified gov employee.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

1. Rebuild app
2. Log in as community@test.com (Admin for Digital and ATIP communities)

Here's a query to find nomination groups in different states:

```sql
select
	tng.id,
	e.name->>'en' event,
	c.name->>'en' community,
	n.first_name || ' ' || n.last_name nominiee,
	n.computed_is_gov_employee,
	ci.consent_to_share_profile
from talent_nomination_groups tng
join talent_nomination_events e on tng.talent_nomination_event_id = e.id
join communities c on e.community_id = c.id
join users n on tng.nominee_id = n.id
left join community_interests ci on  ci.user_id = n.id and ci.community_id = c.id
```

- [x] When the nominee has the community interest and is a verified gov employee then all content is visible (unchanged)
- [x] When the nominee does not have the  community interest then the consent warning is displayed (unchanged)
- [x] When the nominee is not a verified gov employee then the employee warning is 
displayed and the classification and department are hidden


## 📸 Screenshot

<img width="1300" height="725" alt="image" src="https://github.com/user-attachments/assets/0337c40c-11bd-4083-8802-a64357286a7c" />
