### PR TITLE
[Feat] Low priority queue for bulk emails

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -91,7 +91,7 @@ jobs:
         run: npx playwright install chromium webkit
 
       - name: Start queue for downloads
-        run: docker compose exec webserver sh -c "runuser -u www-data -- php /home/site/wwwroot/api/artisan queue:work" &
+        run: docker compose exec webserver sh -c "runuser -u www-data -- php /home/site/wwwroot/api/artisan queue:work --queue=default,default-low" &
 
       - name: Run Tests
         run: pnpm run e2e:playwright --project=${{ matrix.project }} --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}

--- a/.github/workflows/webkit-playwright.yml
+++ b/.github/workflows/webkit-playwright.yml
@@ -80,7 +80,7 @@ jobs:
         run: npx playwright install chromium webkit
 
       - name: Start queue for downloads
-        run: docker compose exec webserver sh -c "runuser -u www-data -- php /home/site/wwwroot/api/artisan queue:work" &
+        run: docker compose exec webserver sh -c "runuser -u www-data -- php /home/site/wwwroot/api/artisan queue:work --queue=default,default-low" &
 
       - name: Run Tests
         run: pnpm run e2e:playwright --project=${{ matrix.project }} --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ phpstan:
 	$(DOCKER_API) "vendor/bin/phpstan analyse -c phpstan.neon"
 
 queue-work:
-	docker compose exec webserver sh -c "runuser -u www-data -- php /home/site/wwwroot/api/artisan queue:work"
+	docker compose exec webserver sh -c "runuser -u www-data -- php /home/site/wwwroot/api/artisan queue:work --queue=default,default-low"
 
 reverb-start:
 	docker compose exec webserver sh -c "runuser -u www-data -- php /home/site/wwwroot/api/artisan reverb:start"

--- a/Makefile.nix
+++ b/Makefile.nix
@@ -69,7 +69,7 @@ compose_down:
 	docker compose $(COMPOSE_FLAGS) down
 
 queue_work:
-	docker compose exec webserver sh -c "runuser -u www-data -- php /home/site/wwwroot/api/artisan queue:work"
+	docker compose exec webserver sh -c "runuser -u www-data -- php /home/site/wwwroot/api/artisan queue:work --queue=default,default-low"
 
 reverb-start:
 	docker compose exec webserver sh -c "runuser -u www-data -- php /home/site/wwwroot/api/artisan reverb:start"

--- a/api/app/Contracts/LowPriorityJob.php
+++ b/api/app/Contracts/LowPriorityJob.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Contracts;
+
+// Mark a job as low priority indicating
+// it should be processed by the low priority worker
+interface LowPriorityJob {}

--- a/api/app/Contracts/LowPriorityJob.php
+++ b/api/app/Contracts/LowPriorityJob.php
@@ -4,4 +4,7 @@ namespace App\Contracts;
 
 // Mark a job as low priority indicating
 // it should be processed by the low priority worker
-interface LowPriorityJob {}
+interface LowPriorityJob
+{
+    public const QUEUE_SUFFIX = '-low';
+}

--- a/api/app/Notifications/AdHocEmail.php
+++ b/api/app/Notifications/AdHocEmail.php
@@ -2,13 +2,14 @@
 
 namespace App\Notifications;
 
+use App\Contracts\LowPriorityJob;
 use App\Enums\Language;
 use App\Models\User;
 use App\Notifications\Messages\GcNotifyEmailMessage;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
 
-class AdHocEmail extends Notification implements CanBeSentViaGcNotifyEmail
+class AdHocEmail extends Notification implements CanBeSentViaGcNotifyEmail, LowPriorityJob
 {
     use Queueable;
 

--- a/api/app/Notifications/ApplicationDeadlineApproaching.php
+++ b/api/app/Notifications/ApplicationDeadlineApproaching.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use App\Contracts\LowPriorityJob;
 use App\Enums\Language;
 use App\Enums\NotificationFamily;
 use App\Models\User;
@@ -10,7 +11,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Carbon;
 
-class ApplicationDeadlineApproaching extends Notification implements CanBeSentViaGcNotifyEmail
+class ApplicationDeadlineApproaching extends Notification implements CanBeSentViaGcNotifyEmail, LowPriorityJob
 {
     use Queueable;
 

--- a/api/app/Notifications/GcNotifyEmailChannel.php
+++ b/api/app/Notifications/GcNotifyEmailChannel.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use App\Contracts\LowPriorityJob;
 use App\Jobs\GcNotifyApiRequest;
 use Illuminate\Support\Facades\Log;
 
@@ -13,6 +14,7 @@ class GcNotifyEmailChannel
     public function send(object $notifiable, CanBeSentViaGcNotifyEmail $notification): void
     {
         $message = $notification->toGcNotifyEmail($notifiable);
+
         if (! config('notify.client.apiKey')) {
             $errorMessage = 'GC Notify API key is missing.';
             Log::error($errorMessage);
@@ -22,7 +24,26 @@ class GcNotifyEmailChannel
             Log::error($errorMessage);
             throw new \Exception($errorMessage);
         } else {
-            GcNotifyApiRequest::dispatch($message);
+            GcNotifyApiRequest::dispatch($message)->onQueue(
+                $this->resolveQueuePriority($notification)
+            );
         }
+    }
+
+    /**
+     * Get the queue name to dispatch the job to
+     *
+     * Send the job to the low priority queue worker
+     * if it implements the low priority interface
+     */
+    private function resolveQueuePriority(CanBeSentViaGcNotifyEmail $notification): string
+    {
+        $queue = config('queue.connections.database.queue');
+
+        if ($notification instanceof LowPriorityJob) {
+            return $queue.LowPriorityJob::QUEUE_SUFFIX;
+        }
+
+        return $queue;
     }
 }

--- a/api/app/Notifications/GcNotifyEmailChannel.php
+++ b/api/app/Notifications/GcNotifyEmailChannel.php
@@ -38,7 +38,7 @@ class GcNotifyEmailChannel
      */
     private function resolveQueuePriority(CanBeSentViaGcNotifyEmail $notification): string
     {
-        $queue = config('queue.connections.database.queue');
+        $queue = config('queue.name');
 
         if ($notification instanceof LowPriorityJob) {
             return $queue.LowPriorityJob::QUEUE_SUFFIX;

--- a/api/app/Notifications/NewJobPosted.php
+++ b/api/app/Notifications/NewJobPosted.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use App\Contracts\LowPriorityJob;
 use App\Enums\Language;
 use App\Enums\NotificationFamily;
 use App\Models\User;
@@ -9,7 +10,7 @@ use App\Notifications\Messages\GcNotifyEmailMessage;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
 
-class NewJobPosted extends Notification implements CanBeSentViaGcNotifyEmail
+class NewJobPosted extends Notification implements CanBeSentViaGcNotifyEmail, LowPriorityJob
 {
     use Queueable;
 

--- a/api/app/Notifications/System.php
+++ b/api/app/Notifications/System.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use App\Contracts\LowPriorityJob;
 use App\Enums\Language;
 use App\Models\User;
 use App\Notifications\Messages\GcNotifyEmailMessage;
@@ -9,7 +10,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\View;
 
-class System extends Notification implements CanBeSentViaGcNotifyEmail
+class System extends Notification implements CanBeSentViaGcNotifyEmail, LowPriorityJob
 {
     use Queueable;
 

--- a/api/config/queue.php
+++ b/api/config/queue.php
@@ -12,8 +12,19 @@ return [
     | syntax for every one. Here you may define a default connection.
     |
     */
-
     'default' => env('QUEUE_CONNECTION', 'sync'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Queue Name
+    |--------------------------------------------------------------------------
+    |
+    | Queue name used to differentiate between separate codebases (deployment slots)
+    | that happen to share a queue connection. This prevents different codebases
+    | from picking up jobs not assigned to it from the connection.
+    |
+    */
+    'name' => env('DEPLOYMENT_SLOT_NAME', 'default'),
 
     /*
     |--------------------------------------------------------------------------
@@ -39,7 +50,7 @@ return [
             'table' => 'jobs',
             // Slot-private queue: each App Service slot dispatches to and works only
             // its own queue, so an idle slot's worker can't steal jobs
-            'queue' => env('QUEUE_NAME', env('DEPLOYMENT_SLOT_NAME', 'default')),
+            'queue' => env('DEPLOYMENT_SLOT_NAME', 'default'),
             'retry_after' => env('QUEUE_RETRY_AFTER', 400),
             'after_commit' => false,
         ],

--- a/api/tests/Feature/GcNotifyEmailChannelTest.php
+++ b/api/tests/Feature/GcNotifyEmailChannelTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\EmailType;
+use App\Jobs\GcNotifyApiRequest;
+use App\Models\User;
+use App\Notifications\AdHocEmail;
+use App\Notifications\VerifyEmails;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class GcNotifyEmailChannelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolePermissionSeeder::class);
+
+        config([
+            'notify.client.apiKey' => 'test-key',
+            'notify.templates.verify_email_en' => 'template-id-en',
+            'notify.templates.verify_email_fr' => 'template-id-fr',
+        ]);
+
+        Queue::fake();
+    }
+
+    public function testLowPriorityNotificationIsQueuedOnTheLowQueue(): void
+    {
+        $user = User::factory()->create();
+
+        $user->notify(new AdHocEmail('template-id-en', 'template-id-fr'));
+
+        Queue::assertPushedOn('default-low', GcNotifyApiRequest::class);
+    }
+
+    public function testOtherNotificationIsQueuedOnTheMainQueue(): void
+    {
+        $user = User::factory()->create();
+
+        $user->notify(new VerifyEmails($user->email, [EmailType::CONTACT]));
+
+        Queue::assertPushedOn('default', GcNotifyApiRequest::class);
+    }
+}

--- a/documentation/gc-notify.md
+++ b/documentation/gc-notify.md
@@ -39,7 +39,7 @@ After the `api/.env` file has been updated, the settings will need to be applied
    - Alternatively, restart the webserver container.
    - Alternatively, use the "refresh api" shortcut from Makfile.nix.
 3. Check the configuration by running `php artisan tinker --execute="echo config('notify.client.apiKey')"`.
-4. Start a queue worker to send the messages. `php artisan queue:work`
+4. Start a queue worker to send the messages. `php artisan queue:work --queue=default,default-low`
    - Alternatively, use the "queue work" makefile shortcuts.
 5. Send a test message with `php artisan send-notifications:test example@example.org`.
 

--- a/infrastructure/conf/laravel-worker.conf
+++ b/infrastructure/conf/laravel-worker.conf
@@ -1,6 +1,6 @@
 [program:laravel-worker]
 process_name=%(program_name)s_%(process_num)02d
-command=php /home/site/wwwroot/api/artisan queue:work --max-time=3600
+command=php /home/site/wwwroot/api/artisan queue:work --queue=%(ENV_DEPLOYMENT_SLOT_NAME)s,%(ENV_DEPLOYMENT_SLOT_NAME)s-low --max-time=3600
 autostart=true
 autorestart=true
 stopasgroup=true

--- a/infrastructure/dev/api-entrypoint.sh
+++ b/infrastructure/dev/api-entrypoint.sh
@@ -20,7 +20,7 @@ php artisan lighthouse:print-schema --write
 
 # Start background workers
 echo "Starting background jobs..."
-php artisan queue:work &
+php artisan queue:work --queue=default,default-low &
 php artisan reverb:start &
 
 # Start the Laravel development server


### PR DESCRIPTION
🤖 Resolves #17221 

## 👋 Introduction

This adds a new queue for lower priorty jobs such as bulk emials.

## 🕵️ Details

Our bulk emails take a longer time to send due to quantity. This was starving our queue since a large set of emails needed to send before it could process other items.

This introduces a new queue suffixed with `-low`. Laravel process queues in order, so it acts as a priotiyy. When we cann `php artisan queue:work --queue=defualt,defualt-low` it will not process any job in `default-low` until all jobs in `defualt` have been processed. So, imagine the follow scenario:

 1. New job posted, trigger bulk email to be sent and sent to `defualt-low`
 2. `default` is empty so emials start sending
 3. During the process of bulk emails, an admin requersts a bulk file download
 4. The download gets pushed to the `default` queue
 5. Since `default` is no longer empty, jobs on `default-low` (emails) get paused
 6. `default` gets processed as soon as the worker is ready
 7. Once the download job is processed, `default-low` sees that `default` is once agian empty and starts procesing its jobs again

### How emails get sent to low prioirty queue

I introduced a very basic interface called `LowPrioirtyJob`. Then, in the `GcNotifyChannel`, where we dispatch the queued jobs, I added a simple conditional where we see if an emial notifixcaiton implements the interface. If it does, we send it to the low priority queue otherqise, it gets send to the default queue.

### What emails are low priority?

This is likely more of a business decision but, I did:

 - Ad-hoc emails
 - New job posted
 - Deadline approaching

These seemd to be the only ones that would send a high number and by extension, candidates for the low priority queue as risks to starving the default queue. 

## 🧪 Testing

> [!IMPORTANT]
> This almost certainly will need to be tested in dev. 

1. Ensure you have your GC notify env vars set
2. Start the queue `make queue-work`
3. Open the database to see the `jobs` table
4. Open another terminal
5. Run `php artisan send-notifications:ad-hoc-email --notifyAllUsers` (with the test emial template ID)
6. Confirm that the jobs get created in the low priory queue by check the `jobs` table `queue` column (it should say `default-low` or if in dev, `default` should be replaced by the deployment slot name)