### PR TITLE
Potential fix for 1 code quality finding

### DIFF
--- a/apps/web/src/pages/CommunityInterests/CommunityTalentPage/CommunityTalentTable.tsx
+++ b/apps/web/src/pages/CommunityInterests/CommunityTalentPage/CommunityTalentTable.tsx
@@ -196,7 +196,7 @@ const defaultState = {
     jobInterest: undefined,
     trainingInterest: undefined,
     lateralMoveInterest: undefined,
-    promotionalMoveInterest: undefined,
+    promotionMoveInterest: undefined,
     languageAbility: undefined,
     positionDuration: [],
     flexibleWorkLocations: [],


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/GCTC-NTGC/gc-digital-talent/security/quality/ai-findings)._

> The field is named `promotionalMoveInterest` here, but the `CommunityInterestFilterInput` type (and `FormValues`) uses `promotionMoveInterest`. Since this typo doesn't match the actual field, the reset values passed to `transformCommunityInterestFilterInputToFormValues(defaultState.filters)` for the promotion move interest filter will always resolve as falsy/undefined rather than clearing the intended field. Rename this to `promotionMoveInterest`.