### PR TITLE
[Fix]  urql mutation guards for errors

### DIFF
--- a/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
@@ -222,17 +222,20 @@ export const ApplicationCareerTimeline = ({
       },
     })
       .then(async (res) => {
-        if (!res.error) {
-          toast.success(
-            intl.formatMessage({
-              defaultMessage: "Successfully updated your career timeline!",
-              id: "dfkNm9",
-              description:
-                "Message displayed to users when saving career timeline is successful.",
-            }),
-          );
-          await navigate(nextStep);
+        if (!res.data || res.error) {
+          throw new Error();
         }
+
+        toast.success(
+          intl.formatMessage({
+            defaultMessage: "Successfully updated your career timeline!",
+            id: "dfkNm9",
+            description:
+              "Message displayed to users when saving career timeline is successful.",
+          }),
+        );
+
+        await navigate(nextStep);
       })
       .catch(() => {
         toast.error(

--- a/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationCareerTimelinePage/ApplicationCareerTimelinePage.tsx
@@ -222,7 +222,7 @@ export const ApplicationCareerTimeline = ({
       },
     })
       .then(async (res) => {
-        if (!res.data || res.error) {
+        if (!res.data?.updateApplication?.id || res.error) {
           throw new Error();
         }
 

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
@@ -273,7 +273,7 @@ const ApplicationEducation = ({
         },
       })
         .then(async (res) => {
-          if (!res.data || res.error) {
+          if (!res.data?.updateApplication?.id || res.error) {
             throw new Error();
           }
 

--- a/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationEducationPage/ApplicationEducationPage.tsx
@@ -273,20 +273,23 @@ const ApplicationEducation = ({
         },
       })
         .then(async (res) => {
-          if (!res.error) {
-            toast.success(
-              intl.formatMessage({
-                defaultMessage:
-                  "Successfully updated your education requirement!",
-                id: "QYlwuE",
-                description:
-                  "Message displayed to users when saving education requirement is successful.",
-              }),
-            );
-            await navigate(
-              formValues.action === "continue" ? nextStep : cancelPath,
-            );
+          if (!res.data || res.error) {
+            throw new Error();
           }
+
+          toast.success(
+            intl.formatMessage({
+              defaultMessage:
+                "Successfully updated your education requirement!",
+              id: "QYlwuE",
+              description:
+                "Message displayed to users when saving education requirement is successful.",
+            }),
+          );
+
+          await navigate(
+            formValues.action === "continue" ? nextStep : cancelPath,
+          );
         })
         .catch(() => {
           toast.error(

--- a/apps/web/src/pages/Applications/ApplicationQuestionsPage/ApplicationQuestionsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsPage/ApplicationQuestionsPage.tsx
@@ -79,21 +79,24 @@ const ApplicationQuestions = ({ application }: ApplicationPageProps) => {
       },
     })
       .then(async (res) => {
-        if (!res.error) {
-          toast.success(
-            intl.formatMessage({
-              defaultMessage: "Successfully updated question responses!",
-              id: "Bs/9PZ",
-              description:
-                "Message displayed to users when saving question responses is successful.",
-            }),
-          );
-          await navigate(
-            formValues.action === "continue"
-              ? paths.applicationReview(application.id)
-              : cancelPath,
-          );
+        if (!res.data || res.error) {
+          throw new Error();
         }
+
+        toast.success(
+          intl.formatMessage({
+            defaultMessage: "Successfully updated question responses!",
+            id: "Bs/9PZ",
+            description:
+              "Message displayed to users when saving question responses is successful.",
+          }),
+        );
+
+        await navigate(
+          formValues.action === "continue"
+            ? paths.applicationReview(application.id)
+            : cancelPath,
+        );
       })
       .catch(() => {
         toast.error(

--- a/apps/web/src/pages/Applications/ApplicationQuestionsPage/ApplicationQuestionsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationQuestionsPage/ApplicationQuestionsPage.tsx
@@ -79,7 +79,7 @@ const ApplicationQuestions = ({ application }: ApplicationPageProps) => {
       },
     })
       .then(async (res) => {
-        if (!res.data || res.error) {
+        if (!res.data?.updateApplication?.id || res.error) {
           throw new Error();
         }
 

--- a/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
@@ -124,7 +124,7 @@ const ApplicationReview = ({ application }: ApplicationPageProps) => {
       signature: formValues.signature,
     })
       .then(async (res) => {
-        if (!res.data || res.error) {
+        if (!res.data?.submitApplication?.id || res.error) {
           throw new Error();
         }
 

--- a/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationReviewPage/ApplicationReviewPage.tsx
@@ -124,31 +124,35 @@ const ApplicationReview = ({ application }: ApplicationPageProps) => {
       signature: formValues.signature,
     })
       .then(async (res) => {
-        if (!res.error) {
-          // Log the submission of the application with app insights
-          if (appInsights) {
-            const aiUserId = appInsights?.context?.user?.id || "unknown";
-            appInsights.trackEvent?.(
-              { name: "Job application submitted" },
-              {
-                aiUserId,
-                pageUrl: window.location.href,
-                timestamp: new Date().toISOString(),
-                referrer: document.referrer || "none",
-                source: "ApplicationReviewPage",
-              },
-            );
-          }
-          toast.success(
-            intl.formatMessage({
-              defaultMessage: "We've successfully received your application",
-              id: "2SSm+L",
-              description:
-                "Success message after submission for the application review page.",
-            }),
-          );
-          await navigate(nextStep);
+        if (!res.data || res.error) {
+          throw new Error();
         }
+
+        // Log the submission of the application with app insights
+        if (appInsights) {
+          const aiUserId = appInsights?.context?.user?.id || "unknown";
+          appInsights.trackEvent?.(
+            { name: "Job application submitted" },
+            {
+              aiUserId,
+              pageUrl: window.location.href,
+              timestamp: new Date().toISOString(),
+              referrer: document.referrer || "none",
+              source: "ApplicationReviewPage",
+            },
+          );
+        }
+
+        toast.success(
+          intl.formatMessage({
+            defaultMessage: "We've successfully received your application",
+            id: "2SSm+L",
+            description:
+              "Success message after submission for the application review page.",
+          }),
+        );
+
+        await navigate(nextStep);
       })
       .catch(() => {
         if (appInsights) {

--- a/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
@@ -157,17 +157,20 @@ export const ApplicationSkills = ({
       },
     })
       .then(async (res) => {
-        if (!res.error) {
-          toast.success(
-            intl.formatMessage({
-              defaultMessage: "Successfully updated your skills!",
-              id: "j7nWu/",
-              description:
-                "Message displayed to users when saving skills is successful.",
-            }),
-          );
-          await navigate(nextStep);
+        if (!res.data || res.error) {
+          throw new Error();
         }
+
+        toast.success(
+          intl.formatMessage({
+            defaultMessage: "Successfully updated your skills!",
+            id: "j7nWu/",
+            description:
+              "Message displayed to users when saving skills is successful.",
+          }),
+        );
+
+        await navigate(nextStep);
       })
       .catch(() => {
         toast.error(

--- a/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
+++ b/apps/web/src/pages/Applications/ApplicationSkillsPage/ApplicationSkillsPage.tsx
@@ -157,7 +157,7 @@ export const ApplicationSkills = ({
       },
     })
       .then(async (res) => {
-        if (!res.data || res.error) {
+        if (!res.data?.updateApplication?.id || res.error) {
           throw new Error();
         }
 

--- a/apps/web/src/pages/Communities/CommunityMembersPage/components/AddCommunityMemberDialog.tsx
+++ b/apps/web/src/pages/Communities/CommunityMembersPage/components/AddCommunityMemberDialog.tsx
@@ -71,7 +71,7 @@ const AddCommunityMemberDialog = ({
       },
     })
       .then((res) => {
-        if (!res.data || res.error) {
+        if (!res.data?.updateUserRoles?.id || res.error) {
           throw new Error();
         }
 

--- a/apps/web/src/pages/Communities/CommunityMembersPage/components/AddCommunityMemberDialog.tsx
+++ b/apps/web/src/pages/Communities/CommunityMembersPage/components/AddCommunityMemberDialog.tsx
@@ -71,17 +71,19 @@ const AddCommunityMemberDialog = ({
       },
     })
       .then((res) => {
-        if (!res.error) {
-          setIsOpen(false);
-          toast.success(
-            intl.formatMessage({
-              defaultMessage: "Member added successfully",
-              id: "KESOSJ",
-              description:
-                "Alert displayed to user when a community member was added to a community",
-            }),
-          );
+        if (!res.data || res.error) {
+          throw new Error();
         }
+
+        setIsOpen(false);
+        toast.success(
+          intl.formatMessage({
+            defaultMessage: "Member added successfully",
+            id: "KESOSJ",
+            description:
+              "Alert displayed to user when a community member was added to a community",
+          }),
+        );
       })
       .catch(() => {
         toast.error(

--- a/apps/web/src/pages/Communities/CommunityMembersPage/components/EditCommunityMemberDialog.tsx
+++ b/apps/web/src/pages/Communities/CommunityMembersPage/components/EditCommunityMemberDialog.tsx
@@ -89,17 +89,19 @@ const EditCommunityMemberDialog = forwardRef<
       },
     })
       .then((res) => {
-        if (!res.error) {
-          setIsOpen(false);
-          toast.success(
-            intl.formatMessage({
-              defaultMessage: "Roles updated successfully",
-              id: "Jc9FDx",
-              description:
-                "Alert displayed to user when a community member's roles have been updated",
-            }),
-          );
+        if (!res.data || res.error) {
+          throw new Error();
         }
+
+        setIsOpen(false);
+        toast.success(
+          intl.formatMessage({
+            defaultMessage: "Roles updated successfully",
+            id: "Jc9FDx",
+            description:
+              "Alert displayed to user when a community member's roles have been updated",
+          }),
+        );
       })
       .catch(() => {
         toast.error(

--- a/apps/web/src/pages/Communities/CommunityMembersPage/components/EditCommunityMemberDialog.tsx
+++ b/apps/web/src/pages/Communities/CommunityMembersPage/components/EditCommunityMemberDialog.tsx
@@ -89,7 +89,7 @@ const EditCommunityMemberDialog = forwardRef<
       },
     })
       .then((res) => {
-        if (!res.data || res.error) {
+        if (!res.data?.updateUserRoles?.id || res.error) {
           throw new Error();
         }
 

--- a/apps/web/src/pages/Communities/CommunityMembersPage/components/RemoveCommunityMemberDialog.tsx
+++ b/apps/web/src/pages/Communities/CommunityMembersPage/components/RemoveCommunityMemberDialog.tsx
@@ -78,7 +78,7 @@ const RemoveCommunityMemberDialog = forwardRef<
       },
     })
       .then((res) => {
-        if (!res.data || res.error) {
+        if (!res.data?.updateUserRoles?.id || res.error) {
           throw new Error();
         }
 

--- a/apps/web/src/pages/Communities/CommunityMembersPage/components/RemoveCommunityMemberDialog.tsx
+++ b/apps/web/src/pages/Communities/CommunityMembersPage/components/RemoveCommunityMemberDialog.tsx
@@ -78,19 +78,19 @@ const RemoveCommunityMemberDialog = forwardRef<
       },
     })
       .then((res) => {
-        if (!res.error) {
-          setIsOpen(false);
-          toast.success(
-            intl.formatMessage({
-              defaultMessage: "Member removed successfully",
-              id: "KWXIKL",
-              description:
-                "Alert displayed to user when a community member is removed",
-            }),
-          );
-        } else {
-          handleError();
+        if (!res.data || res.error) {
+          throw new Error();
         }
+
+        setIsOpen(false);
+        toast.success(
+          intl.formatMessage({
+            defaultMessage: "Member removed successfully",
+            id: "KWXIKL",
+            description:
+              "Alert displayed to user when a community member is removed",
+          }),
+        );
       })
       .catch(handleError);
   };

--- a/apps/web/src/pages/Departments/ManageAccessPage/components/AddDepartmentMembership.tsx
+++ b/apps/web/src/pages/Departments/ManageAccessPage/components/AddDepartmentMembership.tsx
@@ -72,7 +72,7 @@ const AddDepartmentMembershipDialog = ({
       },
     })
       .then((res) => {
-        if (!res.data || res.error) {
+        if (!res.data?.updateUserRoles?.id || res.error) {
           throw new Error();
         }
 

--- a/apps/web/src/pages/Departments/ManageAccessPage/components/AddDepartmentMembership.tsx
+++ b/apps/web/src/pages/Departments/ManageAccessPage/components/AddDepartmentMembership.tsx
@@ -72,17 +72,19 @@ const AddDepartmentMembershipDialog = ({
       },
     })
       .then((res) => {
-        if (!res.error) {
-          setIsOpen(false);
-          toast.success(
-            intl.formatMessage({
-              defaultMessage: "Member added successfully",
-              id: "KESOSJ",
-              description:
-                "Alert displayed to user when a community member was added to a community",
-            }),
-          );
+        if (!res.data || res.error) {
+          throw new Error();
         }
+
+        setIsOpen(false);
+        toast.success(
+          intl.formatMessage({
+            defaultMessage: "Member added successfully",
+            id: "KESOSJ",
+            description:
+              "Alert displayed to user when a community member was added to a community",
+          }),
+        );
       })
       .catch(() => {
         toast.error(

--- a/apps/web/src/pages/Departments/ManageAccessPage/components/EditDepartmentMembership.tsx
+++ b/apps/web/src/pages/Departments/ManageAccessPage/components/EditDepartmentMembership.tsx
@@ -88,7 +88,7 @@ const EditDepartmentMembershipDialog = forwardRef<
       },
     })
       .then((res) => {
-        if (!res.data || res.error) {
+        if (!res.data?.updateUserRoles?.id || res.error) {
           throw new Error();
         }
 

--- a/apps/web/src/pages/Departments/ManageAccessPage/components/EditDepartmentMembership.tsx
+++ b/apps/web/src/pages/Departments/ManageAccessPage/components/EditDepartmentMembership.tsx
@@ -88,17 +88,19 @@ const EditDepartmentMembershipDialog = forwardRef<
       },
     })
       .then((res) => {
-        if (!res.error) {
-          setIsOpen(false);
-          toast.success(
-            intl.formatMessage({
-              defaultMessage: "Roles updated successfully",
-              id: "Jc9FDx",
-              description:
-                "Alert displayed to user when a community member's roles have been updated",
-            }),
-          );
+        if (!res.data || res.error) {
+          throw new Error();
         }
+
+        setIsOpen(false);
+        toast.success(
+          intl.formatMessage({
+            defaultMessage: "Roles updated successfully",
+            id: "Jc9FDx",
+            description:
+              "Alert displayed to user when a community member's roles have been updated",
+          }),
+        );
       })
       .catch(() => {
         toast.error(

--- a/apps/web/src/pages/Departments/ManageAccessPage/components/RemoveDepartmentMembership.tsx
+++ b/apps/web/src/pages/Departments/ManageAccessPage/components/RemoveDepartmentMembership.tsx
@@ -78,19 +78,19 @@ const RemoveDepartmentMembershipDialog = forwardRef<
       },
     })
       .then((res) => {
-        if (!res.error) {
-          setIsOpen(false);
-          toast.success(
-            intl.formatMessage({
-              defaultMessage: "Member removed successfully",
-              id: "KWXIKL",
-              description:
-                "Alert displayed to user when a community member is removed",
-            }),
-          );
-        } else {
-          handleError();
+        if (!res.data || res.error) {
+          throw new Error();
         }
+
+        setIsOpen(false);
+        toast.success(
+          intl.formatMessage({
+            defaultMessage: "Member removed successfully",
+            id: "KWXIKL",
+            description:
+              "Alert displayed to user when a community member is removed",
+          }),
+        );
       })
       .catch(handleError);
   };

--- a/apps/web/src/pages/Departments/ManageAccessPage/components/RemoveDepartmentMembership.tsx
+++ b/apps/web/src/pages/Departments/ManageAccessPage/components/RemoveDepartmentMembership.tsx
@@ -78,7 +78,7 @@ const RemoveDepartmentMembershipDialog = forwardRef<
       },
     })
       .then((res) => {
-        if (!res.data || res.error) {
+        if (!res.data?.updateUserRoles?.id || res.error) {
           throw new Error();
         }
 

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolBookmark.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolBookmark.tsx
@@ -52,7 +52,7 @@ const PoolBookmark = ({
         poolId,
       })
         .then((res) => {
-          if (!res.data || res.error) {
+          if (!res.data?.togglePoolUserBookmark?.id || res.error) {
             throw new Error();
           }
 

--- a/apps/web/src/pages/Pools/IndexPoolPage/components/PoolBookmark.tsx
+++ b/apps/web/src/pages/Pools/IndexPoolPage/components/PoolBookmark.tsx
@@ -52,28 +52,30 @@ const PoolBookmark = ({
         poolId,
       })
         .then((res) => {
-          if (!res.error) {
-            if (!isBookmarked) {
-              toast.success(
-                intl.formatMessage({
-                  defaultMessage: "Process successfully bookmarked.",
-                  id: "lZ8lct",
+          if (!res.data || res.error) {
+            throw new Error();
+          }
 
-                  description:
-                    "Alert displayed to the user when they mark a pool as bookmarked.",
-                }),
-              );
-            } else {
-              toast.success(
-                intl.formatMessage({
-                  defaultMessage: "Process's bookmark removed successfully.",
-                  id: "g4F/WB",
+          if (!isBookmarked) {
+            toast.success(
+              intl.formatMessage({
+                defaultMessage: "Process successfully bookmarked.",
+                id: "lZ8lct",
 
-                  description:
-                    "Alert displayed to the user when they un-mark a pool as bookmarked.",
-                }),
-              );
-            }
+                description:
+                  "Alert displayed to the user when they mark a pool as bookmarked.",
+              }),
+            );
+          } else {
+            toast.success(
+              intl.formatMessage({
+                defaultMessage: "Process's bookmark removed successfully.",
+                id: "g4F/WB",
+
+                description:
+                  "Alert displayed to the user when they un-mark a pool as bookmarked.",
+              }),
+            );
           }
         })
         .catch(() => {

--- a/apps/web/src/pages/Pools/ManageAccessPage/components/AddPoolMembershipDialog.tsx
+++ b/apps/web/src/pages/Pools/ManageAccessPage/components/AddPoolMembershipDialog.tsx
@@ -68,17 +68,19 @@ const AddPoolMembershipDialog = ({ pool }: AddPoolMembershipDialogProps) => {
       },
     })
       .then((res) => {
-        if (!res.error) {
-          setIsOpen(false);
-          toast.success(
-            intl.formatMessage({
-              defaultMessage: "Member added successfully",
-              id: "KESOSJ",
-              description:
-                "Alert displayed to user when a community member was added to a community",
-            }),
-          );
+        if (!res.data || res.error) {
+          throw new Error();
         }
+
+        setIsOpen(false);
+        toast.success(
+          intl.formatMessage({
+            defaultMessage: "Member added successfully",
+            id: "KESOSJ",
+            description:
+              "Alert displayed to user when a community member was added to a community",
+          }),
+        );
       })
       .catch(() => {
         toast.error(

--- a/apps/web/src/pages/Pools/ManageAccessPage/components/AddPoolMembershipDialog.tsx
+++ b/apps/web/src/pages/Pools/ManageAccessPage/components/AddPoolMembershipDialog.tsx
@@ -68,7 +68,7 @@ const AddPoolMembershipDialog = ({ pool }: AddPoolMembershipDialogProps) => {
       },
     })
       .then((res) => {
-        if (!res.data || res.error) {
+        if (!res.data?.updateUserRoles?.id || res.error) {
           throw new Error();
         }
 

--- a/apps/web/src/pages/Pools/ManageAccessPage/components/RemovePoolMembershipDialog.tsx
+++ b/apps/web/src/pages/Pools/ManageAccessPage/components/RemovePoolMembershipDialog.tsx
@@ -65,19 +65,19 @@ const RemovePoolMembershipDialog = ({
       },
     })
       .then((res) => {
-        if (!res.error) {
-          setIsOpen(false);
-          toast.success(
-            intl.formatMessage({
-              defaultMessage: "Member removed successfully",
-              id: "KWXIKL",
-              description:
-                "Alert displayed to user when a community member is removed",
-            }),
-          );
-        } else {
-          handleError();
+        if (!res.data || res.error) {
+          throw new Error();
         }
+
+        setIsOpen(false);
+        toast.success(
+          intl.formatMessage({
+            defaultMessage: "Member removed successfully",
+            id: "KWXIKL",
+            description:
+              "Alert displayed to user when a community member is removed",
+          }),
+        );
       })
       .catch(handleError);
   };

--- a/apps/web/src/pages/Pools/ManageAccessPage/components/RemovePoolMembershipDialog.tsx
+++ b/apps/web/src/pages/Pools/ManageAccessPage/components/RemovePoolMembershipDialog.tsx
@@ -65,7 +65,7 @@ const RemovePoolMembershipDialog = ({
       },
     })
       .then((res) => {
-        if (!res.data || res.error) {
+        if (!res.data?.updateUserRoles?.id || res.error) {
           throw new Error();
         }
 


### PR DESCRIPTION
🤖 Resolves #17789 

## 👋 Introduction

Updates error handling in the response of some graphql mutations to avoid silently ignoring some errors.

## 🕵️ Details

Updates to use an early throw to prevent the success case from executing if we either have no data or do have an error.

> [!NOTE]
> I did not do the `CreateTalentNominationPage` since it already seemd to have the appropriate guards and was incorrectly flagged. 

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as any user
3. Start an application and on each step, attempt to trigger a failed mutation
4. Confirm you see an error toast and do not attempt to move to the next step
5. Repeat steps 3-4 for editing the members of a
    a. Community
    b. Process
    c. Department
