### PR TITLE
[Fix] French pool candidates excel download

### DIFF
--- a/api/app/GraphQL/Mutations/DownloadPoolCandidatesExcel.php
+++ b/api/app/GraphQL/Mutations/DownloadPoolCandidatesExcel.php
@@ -4,6 +4,7 @@ namespace App\GraphQL\Mutations;
 
 use App\Generators\PoolCandidateExcelGenerator;
 use App\Jobs\GenerateUserFile;
+use App\Support\FilePath;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
@@ -29,7 +30,7 @@ final class DownloadPoolCandidatesExcel
 
         try {
             $generator = new PoolCandidateExcelGenerator(
-                fileName: sprintf('%s_%s', __($withROD ? 'filename.candidates_rod' : 'filename.applications'), date('Y-m-d_His')),
+                fileName: FilePath::sanitize(sprintf('%s_%s', __($withROD ? 'filename.candidates_rod' : 'filename.applications'), date('Y-m-d_His'))),
                 dir: $user->id,
                 lang: App::getLocale(),
                 withROD: $withROD,

--- a/api/lang/fr/filename.php
+++ b/api/lang/fr/filename.php
@@ -2,7 +2,7 @@
 
 return [
     'candidates' => 'candidats',
-    'candidates_rod' => 'évaluation_des_candidat(e)s',
+    'candidates_rod' => 'évaluation_des_candidats',
     'candidate' => 'candidat',
     'user' => 'utilisateur',
     'users' => 'utilisateurs',

--- a/api/tests/Feature/Generators/PoolCandidatesExcelTest.php
+++ b/api/tests/Feature/Generators/PoolCandidatesExcelTest.php
@@ -7,6 +7,7 @@ use App\Models\Community;
 use App\Models\Pool;
 use App\Models\PoolCandidate;
 use App\Models\User;
+use App\Support\FilePath;
 use Database\Seeders\RolePermissionSeeder;
 use Database\Seeders\SkillFamilySeeder;
 use Database\Seeders\SkillSeeder;
@@ -81,6 +82,53 @@ class PoolCandidatesExcelTest extends TestCase
     }
 
     /**
+     * Regression test for https://github.com/GCTC-NTGC/gc-digital-talent/issues/17762
+     *
+     * DownloadPoolCandidatesExcel sanitizes the filename before handing it to the
+     * generator, and UserGeneratedFilesController sanitizes again before looking the
+     * file up on disk. This confirms both steps agree on the same on-disk name for
+     * the ROD filename in both locales (the French string previously contained
+     * parentheses that survived generation but were stripped on lookup, causing a 404).
+     */
+    public function testRodFilenameSurvivesSanitizeRoundTripInBothLocales(): void
+    {
+        // arrange
+        $adminUser = User::factory()->asApplicant()->asAdmin()->create();
+        $targetUser = User::factory()->asApplicant()->withNonGovProfile()->create();
+        $application = PoolCandidate::factory()
+            ->availableInSearch()
+            ->withSnapshot()
+            ->create(['user_id' => $targetUser->id]);
+        $disk = Storage::disk('user_generated');
+
+        // act + assert: build the filename the same way DownloadPoolCandidatesExcel
+        // does, generate the file, then confirm it exists both where it was written
+        // and where UserGeneratedFilesController::streamFile() would look it up
+        foreach (['en', 'fr'] as $lang) {
+            $fileName = FilePath::sanitize(sprintf('%s_%s', __('filename.candidates_rod', [], $lang), date('Y-m-d_His')));
+
+            $generator = new PoolCandidateExcelGenerator(
+                fileName: $fileName,
+                dir: 'test',
+                lang: $lang,
+                withROD: true,
+            );
+            $generator
+                ->setAuthenticatedUserId($adminUser->id)
+                ->setIds([$application->id])
+                ->setFilters([]);
+            $generator->generate()->write();
+
+            $writtenPath = 'test'.DIRECTORY_SEPARATOR.$fileName.'.xlsx';
+            $this->assertTrue($disk->exists($writtenPath), "File was not written for locale [$lang]");
+
+            $lookupName = FilePath::sanitize($fileName.'.xlsx', true);
+            $lookupPath = 'test'.DIRECTORY_SEPARATOR.$lookupName;
+            $this->assertTrue($disk->exists($lookupPath), "Download lookup would 404 for locale [$lang]");
+        }
+    }
+
+    /**
      * The "community" filter should exclude candidates whose pool is not in
      * the filtered community, even when no explicit ids are set (full dataset download).
      */
@@ -130,6 +178,23 @@ class PoolCandidatesExcelTest extends TestCase
 
         $this->assertStringContainsString($memberUser->email, $text, 'Candidate inside the filtered community should appear');
         $this->assertStringNotContainsString($outsideUser->email, $text, 'Candidate outside the filtered community should not appear');
+    }
+
+    // FilePath::sanitize() must keep stripping directory traversal characters
+    public function testSanitizeStripsDirectoryTraversalSequences(): void
+    {
+        $sanitized = FilePath::sanitize('../../etc/passwd', true);
+
+        $this->assertStringNotContainsString('..', $sanitized);
+        $this->assertStringNotContainsString('/', $sanitized);
+    }
+
+    public function testSanitizeStripsBackslashes(): void
+    {
+        $sanitized = FilePath::sanitize('..\\..\\windows\\system32', true);
+
+        $this->assertStringNotContainsString('..', $sanitized);
+        $this->assertStringNotContainsString('\\', $sanitized);
     }
 
     // A free-text field starting with "=" must be written as text, not a formula.


### PR DESCRIPTION
🤖 Resolves #17762

## 👋 Introduction

Fixes the French candidate assessment (ROD) export 404ing on download.

- Sanitizes the pool candidate export filename
- Renames the French ROD filename string
- Adds tests confirming the export filename survives the sanitize round-trip in both locales

## 🧪 Testing

1. Login as admin
2. Go to a process, and select the candidates tab
3. Switch to French
4. Ensure downloading the dataset works and has the correct filename
5. Switch back to English
6. Ensure downloading the dataset still works

## 📸 Screenshot

<img width="1920" height="899" alt="image" src="https://github.com/user-attachments/assets/5afd035b-a587-43ee-a570-2ecfea6af51b" />
