### PR TITLE
[Fix] Remove nested `p` tags sign out dialog

### DIFF
--- a/apps/web/src/pages/Auth/SignedOutPage/SignedOutPage.tsx
+++ b/apps/web/src/pages/Auth/SignedOutPage/SignedOutPage.tsx
@@ -235,15 +235,13 @@ export const Component = () => {
           <AlertDialog.Title>
             {intl.formatMessage(authMessages.signOut)}
           </AlertDialog.Title>
-          <AlertDialog.Description>
-            <p className="text-xl/[1.1] lg:text-2xl/[1.1]">
-              {intl.formatMessage({
-                defaultMessage: "Are you sure you would like to sign out?",
-                id: "mNNgEF",
-                description:
-                  "Question displayed when authenticated user lands on /logged-out.",
-              })}
-            </p>
+          <AlertDialog.Description className="text-xl/[1.1] lg:text-2xl/[1.1]">
+            {intl.formatMessage({
+              defaultMessage: "Are you sure you would like to sign out?",
+              id: "mNNgEF",
+              description:
+                "Question displayed when authenticated user lands on /logged-out.",
+            })}
           </AlertDialog.Description>
           <AlertDialog.Footer>
             <AlertDialog.Action>

--- a/packages/ui/src/components/AlertDialog/AlertDialog.tsx
+++ b/packages/ui/src/components/AlertDialog/AlertDialog.tsx
@@ -4,6 +4,7 @@
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 import type { ComponentRef, ComponentPropsWithoutRef, ReactNode } from "react";
 import { forwardRef } from "react";
+import { tv } from "tailwind-variants";
 
 import Separator from "../Separator";
 
@@ -69,14 +70,16 @@ const Title = forwardRef<
   />
 ));
 
+const description = tv({ base: "text-base" });
+
 const Description = forwardRef<
   ComponentRef<typeof AlertDialogPrimitive.Description>,
   ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
->((props, forwardedRef) => (
+>(({ className, ...rest }, forwardedRef) => (
   <AlertDialogPrimitive.Description
-    className="text-base"
+    className={description({ class: className })}
     ref={forwardedRef}
-    {...props}
+    {...rest}
   />
 ));
 


### PR DESCRIPTION
🤖 Resolves #17838 

## 👋 Introduction

Removes a nested `p` tag in the sign out alert dialog.

## 🕵️ Details

Seems this was added to change the text style. In order to remove it, the alert dialog description was updated to allow for overriding it class.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as any user
3. Attempt to logout
4. Confirm the alert dialog that appears has:
    a. No nested `p` tags
    b. No visual regression
