### PR TITLE
[Feature] add post support for refresh

### DIFF
--- a/api/app/Http/Controllers/AuthController.php
+++ b/api/app/Http/Controllers/AuthController.php
@@ -287,7 +287,8 @@ class AuthController extends Controller
             return app(TestTokenController::class)->issue($request);
         }
 
-        $refreshToken = $request->query('refresh_token');
+        // reads from the POST body first, falling back to the legacy GET query param during rollout - see #17682/#17832
+        $refreshToken = $request->input('refresh_token');
         $payload = [
             'grant_type' => 'refresh_token',
             'client_id' => config('oauth.client_id'),

--- a/api/app/Providers/AppServiceProvider.php
+++ b/api/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Reverb\ReverbLogger;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
@@ -38,6 +39,10 @@ class AppServiceProvider extends ServiceProvider
         // https://github.com/PHPOffice/PHPWord/issues/2524#issuecomment-1847981808
         // https://phpoffice.github.io/PHPWord/usage/introduction.html#output-escaping
         Settings::setOutputEscapingEnabled(true);
+
+        // /refresh is an OAuth token endpoint - the refresh token itself proves legitimacy,
+        // same reasoning as exempting other OAuth token endpoints from CSRF checks.
+        PreventRequestForgery::except(['refresh', '*/refresh']);
 
         // enable below for database debugging
         // DB::listen(function ($query) {

--- a/api/routes/web.php
+++ b/api/routes/web.php
@@ -17,7 +17,9 @@ Route::prefix(config('app.app_dir'))->group(function () {
     Route::get('/login', [AuthController::class, 'login']);
     Route::get('/register', [AuthController::class, 'login']);
     Route::get('/auth-callback', [AuthController::class, 'authCallback']);
+    // GET kept temporarily for backward compatibility during rollout - see #17832 for its removal
     Route::get('/refresh', [AuthController::class, 'refresh']);
+    Route::post('/refresh', [AuthController::class, 'refresh']);
     Route::get('/sector-identifier', [AuthController::class, 'sectorIdentifier']);
 });
 
@@ -25,6 +27,8 @@ Route::prefix('')->group(function () {
     Route::get('/login', [AuthController::class, 'login']);
     Route::get('/register', [AuthController::class, 'login']);
     Route::get('/auth-callback', [AuthController::class, 'authCallback']);
+    // GET kept temporarily for backward compatibility during rollout - see #17832 for its removal
     Route::get('/refresh', [AuthController::class, 'refresh']);
+    Route::post('/refresh', [AuthController::class, 'refresh']);
     Route::get('/sector-identifier', [AuthController::class, 'sectorIdentifier']);
 });

--- a/api/tests/Unit/AuthControllerTest.php
+++ b/api/tests/Unit/AuthControllerTest.php
@@ -245,4 +245,57 @@ class AuthControllerTest extends TestCase
         $this->assertStringContainsString('reason=invalid-session', $response->headers->get('Location'));
         Http::assertNothingSent();
     }
+
+    public function testRefreshAcceptsTokenViaPostBody()
+    {
+        Http::fake([
+            '*' => Http::response(['access_token' => 'new-access-token', 'refresh_token' => 'new-refresh-token'], 200),
+        ]);
+
+        $response = $this->postJson('/refresh', ['refresh_token' => 'old-refresh-token']);
+
+        $response->assertStatus(200);
+        $response->assertJson(['access_token' => 'new-access-token', 'refresh_token' => 'new-refresh-token']);
+
+        Http::assertSent(function ($request) {
+            return $request['grant_type'] === 'refresh_token' && $request['refresh_token'] === 'old-refresh-token';
+        });
+    }
+
+    public function testRefreshStillAcceptsLegacyGetQueryParam()
+    {
+        Http::fake([
+            '*' => Http::response(['access_token' => 'new-access-token', 'refresh_token' => 'new-refresh-token'], 200),
+        ]);
+
+        $response = $this->call('GET', '/refresh', ['refresh_token' => 'old-refresh-token']);
+
+        $response->assertStatus(200);
+
+        Http::assertSent(function ($request) {
+            return $request['refresh_token'] === 'old-refresh-token';
+        });
+    }
+
+    public function testRefreshFailsWhenTokenIsMissing()
+    {
+        Http::fake([
+            '*' => Http::response(['error' => 'invalid_grant'], 400),
+        ]);
+
+        $response = $this->postJson('/refresh', []);
+
+        $response->assertStatus(400);
+    }
+
+    public function testRefreshFailsWhenUpstreamRejectsInvalidToken()
+    {
+        Http::fake([
+            '*' => Http::response(['error' => 'invalid_grant'], 400),
+        ]);
+
+        $response = $this->postJson('/refresh', ['refresh_token' => 'not-a-real-token']);
+
+        $response->assertStatus(400);
+    }
 }

--- a/apps/playwright/fixtures/AuthTokenFixture.ts
+++ b/apps/playwright/fixtures/AuthTokenFixture.ts
@@ -34,7 +34,7 @@ class AuthTokenFixture {
     // Prepare the refresh listener
     // eslint-disable-next-line playwright/missing-playwright-await
     const refresh = this.page.waitForRequest(
-      (req) => req.url().includes("/refresh") && req.method() === "GET",
+      (req) => req.url().includes("/refresh") && req.method() === "POST",
     );
 
     // Prepare a graphql request listener
@@ -52,9 +52,10 @@ class AuthTokenFixture {
 
   // Get the refresh token used in the last refresh request made
   async getRefreshTokenUsed(listener: Promise<Request>) {
-    return await listener.then((req) =>
-      new URL(req.url()).searchParams.get("refresh_token"),
-    );
+    return await listener.then((req) => {
+      const body = req.postDataJSON() as { refresh_token?: string };
+      return body.refresh_token ?? null;
+    });
   }
 
   // Get the authorization header from the last graphql request

--- a/packages/auth/src/utils/authenticationState.test.ts
+++ b/packages/auth/src/utils/authenticationState.test.ts
@@ -1,0 +1,90 @@
+/* eslint-disable camelcase */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { ACCESS_TOKEN, ID_TOKEN, REFRESH_TOKEN } from "../const";
+import getAuthenticationState from "./authenticationState";
+
+vi.mock("@gc-digital-talent/logger", () => ({
+  getLogger: () => ({
+    notice: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock("./logout", () => ({
+  default: vi.fn(),
+  getLogoutVars: () => ({
+    logoutUri: "https://example.com/logout",
+    postLogoutRedirectUri: "https://example.com/",
+  }),
+}));
+
+vi.mock("./logoutChannel", () => ({
+  getLogoutChannel: () => vi.fn(),
+}));
+
+vi.mock("./getTokenRefreshPath", () => ({
+  default: () => "/refresh",
+}));
+
+describe("refreshTokenSet", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("requests /refresh via POST with the token in a JSON body", async () => {
+    localStorage.setItem(REFRESH_TOKEN, "stored-refresh-token");
+
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          access_token: "new-access-token",
+          refresh_token: "new-refresh-token",
+          expires_in: null,
+          id_token: null,
+        }),
+    } as Response);
+
+    const { refreshTokenSet } = getAuthenticationState({ locale: "en" });
+    await refreshTokenSet();
+
+    expect(fetchMock).toHaveBeenCalledWith("/refresh", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refresh_token: "stored-refresh-token" }),
+    });
+  });
+
+  it("stores the refreshed tokens on success", async () => {
+    localStorage.setItem(REFRESH_TOKEN, "stored-refresh-token");
+
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          access_token: "new-access-token",
+          refresh_token: "new-refresh-token",
+          expires_in: null,
+          id_token: "new-id-token",
+        }),
+    } as Response);
+
+    const { refreshTokenSet } = getAuthenticationState({ locale: "en" });
+    await refreshTokenSet();
+
+    expect(localStorage.getItem(ACCESS_TOKEN)).toBe("new-access-token");
+    expect(localStorage.getItem(REFRESH_TOKEN)).toBe("new-refresh-token");
+    expect(localStorage.getItem(ID_TOKEN)).toBe("new-id-token");
+  });
+
+  it("does nothing when there is no stored refresh token", async () => {
+    const fetchMock = vi.spyOn(global, "fetch");
+
+    const { refreshTokenSet } = getAuthenticationState({ locale: "en" });
+    await refreshTokenSet();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/auth/src/utils/authenticationState.ts
+++ b/packages/auth/src/utils/authenticationState.ts
@@ -52,9 +52,12 @@ function getAuthenticationState({
         return;
       }
       logger.notice("Attempting to refresh the auth token set");
-      const response = await fetch(
-        `${tokenRefreshPath}?refresh_token=${storedRefreshToken}`,
-      );
+      const response = await fetch(tokenRefreshPath, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        // eslint-disable-next-line camelcase
+        body: JSON.stringify({ refresh_token: storedRefreshToken }),
+      });
       if (response.ok) {
         const responseBody: TokenRefreshResponseBody =
           (await response.json()) as TokenRefreshResponseBody;


### PR DESCRIPTION
🤖 Resolves #17682

## 👋 Introduction

Adds POST support to `/refresh` so the refresh token travels in the request body instead of the URL query string. 
Closes off the query-string leak into Azure `AppServiceHTTPLogs`, browser history, and referrer headers.

## 🕵️ Details

- Frontend now POSTs to `/refresh` with `refresh_token` in a JSON body. 
- `GET /refresh?refresh_token=...` is kept temporarily for backward compatibility 

- `/refresh` is now reachable via POST, which puts it behind `PreventRequestForgery`. 

- Added a CSRF exemption for it (two path patterns since the route is registered in two route groups) — the refresh token itself is the credential proving legitimacy, same reasoning used for exempting any OAuth token endpoint from CSRF.

## 🧪 Testing

Manual 

- Force a token refresh through the real login flow and confirm the Network tab shows `POST /refresh` with `refresh_token` in a JSON body, and that legacy `GET /refresh?refresh_token=...` still succeeds.

- Check `AppServiceHTTPLogs` for both calls: 
           * POST requests log an empty `CsUriQuery` 
           * GET requests still show the token in plaintext there (expected until  #17832).


