### PR TITLE
[Security] `Raw` operations audit

### DIFF
--- a/api/app/Builders/TalentRequestBuilder.php
+++ b/api/app/Builders/TalentRequestBuilder.php
@@ -12,7 +12,7 @@ class TalentRequestBuilder extends Builder
 {
     public function whereId(?string $id): self
     {
-        return $this->when($id, fn ($q) => $q->whereRaw('id::text ILIKE ?', ["%{$id}%"]));
+        return $this->when($id, fn ($q) => $q->where('id', 'ilike', "%{$id}%"));
     }
 
     public function whereFullName(?string $fullName): self
@@ -44,7 +44,7 @@ class TalentRequestBuilder extends Builder
     {
         return $this->when($search, fn ($q) => $q->where(function ($q) use ($search): void {
             $q->where('full_name', 'ilike', "%{$search}%")
-                ->orWhereRaw('id::text ILIKE ?', ["%{$search}%"])
+                ->orWhere('id', 'ilike', "%{$search}%")
                 ->orWhere('email', 'ilike', "%{$search}%")
                 ->orWhere('job_title', 'ilike', "%{$search}%")
                 ->orWhere('additional_comments', 'ilike', "%{$search}%")

--- a/api/app/Builders/UserBuilder.php
+++ b/api/app/Builders/UserBuilder.php
@@ -12,6 +12,7 @@ use App\Enums\PriorityWeight;
 use App\Enums\TalentRequestSource;
 use App\Models\User;
 use App\Support\Query\AdvancedOrder;
+use App\Utilities\PostgresLike;
 use App\Utilities\PostgresTextSearch;
 use App\Utilities\PostgresTextSearchMatchingType;
 use Illuminate\Database\Eloquent\Builder;
@@ -533,8 +534,9 @@ class UserBuilder extends Builder
 
         return $this->where(function ($query) use ($splitName) {
             foreach ($splitName as $value) {
-                $query->whereRaw("f_unaccent(first_name) ilike ('%' || f_unaccent(?) || '%')", $value)
-                    ->orWhereRaw("f_unaccent(last_name) ilike ('%' || f_unaccent(?) || '%')", $value);
+                $escaped = PostgresLike::escape($value);
+                $query->whereRaw("f_unaccent(first_name) ilike ('%' || f_unaccent(?) || '%')", $escaped)
+                    ->orWhereRaw("f_unaccent(last_name) ilike ('%' || f_unaccent(?) || '%')", $escaped);
             }
         });
     }
@@ -545,7 +547,7 @@ class UserBuilder extends Builder
             return $this;
         }
 
-        return $this->where('telephone', 'ilike', "%{$telephone}%");
+        return $this->where('telephone', 'ilike', '%'.PostgresLike::escape($telephone).'%');
     }
 
     public function whereEmail(?string $email): self
@@ -554,7 +556,7 @@ class UserBuilder extends Builder
             return $this;
         }
 
-        return $this->whereRaw("f_unaccent(email) ilike ('%' || f_unaccent(?) || '%')", $email);
+        return $this->whereRaw("f_unaccent(email) ilike ('%' || f_unaccent(?) || '%')", PostgresLike::escape($email));
     }
 
     public function whereWorkEmail(?string $email): self
@@ -563,7 +565,7 @@ class UserBuilder extends Builder
             return $this;
         }
 
-        return $this->whereRaw("f_unaccent(work_email) ilike ('%' || f_unaccent(?) || '%')", $email);
+        return $this->whereRaw("f_unaccent(work_email) ilike ('%' || f_unaccent(?) || '%')", PostgresLike::escape($email));
     }
 
     // just calls another scope, but calling the scope from Lighthouse requires accepting an args array

--- a/api/app/Builders/UserBuilder.php
+++ b/api/app/Builders/UserBuilder.php
@@ -909,6 +909,10 @@ class UserBuilder extends Builder
                 ->addSelect(['users.*'])
                 ->from('users')
                 ->orderByDesc('search_rank');
+        } else {
+            // Sanitising reduced the term to nothing - a whitespace only search, say.
+            // Match no rows rather than falling through and returning every user.
+            $this->whereRaw('1 = 0');
         }
 
         return $this;

--- a/api/app/Builders/UserBuilder.php
+++ b/api/app/Builders/UserBuilder.php
@@ -910,8 +910,8 @@ class UserBuilder extends Builder
                 ->from('users')
                 ->orderByDesc('search_rank');
         } else {
-            // Sanitising reduced the term to nothing - a whitespace only search, say.
-            // Match no rows rather than falling through and returning every user.
+            // The term sanitized away to nothing, e.g. all whitespace.
+            // Match nothing rather than everything.
             $this->whereRaw('1 = 0');
         }
 

--- a/api/app/GraphQL/Directives/AdvancedOrderByDirective.php
+++ b/api/app/GraphQL/Directives/AdvancedOrderByDirective.php
@@ -21,6 +21,8 @@ use Nuwave\Lighthouse\Schema\AST\DocumentAST;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgBuilderDirective;
 use Nuwave\Lighthouse\Support\Contracts\FieldManipulator;
+use ReflectionMethod;
+use ReflectionNamedType;
 
 /**
  * Class AdvancedOrderByDirective
@@ -118,6 +120,19 @@ class AdvancedOrderByDirective extends BaseDirective implements ArgBuilderDirect
 
         if (! method_exists($model, $relationName)) {
             throw new UserError("Invalid relation: {$relationName}");
+        }
+
+        // Decide from the signature whether this is a relation, before calling it.
+        // method_exists() admits every method the model defines, and the instanceof
+        // check below only runs once the call has already happened - together with
+        // whatever that call did.
+        $method = new ReflectionMethod($model, $relationName);
+        $returnType = $method->getReturnType();
+
+        if (! $method->isPublic()
+            || ! $returnType instanceof ReflectionNamedType
+            || ! is_a($returnType->getName(), Relation::class, true)) {
+            throw new UserError("Method {$relationName} is not a valid Eloquent relation.");
         }
 
         $relation = $model->{$relationName}();

--- a/api/app/GraphQL/Directives/AdvancedOrderByDirective.php
+++ b/api/app/GraphQL/Directives/AdvancedOrderByDirective.php
@@ -122,10 +122,8 @@ class AdvancedOrderByDirective extends BaseDirective implements ArgBuilderDirect
             throw new UserError("Invalid relation: {$relationName}");
         }
 
-        // Decide from the signature whether this is a relation, before calling it.
-        // method_exists() admits every method the model defines, and the instanceof
-        // check below only runs once the call has already happened - together with
-        // whatever that call did.
+        // Check the signature before calling: method_exists() is true for any method
+        // on the model, and the instanceof check below runs after the call took effect.
         $method = new ReflectionMethod($model, $relationName);
         $returnType = $method->getReturnType();
 

--- a/api/app/GraphQL/Directives/AdvancedOrderByDirective.php
+++ b/api/app/GraphQL/Directives/AdvancedOrderByDirective.php
@@ -128,6 +128,7 @@ class AdvancedOrderByDirective extends BaseDirective implements ArgBuilderDirect
         $returnType = $method->getReturnType();
 
         if (! $method->isPublic()
+            || $method->isStatic()
             || ! $returnType instanceof ReflectionNamedType
             || ! is_a($returnType->getName(), Relation::class, true)) {
             throw new UserError("Method {$relationName} is not a valid Eloquent relation.");

--- a/api/app/GraphQL/Queries/CountTalentRequestMatchesByCommunity.php
+++ b/api/app/GraphQL/Queries/CountTalentRequestMatchesByCommunity.php
@@ -75,7 +75,7 @@ final class CountTalentRequestMatchesByCommunity
 
         $counts = DB::query()
             ->fromSub($combined, 'matches')
-            ->selectRaw('community_id')
+            ->addSelect('community_id')
             ->selectRaw("count(distinct case when source = 'pool' then user_id end) as qualified_in_pool_count")
             ->selectRaw("count(distinct case when source = 'interest' then user_id end) as at_level_count")
             ->selectRaw('count(distinct user_id) as count')

--- a/api/app/Models/Activity.php
+++ b/api/app/Models/Activity.php
@@ -119,67 +119,68 @@ class Activity extends SpatieActivity
         $escapeLike = function ($value) {
             return str_replace(['\\', '%', '_'], ['\\\\', '\%', '\_'], $value);
         };
+        // Backslash is Postgres's default LIKE escape character, so the escaped
+        // pattern keeps treating % and _ literally without an explicit ESCAPE clause.
         $escapedPattern = '%'.$escapeLike($searchTerm).'%';
-        $ilikeRaw = "ILIKE ? ESCAPE '\\'";
 
-        return $query->where(function (Builder $mainQuery) use ($searchTerm, $escapedPattern, $ilikeRaw) {
+        return $query->where(function (Builder $mainQuery) use ($searchTerm, $escapedPattern) {
             // Search in properties JSON (whole structure)
             self::scopeWherePropertiesLike($mainQuery, $searchTerm);
 
             // Causer (User) name
-            $mainQuery->orWhere(function ($q) use ($escapedPattern, $ilikeRaw) {
-                $q->whereExists(function ($subQ) use ($escapedPattern, $ilikeRaw) {
+            $mainQuery->orWhere(function ($q) use ($escapedPattern) {
+                $q->whereExists(function ($subQ) use ($escapedPattern) {
                     $subQ->selectRaw('1')
                         ->from('users as causer_users')
-                        ->whereRaw('activity_log.causer_id = causer_users.id')
-                        ->whereRaw('activity_log.causer_type = ?', [User::class])
-                        ->where(function ($w) use ($escapedPattern, $ilikeRaw) {
-                            $w->whereRaw("causer_users.first_name $ilikeRaw", [$escapedPattern])
-                                ->orWhereRaw("causer_users.last_name $ilikeRaw", [$escapedPattern]);
+                        ->whereColumn('activity_log.causer_id', 'causer_users.id')
+                        ->where('activity_log.causer_type', User::class)
+                        ->where(function ($w) use ($escapedPattern) {
+                            $w->where('causer_users.first_name', 'ilike', $escapedPattern)
+                                ->orWhere('causer_users.last_name', 'ilike', $escapedPattern);
                         });
                 });
             });
 
             // Subject (PoolCandidate) user name
-            $mainQuery->orWhere(function ($q) use ($escapedPattern, $ilikeRaw) {
+            $mainQuery->orWhere(function ($q) use ($escapedPattern) {
                 $q->where('activity_log.subject_type', PoolCandidate::class)
-                    ->whereExists(function ($subQ) use ($escapedPattern, $ilikeRaw) {
+                    ->whereExists(function ($subQ) use ($escapedPattern) {
                         $subQ->selectRaw('1')
                             ->from('pool_candidates as pc_subject')
                             ->join('users as pc_users', 'pc_subject.user_id', '=', 'pc_users.id')
-                            ->whereRaw('activity_log.subject_id = pc_subject.id')
-                            ->where(function ($w) use ($escapedPattern, $ilikeRaw) {
-                                $w->whereRaw("pc_users.first_name $ilikeRaw", [$escapedPattern])
-                                    ->orWhereRaw("pc_users.last_name $ilikeRaw", [$escapedPattern]);
+                            ->whereColumn('activity_log.subject_id', 'pc_subject.id')
+                            ->where(function ($w) use ($escapedPattern) {
+                                $w->where('pc_users.first_name', 'ilike', $escapedPattern)
+                                    ->orWhere('pc_users.last_name', 'ilike', $escapedPattern);
                             });
                     });
             });
 
             // Subject (PoolSkill) skill name (localized, en/fr)
-            $mainQuery->orWhere(function ($q) use ($escapedPattern, $ilikeRaw) {
+            $mainQuery->orWhere(function ($q) use ($escapedPattern) {
                 $q->where('activity_log.subject_type', PoolSkill::class)
-                    ->whereExists(function ($subQ) use ($escapedPattern, $ilikeRaw) {
+                    ->whereExists(function ($subQ) use ($escapedPattern) {
                         $subQ->selectRaw('1')
                             ->from('pool_skill as ps_subject')
                             ->join('skills as ps_skills', 'ps_subject.skill_id', '=', 'ps_skills.id')
-                            ->whereRaw('activity_log.subject_id = ps_subject.id')
-                            ->where(function ($w) use ($escapedPattern, $ilikeRaw) {
-                                $w->whereRaw("ps_skills.name->>'en' $ilikeRaw", [$escapedPattern])
-                                    ->orWhereRaw("ps_skills.name->>'fr' $ilikeRaw", [$escapedPattern]);
+                            ->whereColumn('activity_log.subject_id', 'ps_subject.id')
+                            ->where(function ($w) use ($escapedPattern) {
+                                $w->where('ps_skills.name->en', 'ilike', $escapedPattern)
+                                    ->orWhere('ps_skills.name->fr', 'ilike', $escapedPattern);
                             });
                     });
             });
 
             // Subject (AssessmentStep) title (en/fr) & type (enum and localized display)
-            $mainQuery->orWhere(function ($q) use ($escapedPattern, $ilikeRaw, $searchTerm) {
+            $mainQuery->orWhere(function ($q) use ($escapedPattern, $searchTerm) {
                 $q->where('activity_log.subject_type', AssessmentStep::class)
-                    ->whereExists(function ($subQ) use ($escapedPattern, $ilikeRaw, $searchTerm) {
+                    ->whereExists(function ($subQ) use ($escapedPattern, $searchTerm) {
                         $subQ->selectRaw('1')
                             ->from('assessment_steps as as_subject')
-                            ->whereRaw('activity_log.subject_id = as_subject.id')
-                            ->where(function ($w) use ($escapedPattern, $ilikeRaw, $searchTerm) {
-                                $w->whereRaw("as_subject.title->>'en' $ilikeRaw", [$escapedPattern])
-                                    ->orWhereRaw("as_subject.title->>'fr' $ilikeRaw", [$escapedPattern]);
+                            ->whereColumn('activity_log.subject_id', 'as_subject.id')
+                            ->where(function ($w) use ($escapedPattern, $searchTerm) {
+                                $w->where('as_subject.title->en', 'ilike', $escapedPattern)
+                                    ->orWhere('as_subject.title->fr', 'ilike', $escapedPattern);
                                 $matchingEnumNames = collect(AssessmentStepType::cases())->filter(function ($enum) use ($searchTerm) {
                                     $display = AssessmentStepType::localizedString($enum->name);
 
@@ -201,7 +202,10 @@ class Activity extends SpatieActivity
             return $query;
         }
 
-        return $query->whereRaw('(properties::text ILIKE ? OR attribute_changes::text ILIKE ?)', ["%$searchTerm%", "%$searchTerm%"]);
+        return $query->where(function (Builder $subQuery) use ($searchTerm) {
+            $subQuery->where('properties', 'ilike', "%$searchTerm%")
+                ->orWhere('attribute_changes', 'ilike', "%$searchTerm%");
+        });
     }
 
     public function scopeAuthorizedToViewPoolActivity(Builder $query)

--- a/api/app/Models/Activity.php
+++ b/api/app/Models/Activity.php
@@ -116,8 +116,7 @@ class Activity extends SpatieActivity
             return $query;
         }
 
-        // Backslash is Postgres's default LIKE escape character, so the escaped
-        // pattern keeps treating % and _ literally without an explicit ESCAPE clause.
+        // No ESCAPE clause needed - backslash is Postgres's default for LIKE.
         $escapedPattern = '%'.PostgresLike::escape($searchTerm).'%';
 
         return $query->where(function (Builder $mainQuery) use ($searchTerm, $escapedPattern) {

--- a/api/app/Models/Activity.php
+++ b/api/app/Models/Activity.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Enums\ActivityLog;
 use App\Enums\AssessmentStepType;
+use App\Utilities\PostgresLike;
 use Database\Helpers\TeamHelpers;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -115,13 +116,9 @@ class Activity extends SpatieActivity
             return $query;
         }
 
-        // Sanitize the input from the user
-        $escapeLike = function ($value) {
-            return str_replace(['\\', '%', '_'], ['\\\\', '\%', '\_'], $value);
-        };
         // Backslash is Postgres's default LIKE escape character, so the escaped
         // pattern keeps treating % and _ literally without an explicit ESCAPE clause.
-        $escapedPattern = '%'.$escapeLike($searchTerm).'%';
+        $escapedPattern = '%'.PostgresLike::escape($searchTerm).'%';
 
         return $query->where(function (Builder $mainQuery) use ($searchTerm, $escapedPattern) {
             // Search in properties JSON (whole structure)
@@ -202,9 +199,11 @@ class Activity extends SpatieActivity
             return $query;
         }
 
-        return $query->where(function (Builder $subQuery) use ($searchTerm) {
-            $subQuery->where('properties', 'ilike', "%$searchTerm%")
-                ->orWhere('attribute_changes', 'ilike', "%$searchTerm%");
+        $pattern = '%'.PostgresLike::escape($searchTerm).'%';
+
+        return $query->where(function (Builder $subQuery) use ($pattern) {
+            $subQuery->where('properties', 'ilike', $pattern)
+                ->orWhere('attribute_changes', 'ilike', $pattern);
         });
     }
 

--- a/api/app/Models/TalentRequestTrackedUser.php
+++ b/api/app/Models/TalentRequestTrackedUser.php
@@ -7,6 +7,7 @@ use App\Enums\TalentRequestTrackedUserReferralDecision;
 use App\Enums\TalentRequestTrackedUserSelectionDecision;
 use App\Enums\TalentRequestTrackedUserStatus;
 use App\Support\Query\AdvancedOrder;
+use App\Utilities\PostgresLike;
 use Database\Factories\TalentRequestTrackedUserFactory;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Builder;
@@ -161,14 +162,16 @@ class TalentRequestTrackedUser extends Pivot
 
     public function scopeWhereUserNameOrEmail(Builder $query, ?string $search): Builder
     {
+        $pattern = $search === null ? null : '%'.PostgresLike::escape($search).'%';
+
         return $query->when(
             $search,
             fn (Builder $query) => $query->whereHas('user', fn (Builder $userQuery) => $userQuery
                 ->where(fn (Builder $nameQuery) => $nameQuery
-                    ->whereRaw("CONCAT(first_name, ' ', last_name) ILIKE ?", ["%{$search}%"])
-                    ->orWhere('first_name', 'ilike', "%{$search}%")
-                    ->orWhere('last_name', 'ilike', "%{$search}%")
-                    ->orWhere('email', 'ilike', "%{$search}%")))
+                    ->whereRaw("CONCAT(first_name, ' ', last_name) ILIKE ?", [$pattern])
+                    ->orWhere('first_name', 'ilike', $pattern)
+                    ->orWhere('last_name', 'ilike', $pattern)
+                    ->orWhere('email', 'ilike', $pattern)))
         );
     }
 

--- a/api/app/Utilities/PostgresLike.php
+++ b/api/app/Utilities/PostgresLike.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Utilities;
+
+/**
+ * Escaping for LIKE / ILIKE search patterns.
+ *
+ * Binding a value protects against injection but not against the pattern language:
+ * % and _ remain wildcards inside the bound value, so a search for "50%" matches far
+ * more than the user asked for, and a search for "%" matches everything.
+ *
+ * https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE
+ */
+class PostgresLike
+{
+    /**
+     * Escape the LIKE metacharacters in a user supplied search term.
+     *
+     * Backslash is Postgres's default escape character for LIKE, so callers do not
+     * need an explicit ESCAPE clause.
+     */
+    public static function escape(string $value): string
+    {
+        return str_replace(['\\', '%', '_'], ['\\\\', '\%', '\_'], $value);
+    }
+}

--- a/api/app/Utilities/PostgresLike.php
+++ b/api/app/Utilities/PostgresLike.php
@@ -5,19 +5,17 @@ namespace App\Utilities;
 /**
  * Escaping for LIKE / ILIKE search patterns.
  *
- * Binding a value protects against injection but not against the pattern language:
- * % and _ remain wildcards inside the bound value, so a search for "50%" matches far
- * more than the user asked for, and a search for "%" matches everything.
+ * Binding a value stops injection but not wildcards: % and _ still work inside the
+ * bound value, so searching for "%" matches every row.
  *
  * https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE
  */
 class PostgresLike
 {
     /**
-     * Escape the LIKE metacharacters in a user supplied search term.
+     * Escape the wildcards in a user supplied search term.
      *
-     * Backslash is Postgres's default escape character for LIKE, so callers do not
-     * need an explicit ESCAPE clause.
+     * No ESCAPE clause needed - backslash is Postgres's default for LIKE.
      */
     public static function escape(string $value): string
     {

--- a/api/app/Utilities/PostgresTextSearch.php
+++ b/api/app/Utilities/PostgresTextSearch.php
@@ -14,22 +14,6 @@ enum PostgresTextSearchMatchingType
 // https://www.postgresql.org/docs/current/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES
 class PostgresTextSearch
 {
-    public static $invalidPatterns =
-        '/'.
-        '^&'.'|'.       // & at the beginning
-        '&$'.'|'.       // & at the end
-        '^\|'.'|'.      // | at the beginning
-        '\|$'.'|'.      // | at the end
-        ':'.'|'.        // : anywhere
-        '^.+?\!'.'|'.   // ! not at the beginning
-        '^\!$'.'|'.     // ! at the end
-        '\('.'|'.       // ( anywhere
-        '\)'.'|'.       // ) anywhere
-        '<'.'|'.        // < anywhere
-        '>'.'|'.        // > anywhere
-        "'$".           // ' at the end
-        '/';
-
     // convert a search string to query text with prefix matching
     // similar to websearch_to_tsquery but adds prefix matching to each term
     // refer to PostgresTextSearchTest for examples of the expected transform
@@ -110,7 +94,7 @@ class PostgresTextSearch
                 is_array($node) => self::nodeToQueryText($node, $matchingType),         // if it's another node, recurse into it
                 default => throw new \Error('Unexpected type')
             })
-            ->filter(fn ($term) => strlen($term) > 0)
+            ->filter(fn ($term) => $term !== null && $term !== '')
             ->join($joiner);
     }
 
@@ -118,19 +102,30 @@ class PostgresTextSearch
     private static function singleTermToQueryText(string $term, PostgresTextSearchMatchingType $matchingType): ?string
     {
         // handle negation
-        if (Str::startsWith($term, '-')) {
-            $term = Str::substrReplace($term, '!', 0, 1);
+        $negated = Str::startsWith($term, '-');
+        if ($negated) {
+            $term = Str::substr($term, 1);
         }
 
-        // remove terms with invalid patterns
-        if (preg_match(self::$invalidPatterns, $term) != false) {
+        if ($term === '') {
             return null;
+        }
+
+        // Quote the term so that tsquery operators inside it (& | ! ( ) : < > *) are read
+        // as text rather than as syntax.  Denylisting them term by term let some through:
+        // 'a&&b' reached to_tsquery as a syntax error, and 'te&rm1' silently became
+        // 'te' & 'rm1', answering a different question than the user asked.
+        // A term holding no lexemes yields an empty tsquery, which matches nothing.
+        $quoted = "'".str_replace("'", "''", $term)."'";
+
+        if ($negated) {
+            $quoted = '!'.$quoted;
         }
 
         // handle prefix searching
         return match ($matchingType) {
-            PostgresTextSearchMatchingType::EXACT => $term,
-            PostgresTextSearchMatchingType::PREFIX => $term.':*',
+            PostgresTextSearchMatchingType::EXACT => $quoted,
+            PostgresTextSearchMatchingType::PREFIX => $quoted.':*',
         };
     }
 }

--- a/api/app/Utilities/PostgresTextSearch.php
+++ b/api/app/Utilities/PostgresTextSearch.php
@@ -111,11 +111,9 @@ class PostgresTextSearch
             return null;
         }
 
-        // Quote the term so that tsquery operators inside it (& | ! ( ) : < > *) are read
-        // as text rather than as syntax.  Denylisting them term by term let some through:
-        // 'a&&b' reached to_tsquery as a syntax error, and 'te&rm1' silently became
-        // 'te' & 'rm1', answering a different question than the user asked.
-        // A term holding no lexemes yields an empty tsquery, which matches nothing.
+        // Quote the term so tsquery operators in it (& | ! ( ) : < > *) are read as
+        // text, not syntax. A term with no lexemes gives an empty tsquery, which
+        // matches nothing.
         $quoted = "'".str_replace("'", "''", $term)."'";
 
         if ($negated) {

--- a/api/app/Utilities/PostgresTextSearch.php
+++ b/api/app/Utilities/PostgresTextSearch.php
@@ -113,8 +113,9 @@ class PostgresTextSearch
 
         // Quote the term so tsquery operators in it (& | ! ( ) : < > *) are read as
         // text, not syntax. A term with no lexemes gives an empty tsquery, which
-        // matches nothing.
-        $quoted = "'".str_replace("'", "''", $term)."'";
+        // matches nothing. Backslash is an escape inside the quotes, so it has to be
+        // doubled or a trailing one escapes the closing quote.
+        $quoted = "'".str_replace(['\\', "'"], ['\\\\', "''"], $term)."'";
 
         if ($negated) {
             $quoted = '!'.$quoted;

--- a/api/tests/Feature/SearchTermSanitisationTest.php
+++ b/api/tests/Feature/SearchTermSanitisationTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Activity;
+use App\Models\User;
+use App\Utilities\PostgresLike;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+/**
+ * Search terms reach ILIKE patterns as bound values, which stops injection but not the
+ * pattern language: unescaped % and _ stay wildcards, so "50%" matches far more than
+ * asked for and "%" matches everything.  These cases execute the scopes rather than
+ * asserting on a built string, so removing the escaping fails here.
+ */
+class SearchTermSanitisationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // the user factory attaches a role
+        $this->seed(RolePermissionSeeder::class);
+    }
+
+    #[DataProvider('escapeProvider')]
+    public function testItEscapesLikeMetacharacters(string $input, string $expected): void
+    {
+        $this->assertSame($expected, PostgresLike::escape($input));
+    }
+
+    public static function escapeProvider(): array
+    {
+        return [
+            'percent' => ['50%', '50\%'],
+            'underscore' => ['a_b', 'a\_b'],
+            'backslash' => ['x\\y', 'x\\\\y'],
+            'backslash before percent' => ['\\%', '\\\\\%'],
+            'several' => ['100%_done', '100\%\_done'],
+            'nothing to escape' => ['plain', 'plain'],
+        ];
+    }
+
+    #[DataProvider('userScopeProvider')]
+    public function testUserSearchTreatsWildcardsAsLiterals(string $scope): void
+    {
+        $literal = User::factory()->create([
+            'first_name' => 'Ab50%X', 'last_name' => 'Ab50%X',
+            'email' => 'ab50%x@test.test', 'work_email' => 'ab50%x@work.test',
+            'telephone' => 'Ab50%X',
+        ]);
+        User::factory()->create([
+            'first_name' => 'Ab50QQX', 'last_name' => 'Ab50QQX',
+            'email' => 'ab50qqx@test.test', 'work_email' => 'ab50qqx@work.test',
+            'telephone' => 'Ab50QQX',
+        ]);
+
+        $terms = [
+            'whereName' => ['Ab50%X', 'Ab50'],
+            'whereTelephone' => ['Ab50%X', 'Ab50'],
+            'whereEmail' => ['ab50%x@test.test', 'ab50'],
+            'whereWorkEmail' => ['ab50%x@work.test', 'ab50'],
+        ];
+        [$wildcardTerm, $sharedPrefix] = $terms[$scope];
+
+        // the % must match literally, so only the row that contains one
+        $matched = User::query()->{$scope}($wildcardTerm)->pluck('id')->all();
+        $this->assertSame([$literal->id], $matched);
+
+        // control: a term both rows share still matches both, so the scope still works
+        $this->assertCount(2, User::query()->{$scope}($sharedPrefix)->get());
+    }
+
+    public static function userScopeProvider(): array
+    {
+        return [
+            'whereName' => ['whereName'],
+            'whereTelephone' => ['whereTelephone'],
+            'whereEmail' => ['whereEmail'],
+            'whereWorkEmail' => ['whereWorkEmail'],
+        ];
+    }
+
+    public function testActivityPropertiesSearchTreatsWildcardsAsLiterals(): void
+    {
+        foreach (['{"attributes":{"notes":"first"}}', '{"attributes":{"notes":"second"}}'] as $properties) {
+            DB::table('activity_log')->insert([
+                'id' => Str::uuid()->toString(),
+                'log_name' => 'default',
+                'description' => 'updated',
+                'properties' => $properties,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        // "%" would otherwise match every row through properties::text
+        $this->assertCount(0, Activity::query()->wherePropertiesLike('%')->get());
+        // control: a term that really is present still matches
+        $this->assertCount(1, Activity::query()->wherePropertiesLike('second')->get());
+    }
+
+    public function testGeneralSearchReturnsNothingWhenTheTermSanitisesToNothing(): void
+    {
+        User::factory()->count(3)->create();
+
+        // whitespace only survives the empty() guard but sanitises away; the filter must
+        // not silently drop out and return every user
+        $this->assertCount(0, User::query()->whereGeneralSearch('   ')->get());
+        $this->assertGreaterThan(0, User::query()->count());
+    }
+}

--- a/api/tests/Feature/SearchTermSanitisationTest.php
+++ b/api/tests/Feature/SearchTermSanitisationTest.php
@@ -13,10 +13,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 /**
- * Search terms reach ILIKE patterns as bound values, which stops injection but not the
- * pattern language: unescaped % and _ stay wildcards, so "50%" matches far more than
- * asked for and "%" matches everything.  These cases execute the scopes rather than
- * asserting on a built string, so removing the escaping fails here.
+ * These run the scopes rather than checking a built string, so dropping the escaping
+ * fails here.
  */
 class SearchTermSanitisationTest extends TestCase
 {
@@ -70,11 +68,11 @@ class SearchTermSanitisationTest extends TestCase
         ];
         [$wildcardTerm, $sharedPrefix] = $terms[$scope];
 
-        // the % must match literally, so only the row that contains one
+        // only the row with a literal % should match
         $matched = User::query()->{$scope}($wildcardTerm)->pluck('id')->all();
         $this->assertSame([$literal->id], $matched);
 
-        // control: a term both rows share still matches both, so the scope still works
+        // control: a shared term still matches both rows
         $this->assertCount(2, User::query()->{$scope}($sharedPrefix)->get());
     }
 
@@ -101,9 +99,9 @@ class SearchTermSanitisationTest extends TestCase
             ]);
         }
 
-        // "%" would otherwise match every row through properties::text
+        // unescaped, "%" would match every row
         $this->assertCount(0, Activity::query()->wherePropertiesLike('%')->get());
-        // control: a term that really is present still matches
+        // control: a real term still matches
         $this->assertCount(1, Activity::query()->wherePropertiesLike('second')->get());
     }
 
@@ -111,8 +109,7 @@ class SearchTermSanitisationTest extends TestCase
     {
         User::factory()->count(3)->create();
 
-        // whitespace only survives the empty() guard but sanitises away; the filter must
-        // not silently drop out and return every user
+        // whitespace passes the empty() guard but sanitises away to nothing
         $this->assertCount(0, User::query()->whereGeneralSearch('   ')->get());
         $this->assertGreaterThan(0, User::query()->count());
     }

--- a/api/tests/Unit/Directives/AdvancedOrderByTest.php
+++ b/api/tests/Unit/Directives/AdvancedOrderByTest.php
@@ -278,6 +278,10 @@ class AdvancedOrderByTest extends TestCase
                 [['relation' => ['name' => 'isDraft', 'column' => 'notes']]],
                 'Method isDraft is not a valid Eloquent relation.',
             ],
+            'Model method with a side effect' => [
+                [['relation' => ['name' => 'save', 'column' => 'notes']]],
+                'Method save is not a valid Eloquent relation.',
+            ],
             'Many to many relation' => [
                 [['relation' => ['name' => 'bookmarkedByUsers', 'column' => 'first_name']]],
                 'Relation type Illuminate\Database\Eloquent\Relations\BelongsToMany is not supported for sub-query sorting.',
@@ -287,6 +291,22 @@ class AdvancedOrderByTest extends TestCase
                 'Invalid scope: orderByNothing',
             ],
         ];
+    }
+
+    /**
+     * A relation name is client supplied, so the method it names must be rejected on its
+     * signature rather than by inspecting what a call returned.
+     */
+    public function testItDoesNotCallMethodsThatAreNotRelations(): void
+    {
+        PoolCandidate::factory()->create(['notes' => 'A']);
+        $before = PoolCandidate::count();
+
+        $this->actingAs($this->admin, 'api')->graphQL($this->query, [
+            'orderBy' => [['relation' => ['name' => 'save', 'column' => 'notes']]],
+        ])->assertGraphQLErrorMessage('Method save is not a valid Eloquent relation.');
+
+        $this->assertSame($before, PoolCandidate::count());
     }
 
     public function testItIgnoresScopesWithoutTheOrderByPrefix(): void

--- a/api/tests/Unit/Directives/AdvancedOrderByTest.php
+++ b/api/tests/Unit/Directives/AdvancedOrderByTest.php
@@ -294,8 +294,8 @@ class AdvancedOrderByTest extends TestCase
     }
 
     /**
-     * A relation name is client supplied, so the method it names must be rejected on its
-     * signature rather than by inspecting what a call returned.
+     * The relation name comes from the client, so reject it on its signature rather
+     * than by calling it and checking the result.
      */
     public function testItDoesNotCallMethodsThatAreNotRelations(): void
     {

--- a/api/tests/Unit/PostgresTextSearchTest.php
+++ b/api/tests/Unit/PostgresTextSearchTest.php
@@ -23,10 +23,8 @@ class PostgresTextSearchTest extends TestCase
     }
 
     /**
-     * Every transform result must be a tsquery Postgres will accept.  Asserting the
-     * string alone is what let the previous denylist ship output the database rejects:
-     * a term such as "'term4" produced a syntax error at query time while this suite
-     * stayed green.
+     * Every result must be a tsquery Postgres accepts. Checking the string alone is
+     * how output the database rejects used to pass here.
      */
     #[DataProvider('tsQueryBuilderProvider')]
     public function testQueryTextIsExecutable(string $matchingType, string $searchString, string $expectedOutput)
@@ -44,92 +42,92 @@ class PostgresTextSearchTest extends TestCase
     public static function tsQueryBuilderProvider()
     {
         return [
-            "prefix, single term" => [
+            'prefix, single term' => [
                 'matchingType' => 'PREFIX',
-                'searchString' => "term",
+                'searchString' => 'term',
                 'expectedOutput' => "'term':*",
             ],
-            "exact, single term" => [
+            'exact, single term' => [
                 'matchingType' => 'EXACT',
-                'searchString' => "term",
+                'searchString' => 'term',
                 'expectedOutput' => "'term'",
             ],
-            "prefix, multiple terms with extra spacing" => [
+            'prefix, multiple terms with extra spacing' => [
                 'matchingType' => 'PREFIX',
-                'searchString' => " term1   term2        term3        ",
+                'searchString' => ' term1   term2        term3        ',
                 'expectedOutput' => "'term1':* & 'term2':* & 'term3':*",
             ],
-            "exact, multiple terms with extra spacing" => [
+            'exact, multiple terms with extra spacing' => [
                 'matchingType' => 'EXACT',
-                'searchString' => " term1   term2        term3        ",
+                'searchString' => ' term1   term2        term3        ',
                 'expectedOutput' => "'term1' & 'term2' & 'term3'",
             ],
-            "prefix, negation with dash" => [
+            'prefix, negation with dash' => [
                 'matchingType' => 'PREFIX',
-                'searchString' => "term1 -term2",
+                'searchString' => 'term1 -term2',
                 'expectedOutput' => "'term1':* & !'term2':*",
             ],
-            "exact, negation with dash" => [
+            'exact, negation with dash' => [
                 'matchingType' => 'EXACT',
-                'searchString' => "term1 -term2",
+                'searchString' => 'term1 -term2',
                 'expectedOutput' => "'term1' & !'term2'",
             ],
-            "prefix, explicit and-ing" => [
+            'prefix, explicit and-ing' => [
                 'matchingType' => 'PREFIX',
-                'searchString' => "term1 AND term2",
+                'searchString' => 'term1 AND term2',
                 'expectedOutput' => "'term1':* & 'term2':*",
             ],
-            "exact, explicit and-ing" => [
+            'exact, explicit and-ing' => [
                 'matchingType' => 'EXACT',
-                'searchString' => "term1 AND term2",
+                'searchString' => 'term1 AND term2',
                 'expectedOutput' => "'term1' & 'term2'",
             ],
-            "prefix, explicit or-ing" => [
+            'prefix, explicit or-ing' => [
                 'matchingType' => 'PREFIX',
-                'searchString' => "term1 OR term2",
+                'searchString' => 'term1 OR term2',
                 'expectedOutput' => "'term1':* | 'term2':*",
             ],
-            "exact, explicit or-ing" => [
+            'exact, explicit or-ing' => [
                 'matchingType' => 'EXACT',
-                'searchString' => "term1 OR term2",
+                'searchString' => 'term1 OR term2',
                 'expectedOutput' => "'term1' | 'term2'",
             ],
-            "prefix, quotes" => [
+            'prefix, quotes' => [
                 'matchingType' => 'PREFIX',
-                'searchString' => " term1 \"term2 term3\"   \"term4 term5\" term6",
+                'searchString' => ' term1 "term2 term3"   "term4 term5" term6',
                 'expectedOutput' => "'term1':* & 'term2':* <-> 'term3':* & 'term4':* <-> 'term5':* & 'term6':*",
             ],
-            "exact, quotes" => [
+            'exact, quotes' => [
                 'matchingType' => 'EXACT',
-                'searchString' => " term1 \"term2 term3\"   \"term4 term5\" term6",
+                'searchString' => ' term1 "term2 term3"   "term4 term5" term6',
                 'expectedOutput' => "'term1' & 'term2' <-> 'term3' & 'term4' <-> 'term5' & 'term6'",
             ],
-            "prefix, quote followed by or" => [
+            'prefix, quote followed by or' => [
                 'matchingType' => 'PREFIX',
-                'searchString' => "\"term1\" OR term2",
+                'searchString' => '"term1" OR term2',
                 'expectedOutput' => "'term1':* | 'term2':*",
             ],
-            "exact, quote followed by or" => [
+            'exact, quote followed by or' => [
                 'matchingType' => 'EXACT',
-                'searchString' => "\"term1\" OR term2",
+                'searchString' => '"term1" OR term2',
                 'expectedOutput' => "'term1' | 'term2'",
             ],
-            "prefix, terms containing tsquery operators" => [
+            'prefix, terms containing tsquery operators' => [
                 'matchingType' => 'PREFIX',
                 'searchString' => "term1& &term2 term3| |term4 :term5 te:rm6 term7: term!8 term9! ! ( ) < > term10'",
                 'expectedOutput' => "'term1&':* & '&term2':* & 'term3|':* & '|term4':* & ':term5':* & 'te:rm6':* & 'term7:':* & 'term!8':* & 'term9!':* & '!':* & '(':* & ')':* & '<':* & '>':* & 'term10''':*",
             ],
-            "exact, terms containing tsquery operators" => [
+            'exact, terms containing tsquery operators' => [
                 'matchingType' => 'EXACT',
                 'searchString' => "term1& &term2 term3| |term4 :term5 te:rm6 term7: term!8 term9! ! ( ) < > term10'",
                 'expectedOutput' => "'term1&' & '&term2' & 'term3|' & '|term4' & ':term5' & 'te:rm6' & 'term7:' & 'term!8' & 'term9!' & '!' & '(' & ')' & '<' & '>' & 'term10'''",
             ],
-            "prefix, terms containing operators and apostrophes" => [
+            'prefix, terms containing operators and apostrophes' => [
                 'matchingType' => 'PREFIX',
                 'searchString' => "te&rm1 te|rm2 !term3 'term4 te'rm5",
                 'expectedOutput' => "'te&rm1':* & 'te|rm2':* & '!term3':* & '''term4':* & 'te''rm5':*",
             ],
-            "exact, terms containing operators and apostrophes" => [
+            'exact, terms containing operators and apostrophes' => [
                 'matchingType' => 'EXACT',
                 'searchString' => "te&rm1 te|rm2 !term3 'term4 te'rm5",
                 'expectedOutput' => "'te&rm1' & 'te|rm2' & '!term3' & '''term4' & 'te''rm5'",

--- a/api/tests/Unit/PostgresTextSearchTest.php
+++ b/api/tests/Unit/PostgresTextSearchTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use App\Utilities\PostgresTextSearch;
 use App\Utilities\PostgresTextSearchMatchingType;
+use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
@@ -21,99 +22,117 @@ class PostgresTextSearchTest extends TestCase
         $this->assertEquals($expectedOutput, $actualOutput);
     }
 
+    /**
+     * Every transform result must be a tsquery Postgres will accept.  Asserting the
+     * string alone is what let the previous denylist ship output the database rejects:
+     * a term such as "'term4" produced a syntax error at query time while this suite
+     * stayed green.
+     */
+    #[DataProvider('tsQueryBuilderProvider')]
+    public function testQueryTextIsExecutable(string $matchingType, string $searchString, string $expectedOutput)
+    {
+        $queryText = PostgresTextSearch::searchStringToQueryText($searchString, PostgresTextSearchMatchingType::{$matchingType});
+
+        if ($queryText === '') {
+            $this->markTestSkipped('no query text to execute');
+        }
+
+        $result = DB::select('select to_tsquery(?, ?) as q', ['simple', $queryText]);
+        $this->assertNotNull($result[0]->q);
+    }
+
     public static function tsQueryBuilderProvider()
     {
-
         return [
-            'prefix, single term' => [
+            "prefix, single term" => [
                 'matchingType' => 'PREFIX',
-                'searchString' => 'term',
-                'expectedOutput' => 'term:*',
+                'searchString' => "term",
+                'expectedOutput' => "'term':*",
             ],
-            'exact, single term' => [
+            "exact, single term" => [
                 'matchingType' => 'EXACT',
-                'searchString' => 'term',
-                'expectedOutput' => 'term',
+                'searchString' => "term",
+                'expectedOutput' => "'term'",
             ],
-            'prefix, multiple terms with extra spacing' => [
+            "prefix, multiple terms with extra spacing" => [
                 'matchingType' => 'PREFIX',
-                'searchString' => ' term1   term2        term3        ',
-                'expectedOutput' => 'term1:* & term2:* & term3:*',
+                'searchString' => " term1   term2        term3        ",
+                'expectedOutput' => "'term1':* & 'term2':* & 'term3':*",
             ],
-            'exact, multiple terms with extra spacing' => [
+            "exact, multiple terms with extra spacing" => [
                 'matchingType' => 'EXACT',
-                'searchString' => ' term1   term2        term3        ',
-                'expectedOutput' => 'term1 & term2 & term3',
+                'searchString' => " term1   term2        term3        ",
+                'expectedOutput' => "'term1' & 'term2' & 'term3'",
             ],
-            'prefix, negation with dash' => [
+            "prefix, negation with dash" => [
                 'matchingType' => 'PREFIX',
-                'searchString' => 'term1 -term2',
-                'expectedOutput' => 'term1:* & !term2:*',
+                'searchString' => "term1 -term2",
+                'expectedOutput' => "'term1':* & !'term2':*",
             ],
-            'exact, negation with dash' => [
+            "exact, negation with dash" => [
                 'matchingType' => 'EXACT',
-                'searchString' => 'term1 -term2',
-                'expectedOutput' => 'term1 & !term2',
+                'searchString' => "term1 -term2",
+                'expectedOutput' => "'term1' & !'term2'",
             ],
-            'prefix, explicit and-ing' => [
+            "prefix, explicit and-ing" => [
                 'matchingType' => 'PREFIX',
-                'searchString' => 'term1 AND term2',
-                'expectedOutput' => 'term1:* & term2:*',
+                'searchString' => "term1 AND term2",
+                'expectedOutput' => "'term1':* & 'term2':*",
             ],
-            'exact, explicit and-ing' => [
+            "exact, explicit and-ing" => [
                 'matchingType' => 'EXACT',
-                'searchString' => 'term1 AND term2',
-                'expectedOutput' => 'term1 & term2',
+                'searchString' => "term1 AND term2",
+                'expectedOutput' => "'term1' & 'term2'",
             ],
-            'prefix, explicit or-ing' => [
+            "prefix, explicit or-ing" => [
                 'matchingType' => 'PREFIX',
-                'searchString' => 'term1 OR term2',
-                'expectedOutput' => 'term1:* | term2:*',
+                'searchString' => "term1 OR term2",
+                'expectedOutput' => "'term1':* | 'term2':*",
             ],
-            'exact, explicit or-ing' => [
+            "exact, explicit or-ing" => [
                 'matchingType' => 'EXACT',
-                'searchString' => 'term1 OR term2',
-                'expectedOutput' => 'term1 | term2',
+                'searchString' => "term1 OR term2",
+                'expectedOutput' => "'term1' | 'term2'",
             ],
-            'prefix, quotes' => [
+            "prefix, quotes" => [
                 'matchingType' => 'PREFIX',
-                'searchString' => ' term1 "term2 term3"   "term4 term5" term6',
-                'expectedOutput' => 'term1:* & term2:* <-> term3:* & term4:* <-> term5:* & term6:*',
+                'searchString' => " term1 \"term2 term3\"   \"term4 term5\" term6",
+                'expectedOutput' => "'term1':* & 'term2':* <-> 'term3':* & 'term4':* <-> 'term5':* & 'term6':*",
             ],
-            'exact, quotes' => [
+            "exact, quotes" => [
                 'matchingType' => 'EXACT',
-                'searchString' => ' term1 "term2 term3"   "term4 term5" term6',
-                'expectedOutput' => 'term1 & term2 <-> term3 & term4 <-> term5 & term6',
+                'searchString' => " term1 \"term2 term3\"   \"term4 term5\" term6",
+                'expectedOutput' => "'term1' & 'term2' <-> 'term3' & 'term4' <-> 'term5' & 'term6'",
             ],
-            'prefix, quote followed by or' => [
+            "prefix, quote followed by or" => [
                 'matchingType' => 'PREFIX',
-                'searchString' => '"term1" OR term2',
-                'expectedOutput' => 'term1:* | term2:*',
+                'searchString' => "\"term1\" OR term2",
+                'expectedOutput' => "'term1':* | 'term2':*",
             ],
-            'exact, quote followed by or' => [
+            "exact, quote followed by or" => [
                 'matchingType' => 'EXACT',
-                'searchString' => '"term1" OR term2',
-                'expectedOutput' => 'term1 | term2',
+                'searchString' => "\"term1\" OR term2",
+                'expectedOutput' => "'term1' | 'term2'",
             ],
-            'prefix, removes terms with invalid patterns' => [
+            "prefix, terms containing tsquery operators" => [
                 'matchingType' => 'PREFIX',
                 'searchString' => "term1& &term2 term3| |term4 :term5 te:rm6 term7: term!8 term9! ! ( ) < > term10'",
-                'expectedOutput' => '',
+                'expectedOutput' => "'term1&':* & '&term2':* & 'term3|':* & '|term4':* & ':term5':* & 'te:rm6':* & 'term7:':* & 'term!8':* & 'term9!':* & '!':* & '(':* & ')':* & '<':* & '>':* & 'term10''':*",
             ],
-            'exact, removes terms with invalid patterns' => [
+            "exact, terms containing tsquery operators" => [
                 'matchingType' => 'EXACT',
                 'searchString' => "term1& &term2 term3| |term4 :term5 te:rm6 term7: term!8 term9! ! ( ) < > term10'",
-                'expectedOutput' => '',
+                'expectedOutput' => "'term1&' & '&term2' & 'term3|' & '|term4' & ':term5' & 'te:rm6' & 'term7:' & 'term!8' & 'term9!' & '!' & '(' & ')' & '<' & '>' & 'term10'''",
             ],
-            'prefix, allows terms with valid patterns' => [
+            "prefix, terms containing operators and apostrophes" => [
                 'matchingType' => 'PREFIX',
                 'searchString' => "te&rm1 te|rm2 !term3 'term4 te'rm5",
-                'expectedOutput' => "te&rm1:* & te|rm2:* & !term3:* & 'term4:* & te'rm5:*",
+                'expectedOutput' => "'te&rm1':* & 'te|rm2':* & '!term3':* & '''term4':* & 'te''rm5':*",
             ],
-            'exact, allows terms with valid patterns' => [
+            "exact, terms containing operators and apostrophes" => [
                 'matchingType' => 'EXACT',
                 'searchString' => "te&rm1 te|rm2 !term3 'term4 te'rm5",
-                'expectedOutput' => "te&rm1 & te|rm2 & !term3 & 'term4 & te'rm5",
+                'expectedOutput' => "'te&rm1' & 'te|rm2' & '!term3' & '''term4' & 'te''rm5'",
             ],
         ];
     }

--- a/api/tests/Unit/PostgresTextSearchTest.php
+++ b/api/tests/Unit/PostgresTextSearchTest.php
@@ -132,6 +132,21 @@ class PostgresTextSearchTest extends TestCase
                 'searchString' => "te&rm1 te|rm2 !term3 'term4 te'rm5",
                 'expectedOutput' => "'te&rm1' & 'te|rm2' & '!term3' & '''term4' & 'te''rm5'",
             ],
+            'prefix, trailing backslash' => [
+                'matchingType' => 'PREFIX',
+                'searchString' => 'abc\\',
+                'expectedOutput' => "'abc\\\\':*",
+            ],
+            'exact, trailing backslash' => [
+                'matchingType' => 'EXACT',
+                'searchString' => 'abc\\',
+                'expectedOutput' => "'abc\\\\'",
+            ],
+            'prefix, backslash only' => [
+                'matchingType' => 'PREFIX',
+                'searchString' => '\\',
+                'expectedOutput' => "'\\\\':*",
+            ],
         ];
     }
 }


### PR DESCRIPTION
🤖 Resolves #17905

## 👋 Introduction

Address the issue goal across three facets 
- security (the most abstract)
- input sanitization
- reducing usage of `raw` class methods where reasonable

Leveraged Claude a lot since it is very much in its element for these kinds of tasks

## 🕵️ Details

### Changes

#### Security vulnerabilities 

No SQL vulnerabilities. 
One minor issue, dependent on being an authenticated user through `AdvancedOrderByDirective::resolveRelationExpression`
A method was called without properly checking it was a relation first, which allows the possibility of passing in things like `save` or `update` which would fire without being rejected due to not being model relations. 

This could run the risk of creation of junk data
Directive that is related `advancedOrderBy` is usage restricted so not risky and currently there is no path where passing in delete would delete a record. Which is due to `Model::query()` starting from a blank
_At the moment_ that is

> No SQL injection found. All 64 raw call sites bind their parameters; the 15 that interpolate into SQL only interpolate literals, values already allowlisted in PHP, or column names read back from the database.
> 
> One issue surfaced in AdvancedOrderByDirective::resolveRelationExpression, which builds a subquery string from a client-supplied relation name. It gated that name with method_exists — true for any model method, not just relations — and only confirmed the result was a relation after calling it, so a name pointing at a non-relation method took effect before being refused. It now checks the method's declared return type first, with the instanceof check kept as a backstop.

#### Sanitization 

Things to improve with input passed to full text search, like characters that were to be stripped could pass in midword. Handling when a term sanitized to nothing. And wildcard consistency

On the improved term cleaning, something like A&&B threw errors to the user before

> Three defects, all on user input feeding a raw call.
> 
> Full-text search. Symbol operators typed mid-word reached to_tsquery as syntax: A&B searched for "A and B anywhere", and A&&B errored. Terms are now quoted, so A&B searches for "A followed by B" and A&&B no longer errors. Word-based AND / OR and "quoted phrases" are unchanged; prefix matching survives, which websearch_to_tsquery would have silently dropped.
> 
> Filter could drop out. When cleaning reduced a term to nothing, whereGeneralSearch skipped its filter entirely and returned every user. It now returns none.
> 
> LIKE wildcards. % and _ typed into a search box acted as wildcards — % alone matched every row. A new PostgresLike::escape covers the user and activity search scopes. It replaces a closure private to one function, which is how the handling diverged: Activity::scopeWhereProcessGeneralSearch escaped eight branches and not the ninth.
> 
> Each search function is escaped whole rather than just its raw calls, so whereName and whereTelephone aren't left inconsistent. 14 unescaped ilike sites remain in TalentRequestBuilder, PoolBuilder and PoolCandidateBuilder — no raw calls among them, so out of scope.

#### Raw

There are 17 instances converted away from `raw`. A hotspot being file `Activity.php`
Conversion depended on presence of clean alternatives available AND checking for performance impact. So a change that is hard to parse and potentially impacted performance, I'd say may be better left as

> 64 raw call sites → 48. 17 converted, one added deliberately.
> 
> Activity.php is most of it, dropping from 20 to 6: four correlated join conditions became whereColumn, a bound equality became where, and eight ILIKE branches became where/orWhere — the localized ones through Laravel's JSON selector, which emits the same ->>'en'. That deleted $ilikeRaw, the only fragment in the file interpolated into a SQL string.
> 
> Elsewhere, TalentRequestBuilder's two id::text ILIKE calls became where('id', 'ilike', …), since the Postgres grammar appends the same cast for any like operator, and a bare column name moved from selectRaw to addSelect.
> 
> The one addition is the deny-all in the new fail-closed guard, written as whereRaw('1 = 0') rather than whereIn('id', []). Both compile to a constant-false one-time filter, but the raw form states the intent — with whereIn the denial depends on the array happening to be empty, which is a fragile thing to rest on in a guard whose job is to fail closed.

### Instances of preserving raw

There remain 48 uses. Reasons not to convert them
- No builder substitute
- Substitute behaves differently
- Code quality or comprehensibility trade off

>No builder method exists. Most of them: Postgres functions (LOWER, CONCAT, f_unaccent, to_tsquery, array_position, jsonb_array_elements), aggregate expressions inside a select list (count(distinct case when …)), select-list literals ('pool' as source), and NULLS FIRST/LAST, which no Laravel grammar supports at all.

Examples of behavioural discrepancy

> `inOrderOf` replaces array_position, but accepts no direction and sorts unmatched values the other way.
> `withCount` replaces the skill-count subqueries, except it can't do nested relations, and on User it excludes soft-deleted rows the current query counts and returns 0 where the field is meant to be null.
> `whereLike(caseSensitive: false)` replaces `LOWER(col) = ?`, except `%` in the value stays a wildcard — enough to make a uniqueness check match unrelated rows.
> `whereFullText` expresses the search filter but not its ranking, so the raw call stays either way.


## 🧪 Testing

Examples to test

Signed in as a platform admin.

#### Users table

1. Go to Users table — `http://localhost:8000/en/admin/users`
2. With no field selected, search spaces only → no results. Previously returned every user.
3. Search 'John Smith', quotes included → results or none, but no error. Previously an error.
4. Set the field selector to Name, enter % → no results, unless a name genuinely contains one. Previously matched everyone. Same for email, work email and phone.

#### Pool Activity 

1. Go to Pool activity for some pool — `http://localhost:8000/en/admin/pools/{poolId}/activity`
2. Search % → no results. Previously matched every entry.
3. Search a causer's first name, a candidate's name, a skill name, and an assessment step title → each still returns its matching entries. This is the step that covers the bulk of the `Activity.php` rewrite.

#### All candidates table

1. Go to Candidates table `http://localhost:8000/en/admin/pool-candidates`
2. Sort by the candidate name column (uses the user relation) or the pool column (uses the pool relation) → still sorts, confirming the relation gate didn't break legitimate relations.

