### PR TITLE
[Fix] Close parent dialog on remove email success

### DIFF
--- a/apps/playwright/fixtures/EmployeeProfile.ts
+++ b/apps/playwright/fixtures/EmployeeProfile.ts
@@ -151,7 +151,6 @@ class EmployeeProfile extends AppPage {
     await this.page.getByRole("button", { name: "Remove work email" }).click();
     await this.page.getByRole("button", { name: "Remove work email" }).click();
     await this.waitForGraphqlResponse("RemoveUserWorkEmail");
-    await this.page.getByRole("button", { name: "Cancel" }).click();
   }
 }
 

--- a/apps/web/src/components/EmailVerificationDialog/EmailVerificationDialog.tsx
+++ b/apps/web/src/components/EmailVerificationDialog/EmailVerificationDialog.tsx
@@ -63,14 +63,14 @@ interface EmailVerificationFormProps {
   formEmailType: EmailType;
   initialEmailAddress: string | null;
   onFormSubmit: (formValues: FormValues) => Promise<void>;
-  onClickCancel: () => void;
+  onClose: () => void;
 }
 
 const EmailVerificationForm = ({
   formEmailType,
   initialEmailAddress,
   onFormSubmit,
-  onClickCancel,
+  onClose,
 }: EmailVerificationFormProps) => {
   const intl = useIntl();
   const {
@@ -166,9 +166,10 @@ const EmailVerificationForm = ({
               <WipeWorkEmailDialog
                 id={auth.userAuthInfo.id}
                 workEmail={initialEmailAddress}
+                onSuccess={onClose}
               />
             ) : null}
-            <Button color="warning" mode="inline" onClick={onClickCancel}>
+            <Button color="warning" mode="inline" onClick={onClose}>
               {intl.formatMessage(commonMessages.cancel)}
             </Button>
           </Dialog.Footer>
@@ -255,7 +256,7 @@ const EmailVerificationDialog = ({
                 formEmailType={dialogEmailType}
                 initialEmailAddress={initialEmailAddress}
                 onFormSubmit={handleFormSubmit}
-                onClickCancel={() => setOpen(false)}
+                onClose={() => setOpen(false)}
               />
             </EmailVerification.Provider>
           ) : null}

--- a/apps/web/src/components/WorkEmailCard/RemoveWorkEmailDialog.tsx
+++ b/apps/web/src/components/WorkEmailCard/RemoveWorkEmailDialog.tsx
@@ -18,9 +18,14 @@ const RemoveUserWorkEmail_Mutation = graphql(/* GraphQL */ `
 interface WipeWorkEmailDialogProps {
   id: string;
   workEmail: string;
+  onSuccess?: () => void;
 }
 
-const WipeWorkEmailDialog = ({ id, workEmail }: WipeWorkEmailDialogProps) => {
+const WipeWorkEmailDialog = ({
+  id,
+  workEmail,
+  onSuccess,
+}: WipeWorkEmailDialogProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const intl = useIntl();
 
@@ -54,6 +59,7 @@ const WipeWorkEmailDialog = ({ id, workEmail }: WipeWorkEmailDialogProps) => {
             }),
           );
           setIsOpen(false);
+          onSuccess?.();
         } else {
           void handleError();
         }


### PR DESCRIPTION
🤖 Resolves #17177 

## 👋 Introduction

Updates the work email verification dialog to close when the work email is closed.

## 🕵️ Details

This was, thankfully, much easier to complete than I first assumed. It accmplishes this by closing the parent dialog (email verification) with an `onSucess` callback from the child dialog (remove email).

## 🧪 Testing

> [!TIP]
> Complete the steps with keyboard only to ensure proper focus management. 

1. Build `pnpm dev:fresh`
2. Login as `applicant-employee@test.com`
3. Navigate to `/employee`
4. Open the work emial verification dialog
5. OPpen the remove work email dailog
6. Remove the work email
7. Confirm both dialogs close and focus resolves to the "Verify work email" button