### PR TITLE
[Feature] Classifications for advancement nomination

### DIFF
--- a/api/app/GraphQL/Mutations/SubmitTalentNomination.php
+++ b/api/app/GraphQL/Mutations/SubmitTalentNomination.php
@@ -18,7 +18,8 @@ final class SubmitTalentNomination
     {
         $nomination = TalentNomination::find($args['id'])
             ->load('communityDevelopmentPrograms')
-            ->load('skills');
+            ->load('skills')
+            ->load('advancementClassifications');
         $submitValidator = new SubmitTalentNominationValidator($nomination);
         $validator = Validator::make($nomination->toArray(), $submitValidator->rules(), $submitValidator->messages());
         if ($validator->fails()) {

--- a/api/app/GraphQL/Validators/CreateTalentNominationInputValidator.php
+++ b/api/app/GraphQL/Validators/CreateTalentNominationInputValidator.php
@@ -98,7 +98,7 @@ final class CreateTalentNominationInputValidator extends Validator
                 'exists:departments,id',
             ],
             'advancementClassifications' => [
-                'required_with:nominateForAdvancement,nominateForLateralMovement,nominateForDevelopmentPrograms',
+                'required_with:nominateForAdvancement',
             ],
             'advancementClassifications.sync' => [
                 'list',
@@ -156,6 +156,7 @@ final class CreateTalentNominationInputValidator extends Validator
             'advancementReferenceFallbackClassification.connect.exists' => ErrorCode::ADVANCEMENT_REFERENCE_CLASSIFICATION_NOT_FOUND->name,
             'advancementReferenceFallbackDepartment.connect.exists' => ErrorCode::ADVANCEMENT_REFERENCE_DEPARTMENT_NOT_FOUND->name,
             'communityDevelopmentPrograms.sync.exists' => ErrorCode::COMMUNITY_DEVELOPMENT_PROGRAM_NOT_FOUND->name,
+            'advancementClassifications.sync.*.exists' => ErrorCode::CLASSIFICATION_NOT_FOUND->name,
             'skills.sync.exists' => ErrorCode::SKILL_NOT_FOUND->name,
             'skills.sync.*.in' => ErrorCode::SKILL_NOT_KLC->name,
             'skills.sync.prohibited' => ErrorCode::SKILLS_NOT_ALLOWED_FOR_EVENT->name,

--- a/api/app/GraphQL/Validators/CreateTalentNominationInputValidator.php
+++ b/api/app/GraphQL/Validators/CreateTalentNominationInputValidator.php
@@ -97,6 +97,17 @@ final class CreateTalentNominationInputValidator extends Validator
                 'uuid',
                 'exists:departments,id',
             ],
+            'advancementClassifications' => [
+                'required_with:nominateForAdvancement,nominateForLateralMovement,nominateForDevelopmentPrograms',
+            ],
+            'advancementClassifications.sync' => [
+                'list',
+                'distinct',
+                Rule::prohibitedUnless(fn ($attributes) => $attributes->get('nominateForAdvancement')),
+            ],
+            'advancementClassifications.sync.*' => [
+                'exists:classifications,id',
+            ],
 
             'lateralMovementOptions' => ['array'],
             'lateralMovementOptions.*' => [

--- a/api/app/GraphQL/Validators/CreateTalentNominationInputValidator.php
+++ b/api/app/GraphQL/Validators/CreateTalentNominationInputValidator.php
@@ -103,7 +103,7 @@ final class CreateTalentNominationInputValidator extends Validator
             'advancementClassifications.sync' => [
                 'list',
                 'distinct',
-                Rule::prohibitedUnless(fn ($attributes) => $attributes->get('nominateForAdvancement')),
+                Rule::prohibitedUnless(fn () => $this->arg('nominateForAdvancement')),
             ],
             'advancementClassifications.sync.*' => [
                 'exists:classifications,id',

--- a/api/app/GraphQL/Validators/Mutation/SubmitTalentNominationValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/SubmitTalentNominationValidator.php
@@ -147,7 +147,7 @@ final class SubmitTalentNominationValidator extends Validator
                 'array',
                 Rule::prohibitedUnless(fn () => $this->nomination->nominate_for_advancement),
             ],
-            'advancement_classifications.*' => [
+            'advancement_classifications.*.id' => [
                 'distinct',
                 'exists:classifications,id',
             ],

--- a/api/app/GraphQL/Validators/Mutation/SubmitTalentNominationValidator.php
+++ b/api/app/GraphQL/Validators/Mutation/SubmitTalentNominationValidator.php
@@ -143,6 +143,14 @@ final class SubmitTalentNominationValidator extends Validator
                 'required_with:advancement_reference_fallback_work_email,advancement_reference_fallback_name,advancement_reference_fallback_classification_id',
                 'prohibited_unless:advancement_reference_id,null',
             ],
+            'advancement_classifications' => [
+                'array',
+                Rule::prohibitedUnless(fn () => $this->nomination->nominate_for_advancement),
+            ],
+            'advancement_classifications.*' => [
+                'distinct',
+                'exists:classifications,id',
+            ],
 
             'lateral_movement_options' => ['array'],
             'lateral_movement_options.*' => [

--- a/api/app/GraphQL/Validators/UpdateTalentNominationInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdateTalentNominationInputValidator.php
@@ -116,7 +116,7 @@ final class UpdateTalentNominationInputValidator extends Validator
             'advancementClassifications.sync' => [
                 'list',
                 'distinct',
-                Rule::prohibitedUnless(fn ($attributes) => $attributes->get('nominateForAdvancement')),
+                Rule::prohibitedUnless(fn () => $this->arg('nominateForAdvancement')),
             ],
             'advancementClassifications.sync.*' => [
                 'exists:classifications,id',

--- a/api/app/GraphQL/Validators/UpdateTalentNominationInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdateTalentNominationInputValidator.php
@@ -110,6 +110,17 @@ final class UpdateTalentNominationInputValidator extends Validator
                 'uuid',
                 'exists:departments,id',
             ],
+            'advancementClassifications' => [
+                'required_with:nominateForAdvancement,nominateForLateralMovement,nominateForDevelopmentPrograms',
+            ],
+            'advancementClassifications.sync' => [
+                'list',
+                'distinct',
+                Rule::prohibitedUnless(fn ($attributes) => $attributes->get('nominateForAdvancement')),
+            ],
+            'advancementClassifications.sync.*' => [
+                'exists:classifications,id',
+            ],
 
             'lateralMovementOptions' => ['array'],
             'lateralMovementOptions.*' => [

--- a/api/app/GraphQL/Validators/UpdateTalentNominationInputValidator.php
+++ b/api/app/GraphQL/Validators/UpdateTalentNominationInputValidator.php
@@ -180,6 +180,7 @@ final class UpdateTalentNominationInputValidator extends Validator
             'advancementReferenceFallbackClassification.connect.exists' => ErrorCode::ADVANCEMENT_REFERENCE_CLASSIFICATION_NOT_FOUND->name,
             'advancementReferenceFallbackDepartment.connect.exists' => ErrorCode::ADVANCEMENT_REFERENCE_DEPARTMENT_NOT_FOUND->name,
             'communityDevelopmentPrograms.sync.exists' => ErrorCode::COMMUNITY_DEVELOPMENT_PROGRAM_NOT_FOUND->name,
+            'advancementClassifications.sync.*.exists' => ErrorCode::CLASSIFICATION_NOT_FOUND->name,
             'skills.sync.exists' => ErrorCode::SKILL_NOT_FOUND->name,
             'skills.sync.*.in' => ErrorCode::SKILL_NOT_KLC->name,
             'skills.sync.prohibited' => ErrorCode::SKILLS_NOT_ALLOWED_FOR_EVENT->name,

--- a/api/app/Models/TalentNomination.php
+++ b/api/app/Models/TalentNomination.php
@@ -259,4 +259,12 @@ class TalentNomination extends Model
     {
         return $query->with(['talentNominationEvent']);
     }
+
+    /** @return BelongsToMany<Classification, $this> */
+    public function advancementClassifications(): BelongsToMany
+    {
+        return $this
+            ->belongsToMany(Classification::class, 'classification_talent_nomination_advancement')
+            ->withTimestamps();
+    }
 }

--- a/api/database/factories/TalentNominationFactory.php
+++ b/api/database/factories/TalentNominationFactory.php
@@ -228,6 +228,12 @@ class TalentNominationFactory extends Factory
                         )
                     );
                 }
+
+                if ($talentNomination->nominate_for_advancement) {
+                    $talentNomination->advancementClassifications()->sync(
+                        Classification::inRandomOrder()->limit($this->faker->numberBetween(1, 3))->get()
+                    );
+                }
             });
     }
 

--- a/api/database/migrations/2026_08_25_163752_add_nomination_classifications.php
+++ b/api/database/migrations/2026_08_25_163752_add_nomination_classifications.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('classification_talent_nomination_advancement', function (Blueprint $table) {
+            $table->uuid('id')
+                ->primary()
+                ->default(new Expression('public.gen_random_uuid()'));
+            $table->timestamps();
+            $table->foreignUuid('classification_id')
+                ->constrained();
+            $table->foreignUuid('talent_nomination_id')
+                ->constrained();
+            $table->unique(['classification_id', 'talent_nomination_id'], 'classification_nomination_advancement_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('classification_talent_nomination_advancement');
+    }
+};

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -960,6 +960,7 @@ type TalentNomination {
     @rename(attribute: "advancement_reference_fallback_name")
   advancementReferenceFallbackClassification: Classification @belongsTo
   advancementReferenceFallbackDepartment: Department @belongsTo
+  advancementClassifications: [Classification!] @belongsToMany
 
   lateralMovementOptions: [LocalizedTalentNominationLateralMovementOption!]
     @rename(attribute: "lateral_movement_options")
@@ -2643,6 +2644,7 @@ input CreateTalentNominationInput @validator {
     @rename(attribute: "advancement_reference_fallback_name")
   advancementReferenceFallbackClassification: ClassificationBelongsTo
   advancementReferenceFallbackDepartment: DepartmentBelongsTo
+  advancementClassifications: ClassificationBelongsToMany
 
   lateralMovementOptions: [TalentNominationLateralMovementOption!]
     @rename(attribute: "lateral_movement_options")
@@ -2699,6 +2701,7 @@ input UpdateTalentNominationInput @validator {
     @rename(attribute: "advancement_reference_fallback_name")
   advancementReferenceFallbackClassification: ClassificationBelongsTo
   advancementReferenceFallbackDepartment: DepartmentBelongsTo
+  advancementClassifications: ClassificationBelongsToMany
 
   lateralMovementOptions: [TalentNominationLateralMovementOption!]
     @rename(attribute: "lateral_movement_options")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1492,6 +1492,7 @@ type TalentNomination {
   advancementReferenceFallbackName: String
   advancementReferenceFallbackClassification: Classification
   advancementReferenceFallbackDepartment: Department
+  advancementClassifications: [Classification!]
   lateralMovementOptions: [LocalizedTalentNominationLateralMovementOption!]
   lateralMovementOptionsOther: String
   communityDevelopmentPrograms(
@@ -2624,6 +2625,7 @@ input CreateTalentNominationInput {
   advancementReferenceFallbackName: String
   advancementReferenceFallbackClassification: ClassificationBelongsTo
   advancementReferenceFallbackDepartment: DepartmentBelongsTo
+  advancementClassifications: ClassificationBelongsToMany
   lateralMovementOptions: [TalentNominationLateralMovementOption!]
   lateralMovementOptionsOther: String
   communityDevelopmentPrograms: CommunityDevelopmentProgramBelongsToMany
@@ -2659,6 +2661,7 @@ input UpdateTalentNominationInput {
   advancementReferenceFallbackName: String
   advancementReferenceFallbackClassification: ClassificationBelongsTo
   advancementReferenceFallbackDepartment: DepartmentBelongsTo
+  advancementClassifications: ClassificationBelongsToMany
   lateralMovementOptions: [TalentNominationLateralMovementOption!]
   lateralMovementOptionsOther: String
   communityDevelopmentPrograms: CommunityDevelopmentProgramBelongsToMany

--- a/api/tests/Feature/TalentNominationTest.php
+++ b/api/tests/Feature/TalentNominationTest.php
@@ -666,6 +666,7 @@ class TalentNominationTest extends TestCase
             ->create([
                 // override factory logic
                 'nominate_for_advancement' => true,
+                'advancement_reference_id' => null,
                 'advancement_reference_fallback_work_email' => 'reference@gc.ca',
                 'advancement_reference_fallback_name' => 'Reference Name',
                 'advancement_reference_fallback_classification_id' => Classification::factory()->create()->id,

--- a/api/tests/Feature/TalentNominationTest.php
+++ b/api/tests/Feature/TalentNominationTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature;
 
 use App\Enums\ErrorCode;
+use App\Models\Classification;
+use App\Models\Department;
 use App\Models\SkillFamily;
 use App\Models\TalentNomination;
 use App\Models\TalentNominationEvent;
@@ -539,5 +541,176 @@ class TalentNominationTest extends TestCase
                     ],
                 ],
             ]);
+    }
+
+    // Can create a nomination with advancement classifications when the advancement option is chosen
+    public function testCanCreateNominationWithAdvancementWithClassifications()
+    {
+        $classification = Classification::factory()->create();
+
+        $response = $this->actingAs($this->employee1, 'api')
+            ->graphQL($this->createMutation, [
+                'talentNomination' => [
+                    'talentNominationEvent' => [
+                        'connect' => $this->nominationEvent->id,
+                    ],
+                    'nominateForAdvancement' => true,
+                    'advancementClassifications' => [
+                        'sync' => [$classification->id],
+                    ],
+                ],
+            ]);
+
+        $response->assertJsonStructure([
+            'data' => [
+                'createTalentNomination' => [
+                    'id',
+                ],
+            ],
+        ]);
+
+        $response->assertGraphQLErrorFree();
+    }
+
+    // Can't create a nomination with advancement classifications when the advancement option is not chosen
+    public function testCantCreateNominationWithoutAdvancementWithClassifications()
+    {
+        $classification = Classification::factory()->create();
+
+        $response = $this->actingAs($this->employee1, 'api')
+            ->graphQL($this->createMutation, [
+                'talentNomination' => [
+                    'talentNominationEvent' => [
+                        'connect' => $this->nominationEvent->id,
+                    ],
+                    'advancementClassifications' => [
+                        'sync' => [$classification->id],
+                    ],
+                ],
+            ]);
+
+        $response->assertGraphQLValidationError('talentNomination.advancementClassifications.sync', 'The talent nomination.advancement classifications.sync field is prohibited.');
+    }
+
+    // Can update a nomination with advancement classifications when the advancement option is chosen
+    public function testCanUpdateNominationWithAdvancementWithClassifications()
+    {
+        $classification = Classification::factory()->create();
+        $nomination = TalentNomination::factory()->create([
+            'talent_nomination_event_id' => $this->nominationEvent->id,
+            'submitter_id' => $this->employee1->id,
+            'submitted_at' => null,
+        ]);
+
+        $response = $this->actingAs($this->employee1, 'api')
+            ->graphQL($this->updateMutation, [
+                'talentNomination' => [
+                    'id' => $nomination->id,
+                    'nominateForAdvancement' => true,
+                    'advancementClassifications' => [
+                        'sync' => [$classification->id],
+                    ],
+                ],
+            ]);
+
+        $response->assertJsonStructure([
+            'data' => [
+                'updateTalentNomination' => [
+                    'id',
+                ],
+            ],
+        ]);
+
+        $response->assertGraphQLErrorFree();
+        $this->assertSame([$classification->id], $nomination->fresh()->advancementClassifications->pluck('id')->all());
+    }
+
+    // Can't update a nomination with advancement classifications when the advancement option is not chosen
+    public function testUpdateCreateNominationWithoutAdvancementWithClassifications()
+    {
+        $classification = Classification::factory()->create();
+        $nomination = TalentNomination::factory()->create([
+            'talent_nomination_event_id' => $this->nominationEvent->id,
+            'submitter_id' => $this->employee1->id,
+            'submitted_at' => null,
+            'nominate_for_advancement' => false,
+        ]);
+
+        $response = $this->actingAs($this->employee1, 'api')
+            ->graphQL($this->updateMutation, [
+                'talentNomination' => [
+                    'id' => $nomination->id,
+                    'advancementClassifications' => [
+                        'sync' => [$classification->id],
+                    ],
+                ],
+            ]);
+
+        $response->assertGraphQLValidationError('talentNomination.advancementClassifications.sync', 'The talent nomination.advancement classifications.sync field is prohibited.');
+    }
+
+    // Can submit a nomination with advancement classifications when the advancement option is chosen
+    public function testCanSubmitNominationWithAdvancementWithClassifications()
+    {
+        $classification = Classification::factory()->create();
+        $nomination = TalentNomination::factory()
+            ->state([
+                'submitter_id' => $this->employee1->id,
+                'talent_nomination_event_id' => $this->nominationEvent->id,
+            ])
+            ->submittedRationale()
+            ->create([
+                // override factory logic
+                'nominate_for_advancement' => true,
+                'advancement_reference_fallback_work_email' => 'reference@gc.ca',
+                'advancement_reference_fallback_name' => 'Reference Name',
+                'advancement_reference_fallback_classification_id' => Classification::factory()->create()->id,
+                'advancement_reference_fallback_department_id' => Department::factory()->create()->id,
+            ]);
+        $nomination->advancementClassifications()->sync([$classification->id]);
+
+        $response = $this->actingAs($this->employee1, 'api')
+            ->graphQL($this->submitMutation, [
+                'id' => $nomination->id,
+            ]);
+
+        $response->assertJsonStructure([
+            'data' => [
+                'submitTalentNomination' => [
+                    'id',
+                ],
+            ],
+        ]);
+
+        $response->assertGraphQLErrorFree();
+    }
+
+    // Can't submit a nomination with advancement classifications when the advancement option is not chosen
+    public function testCantSubmitNominationWithoutAdvancementWithClassifications()
+    {
+        $classification = Classification::factory()->create();
+        $nomination = TalentNomination::factory()
+            ->state([
+                'submitter_id' => $this->employee1->id,
+                'talent_nomination_event_id' => $this->nominationEvent->id,
+            ])
+            ->submittedRationale()
+            ->create([
+                // override factory logic
+                'nominate_for_advancement' => false,
+                'advancement_reference_id' => null,
+                'advancement_reference_fallback_work_email' => null,
+                'advancement_reference_fallback_name' => null,
+                'advancement_reference_fallback_classification_id' => null,
+                'advancement_reference_fallback_department_id' => null,
+            ]);
+        $nomination->advancementClassifications()->sync([$classification->id]);
+
+        $response = $this->actingAs($this->employee1, 'api')
+            ->graphQL($this->submitMutation, [
+                'id' => $nomination->id,
+            ]);
+
+        $response->assertGraphQLValidationError('advancement_classifications', 'The advancement classifications field is prohibited.');
     }
 }

--- a/api/tests/Feature/TalentNominationTest.php
+++ b/api/tests/Feature/TalentNominationTest.php
@@ -583,6 +583,7 @@ class TalentNominationTest extends TestCase
                     'talentNominationEvent' => [
                         'connect' => $this->nominationEvent->id,
                     ],
+                    'nominateForAdvancement' => false,
                     'advancementClassifications' => [
                         'sync' => [$classification->id],
                     ],
@@ -596,11 +597,13 @@ class TalentNominationTest extends TestCase
     public function testCanUpdateNominationWithAdvancementWithClassifications()
     {
         $classification = Classification::factory()->create();
-        $nomination = TalentNomination::factory()->create([
-            'talent_nomination_event_id' => $this->nominationEvent->id,
-            'submitter_id' => $this->employee1->id,
-            'submitted_at' => null,
-        ]);
+        $nomination = TalentNomination::factory()
+            ->submittedNominationDetails()
+            ->create([
+                'talent_nomination_event_id' => $this->nominationEvent->id,
+                'submitter_id' => $this->employee1->id,
+
+            ]);
 
         $response = $this->actingAs($this->employee1, 'api')
             ->graphQL($this->updateMutation, [
@@ -629,17 +632,18 @@ class TalentNominationTest extends TestCase
     public function testUpdateCreateNominationWithoutAdvancementWithClassifications()
     {
         $classification = Classification::factory()->create();
-        $nomination = TalentNomination::factory()->create([
-            'talent_nomination_event_id' => $this->nominationEvent->id,
-            'submitter_id' => $this->employee1->id,
-            'submitted_at' => null,
-            'nominate_for_advancement' => false,
-        ]);
+        $nomination = TalentNomination::factory()
+            ->submittedNominationDetails()
+            ->create([
+                'talent_nomination_event_id' => $this->nominationEvent->id,
+                'submitter_id' => $this->employee1->id,
+            ]);
 
         $response = $this->actingAs($this->employee1, 'api')
             ->graphQL($this->updateMutation, [
                 'talentNomination' => [
                     'id' => $nomination->id,
+                    'nominateForAdvancement' => false,
                     'advancementClassifications' => [
                         'sync' => [$classification->id],
                     ],

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -799,10 +799,6 @@
     "defaultMessage": "nous <strong>recherchons un employé hautement qualifié ou expérimenté</strong> qui peut assumer immédiatement toutes les responsabilités du poste.",
     "description": "List of conditions for starting at a higher rate, item 3"
   },
-  "sDBI5c": {
-    "defaultMessage": "Options de classification recommandées pour le candidat",
-    "description": "Label for advancement eligible classifications field"
-  },
   "13WmnE": {
     "defaultMessage": "Modifier le stade de l'évaluation",
     "description": "Heading for form to update a candidates assessment stage"
@@ -13957,6 +13953,10 @@
   "sBU6QB": {
     "defaultMessage": "Membres du ministère",
     "description": "Page title for the department manage access page"
+  },
+  "sDBI5c": {
+    "defaultMessage": "Options de classification recommandées pour le candidat",
+    "description": "Label for advancement eligible classifications field"
   },
   "sDqpzq": {
     "defaultMessage": "Télécharger la trousse du gestionnaire",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -799,6 +799,10 @@
     "defaultMessage": "nous <strong>recherchons un employé hautement qualifié ou expérimenté</strong> qui peut assumer immédiatement toutes les responsabilités du poste.",
     "description": "List of conditions for starting at a higher rate, item 3"
   },
+  "12rHnD": {
+    "defaultMessage": "Options de classification recommandées pour le candidat",
+    "description": "Label for advancement eligible classifications field"
+  },
   "13WmnE": {
     "defaultMessage": "Modifier le stade de l'évaluation",
     "description": "Heading for form to update a candidates assessment stage"
@@ -974,6 +978,10 @@
   "1d2BaE": {
     "defaultMessage": "<strong>Les postes hybrides</strong> requièrent une présence au bureau au moins trois jours par semaine, le reste du temps pouvant être travaillé depuis le lieu de votre choix.",
     "description": "Definition for 'hybrid positions'"
+  },
+  "1e2+hH": {
+    "defaultMessage": "Classifications recommandées pour promotion",
+    "description": "Label for advancement eligible classifications field"
   },
   "1e84jV": {
     "defaultMessage": "Les visiteurs doivent également savoir que l’information offerte par les sites autres que ceux du gouvernement du Canada, accessibles à l’aide des liens de ce site Web, n’est pas assujettie à la <privacyActLink>Loi sur la protection des renseignements personnels</privacyActLink> ni à la <langActLink>Loi sur les langues officielles</langActLink> et pourrait ne pas être accessible aux personnes handicapées. Il est probable que l’information offerte ne soit disponible que dans les langues employées dans les sites en question. En ce qui a trait aux renseignements personnels, nous invitons les visiteurs à consulter les politiques de ces sites Web non gouvernementaux en matière de protection des renseignements personnels avant de fournir leurs renseignements personnels.",
@@ -5510,6 +5518,10 @@
   "Jv/Blc": {
     "defaultMessage": "Afficher toutes les informations disponibles pour cet utilisateur ou cette utilisatrice.",
     "description": "Subtitle for user section"
+  },
+  "JwOJSW": {
+    "defaultMessage": "Veuillez recommander une ou plusieurs options de classification pour lesquelles le candidat doit être pris en considération durant le processus de recommandation, compte tenu de la classification de son poste d’attache et de son rendement actuels.",
+    "description": "Intro for advancement nomination classification selection"
   },
   "JxDtt+": {
     "defaultMessage": "Révisez votre candidature",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -799,7 +799,7 @@
     "defaultMessage": "nous <strong>recherchons un employé hautement qualifié ou expérimenté</strong> qui peut assumer immédiatement toutes les responsabilités du poste.",
     "description": "List of conditions for starting at a higher rate, item 3"
   },
-  "12rHnD": {
+  "sDBI5c": {
     "defaultMessage": "Options de classification recommandées pour le candidat",
     "description": "Label for advancement eligible classifications field"
   },

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
@@ -1,7 +1,7 @@
 import RectangleGroupIcon from "@heroicons/react/24/outline/RectangleGroupIcon";
 import { useIntl } from "react-intl";
 import { useFormContext } from "react-hook-form";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useId } from "react";
 
 import type {
   FragmentType,
@@ -17,6 +17,7 @@ import {
 } from "@gc-digital-talent/graphql";
 import {
   Checklist,
+  Combobox,
   Input,
   localizedEnumToOptions,
   RadioGroup,
@@ -67,6 +68,8 @@ const DetailsFieldsOptions_Fragment = graphql(/* GraphQL */ `
     }
     classifications {
       ...ClassificationInput
+      id
+      groupAndLevel
     }
     departments {
       id
@@ -126,6 +129,7 @@ interface FormValues extends BaseFormValues {
   advancementReferenceFallbackClassificationGroup: string | null;
   advancementReferenceFallbackClassificationLevel: string | null;
   advancementReferenceFallbackDepartment: string;
+  advancementClassifications: string[];
   lateralMovementOptions: TalentNominationLateralMovementOption[] | null;
   lateralMovementOptionsOther: string | null;
   communityDevelopmentPrograms: string[];
@@ -214,6 +218,9 @@ const DetailsFields = ({
       resetField("advancementReferenceReview");
     }
   }, [advancementReference, resetField]);
+
+  const advancementReferenceDescription = useId();
+  const advancementClassificationsDescription = useId();
 
   return (
     <div className="flex flex-col gap-6">
@@ -352,7 +359,7 @@ const DetailsFields = ({
                       "Title for advancement options section in nominations details step",
                   })}
                 </Heading>
-                <p>
+                <p id={advancementReferenceDescription}>
                   {intl.formatMessage({
                     defaultMessage:
                       "Provide a secondary senior leader reference who can confirm the candidate's readiness for promotion.",
@@ -374,6 +381,7 @@ const DetailsFields = ({
                     "Label for search reference input field on a nomination",
                 })}
                 errorSeverities={{ NO_PROFILE: "warning" }}
+                aria-describedby={advancementReferenceDescription}
               />
               {!advancementReferenceUnset && !advancementReferenceNotFound && (
                 <>
@@ -472,6 +480,36 @@ const DetailsFields = ({
                   />
                 </>
               )}
+              <p id={advancementClassificationsDescription}>
+                {intl.formatMessage({
+                  defaultMessage:
+                    "Based on the nominee’s current substantive classification and performance, please recommend one or more classification options the nominee should be considered for during the referral process.",
+                  id: "JwOJSW",
+                  description:
+                    "Intro for advancement nomination classification selection",
+                })}
+              </p>
+              <Combobox
+                id="advancementClassifications"
+                name="advancementClassifications"
+                isMulti
+                label={intl.formatMessage({
+                  defaultMessage:
+                    "Classifications this nominee is recommended to advance to",
+                  id: "12rHnD",
+                  description:
+                    "Label for advancement eligible classifications field",
+                })}
+                options={unpackMaybes(options?.classifications).map(
+                  ({ id, groupAndLevel }) => ({
+                    value: id,
+                    label:
+                      groupAndLevel ??
+                      intl.formatMessage(commonMessages.notProvided),
+                  }),
+                )}
+                aria-describedby={advancementClassificationsDescription}
+              />
             </div>
           )}
           {lateralMovement && (
@@ -654,6 +692,9 @@ const NominateTalentDetails_Fragment = graphql(/* GraphQL */ `
     advancementReferenceFallbackDepartment {
       id
     }
+    advancementClassifications {
+      id
+    }
     nominateForLateralMovement
     nominateForDevelopmentPrograms
     lateralMovementOptions {
@@ -716,6 +757,9 @@ const transformSubmitData: SubmitDataTransformer<FormValues> = (values) => {
       hasAdvancement && !hasAdvancementReference
         ? { connect: values.advancementReferenceFallbackDepartment }
         : { disconnect: true },
+    advancementClassifications: {
+      sync: hasAdvancement ? values.advancementClassifications : [],
+    },
     lateralMovementOptions: hasLateralMovement
       ? values.lateralMovementOptions
       : [],
@@ -827,6 +871,9 @@ const Details = ({ detailsQuery, optionsQuery }: DetailsProps) => {
           talentNomination?.advancementReferenceFallbackClassification?.level.toString(),
         advancementReferenceFallbackDepartment:
           talentNomination?.advancementReferenceFallbackDepartment?.id,
+        advancementClassifications: unpackMaybes(
+          talentNomination?.advancementClassifications?.flatMap((c) => c.id),
+        ),
         lateralMovementOptions:
           talentNomination?.lateralMovementOptions?.map((x) => x.value) ?? null,
         lateralMovementOptionsOther:

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
@@ -495,8 +495,8 @@ const DetailsFields = ({
                 isMulti
                 label={intl.formatMessage({
                   defaultMessage:
-                    "Classifications this nominee is recommended to advance to",
-                  id: "12rHnD",
+                    "Classification options recommended for this nominee",
+                  id: "sDBI5c",
                   description:
                     "Label for advancement eligible classifications field",
                 })}

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/ReviewAndSubmit/NominationDetailsReview.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/ReviewAndSubmit/NominationDetailsReview.tsx
@@ -82,6 +82,10 @@ const NominationDetailsReview_Fragment = graphql(/* GraphQL */ `
     advancementReferenceFallbackClassification {
       groupAndLevel
     }
+    advancementClassifications {
+      id
+      groupAndLevel
+    }
 
     # Lateral movement details
     lateralMovementOptionsOther
@@ -263,6 +267,25 @@ const NominationDetailsReview = ({
               label={intl.formatMessage(labels.referencesDepartment)}
             >
               {referenceDepartment?.name?.localized ?? notProvided}
+            </FieldDisplay>
+            <FieldDisplay
+              className="col-span-2"
+              label={intl.formatMessage({
+                defaultMessage: "Recommended classifications for advancement",
+                id: "1e2+hH",
+                description:
+                  "Label for advancement eligible classifications field",
+              })}
+            >
+              {talentNomination.advancementClassifications?.length ? (
+                <Ul space="md">
+                  {talentNomination.advancementClassifications.map((c) => (
+                    <li key={c.id}>{c.groupAndLevel}</li>
+                  ))}
+                </Ul>
+              ) : (
+                intl.formatMessage(commonMessages.notProvided)
+              )}
             </FieldDisplay>
           </>
         )}


### PR DESCRIPTION
🤖 Resolves #17856 

## 👋 Introduction

Adds recommended classifications for advancement to the nomination process.

## 🕵️ Details

- Migration for database
- Model, factory, schema, validator updates
- Unit tests
- Update, submit nomination pages

Nomination review and downloads are out of scope.

## 🧪 Testing

1. Run migration
2. Rebuild
3. Log in as applicant-employee@test.com

- [x] Can roll back and forward migration
- [x] Can submit nomination with advancement classification
- [x] Can submit nomination without advancement classification


## 📸 Screenshot

<img width="794" height="496" alt="image" src="https://github.com/user-attachments/assets/6df17208-cf84-44a4-80f2-f14db04c6512" />
