### PR TITLE
[Feature] Populate advancement recommendation classifications

### DIFF
--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3110,10 +3110,6 @@
     "defaultMessage": "Passer au contenu principal",
     "description": "Default Skip to main content message."
   },
-  "A4+XAq": {
-    "defaultMessage": " Veuillez indiquer les classifications pour lesquelles la personne nominée doit être recommandée. Les classifications recommandées par la nominatrice ou le nominateur sont présentées à titre indicatif.",
-    "description": "introduction for advancement classifications"
-  },
   "A4dp/3": {
     "defaultMessage": "Masquer tout<hidden>es les sections de perfectionnement de carrière</hidden>",
     "description": "Button text to hide all career development sections"
@@ -11409,6 +11405,10 @@
   "h8BHov": {
     "defaultMessage": "Étape {stepOrdinal} (Intro)",
     "description": "Breadcrumb link text for a numbered application step introduction page"
+  },
+  "h8vBvw": {
+    "defaultMessage": " Veuillez indiquer les classifications pour lesquelles la personne nominée doit être recommandée. Les classifications recommandées par la nominatrice ou le nominateur sont présentées à titre indicatif.",
+    "description": "introduction for advancement classifications"
   },
   "h9XSU5": {
     "defaultMessage": "Notes complémentaires",

--- a/apps/web/src/lang/fr.json
+++ b/apps/web/src/lang/fr.json
@@ -3110,6 +3110,10 @@
     "defaultMessage": "Passer au contenu principal",
     "description": "Default Skip to main content message."
   },
+  "A4+XAq": {
+    "defaultMessage": " Veuillez indiquer les classifications pour lesquelles la personne nominée doit être recommandée. Les classifications recommandées par la nominatrice ou le nominateur sont présentées à titre indicatif.",
+    "description": "introduction for advancement classifications"
+  },
   "A4dp/3": {
     "defaultMessage": "Masquer tout<hidden>es les sections de perfectionnement de carrière</hidden>",
     "description": "Button text to hide all career development sections"
@@ -4381,6 +4385,10 @@
   "FEffiH": {
     "defaultMessage": "Description de l’apprentissage",
     "description": "Label displayed on Personal Experience form for learning description input"
+  },
+  "FEjHL6": {
+    "defaultMessage": "Classifications proposées pour la promotion",
+    "description": "A list of classifications for advancement"
   },
   "FGUGtr": {
     "defaultMessage": "Groupe et niveau",

--- a/apps/web/src/pages/TalentNominations/NominateTalent/components/ReviewAndSubmit/NominationDetailsReview.tsx
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/components/ReviewAndSubmit/NominationDetailsReview.tsx
@@ -270,12 +270,9 @@ const NominationDetailsReview = ({
             </FieldDisplay>
             <FieldDisplay
               className="col-span-2"
-              label={intl.formatMessage({
-                defaultMessage: "Recommended classifications for advancement",
-                id: "1e2+hH",
-                description:
-                  "Label for advancement eligible classifications field",
-              })}
+              label={intl.formatMessage(
+                labels.recommendedAdvancementClassifications,
+              )}
             >
               {talentNomination.advancementClassifications?.length ? (
                 <Ul space="md">

--- a/apps/web/src/pages/TalentNominations/NominateTalent/labels.ts
+++ b/apps/web/src/pages/TalentNominations/NominateTalent/labels.ts
@@ -171,6 +171,11 @@ const labels = defineMessages({
     id: "jT5w4o",
     description: "label for high potential definition",
   },
+  recommendedAdvancementClassifications: {
+    defaultMessage: "Recommended classifications for advancement",
+    id: "1e2+hH",
+    description: "Label for advancement eligible classifications field",
+  },
 });
 
 export default labels;

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/TalentNominationAccordionItem.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/TalentNominationAccordionItem.tsx
@@ -11,7 +11,7 @@ import {
 import { Accordion, Ul } from "@gc-digital-talent/ui";
 import { commonMessages } from "@gc-digital-talent/i18n";
 import { localizedEnumToOptions } from "@gc-digital-talent/forms";
-import { unpackMaybes } from "@gc-digital-talent/helpers";
+import { uniqueItems, unpackMaybes } from "@gc-digital-talent/helpers";
 
 import { getFullNameLabel } from "~/utils/nameUtils";
 import FieldDisplay from "~/components/FieldDisplay/FieldDisplay";
@@ -103,6 +103,10 @@ const TalentNominationAccordionItem_Fragment = graphql(/* GraphQL */ `
       name {
         localized
       }
+    }
+    advancementClassifications {
+      id
+      groupAndLevel
     }
 
     lateralMovementOptions {
@@ -207,6 +211,10 @@ const TalentNominationAccordionItem = ({
         });
 
   const advancementReferenceIsAUser = !!talentNomination.advancementReference;
+
+  talentNomination.advancementClassifications?.sort((a, b) =>
+    (a?.groupAndLevel ?? "").localeCompare(b?.groupAndLevel ?? ""),
+  );
 
   const lateralMovementOptionValuesInThisNomination =
     talentNomination.lateralMovementOptions?.map((option) => option.value) ??
@@ -392,6 +400,18 @@ const TalentNominationAccordionItem = ({
                       : talentNomination.advancementReferenceFallbackDepartment
                           ?.name.localized) ??
                       intl.formatMessage(commonMessages.notFound)}
+                  </FieldDisplay>
+                  <FieldDisplay
+                    label={intl.formatMessage(
+                      nominationLabels.recommendedAdvancementClassifications,
+                    )}
+                    className="xs:col-span-2"
+                  >
+                    <Ul space="md">
+                      {talentNomination.advancementClassifications?.map((c) => (
+                        <li key={c.id}>{c.groupAndLevel}</li>
+                      ))}
+                    </Ul>
                   </FieldDisplay>
                 </div>
               </Accordion.Content>

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/TalentNominationAccordionItem.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/TalentNominationAccordionItem.tsx
@@ -11,7 +11,7 @@ import {
 import { Accordion, Ul } from "@gc-digital-talent/ui";
 import { commonMessages } from "@gc-digital-talent/i18n";
 import { localizedEnumToOptions } from "@gc-digital-talent/forms";
-import { unpackMaybes } from "@gc-digital-talent/helpers";
+import { sortAlphaBy, unpackMaybes } from "@gc-digital-talent/helpers";
 
 import { getFullNameLabel } from "~/utils/nameUtils";
 import FieldDisplay from "~/components/FieldDisplay/FieldDisplay";
@@ -212,9 +212,9 @@ const TalentNominationAccordionItem = ({
 
   const advancementReferenceIsAUser = !!talentNomination.advancementReference;
 
-  talentNomination.advancementClassifications?.sort((a, b) =>
-    (a?.groupAndLevel ?? "").localeCompare(b?.groupAndLevel ?? ""),
-  );
+  const sortedAdvancementClassifications = unpackMaybes(
+    talentNomination.advancementClassifications,
+  ).sort(sortAlphaBy((c) => c.groupAndLevel));
 
   const lateralMovementOptionValuesInThisNomination =
     talentNomination.lateralMovementOptions?.map((option) => option.value) ??
@@ -407,11 +407,15 @@ const TalentNominationAccordionItem = ({
                     )}
                     className="xs:col-span-2"
                   >
-                    <Ul space="md">
-                      {talentNomination.advancementClassifications?.map((c) => (
-                        <li key={c.id}>{c.groupAndLevel}</li>
-                      ))}
-                    </Ul>
+                    {sortedAdvancementClassifications?.length ? (
+                      <Ul space="md">
+                        {sortedAdvancementClassifications.map((c) => (
+                          <li key={c.id}>{c.groupAndLevel}</li>
+                        ))}
+                      </Ul>
+                    ) : (
+                      intl.formatMessage(commonMessages.notProvided)
+                    )}
                   </FieldDisplay>
                 </div>
               </Accordion.Content>

--- a/apps/web/src/pages/TalentNominations/NominationGroup/components/TalentNominationAccordionItem.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroup/components/TalentNominationAccordionItem.tsx
@@ -11,7 +11,7 @@ import {
 import { Accordion, Ul } from "@gc-digital-talent/ui";
 import { commonMessages } from "@gc-digital-talent/i18n";
 import { localizedEnumToOptions } from "@gc-digital-talent/forms";
-import { uniqueItems, unpackMaybes } from "@gc-digital-talent/helpers";
+import { unpackMaybes } from "@gc-digital-talent/helpers";
 
 import { getFullNameLabel } from "~/utils/nameUtils";
 import FieldDisplay from "~/components/FieldDisplay/FieldDisplay";

--- a/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/components/AdvancementSection.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/components/AdvancementSection.tsx
@@ -1,6 +1,7 @@
 import { useIntl } from "react-intl";
 import { useFormContext } from "react-hook-form";
 import { useEffect, useId } from "react";
+import uniqBy from "lodash/uniqBy";
 
 import {
   Checkbox,
@@ -17,11 +18,7 @@ import {
   graphql,
   TalentNominationGroupDecision,
 } from "@gc-digital-talent/graphql";
-import {
-  notEmpty,
-  uniqueItems,
-  unpackMaybes,
-} from "@gc-digital-talent/helpers";
+import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
 
 import FieldDisplay from "~/components/FieldDisplay/FieldDisplay";
 
@@ -126,10 +123,11 @@ const AdvancementSection = ({
     .filter(notEmpty)
     .join(", ");
 
-  const allRecommendedAdvancementClassifications = uniqueItems(
+  const allRecommendedAdvancementClassifications = uniqBy(
     unpackMaybes(
       nominations?.flatMap((n) => n.recommendedAdvancementClassifications),
     ),
+    (classification) => classification.id,
   );
   allRecommendedAdvancementClassifications.sort((a, b) =>
     (a?.groupAndLevel ?? "").localeCompare(b?.groupAndLevel ?? ""),

--- a/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/components/AdvancementSection.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/components/AdvancementSection.tsx
@@ -1,6 +1,6 @@
 import { useIntl } from "react-intl";
 import { useFormContext } from "react-hook-form";
-import { useEffect } from "react";
+import { useEffect, useId } from "react";
 
 import {
   Checkbox,
@@ -9,7 +9,7 @@ import {
   RadioGroup,
   RichTextInput,
 } from "@gc-digital-talent/forms";
-import { Heading, Notice } from "@gc-digital-talent/ui";
+import { Heading, Notice, Ul } from "@gc-digital-talent/ui";
 import { commonMessages, errorMessages } from "@gc-digital-talent/i18n";
 import type { FragmentType } from "@gc-digital-talent/graphql";
 import {
@@ -17,7 +17,11 @@ import {
   graphql,
   TalentNominationGroupDecision,
 } from "@gc-digital-talent/graphql";
-import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
+import {
+  notEmpty,
+  uniqueItems,
+  unpackMaybes,
+} from "@gc-digital-talent/helpers";
 
 import FieldDisplay from "~/components/FieldDisplay/FieldDisplay";
 
@@ -34,6 +38,10 @@ const NominationGroupEvaluationDialogAdvancement_Fragment = graphql(
           workEmail
         }
         advancementReferenceFallbackWorkEmail
+        recommendedAdvancementClassifications: advancementClassifications {
+          id
+          groupAndLevel
+        }
       }
       advancementClassifications {
         id
@@ -69,6 +77,7 @@ const AdvancementSection = ({
   talentNominationGroupOptionsQuery,
 }: AdvancementSectionProps) => {
   const intl = useIntl();
+  const advancementClassificationIntroductionId = useId();
 
   const { watch, resetField } = useFormContext<FormValues>();
   const [selectedAdvancementDecision] = watch(["advancementDecision"]);
@@ -116,6 +125,15 @@ const AdvancementSection = ({
     )
     .filter(notEmpty)
     .join(", ");
+
+  const allRecommendedAdvancementClassifications = uniqueItems(
+    unpackMaybes(
+      nominations?.flatMap((n) => n.recommendedAdvancementClassifications),
+    ),
+  );
+  allRecommendedAdvancementClassifications.sort((a, b) =>
+    (a?.groupAndLevel ?? "").localeCompare(b?.groupAndLevel ?? ""),
+  );
 
   return (
     <div className="flex flex-col gap-6">
@@ -172,6 +190,27 @@ const AdvancementSection = ({
               required: intl.formatMessage(errorMessages.required),
             }}
           />
+          <p id={advancementClassificationIntroductionId}>
+            {intl.formatMessage({
+              defaultMessage:
+                "Please indicate the classifications this nominee should be referred for. The recommended classifications supplied by the nominator have been provided as reference.",
+              id: "A4+XAq",
+              description: "introduction for advancement classifications",
+            })}
+          </p>
+          <FieldDisplay
+            label={intl.formatMessage({
+              defaultMessage: "Proposed classifications for advancement",
+              id: "FEjHL6",
+              description: "A list of classifications for advancement",
+            })}
+          >
+            <Ul space="md">
+              {allRecommendedAdvancementClassifications.map((c) => (
+                <li key={c.id}>{c.groupAndLevel}</li>
+              ))}
+            </Ul>
+          </FieldDisplay>
           <Combobox
             id="advancementClassifications"
             name="advancementClassifications"
@@ -193,6 +232,7 @@ const AdvancementSection = ({
             rules={{
               required: intl.formatMessage(errorMessages.required),
             }}
+            aria-describedby={advancementClassificationIntroductionId}
           />
           <DateInput
             id="advancementReferralExpiryDate"

--- a/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/components/AdvancementSection.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/components/AdvancementSection.tsx
@@ -18,7 +18,11 @@ import {
   graphql,
   TalentNominationGroupDecision,
 } from "@gc-digital-talent/graphql";
-import { notEmpty, unpackMaybes } from "@gc-digital-talent/helpers";
+import {
+  notEmpty,
+  sortAlphaBy,
+  unpackMaybes,
+} from "@gc-digital-talent/helpers";
 
 import FieldDisplay from "~/components/FieldDisplay/FieldDisplay";
 
@@ -129,8 +133,8 @@ const AdvancementSection = ({
     ),
     (classification) => classification.id,
   );
-  allRecommendedAdvancementClassifications.sort((a, b) =>
-    (a?.groupAndLevel ?? "").localeCompare(b?.groupAndLevel ?? ""),
+  allRecommendedAdvancementClassifications.sort(
+    sortAlphaBy((c) => c.groupAndLevel),
   );
 
   return (
@@ -203,11 +207,15 @@ const AdvancementSection = ({
               description: "A list of classifications for advancement",
             })}
           >
-            <Ul space="md">
-              {allRecommendedAdvancementClassifications.map((c) => (
-                <li key={c.id}>{c.groupAndLevel}</li>
-              ))}
-            </Ul>
+            {allRecommendedAdvancementClassifications.length ? (
+              <Ul space="md">
+                {allRecommendedAdvancementClassifications.map((c) => (
+                  <li key={c.id}>{c.groupAndLevel}</li>
+                ))}
+              </Ul>
+            ) : (
+              intl.formatMessage(commonMessages.notProvided)
+            )}
           </FieldDisplay>
           <Combobox
             id="advancementClassifications"

--- a/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/components/AdvancementSection.tsx
+++ b/apps/web/src/pages/TalentNominations/NominationGroupEvaluationDialog/components/AdvancementSection.tsx
@@ -195,8 +195,8 @@ const AdvancementSection = ({
           <p id={advancementClassificationIntroductionId}>
             {intl.formatMessage({
               defaultMessage:
-                "Please indicate the classifications this nominee should be referred for. The recommended classifications supplied by the nominator have been provided as reference.",
-              id: "A4+XAq",
+                "Please indicate the classifications this nominee should be referred for. The recommended classifications supplied by the nominator have been provided as a reference.",
+              id: "h8vBvw",
               description: "introduction for advancement classifications",
             })}
           </p>


### PR DESCRIPTION
🤖 Resolves #17859 

## 👋 Introduction

Shows the recommended advancement classifications on the details page and the evaluation dialog.

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

1. Rebuild
2. Log in as community@test.com
3. Find (or probably set up) a nomination group with two or more nominations including recommended advancement classifications.

Here's a SQL query to help find them:
```sql
select
	e.name->>'en' event_name,	
	u.first_name || ' ' || u.last_name nominiee,
	n.id nomination_id,
	string_agg(c.group || '-' || c.level, ', ') recommended_classifications
from talent_nomination_events e
join talent_nomination_groups g on g.talent_nomination_event_id = e.id
join users u on g.nominee_id = u.id
join talent_nominations n on n.talent_nomination_group_id = g.id
left join classification_talent_nomination_advancement c_n on c_n.talent_nomination_id = n.id
left join classifications c on c.id = c_n.classification_id
group by e.name->>'en', u.first_name || ' ' || u.last_name, n.id
order by e.name->>'en', u.first_name || ' ' || u.last_name, n.id
```

- [x] On the details page, each nomination shows its own list of classifications
- [x] In the evaluation dialog, the combined list of nominations is shown

## 📸 Screenshot

<img width="747" height="667" alt="image" src="https://github.com/user-attachments/assets/b943e5ff-24b7-4bff-90ad-c11d894f9f6f" />

