### PR TITLE
[Fix] Update app insights auth event flushing

### DIFF
--- a/apps/web/src/pages/Auth/SignInPage/SignInPage.tsx
+++ b/apps/web/src/pages/Auth/SignInPage/SignInPage.tsx
@@ -16,6 +16,7 @@ import {
   Notice,
   Chip,
 } from "@gc-digital-talent/ui";
+g;
 import { useApiRoutes } from "@gc-digital-talent/auth";
 import { getLocale } from "@gc-digital-talent/i18n";
 import { RadioGroup } from "@gc-digital-talent/forms";
@@ -122,7 +123,7 @@ export const Component = () => {
     );
     // The click triggers a full-page navigation off-site, so flush the buffer
     // to avoid the event being dropped on unload.
-    void appInsights.flush();
+    void appInsights.onunloadFlush();
   };
 
   const InstructionCards = () => {

--- a/apps/web/src/pages/Auth/SignInPage/SignInPage.tsx
+++ b/apps/web/src/pages/Auth/SignInPage/SignInPage.tsx
@@ -16,7 +16,6 @@ import {
   Notice,
   Chip,
 } from "@gc-digital-talent/ui";
-g;
 import { useApiRoutes } from "@gc-digital-talent/auth";
 import { getLocale } from "@gc-digital-talent/i18n";
 import { RadioGroup } from "@gc-digital-talent/forms";

--- a/packages/auth/src/utils/logout.ts
+++ b/packages/auth/src/utils/logout.ts
@@ -100,6 +100,8 @@ function logoutAndRefreshPage({
         logoutReason: logoutReason ?? "unknown",
       },
     );
+
+    void appInsights.onunloadFlush?.();
   }
   let authSessionIsCurrentlyActive = false; // assume false unless we can prove it below
 


### PR DESCRIPTION
🤖 Resolves #17454 

## 👋 Introduction

Updates how app insights flushing works on auth events to reduce chances of losing events.

## 🕵️ Details

Seems app insights is async and these events result in leaving the site. The change/addition of flush sends the events immediatley to prevent losses in the event that we leave the site before sending the event.

> (method) ApplicationInsights.onunloadFlush(async?: boolean): void
> Manually trigger an immediate send of all telemetry still in the buffer using beacon Sender.


## 🧪 Testing

> [!IMPORTANT]
> This will liklely need to be tested in Azure so we can confirm events get sent to app insights. 

1. Build `pnpm dev:fresh`
2. Login as any user
3. Logout
4. Confirm both events (Auth Login Initiated, Auth logout) are still tracked in app insights