### PR TITLE
[Bug] Remove consent check for nomination fields

### DIFF
--- a/api/app/Generators/NominationsExcelGenerator.php
+++ b/api/app/Generators/NominationsExcelGenerator.php
@@ -481,13 +481,13 @@ class NominationsExcelGenerator extends ExcelGenerator implements FileGeneratorI
                         $referenceDetails['department'], // reference department
                         $this->localizeEnum($nomination->nine_box_performance?->name, NineBoxRating::class), // nine box performance
                         $this->localizeEnum($nomination->nine_box_leadership_potential?->name, NineBoxRating::class), // nine box leadership potential
-                        $this->canShare($consentToShare, $lateralMovementOptionsStr),  // lateral experience recommendations
-                        $this->canShare($consentToShare, $nomination->lateral_movement_options_other ?? ''), // other lateral experience
-                        $this->canShare($consentToShare, $developmentProgramsStr),   // development program recommendations
-                        $this->canShare($consentToShare, $nomination->development_program_options_other ?? ''), // other development program experience
-                        $this->canShare($consentToShare, $nomination->nomination_rationale ?? ''), // rationale
+                        $lateralMovementOptionsStr,  // lateral experience recommendations
+                        $nomination->lateral_movement_options_other ?? '', // other lateral experience
+                        $developmentProgramsStr,   // development program recommendations
+                        $nomination->development_program_options_other ?? '', // other development program experience
+                        $nomination->nomination_rationale ?? '', // rationale
                         $leadershipCompetenciesStr, // leadership competencies
-                        $this->canShare($consentToShare, $nomination->additional_comments ?? ''), // additional comments
+                        $nomination->additional_comments ?? '', // additional comments
                     ];
 
                     $this->writer->addRow($this->row($values));

--- a/api/app/Generators/NominationsExcelGenerator.php
+++ b/api/app/Generators/NominationsExcelGenerator.php
@@ -447,7 +447,6 @@ class NominationsExcelGenerator extends ExcelGenerator implements FileGeneratorI
         $query = $this->buildQuery();
         $query->chunk(200, function ($talentNominationGroups) {
             foreach ($talentNominationGroups as $talentNominationGroup) {
-                $consentToShare = $talentNominationGroup->consentToShareProfile;
                 $user = $talentNominationGroup->nominee;
 
                 foreach ($talentNominationGroup->nominations as $nomination) {


### PR DESCRIPTION
🤖 Resolves #17632 

## 👋 Introduction

Removes the "consent to share profile" check for nomination fields.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

1. Rebuild app
2. Start a queue worker
3. Log in as community@test.com (Admin for Digital and ATIP communities)

Here's a query to find nomination groups in different states:

```sql
select
	tng.id,
	e.name->>'en' event,
	c.name->>'en' community,
	n.first_name || ' ' || n.last_name nominiee,
	ci.consent_to_share_profile
from talent_nomination_groups tng
join talent_nomination_events e on tng.talent_nomination_event_id = e.id
join communities c on e.community_id = c.id
join users n on tng.nominee_id = n.id
left join community_interests ci on  ci.user_id = n.id and ci.community_id = c.id
```

- [x] When the nominee has given consent then all content is visible (unchanged)
- [ ] When the nominee has not given consent then all content is visible (changed)
