### PR TITLE
[Fix] Combobox aria described by prop

### DIFF
--- a/packages/forms/src/components/Combobox/Combobox.test.tsx
+++ b/packages/forms/src/components/Combobox/Combobox.test.tsx
@@ -33,7 +33,10 @@ const Form = ({ defaultValues, comboboxProps }: FormProps) => {
   );
 };
 
-const renderCombobox = (defaultValues: FieldValues) =>
+const renderCombobox = (
+  defaultValues: FieldValues,
+  overrideProps: Partial<ComboboxProps> = {},
+) =>
   renderWithProviders(
     <Form
       defaultValues={defaultValues}
@@ -43,6 +46,7 @@ const renderCombobox = (defaultValues: FieldValues) =>
         isMulti: true,
         label: "Work streams",
         options,
+        ...overrideProps,
       }}
     />,
   );
@@ -78,5 +82,34 @@ describe("Combobox", () => {
     expect(
       screen.getByRole("button", { name: /access to information/i }),
     ).toBeInTheDocument();
+  });
+
+  it("forwards a caller-supplied aria-describedby to the input", async () => {
+    renderCombobox({ streams: [] }, { "aria-describedby": "external-help" });
+
+    expect(await screen.findByRole("combobox")).toHaveAttribute(
+      "aria-describedby",
+      "external-help",
+    );
+  });
+
+  it("merges a caller-supplied aria-describedby with the internal context id", async () => {
+    renderCombobox(
+      { streams: [] },
+      { "aria-describedby": "external-help", context: "Pick your streams" },
+    );
+
+    expect(await screen.findByRole("combobox")).toHaveAttribute(
+      "aria-describedby",
+      "external-help context-streams",
+    );
+  });
+
+  it("omits aria-describedby when the caller passes none", async () => {
+    renderCombobox({ streams: [] });
+
+    expect(await screen.findByRole("combobox")).not.toHaveAttribute(
+      "aria-describedby",
+    );
   });
 });

--- a/packages/forms/src/components/Combobox/Combobox.tsx
+++ b/packages/forms/src/components/Combobox/Combobox.tsx
@@ -61,6 +61,7 @@ const Combobox = ({
   isExternalSearch = false,
   isMulti = false,
   doNotSort = false,
+  "aria-describedby": describedBy,
 }: ComboboxProps) => {
   const intl = useIntl();
   const locale = getLocale(intl);
@@ -83,6 +84,7 @@ const Combobox = ({
   const hasSelection = Array.isArray(rawValue) ? !!rawValue.length : !!rawValue;
   const [descriptionIds, ariaDescribedBy] = useInputDescribedBy({
     id,
+    describedBy,
     show: {
       error: isInvalid,
       context,


### PR DESCRIPTION
🤖 Resolves #17866 

## 👋 Introduction

Fixes the `Combobox` input from silently ignoring aria described by.

## 🧪 Testing

1. Pass `aria-describedby` to a `Combobox`
2. Build `pnpm dev:fresh`
3. Trigger an error on the field
4. Confirm it still contains the original ID for `aria-describedby` along with the id for the error message
