### PR TITLE
[Feat] Make screening result sortable

### DIFF
--- a/api/app/Builders/PoolCandidateBuilder.php
+++ b/api/app/Builders/PoolCandidateBuilder.php
@@ -4,6 +4,7 @@ namespace App\Builders;
 
 use App\Contracts\TalentRequestMatchable;
 use App\Enums\ApplicationStatus;
+use App\Enums\AssessmentDecision;
 use App\Enums\CandidateExpiryFilter;
 use App\Enums\CandidateReferralFilter;
 use App\Enums\CandidateSuspendedFilter;
@@ -762,6 +763,35 @@ class PoolCandidateBuilder extends Builder implements TalentRequestMatchable
         ];
 
         return $this->orderByRaw('array_position(ARRAY[?, ?, ?, ?]::varchar[], screening_stage) '.$args->direction, $enumOrder);
+    }
+
+    public function orderByScreeningResult(AdvancedOrder $args): self
+    {
+        $decisionOrder = [
+            AssessmentDecision::HOLD->name,
+            AssessmentDecision::SUCCESSFUL->name,
+            AssessmentDecision::UNSUCCESSFUL->name,
+        ];
+
+        $screeningResult = <<<'SQL'
+        (
+            SELECT assessment_status->>'decision'
+            FROM jsonb_array_elements(pool_candidates.computed_assessment_status->'assessmentStepStatuses') assessment_status
+            WHERE assessment_status->>'step' = (
+                SELECT assessment_steps.id::text
+                FROM assessment_steps
+                WHERE assessment_steps.pool_id = pool_candidates.pool_id
+                AND assessment_steps.type = 'APPLICATION_SCREENING'
+            )
+        )
+        SQL;
+
+        $nulls = $args->direction === 'ASC' ? 'FIRST' : 'LAST';
+
+        return $this->orderByRaw(
+            sprintf('array_position(ARRAY[?, ?, ?]::varchar[], %s) %s NULLS %s', $screeningResult, $args->direction, $nulls),
+            $decisionOrder
+        );
     }
 
     public function orderBySkillCount(AdvancedOrder $args): self

--- a/api/tests/Feature/PoolCandidateAdminViewTest.php
+++ b/api/tests/Feature/PoolCandidateAdminViewTest.php
@@ -777,7 +777,7 @@ class PoolCandidateAdminViewTest extends TestCase
             ->create();
         $unsuccessful = PoolCandidate::factory()
             ->submitted()
-            ->for($this->pool)
+            ->for($this->otherPool)
             ->create();
 
         $decisions = [
@@ -786,11 +786,17 @@ class PoolCandidateAdminViewTest extends TestCase
             $unsuccessful->id => AssessmentDecision::UNSUCCESSFUL->name,
         ];
 
+        $screeningSteps = [
+            $hold->id => $this->pool->screening_step->id,
+            $successful->id => $this->pool->screening_step->id,
+            $unsuccessful->id => $this->otherPool->screening_step->id,
+        ];
+
         foreach ($decisions as $candidateId => $decision) {
             AssessmentResult::factory()
                 ->withResultType(AssessmentResultType::EDUCATION)
                 ->create([
-                    'assessment_step_id' => $this->pool->screening_step->id,
+                    'assessment_step_id' => $screeningSteps[$candidateId],
                     'pool_candidate_id' => $candidateId,
                     'assessment_decision' => $decision,
                 ]);

--- a/api/tests/Feature/PoolCandidateAdminViewTest.php
+++ b/api/tests/Feature/PoolCandidateAdminViewTest.php
@@ -3,7 +3,10 @@
 namespace Tests\Feature;
 
 use App\Enums\ApplicationStatus;
+use App\Enums\AssessmentDecision;
+use App\Enums\AssessmentResultType;
 use App\Enums\ScreeningStage;
+use App\Models\AssessmentResult;
 use App\Models\AwardExperience;
 use App\Models\Community;
 use App\Models\CommunityInterest;
@@ -739,6 +742,95 @@ class PoolCandidateAdminViewTest extends TestCase
                         'data' => [
                             ['poolCandidate' => ['id' => $underAssessment->id]],
                             ['poolCandidate' => ['id' => $newApplication->id]],
+                        ],
+                    ],
+                ],
+            ]);
+    }
+
+    public function testOrderByScreeningResult(): void
+    {
+        $query = <<<'GRAPHQL'
+            query PoolCandidates($orderBy: AdvancedOrderByInput!) {
+                poolCandidatesPaginated(orderBy: [$orderBy]) {
+                    data {
+                        poolCandidate {
+                            id
+                        }
+                    }
+                }
+            }
+        GRAPHQL;
+
+        PoolCandidate::truncate();
+        $notAssessed = PoolCandidate::factory()
+            ->submitted()
+            ->for($this->pool)
+            ->create();
+        $hold = PoolCandidate::factory()
+            ->submitted()
+            ->for($this->pool)
+            ->create();
+        $successful = PoolCandidate::factory()
+            ->submitted()
+            ->for($this->pool)
+            ->create();
+        $unsuccessful = PoolCandidate::factory()
+            ->submitted()
+            ->for($this->pool)
+            ->create();
+
+        $decisions = [
+            $hold->id => AssessmentDecision::HOLD->name,
+            $successful->id => AssessmentDecision::SUCCESSFUL->name,
+            $unsuccessful->id => AssessmentDecision::UNSUCCESSFUL->name,
+        ];
+
+        foreach ($decisions as $candidateId => $decision) {
+            AssessmentResult::factory()
+                ->withResultType(AssessmentResultType::EDUCATION)
+                ->create([
+                    'assessment_step_id' => $this->pool->screening_step->id,
+                    'pool_candidate_id' => $candidateId,
+                    'assessment_decision' => $decision,
+                ]);
+        }
+
+        $this->actingAs($this->platformAdmin, 'api')
+            ->graphQL($query, [
+                'orderBy' => [
+                    'scope' => 'orderByScreeningResult',
+                    'direction' => 'ASC',
+                ],
+            ])
+            ->assertJson([
+                'data' => [
+                    'poolCandidatesPaginated' => [
+                        'data' => [
+                            ['poolCandidate' => ['id' => $notAssessed->id]],
+                            ['poolCandidate' => ['id' => $hold->id]],
+                            ['poolCandidate' => ['id' => $successful->id]],
+                            ['poolCandidate' => ['id' => $unsuccessful->id]],
+                        ],
+                    ],
+                ],
+            ]);
+
+        $this->actingAs($this->platformAdmin, 'api')
+            ->graphQL($query, [
+                'orderBy' => [
+                    'scope' => 'orderByScreeningResult',
+                    'direction' => 'DESC',
+                ],
+            ])
+            ->assertJson([
+                'data' => [
+                    'poolCandidatesPaginated' => [
+                        'data' => [
+                            ['poolCandidate' => ['id' => $unsuccessful->id]],
+                            ['poolCandidate' => ['id' => $successful->id]],
+                            ['poolCandidate' => ['id' => $hold->id]],
+                            ['poolCandidate' => ['id' => $notAssessed->id]],
                         ],
                     ],
                 ],

--- a/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/PoolCandidatesTable.tsx
@@ -918,7 +918,6 @@ const PoolCandidatesTable = ({
           id: "qwLrrx",
           description: "Label for the result of an application screening",
         }),
-        enableSorting: false,
         enableColumnFilter: false,
         cell: ({
           row: {

--- a/apps/web/src/components/PoolCandidatesTable/helpers.tsx
+++ b/apps/web/src/components/PoolCandidatesTable/helpers.tsx
@@ -297,6 +297,7 @@ const SCOPE_SORTS: Record<string, string> = {
   priority: "orderByClaimVerification",
   department: "orderByEmployeeDepartment",
   screeningStage: "orderByScreeningStage",
+  screeningResult: "orderByScreeningResult",
 };
 
 const BOOKMARK_SORT: AdvancedOrderByInput = { scope: "orderByBookmark" };


### PR DESCRIPTION
🤖 Resolves #17712 

## 👋 Introduction

Updates the screening result column on the pool candidates table to enable sorting.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Navigate to `/admin/pool-candidates`
4. Confirm the screening reuslt column is sortable and matches the expected order

## 📸 Screenshot

<img width="1825" height="968" alt="image" src="https://github.com/user-attachments/assets/1e33b5dc-9404-489e-aec7-81d51a372b92" />
