### PR TITLE
[Fix] Child lists respect space prop

### DIFF
--- a/packages/ui/src/components/List/List.stories.tsx
+++ b/packages/ui/src/components/List/List.stories.tsx
@@ -98,6 +98,30 @@ const Template: StoryFn<typeof Ul> = () => (
         </div>
       </div>
     </div>
+    <div>
+      <p className="mb-3 font-bold">Nested (mismatched space)</p>
+      <div className="grid gap-6 sm:grid-cols-3">
+        <div>
+          <Ul space="lg">
+            <li>
+              Parent one
+              <Ul space="sm">
+                <li>Child one</li>
+                <li>Child two</li>
+              </Ul>
+            </li>
+            <li>
+              Parent two
+              <Ul space="sm">
+                <li>Child one</li>
+                <li>Child two</li>
+              </Ul>
+            </li>
+          </Ul>
+          <Boundary />
+        </div>
+      </div>
+    </div>
   </div>
 );
 

--- a/packages/ui/src/components/List/styles.ts
+++ b/packages/ui/src/components/List/styles.ts
@@ -9,10 +9,10 @@ export const list = tv({
       unordered: "list-disc [&_ul]:list-[circle]",
     },
     space: {
-      sm: "[&_li]:not-last:mb-0.75",
-      md: "[&_li]:not-last:mb-1.5",
-      lg: "[&_li]:not-last:mb-3",
-      xl: "[&_li]:not-last:mb-6",
+      sm: "[&>li]:not-last:mb-0.75",
+      md: "[&>li]:not-last:mb-1.5",
+      lg: "[&>li]:not-last:mb-3",
+      xl: "[&>li]:not-last:mb-6",
     },
     unStyled: {
       true: "",


### PR DESCRIPTION
🤖 Resolves #17571 

## 👋 Introduction

Fixes child lists to respecting the space prop

## 🕵️ Details

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

## 🧪 Testing

1. Check out the new storybook story
2. Check out instances ff child lists with different spaces
    3. [apps/web/src/pages/TermsAndConditions/TermsAndConditions.tsx](https://github.com/GCTC-NTGC/gc-digital-talent/blob/main/apps/web/src/pages/TermsAndConditions/TermsAndConditions.tsx)
    4. [apps/web/src/pages/AccessibilityStatementPage/AccessibilityStatementPage.tsx](https://github.com/GCTC-NTGC/gc-digital-talent/blob/main/apps/web/src/pages/AccessibilityStatementPage/AccessibilityStatementPage.tsx)

## 📸 Screenshot

<img width="546" height="293" alt="image" src="https://github.com/user-attachments/assets/706a6952-01c7-4b04-ab19-b13097da5e17" />
