### PR TITLE
[Refactor] Rename classification at approval

### DIFF
--- a/api/app/Models/TalentNominationGroup.php
+++ b/api/app/Models/TalentNominationGroup.php
@@ -284,7 +284,7 @@ class TalentNominationGroup extends Model
     }
 
     /** @return BelongsTo<Classification, $this> */
-    public function classificationAtTimeOfAdvancementApproval(): BelongsTo
+    public function classificationAtTimeOfLastApproval(): BelongsTo
     {
         return $this->belongsTo(Classification::class);
     }

--- a/api/app/Observers/TalentNominationGroupObserver.php
+++ b/api/app/Observers/TalentNominationGroupObserver.php
@@ -30,13 +30,13 @@ class TalentNominationGroupObserver
             // withTrashed() so approving a decision never fails just because the
             // nominee has since been archived
             $nominee = User::withTrashed()->find($talentNominationGroup->nominee_id);
-            $talentNominationGroup->classificationAtTimeOfAdvancementApproval()->associate($nominee?->currentClassification);
+            $talentNominationGroup->classificationAtTimeOfLastApproval()->associate($nominee?->currentClassification);
         }
 
         // if advancement decision changes from approved then clear the classification
         if ($talentNominationGroup->getOriginal('advancement_decision') === TalentNominationGroupDecision::APPROVED->name &&
            $talentNominationGroup->advancement_decision !== TalentNominationGroupDecision::APPROVED->name) {
-            $talentNominationGroup->classificationAtTimeOfAdvancementApproval()->dissociate();
+            $talentNominationGroup->classificationAtTimeOfLastApproval()->dissociate();
         }
 
         $talentNominationGroup->saveQuietly();

--- a/api/app/Observers/TalentNominationGroupObserver.php
+++ b/api/app/Observers/TalentNominationGroupObserver.php
@@ -2,7 +2,6 @@
 
 namespace App\Observers;
 
-use App\Enums\TalentNominationGroupDecision;
 use App\Models\TalentNominationGroup;
 use App\Models\User;
 
@@ -23,20 +22,19 @@ class TalentNominationGroupObserver
      */
     public function updated(TalentNominationGroup $talentNominationGroup): void
     {
-        // if advancement decision changes to approved then record the classification
-        if ($talentNominationGroup->getOriginal('advancement_decision') !== TalentNominationGroupDecision::APPROVED->name &&
-            $talentNominationGroup->advancement_decision === TalentNominationGroupDecision::APPROVED->name) {
+        $advancementDecisionChanged = $talentNominationGroup->getOriginal('advancement_decision') !== $talentNominationGroup->advancement_decision;
+        $lateralMovementDecisionChanged = $talentNominationGroup->getOriginal('lateralMovementDecision') !== $talentNominationGroup->lateralMovementDecision;
+        $developmentProgramsDecisionChanged = $talentNominationGroup->getOriginal('developmentProgramsDecision') !== $talentNominationGroup->developmentProgramsDecision;
+
+        $decisionsChanged = collect([$advancementDecisionChanged, $lateralMovementDecisionChanged, $developmentProgramsDecisionChanged]);
+
+        // if any decision changes to approved then record the classification
+        if ($decisionsChanged->contains(true)) {
             // nominee() excludes archived users by default; look up directly with
             // withTrashed() so approving a decision never fails just because the
             // nominee has since been archived
             $nominee = User::withTrashed()->find($talentNominationGroup->nominee_id);
             $talentNominationGroup->classificationAtTimeOfLastApproval()->associate($nominee?->currentClassification);
-        }
-
-        // if advancement decision changes from approved then clear the classification
-        if ($talentNominationGroup->getOriginal('advancement_decision') === TalentNominationGroupDecision::APPROVED->name &&
-           $talentNominationGroup->advancement_decision !== TalentNominationGroupDecision::APPROVED->name) {
-            $talentNominationGroup->classificationAtTimeOfLastApproval()->dissociate();
         }
 
         $talentNominationGroup->saveQuietly();

--- a/api/app/Observers/TalentNominationGroupObserver.php
+++ b/api/app/Observers/TalentNominationGroupObserver.php
@@ -23,8 +23,8 @@ class TalentNominationGroupObserver
     public function updated(TalentNominationGroup $talentNominationGroup): void
     {
         $advancementDecisionChanged = $talentNominationGroup->getOriginal('advancement_decision') !== $talentNominationGroup->advancement_decision;
-        $lateralMovementDecisionChanged = $talentNominationGroup->getOriginal('lateralMovementDecision') !== $talentNominationGroup->lateralMovementDecision;
-        $developmentProgramsDecisionChanged = $talentNominationGroup->getOriginal('developmentProgramsDecision') !== $talentNominationGroup->developmentProgramsDecision;
+        $lateralMovementDecisionChanged = $talentNominationGroup->getOriginal('lateral_movement_decision') !== $talentNominationGroup->lateral_movement_decision;
+        $developmentProgramsDecisionChanged = $talentNominationGroup->getOriginal('development_programs_decision') !== $talentNominationGroup->development_programs_decision;
 
         $decisionsChanged = collect([$advancementDecisionChanged, $lateralMovementDecisionChanged, $developmentProgramsDecisionChanged]);
 

--- a/api/database/migrations/2026_09_03_140000_rename_classification_at_approval_column.php
+++ b/api/database/migrations/2026_09_03_140000_rename_classification_at_approval_column.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('talent_nomination_groups', function (Blueprint $table) {
+            $table->renameColumn('classification_at_time_of_advancement_approval_id', 'classification_at_time_of_last_approval_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('talent_nomination_groups', function (Blueprint $table) {
+            $table->renameColumn('classification_at_time_of_last_approval_id', 'classification_at_time_of_advancement_approval_id');
+        });
+    }
+};

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1014,7 +1014,7 @@ type TalentNominationGroup {
   status: LocalizedTalentNominationGroupStatus
   consentToShareProfile: Boolean @rename(attribute: "consent_to_share_profile")
   comments: String
-  classificationAtTimeOfAdvancementApproval: Classification @belongsTo
+  classificationAtTimeOfLastApproval: Classification @belongsTo
   advancementClassifications: [Classification!] @belongsToMany
   advancementReferralExpiryDate: Date
     @rename(attribute: "advancement_referral_expiry_date")

--- a/api/storage/app/lighthouse-schema.graphql
+++ b/api/storage/app/lighthouse-schema.graphql
@@ -1528,7 +1528,7 @@ type TalentNominationGroup {
   consentToShareProfile: Boolean
   status: LocalizedTalentNominationGroupStatus
   comments: String
-  classificationAtTimeOfAdvancementApproval: Classification
+  classificationAtTimeOfLastApproval: Classification
   advancementClassifications: [Classification!]
   advancementReferralExpiryDate: Date
 }

--- a/api/tests/Feature/TalentNominationGroupClassificationAtApprovalTest.php
+++ b/api/tests/Feature/TalentNominationGroupClassificationAtApprovalTest.php
@@ -64,7 +64,7 @@ class TalentNominationGroupClassificationAtApprovalTest extends TestCase
             ]);
 
         $this->talentNominationGroup = TalentNominationGroup::sole();
-        $this->assertNull($this->talentNominationGroup->classification_at_time_of_advancement_approval_id);
+        $this->assertNull($this->talentNominationGroup->classification_at_time_of_last_approval_id);
     }
 
     public function testClassificationIsRecordedWhenAdvancementIsApproved()
@@ -75,24 +75,20 @@ class TalentNominationGroupClassificationAtApprovalTest extends TestCase
 
         $this->assertEquals(
             $this->nomineeClassification->id,
-            $this->talentNominationGroup->fresh()->classification_at_time_of_advancement_approval_id
+            $this->talentNominationGroup->fresh()->classification_at_time_of_last_approval_id
         );
     }
 
-    public function testClassificationIsClearedWhenAdvancementIsRejected()
+    public function testRejectingLateralMovementOnlyUpdatesClassification()
     {
-        // first approve so a classification is recorded
         $this->talentNominationGroup->update([
-            'advancement_decision' => TalentNominationGroupDecision::APPROVED->name,
-        ]);
-        $this->assertNotNull($this->talentNominationGroup->fresh()->classification_at_time_of_advancement_approval_id);
-
-        // then reject and confirm the classification is cleared
-        $this->talentNominationGroup->update([
-            'advancement_decision' => TalentNominationGroupDecision::REJECTED->name,
+            'lateral_movement_decision' => TalentNominationGroupDecision::REJECTED->name,
         ]);
 
-        $this->assertNull($this->talentNominationGroup->fresh()->classification_at_time_of_advancement_approval_id);
+        $this->assertEquals(
+            $this->nomineeClassification->id,
+            $this->talentNominationGroup->fresh()->classification_at_time_of_last_approval_id
+        );
     }
 
     public function testApprovingAdvancementWithNoNomineeClassificationLeavesFieldNull()
@@ -130,20 +126,46 @@ class TalentNominationGroupClassificationAtApprovalTest extends TestCase
             'advancement_decision' => TalentNominationGroupDecision::APPROVED->name,
         ]);
 
-        $this->assertNull($talentNominationGroup->fresh()->classification_at_time_of_advancement_approval_id);
+        $this->assertNull($talentNominationGroup->fresh()->classification_at_time_of_last_approval_id);
     }
 
-    public function testUnrelatedDecisionChangesDoNotAffectClassification()
+    public function testUpdatingCommentsWithoutDecisionsDoesNotAffectClassification()
     {
+        // first approve so a classification is recorded
         $this->talentNominationGroup->update([
-            'lateral_movement_decision' => TalentNominationGroupDecision::APPROVED->name,
+            'advancement_decision' => TalentNominationGroupDecision::APPROVED->name,
         ]);
-        $this->assertNull($this->talentNominationGroup->fresh()->classification_at_time_of_advancement_approval_id);
+        $this->assertEquals(
+            $this->nomineeClassification->id,
+            $this->talentNominationGroup->fresh()->classification_at_time_of_last_approval_id
+        );
 
+        // comments is not mass-assignable, so set and save the attribute directly
+        $this->talentNominationGroup->comments = 'A comment with no decision change';
+        $this->talentNominationGroup->save();
+
+        $this->assertEquals(
+            $this->nomineeClassification->id,
+            $this->talentNominationGroup->fresh()->classification_at_time_of_last_approval_id
+        );
+    }
+
+    public function testDecisionClearsClassificationWhenNomineeHasNoCurrentClassification()
+    {
+        // first approve so a classification is recorded
+        $this->talentNominationGroup->update([
+            'advancement_decision' => TalentNominationGroupDecision::APPROVED->name,
+        ]);
+        $this->assertNotNull($this->talentNominationGroup->fresh()->classification_at_time_of_last_approval_id);
+
+        // the nominee's classification is later removed
+        $this->talentNominationGroup->nominee->update(['computed_classification' => null]);
+
+        // any subsequent decision re-records the (now null) current classification
         $this->talentNominationGroup->update([
             'lateral_movement_decision' => TalentNominationGroupDecision::REJECTED->name,
-            'development_programs_decision' => TalentNominationGroupDecision::APPROVED->name,
         ]);
-        $this->assertNull($this->talentNominationGroup->fresh()->classification_at_time_of_advancement_approval_id);
+
+        $this->assertNull($this->talentNominationGroup->fresh()->classification_at_time_of_last_approval_id);
     }
 }

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/NominationDetailsDialog/NominationDetailsSection.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/NominationDetailsDialog/NominationDetailsSection.tsx
@@ -78,7 +78,7 @@ const TalentNominationDetailsDialogNominationDetailsNomination_Fragment =
 const TalentNominationDetailsDialogNominationDetailsNominationGroup_Fragment =
   graphql(/* GraphQL */ `
     fragment TalentNominationDetailsDialogNominationDetailsNominationGroup on TalentNominationGroup {
-      classificationAtTimeOfAdvancementApproval {
+      classificationAtTimeOfLastApproval {
         groupAndLevel
       }
     }
@@ -243,7 +243,7 @@ const NominationDetailsSection = ({
               className="xs:col-span-2"
             >
               {/* this mismatch, time of nomination vs time of approval, is intentional */}
-              {nominationGroup.classificationAtTimeOfAdvancementApproval
+              {nominationGroup.classificationAtTimeOfLastApproval
                 ?.groupAndLevel ?? nullMessage}
             </FieldDisplay>
             <FieldDisplay


### PR DESCRIPTION
🤖 Resolves #17847 

## 👋 Introduction

Renames classification at **advancement** approval to **last** approval.

## 🕵️ Details

Note that it is no longer possible to clear the classification unless making a decision when the nominee has no classification.

## 🧪 Testing

Here's a query showing the nomination group's classification vs the nominee's classification to help with testing:

```sql
select
	g.id nomination_group_id,
	c_n.group || ' ' || c_n.level nominee_classification,
	c_g.group || ' ' || c_g.level nomination_group_classification
from talent_nomination_groups g
left join classifications c_g on g.classification_at_time_of_last_approval_id = c_g.id
join users n on g.nominee_id = n.id
left join classifications c_n on n.computed_classification = c_n.id
```

1. Rebuild
2. Log in as community@test.com

- [x] Any decision (approve or reject) updates the nomination group's classification
- [x] Any decision while the nominee's classification is null updates the group's classification to null
- [x] Updating the comments only does not update the group's classification
