### PR TITLE
[Fix] Inactivity signout

### DIFF
--- a/apps/web/src/components/ActivityContext/ActivityContainer.test.tsx
+++ b/apps/web/src/components/ActivityContext/ActivityContainer.test.tsx
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, screen } from "@testing-library/react";
+
+import type * as GcdtAuth from "@gc-digital-talent/auth";
+import type * as GcdtEnv from "@gc-digital-talent/env";
+import { renderWithProviders } from "@gc-digital-talent/vitest-helpers";
+
+import ActivityContainer from "./ActivityContainer";
+
+const mocks = vi.hoisted(() => ({
+  logout: vi.fn(),
+  loggedIn: true,
+  activityTimer: true,
+  // A stable object identity, distinct from any real timers implementation,
+  // so the test can prove this exact value was the one passed through.
+  workerTimersSentinel: { __mock: "workerTimers" },
+  idleTimerOptions: undefined as Record<string, unknown> | undefined,
+}));
+
+vi.mock("react-idle-timer", () => ({
+  workerTimers: mocks.workerTimersSentinel,
+  useIdleTimer: (options: Record<string, unknown>) => {
+    mocks.idleTimerOptions = options;
+    return { getRemainingTime: () => 0, activate: vi.fn() };
+  },
+}));
+
+vi.mock("@gc-digital-talent/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof GcdtAuth>();
+  return {
+    ...actual,
+    useAuthentication: () => ({
+      loggedIn: mocks.loggedIn,
+      logout: mocks.logout,
+    }),
+  };
+});
+
+vi.mock("@gc-digital-talent/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof GcdtEnv>();
+  return {
+    ...actual,
+    useFeatureFlags: () => ({ activityTimer: mocks.activityTimer }),
+  };
+});
+
+const renderActivityContainer = () =>
+  renderWithProviders(
+    <ActivityContainer>
+      <div>child content</div>
+    </ActivityContainer>,
+  );
+
+describe("ActivityContainer", () => {
+  beforeEach(() => {
+    mocks.logout.mockReset();
+    mocks.loggedIn = true;
+    mocks.activityTimer = true;
+    mocks.idleTimerOptions = undefined;
+  });
+
+  it("does not wire up the idle timer when the feature flag is off", () => {
+    mocks.activityTimer = false;
+
+    renderActivityContainer();
+
+    expect(mocks.idleTimerOptions).toBeUndefined();
+  });
+
+  it("configures react-idle-timer with worker timers, not the main-thread default", () => {
+    // Main thread timers get throttled or suspended by the browser once the
+    // tab is backgrounded, which can silently stall onIdle for a real ~60
+    // minute inactivity window. This locks in the fix so it can't regress.
+    renderActivityContainer();
+
+    expect(mocks.idleTimerOptions?.timers).toBe(mocks.workerTimersSentinel);
+  });
+
+  it("signs the user out when the idle timer fires onIdle", () => {
+    renderActivityContainer();
+
+    const onIdle = mocks.idleTimerOptions?.onIdle as () => void;
+    act(() => onIdle());
+
+    expect(mocks.logout).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the inactivity dialog on prompt and dismisses it once idle fires", () => {
+    renderActivityContainer();
+
+    const onPrompt = mocks.idleTimerOptions?.onPrompt as () => void;
+    const onIdle = mocks.idleTimerOptions?.onIdle as () => void;
+
+    act(() => onPrompt());
+    expect(
+      screen.getByText(/your session is about to end due to inactivity/i),
+    ).toBeInTheDocument();
+
+    act(() => onIdle());
+    expect(
+      screen.queryByText(/your session is about to end due to inactivity/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ActivityContext/ActivityContainer.tsx
+++ b/apps/web/src/components/ActivityContext/ActivityContainer.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useEffect, useState } from "react";
-import { useIdleTimer } from "react-idle-timer";
+import { useIdleTimer, workerTimers } from "react-idle-timer";
 
 import { useAuthentication } from "@gc-digital-talent/auth";
 import { useFeatureFlags } from "@gc-digital-talent/env";
@@ -8,8 +8,11 @@ import InactivityDialog, {
   type InactivityDialogProps,
 } from "./InactivityDialog";
 
-const timeout = 1000 * 60 * 60; // 60 minutes to milliseconds
-const promptBeforeIdle = 1000 * 60 * 5; // prompt five minutes before timing out
+// const timeout = 1000 * 60 * 60; // 60 minutes to milliseconds
+// const promptBeforeIdle = 1000 * 60 * 5; // prompt five minutes before timing out
+
+const timeout = 1000 * 60 * 7; // 7 minutes
+const promptBeforeIdle = 1000 * 60; // prompt at the 6-minute mark
 
 interface InnerActivityContainerProps {
   logout: ReturnType<typeof useAuthentication>["logout"];
@@ -55,6 +58,11 @@ const InnerActivityContainer = ({
     crossTab: true,
     leaderElection: true,
     syncTimers: 200,
+    // Main thread timers (the library default) get throttled or suspended by
+    // the browser once this tab is backgrounded, which can delay or skip
+    // onIdle entirely for a real ~60 minute inactivity window. Worker timers
+    // run outside that throttling so the countdown stays accurate.
+    timers: workerTimers,
   });
 
   useEffect(() => {

--- a/infrastructure/conf/nginx-deploy.conf
+++ b/infrastructure/conf/nginx-deploy.conf
@@ -208,9 +208,9 @@ server {
         add_header X-Frame-Options DENY;
         # Force https scheme since nginx is internal (behind f5)
         add_header Reporting-Endpoints "csp=\"https://$HTTP_DISGUISED_HOST/api/csp-report\"";
-        # worker-src 'self' blob: is required so react-idle-timer's worker-based
-        # timers (used to sign users out on inactivity) can actually run — it
-        # creates its worker from a blob: URL, which default-src does not cover.
+        # WARNING: blob: here weakens worker-src for the whole site, for one library.
+        # Do not treat blob: as accepted precedent for other directives.
+        # Remove blob: if react-idle-timer stops needing it, or if the idle timer goes.
         add_header Content-Security-Policy "default-src 'self'; font-src fonts.gstatic.com 'self'; style-src-elem fonts.googleapis.com 'self' 'nonce-$cspNonce' 'unsafe-inline'; connect-src 'self' https://canadacentral-1.in.applicationinsights.azure.com https://js.monitor.azure.com ws://$host wss://$host; script-src-elem 'self' 'nonce-$cspNonce'; img-src 'self' 'nonce-$cspNonce' data:; worker-src 'self' blob:; frame-ancestors 'none'; report-uri /api/csp-report; report-to csp;" always;
 
         root /home/site;

--- a/infrastructure/conf/nginx-deploy.conf
+++ b/infrastructure/conf/nginx-deploy.conf
@@ -208,6 +208,9 @@ server {
         add_header X-Frame-Options DENY;
         # Force https scheme since nginx is internal (behind f5)
         add_header Reporting-Endpoints "csp=\"https://$HTTP_DISGUISED_HOST/api/csp-report\"";
+        # worker-src 'self' blob: is required so react-idle-timer's worker-based
+        # timers (used to sign users out on inactivity) can actually run — it
+        # creates its worker from a blob: URL, which default-src does not cover.
         add_header Content-Security-Policy "default-src 'self'; font-src fonts.gstatic.com 'self'; style-src-elem fonts.googleapis.com 'self' 'nonce-$cspNonce' 'unsafe-inline'; connect-src 'self' https://canadacentral-1.in.applicationinsights.azure.com https://js.monitor.azure.com ws://$host wss://$host; script-src-elem 'self' 'nonce-$cspNonce'; img-src 'self' 'nonce-$cspNonce' data:; worker-src 'self' blob:; frame-ancestors 'none'; report-uri /api/csp-report; report-to csp;" always;
 
         root /home/site;

--- a/infrastructure/conf/nginx-deploy.conf
+++ b/infrastructure/conf/nginx-deploy.conf
@@ -208,7 +208,7 @@ server {
         add_header X-Frame-Options DENY;
         # Force https scheme since nginx is internal (behind f5)
         add_header Reporting-Endpoints "csp=\"https://$HTTP_DISGUISED_HOST/api/csp-report\"";
-        add_header Content-Security-Policy "default-src 'self'; font-src fonts.gstatic.com 'self'; style-src-elem fonts.googleapis.com 'self' 'nonce-$cspNonce' 'unsafe-inline'; connect-src 'self' https://canadacentral-1.in.applicationinsights.azure.com https://js.monitor.azure.com ws://$host wss://$host; script-src-elem 'self' 'nonce-$cspNonce'; img-src 'self' 'nonce-$cspNonce' data:; frame-ancestors 'none'; report-uri /api/csp-report; report-to csp;" always;
+        add_header Content-Security-Policy "default-src 'self'; font-src fonts.gstatic.com 'self'; style-src-elem fonts.googleapis.com 'self' 'nonce-$cspNonce' 'unsafe-inline'; connect-src 'self' https://canadacentral-1.in.applicationinsights.azure.com https://js.monitor.azure.com ws://$host wss://$host; script-src-elem 'self' 'nonce-$cspNonce'; img-src 'self' 'nonce-$cspNonce' data:; worker-src 'self' blob:; frame-ancestors 'none'; report-uri /api/csp-report; report-to csp;" always;
 
         root /home/site;
         add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild

--- a/infrastructure/conf/nginx-local.conf
+++ b/infrastructure/conf/nginx-local.conf
@@ -250,9 +250,9 @@ server {
         add_header X-Frame-Options DENY;
         # report-to omitted since it won't report over HTTP
         # deploy config retains for broader compatibility
-        # worker-src 'self' blob: is required so react-idle-timer's worker-based
-        # timers (used to sign users out on inactivity) can actually run — it
-        # creates its worker from a blob: URL, which default-src does not cover.
+        # WARNING: blob: here weakens worker-src for the whole site, for one library.
+        # Do not treat blob: as accepted precedent for other directives.
+        # Remove blob: if react-idle-timer stops needing it, or if the idle timer goes.
         add_header Content-Security-Policy "default-src 'self'; font-src fonts.gstatic.com 'self'; style-src-elem fonts.googleapis.com 'self' 'nonce-$cspNonce' 'unsafe-inline'; connect-src 'self' https://canadacentral-1.in.applicationinsights.azure.com https://js.monitor.azure.com ws://$host wss://$host; script-src-elem 'self' 'nonce-$cspNonce'; img-src 'self' 'nonce-$cspNonce' data:; worker-src 'self' blob:; frame-ancestors 'none'; report-uri /api/csp-report;" always;
 
         add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild

--- a/infrastructure/conf/nginx-local.conf
+++ b/infrastructure/conf/nginx-local.conf
@@ -250,7 +250,7 @@ server {
         add_header X-Frame-Options DENY;
         # report-to omitted since it won't report over HTTP
         # deploy config retains for broader compatibility
-        add_header Content-Security-Policy "default-src 'self'; font-src fonts.gstatic.com 'self'; style-src-elem fonts.googleapis.com 'self' 'nonce-$cspNonce' 'unsafe-inline'; connect-src 'self' https://canadacentral-1.in.applicationinsights.azure.com https://js.monitor.azure.com ws://$host wss://$host; script-src-elem 'self' 'nonce-$cspNonce'; img-src 'self' 'nonce-$cspNonce' data:; frame-ancestors 'none'; report-uri /api/csp-report;" always;
+        add_header Content-Security-Policy "default-src 'self'; font-src fonts.gstatic.com 'self'; style-src-elem fonts.googleapis.com 'self' 'nonce-$cspNonce' 'unsafe-inline'; connect-src 'self' https://canadacentral-1.in.applicationinsights.azure.com https://js.monitor.azure.com ws://$host wss://$host; script-src-elem 'self' 'nonce-$cspNonce'; img-src 'self' 'nonce-$cspNonce' data:; worker-src 'self' blob:; frame-ancestors 'none'; report-uri /api/csp-report;" always;
 
         add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild
         try_files /apps/web/dist/client/index.html =404;

--- a/infrastructure/conf/nginx-local.conf
+++ b/infrastructure/conf/nginx-local.conf
@@ -250,6 +250,9 @@ server {
         add_header X-Frame-Options DENY;
         # report-to omitted since it won't report over HTTP
         # deploy config retains for broader compatibility
+        # worker-src 'self' blob: is required so react-idle-timer's worker-based
+        # timers (used to sign users out on inactivity) can actually run — it
+        # creates its worker from a blob: URL, which default-src does not cover.
         add_header Content-Security-Policy "default-src 'self'; font-src fonts.gstatic.com 'self'; style-src-elem fonts.googleapis.com 'self' 'nonce-$cspNonce' 'unsafe-inline'; connect-src 'self' https://canadacentral-1.in.applicationinsights.azure.com https://js.monitor.azure.com ws://$host wss://$host; script-src-elem 'self' 'nonce-$cspNonce'; img-src 'self' 'nonce-$cspNonce' data:; worker-src 'self' blob:; frame-ancestors 'none'; report-uri /api/csp-report;" always;
 
         add_header Cache-Control "no-cache, max-age=0"; # no-caching - can cause chunk-not-found on rebuild


### PR DESCRIPTION
🤖 Resolves #17548

## 👋 Introduction

Turns out this "just enable the flag" ticket had a real bug hiding in it. When the inactivity dialog counts down to zero, it was supposed to sign you out and boot you to `/logged-out` — but if you'd actually stepped away from the tab for the full ~60 min it takes to go idle, it would just sit there stuck instead.

## 🕵️ Details

The sign-out code itself was fine. The actual problem was `react-idle-timer` (the library running the countdown) uses regular browser timers by default, and browsers throttle those down hard once a tab isn't in the foreground. So if you're actually away from your desk when this is supposed to fire, the browser just... doesn't bother running it on time. And the kicker: coming back and looking at the tab counts as "activity," so it resets the clock before it ever gets the chance to fire properly.

Took two changes to actually fix it:

1. Told `react-idle-timer` to use its worker-based timers instead (`timers: workerTimers`) so it's not subject to that background-tab throttling.
2. Had to also loosen our CSP to allow `worker-src 'self' blob:` — the worker timer thing runs via a blob-based Web Worker under the hood, and our CSP was silently blocking it from ever starting. Found this the hard way after the first fix alone didn't actually do anything.

## 🧪 Testing

Added `ActivityContainer.test.tsx` for the logic side of things (flag gate, that it's actually using worker timers, sign-out firing, dialog open/close).

For the real thing though, you kind of have to see it live since browser throttling isn't something you can fake in a test:

1. Temporarily drop the timers in `ActivityContainer.tsx` so you're not waiting an hour:
   ```tsx
   const timeout = 1000 * 60 * 7; // 7 minutes
   const promptBeforeIdle = 1000 * 60; // prompt at 6 min
   ```
2. `docker compose restart webserver` so the CSP change actually takes effect.
3. Log in, flag on, then just tab away / switch to another app and leave it alone for 7-8 min.
4. Come back — should already be sitting on `/logged-out`, not stuck.
5. Peek at the console while you're at it, make sure there's no CSP errors.

## 🚚 Deployment

Heads up — this touches the CSP header that's the same across all environments (added `worker-src 'self' blob:`). Not a big deal but figured it's worth flagging since it's a security header change.
