### PR TITLE
[Fix] Referral test date overflow issue

### DIFF
--- a/apps/playwright/utils/id.ts
+++ b/apps/playwright/utils/id.ts
@@ -1,6 +1,6 @@
 import { randomBytes, randomInt } from "node:crypto";
 
-import { add, format } from "date-fns";
+import { format } from "date-fns";
 
 // Keep CodeQL happy and sanitize our env vars
 function sanitize(str: string) {
@@ -37,7 +37,9 @@ export function fetchIdentificationNumber(url: string, entity: string): string {
 }
 
 export function getFutureDateByMonths(monthsToAdd: number): string {
-  return format(add(new Date(), { months: monthsToAdd }), "yyyy-MM-dd");
+  const futureDate = new Date();
+  futureDate.setMonth(futureDate.getMonth() + monthsToAdd);
+  return format(futureDate, "yyyy-MM-dd");
 }
 
 // copied from apps/web/src/hooks/useRequiredParams.ts


### PR DESCRIPTION
🤖 Resolves #17923 

## 👋 Introduction

Fixes an issue where the referral date test helper was not overflowing so disagreed with the server logic.

## 🕵️ Details

There is a very specific edge case where our test date (runing in node) was disagreeing with the app date (running in PHP). If, when adding a mmonth to the date, the base date was the 31st of the month and the target month only had 31 days, the target date would be invalid and there would be two  resolutions:

 1. **No overflow:** Remove 1 day to be the 30th of the month
 2. **With overflow:** Add 1 day to be the 1st of the next month

Our server was overflowing while our playwright code was not. So, on August 31st, our test was adding 1 month and playwright was expecting no overlow (Sept 30th) but, the server was producing overflow (Oct 1st).

This updates the playwright code to use a method that will overflow and agree with the actual value.

## 🧪 Testing

> [!IMPORTANT]
> Testing this will be diffulkct since it requries a speciifc date. I guess you could hardcode the original date or hack the server time when running the test? 

1. Confirm test passes consistently (event if the date is Augusrt 31st or meets the speciifc overlfow logic stated)