### PR TITLE
[Fix] Improve talent request query time

### DIFF
--- a/api/app/Builders/UserBuilder.php
+++ b/api/app/Builders/UserBuilder.php
@@ -342,13 +342,7 @@ class UserBuilder extends Builder
         $filters = $args ? ($args['applicantFilter'] ?? $args) : [];
         $skillIds = $filters['skills'] ?? []; // already plain ids via ApplicantFilterInput @pluck
 
-        $this->where(function ($query) use ($filters) {
-            $query->whereRaw('1 = 0'); // false starting point for the orWhereHas chain
-            foreach (TalentRequestSource::selected($filters['talentSources'] ?? null) as $source) {
-                $query->orWhereHas($source->matchRelation(), fn ($r) => $r->whereMatchesTalentRequest($filters));
-            }
-        });
-
+        $this->whereMatchesAnyTalentSource($filters['talentSources'] ?? null, $filters);
         $this->whereUserAttributesMatchTalentRequest($filters);
         $this->addSkillCountSelect($skillIds);
         $this->withTalentRequestMatches($filters);
@@ -360,6 +354,27 @@ class UserBuilder extends Builder
         }
 
         return $this;
+    }
+
+    // Users matching at least one of the request's talent sources.
+    public function whereMatchesAnyTalentSource(?array $talentSources, array $filters): self
+    {
+        $sources = TalentRequestSource::selected($talentSources);
+
+        if (empty($sources)) {
+            return $this->whereRaw('1 = 0');
+        }
+
+        return $this->where(function ($query) use ($sources, $filters) {
+            foreach ($sources as $index => $source) {
+                if ($index === 0) {
+                    // First iteration must use whereHas instead of orWhereHas
+                    $query->whereHas($source->matchRelation(), fn ($r) => $r->whereMatchesTalentRequest($filters));
+                } else {
+                    $query->orWhereHas($source->matchRelation(), fn ($r) => $r->whereMatchesTalentRequest($filters));
+                }
+            }
+        });
     }
 
     // Only the request's user-level attribute and location filters.

--- a/api/app/Builders/UserBuilder.php
+++ b/api/app/Builders/UserBuilder.php
@@ -367,12 +367,7 @@ class UserBuilder extends Builder
 
         return $this->where(function ($query) use ($sources, $filters) {
             foreach ($sources as $index => $source) {
-                if ($index === 0) {
-                    // First iteration must use whereHas instead of orWhereHas
-                    $query->whereHas($source->matchRelation(), fn ($r) => $r->whereMatchesTalentRequest($filters));
-                } else {
-                    $query->orWhereHas($source->matchRelation(), fn ($r) => $r->whereMatchesTalentRequest($filters));
-                }
+                $query->orWhereHas($source->matchRelation(), fn ($r) => $r->whereMatchesTalentRequest($filters));
             }
         });
     }

--- a/api/app/GraphQL/Queries/CountTalentRequestMatchesByCommunity.php
+++ b/api/app/GraphQL/Queries/CountTalentRequestMatchesByCommunity.php
@@ -33,15 +33,12 @@ final class CountTalentRequestMatchesByCommunity
         /** @var Builder[] $subQueries */
         $subQueries = [];
 
-        // NOTE: PoolCandidateBuilder->whereMatchesTalentRequest will run twice,
-        // since it is called here and again from within the call to $user->whereMatchesTalentRequest.
-        // While redundant now, this prevents false positives when
-        // alternative talent sources are introduced in the future (mirrors
-        // CountTalentRequestMatchesByPool).
+        // The candidate filter below already establishes the qualifying candidacy, so the user
+        // only needs its own attribute filters applied.
         if (in_array(TalentRequestSource::QUALIFIED_IN_POOL, $selected, true)) {
             $subQueries[] = PoolCandidate::query()
                 ->whereMatchesTalentRequest($filters)
-                ->whereHas('user', fn ($user) => $user->whereMatchesTalentRequest($filters))
+                ->whereHas('user', fn ($user) => $user->whereUserAttributesMatchTalentRequest($filters))
                 ->join('pools', 'pools.id', '=', 'pool_candidates.pool_id')
                 ->whereNotNull('pools.community_id')
                 ->select('pool_candidates.user_id', 'pools.community_id')

--- a/api/tests/Feature/TalentRequestMatchesTest.php
+++ b/api/tests/Feature/TalentRequestMatchesTest.php
@@ -882,6 +882,29 @@ class TalentRequestMatchesTest extends TestCase
             ->assertJson(['data' => ['countTalentRequestMatches' => $listTotal]]);
     }
 
+    public function testCountByCommunityAppliesUserAttributeFilters(): void
+    {
+        $community = Community::factory()->create();
+        $pool = Pool::factory()->candidatesAvailableInSearch()->create([
+            'community_id' => $community->id,
+        ]);
+        $this->matchingUser($pool, ['looking_for_english' => true, 'looking_for_french' => false]);
+        $this->matchingUser($pool, ['looking_for_english' => false, 'looking_for_french' => true]);
+
+        $this->runCountByCommunity([
+            'applicantFilter' => [
+                'talentSources' => [TalentRequestSource::QUALIFIED_IN_POOL->name],
+                'languageAbility' => LanguageAbility::FRENCH->name,
+            ],
+        ])->assertExactJson([
+            'data' => [
+                'countTalentRequestMatchesByCommunity' => [
+                    ['community' => ['id' => $community->id], 'qualifiedInPoolCount' => 1, 'atLevelCount' => 0, 'count' => 1],
+                ],
+            ],
+        ]);
+    }
+
     // The following tests port applicantFilter scenarios previously covered only by the
     // now-removed countApplicantsForSearch/countPoolCandidatesByPool queries.
 


### PR DESCRIPTION
🤖 Resolves #17775 

## 👋 Introduction

Updates how we match users to a talent request to hopfully improve the performance.

## 🕵️ Details

This replaced the mathcing scope with the simpler, user attribute matching which resulted in most of the improvements.

The other change was to move the talent source matching to a separate scope. But, more importantly, it does its best effort of short-circuting the loop when no source is applied to improve the query there as well.

All of this results in a query time decrease of **~150s**, which is **~47%** descrease while complexity remained relativley flat.

| State  | Cost    | Time   | Scans |
|--------|---------|--------|-------|
| Before | 1746.18 | ~320ms | 2     |
| After  | 1731.61 | ~170ms | 1     |


## 🧪 Testing

1. Confirm no regression in funcitonality (tests should provide coverage)
2. Confirm the query is noticeably faster with larger datasets

## :truck: Deployment

https://github.com/GCTC-NTGC/gc-digital-talent/issues/17899
