### PR TITLE
[Fix] Use correct seeding method in `AssessmentResultFactory`

### DIFF
--- a/api/database/factories/AssessmentResultFactory.php
+++ b/api/database/factories/AssessmentResultFactory.php
@@ -62,7 +62,7 @@ class AssessmentResultFactory extends Factory
                     $justifications = $this->faker->randomElements(array_column(AssessmentResultJustification::educationJustificationsSuccess(), 'name'), null);
                 }
                 if ($assessmentDecision === AssessmentDecision::UNSUCCESSFUL->name) {
-                    $justifications = $this->faker->randomElement(array_column(AssessmentResultJustification::educationJustificationsFailure(), 'name'), null);
+                    $justifications = $this->faker->randomElements(array_column(AssessmentResultJustification::educationJustificationsFailure(), 'name'), null);
                 }
 
                 return [


### PR DESCRIPTION
🤖 Resolves 

## 👋 Introduction

Fix a typo that may sometimes result in seeding of invalid data

## 🕵️ Details

Variable `$justifications` expects to be an array, and all but one call assigns using `randomElements()`
The odd instance out assigns with `randomElement()`
Emphasis on the lack of plural, which then doesn't assign the expected array, instead an unexpected type

The lack of strictness you get with TypeScript allows such things to go unmissed 😢 

Revised now has the right method in all three places

<img width="1327" height="530" alt="image" src="https://github.com/user-attachments/assets/828319ed-796e-4974-87d6-6aa0fac47d6d" />



## 🧪 Testing

1. Can seed normally I guess?
