### PR TITLE
[Fix] Flaky search test

### DIFF
--- a/api/tests/Feature/KeywordSearchTest.php
+++ b/api/tests/Feature/KeywordSearchTest.php
@@ -46,6 +46,7 @@ class KeywordSearchTest extends TestCase
                 'telephone' => null,
                 'first_name' => null,
                 'last_name' => null,
+                'current_city' => 'zzcity',
             ]);
     }
 


### PR DESCRIPTION
🤖 Resolves #17854 

## 👋 Introduction

Fixes an issue in the fkaly test where the unexpected user was appearing unintentionally. 

## 🕵️ Details

After running this many, many times, it seems that the random city selection was overlapping some of the search trms. In the specific case I encountered, it was "Johnsonville". The fix was to hard code a city that that decidedly does not match any of the terms we use in the test.

## 🧪 Testing

1. Run the teest a lot of times (I did it 300 times since this is exceedingly rare it seems)
2. Confirm no failures