### PR TITLE
[Feature] Remove the word senior

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -10847,7 +10847,7 @@
     "description": "Subtitle for talent request referral"
   },
   "fhpWug": {
-    "defaultMessage": "Veuillez fournir les informations d’une deuxième personne de référence de niveau cadre supérieur qui peut confirmer que la personne nominée est prête à être promue.",
+    "defaultMessage": "Veuillez fournir les informations d’une deuxième personne de référence de niveau supérieur qui peut confirmer que la personne nominée est prête à être promue.",
     "description": "Description for advancement options section in nominations details step"
   },
   "fkYYe3": {

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -10846,10 +10846,6 @@
     "defaultMessage": "Examinez le profil de {userName} et modifiez son statut pour cette demande.",
     "description": "Subtitle for talent request referral"
   },
-  "fhpWug": {
-    "defaultMessage": "Veuillez fournir les informations d’une deuxième personne de référence de niveau supérieur qui peut confirmer que la personne nominée est prête à être promue.",
-    "description": "Description for advancement options section in nominations details step"
-  },
   "fkYYe3": {
     "defaultMessage": "Plan d'évaluation",
     "description": "Title for the assessment plan builder"
@@ -11389,6 +11385,10 @@
   "hhVBJP": {
     "defaultMessage": "Gérer les demandes de talents",
     "description": "Permissions related to managing talent requests"
+  },
+  "hhvfWc": {
+    "defaultMessage": "Veuillez fournir les informations d’une deuxième personne de référence de niveau supérieur qui peut confirmer que la personne nominée est prête à être promue.",
+    "description": "Description for advancement options section in nominations details step"
   },
   "hjxxaQ": {
     "defaultMessage": "Titres des compétences",

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
@@ -355,7 +355,7 @@ const DetailsFields = ({
                 <p>
                   {intl.formatMessage({
                     defaultMessage:
-                      "Provide a secondary senior leader reference who can confirm the candidate's readiness for promotion.",
+                      "Provide a secondary leader reference who can confirm the candidate's readiness for promotion.",
                     id: "fhpWug",
                     description:
                       "Description for advancement options section in nominations details step",

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/Details.tsx
@@ -356,7 +356,7 @@ const DetailsFields = ({
                   {intl.formatMessage({
                     defaultMessage:
                       "Provide a secondary leader reference who can confirm the candidate's readiness for promotion.",
-                    id: "fhpWug",
+                    id: "hhvfWc",
                     description:
                       "Description for advancement options section in nominations details step",
                   })}


### PR DESCRIPTION
🤖 Resolves #17846 

## 👋 Introduction

Removes the word "senior" from advancement reference.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

1. Rebuild the app
2. Log in as applicant-employee@test.com
3. Start a nomination
4. Choose the advancement option

- [x] Changed copy matches the issue in English and French


## 📸 Screenshot

<img width="878" height="400" alt="image" src="https://github.com/user-attachments/assets/0d89f767-d1df-4813-8b40-616f25cf0545" />

<img width="883" height="454" alt="image" src="https://github.com/user-attachments/assets/367df344-b376-4e6d-8853-9adf18222744" />

