### PR TITLE
[Feature] Log Artisan commands

### DIFF
--- a/api/app/Console/Commands/CheckExternalLinks.php
+++ b/api/app/Console/Commands/CheckExternalLinks.php
@@ -64,10 +64,12 @@ class CheckExternalLinks extends Command
 
         Storage::disk('local')->put('external-broken-links.json', json_encode($brokenLinks, JSON_PRETTY_PRINT));
 
-        CommandProducedResults::dispatch($this->getName(), [
-            'linksChecked' => count($links),
-            'brokenLinks' => count($brokenLinks),
-        ]);
+        $resultSet = [
+            'Links Checked' => count($links),
+            'Broken Links' => count($brokenLinks),
+        ];
+        CommandProducedResults::dispatch($this->getName(), $resultSet);
+        $this->table(['Metric', 'Count'], collect($resultSet)->map(fn ($v, $k) => [$k, $v]));
 
         return Command::SUCCESS;
     }

--- a/api/app/Console/Commands/CheckExternalLinks.php
+++ b/api/app/Console/Commands/CheckExternalLinks.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Events\CommandProducedResults;
 use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
@@ -63,7 +64,10 @@ class CheckExternalLinks extends Command
 
         Storage::disk('local')->put('external-broken-links.json', json_encode($brokenLinks, JSON_PRETTY_PRINT));
 
-        $this->info(count($links).' links checked, '.count($brokenLinks).' broken.');
+        CommandProducedResults::dispatch($this->getName(), [
+            'linksChecked' => count($links),
+            'brokenLinks' => count($brokenLinks),
+        ]);
 
         return Command::SUCCESS;
     }

--- a/api/app/Events/CommandProducedResults.php
+++ b/api/app/Events/CommandProducedResults.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class CommandProducedResults
+{
+    use Dispatchable, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    public function __construct(
+        public string $command,
+        public array $context = [],
+    ) {}
+}

--- a/api/app/Listeners/LogArtisanCommand.php
+++ b/api/app/Listeners/LogArtisanCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Console\Events\CommandFinished;
+use Illuminate\Console\Events\CommandStarting;
+use Illuminate\Support\Facades\Log;
+
+// Logs to the "cli" channel explicitly (rather than the default channel) so every
+// artisan invocation is recorded regardless of how LOG_CHANNEL is configured.
+class LogArtisanCommand
+{
+    private static ?float $startedAt = null;
+
+    public function started(CommandStarting $event): void
+    {
+        self::$startedAt = microtime(true);
+
+        Log::channel('cli')->info('Artisan command starting', [
+            'command' => $event->command,
+            'arguments' => (string) $event->input,
+        ]);
+    }
+
+    public function finished(CommandFinished $event): void
+    {
+        Log::channel('cli')->info('Artisan command finished', [
+            'command' => $event->command,
+            'arguments' => (string) $event->input,
+            'exitCode' => $event->exitCode,
+            'durationMs' => $this->durationMs(),
+        ]);
+
+        self::$startedAt = null;
+    }
+
+    private function durationMs(): ?int
+    {
+        if (self::$startedAt === null) {
+            return null;
+        }
+
+        return (int) round((microtime(true) - self::$startedAt) * 1000);
+    }
+}

--- a/api/app/Listeners/LogArtisanCommand.php
+++ b/api/app/Listeners/LogArtisanCommand.php
@@ -12,7 +12,7 @@ class LogArtisanCommand
 {
     private static ?float $startedAt = null;
 
-    public function started(CommandStarting $event): void
+    public function starting(CommandStarting $event): void
     {
         self::$startedAt = microtime(true);
 

--- a/api/app/Listeners/LogArtisanCommand.php
+++ b/api/app/Listeners/LogArtisanCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Listeners;
 
+use App\Events\CommandProducedResults;
 use Illuminate\Console\Events\CommandFinished;
 use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Support\Facades\Log;
@@ -32,6 +33,14 @@ class LogArtisanCommand
         ]);
 
         self::$startedAt = null;
+    }
+
+    public function produced(CommandProducedResults $event): void
+    {
+        Log::channel('cli')->info('Artisan command produced results', [
+            'command' => $event->command,
+            ...$event->context,
+        ]);
     }
 
     private function durationMs(): ?int

--- a/api/app/Providers/EventServiceProvider.php
+++ b/api/app/Providers/EventServiceProvider.php
@@ -9,10 +9,13 @@ use App\Events\WorkExperienceSaved;
 use App\Listeners\BroadcastNotificationReceived;
 use App\Listeners\ComputeCandidateAssessmentStatus;
 use App\Listeners\ComputeGovEmployeeProfileData;
+use App\Listeners\LogArtisanCommand;
 use App\Listeners\LogTimedOutJob;
 use App\Listeners\SendFileGeneratedNotification;
 use App\Listeners\SendTalentNominationSubmittedNotifications;
 use BeyondCode\ServerTiming\Facades\ServerTiming;
+use Illuminate\Console\Events\CommandFinished;
+use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Queue\Events\JobTimedOut;
@@ -30,7 +33,7 @@ class EventServiceProvider extends ServiceProvider
     /**
      * The event listener mappings for the application.
      *
-     * @var array<class-string, array<int, class-string>>
+     * @var array<class-string, array<int, string>>
      */
     protected $listen = [
         AssessmentResultSaved::class => [
@@ -50,6 +53,12 @@ class EventServiceProvider extends ServiceProvider
         ],
         JobTimedOut::class => [
             LogTimedOutJob::class,
+        ],
+        CommandStarting::class => [
+            LogArtisanCommand::class.'@started',
+        ],
+        CommandFinished::class => [
+            LogArtisanCommand::class.'@finished',
         ],
     ];
 

--- a/api/app/Providers/EventServiceProvider.php
+++ b/api/app/Providers/EventServiceProvider.php
@@ -55,7 +55,7 @@ class EventServiceProvider extends ServiceProvider
             LogTimedOutJob::class,
         ],
         CommandStarting::class => [
-            LogArtisanCommand::class.'@started',
+            LogArtisanCommand::class.'@starting',
         ],
         CommandFinished::class => [
             LogArtisanCommand::class.'@finished',

--- a/api/app/Providers/EventServiceProvider.php
+++ b/api/app/Providers/EventServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Events\AssessmentResultSaved;
+use App\Events\CommandProducedResults;
 use App\Events\TalentNominationSubmitted;
 use App\Events\UserFileGenerated;
 use App\Events\WorkExperienceSaved;
@@ -59,6 +60,9 @@ class EventServiceProvider extends ServiceProvider
         ],
         CommandFinished::class => [
             LogArtisanCommand::class.'@finished',
+        ],
+        CommandProducedResults::class => [
+            LogArtisanCommand::class.'@produced',
         ],
     ];
 

--- a/api/tests/Unit/LogArtisanCommandTest.php
+++ b/api/tests/Unit/LogArtisanCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use App\Events\CommandProducedResults;
 use App\Listeners\LogArtisanCommand;
 use Illuminate\Console\Events\CommandFinished;
 use Illuminate\Console\Events\CommandStarting;
@@ -47,5 +48,21 @@ class LogArtisanCommandTest extends TestCase
 
         $listener = new LogArtisanCommand();
         $listener->finished(new CommandFinished('migrate', $input, $output, 0));
+    }
+
+    public function testProducedResultsLogsMessageAndContext(): void
+    {
+        Log::shouldReceive('channel')->with('cli')->andReturnSelf();
+        Log::shouldReceive('info')->once()->with('Artisan command produced results', [
+            'command' => 'app:check-external-links',
+            'linksChecked' => 42,
+            'brokenLinks' => 2,
+        ]);
+
+        $listener = new LogArtisanCommand();
+        $listener->produced(new CommandProducedResults('app:check-external-links', [
+            'linksChecked' => 42,
+            'brokenLinks' => 2,
+        ]));
     }
 }

--- a/api/tests/Unit/LogArtisanCommandTest.php
+++ b/api/tests/Unit/LogArtisanCommandTest.php
@@ -31,7 +31,7 @@ class LogArtisanCommandTest extends TestCase
         }));
 
         $listener = new LogArtisanCommand();
-        $listener->started(new CommandStarting('migrate', $input, $output));
+        $listener->starting(new CommandStarting('migrate', $input, $output));
         $listener->finished(new CommandFinished('migrate', $input, $output, 0));
     }
 

--- a/api/tests/Unit/LogArtisanCommandTest.php
+++ b/api/tests/Unit/LogArtisanCommandTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Listeners\LogArtisanCommand;
+use Illuminate\Console\Events\CommandFinished;
+use Illuminate\Console\Events\CommandStarting;
+use Illuminate\Support\Facades\Log;
+use Mockery;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Tests\TestCase;
+
+class LogArtisanCommandTest extends TestCase
+{
+    public function testLogsToCliChannelExplicitly(): void
+    {
+        $input = new ArgvInput(['artisan', 'migrate', '--force']);
+        $output = new NullOutput();
+
+        Log::shouldReceive('channel')->with('cli')->andReturnSelf();
+        Log::shouldReceive('info')->once()->with('Artisan command starting', [
+            'command' => 'migrate',
+            'arguments' => (string) $input,
+        ]);
+        Log::shouldReceive('info')->once()->with('Artisan command finished', Mockery::on(function ($context) {
+            return $context['command'] === 'migrate'
+                && $context['exitCode'] === 0
+                && is_int($context['durationMs'])
+                && $context['durationMs'] >= 0;
+        }));
+
+        $listener = new LogArtisanCommand();
+        $listener->started(new CommandStarting('migrate', $input, $output));
+        $listener->finished(new CommandFinished('migrate', $input, $output, 0));
+    }
+
+    public function testFinishedWithoutStartingStillLogsWithNullDuration(): void
+    {
+        $input = new ArgvInput(['artisan', 'migrate']);
+        $output = new NullOutput();
+
+        Log::shouldReceive('channel')->with('cli')->andReturnSelf();
+        Log::shouldReceive('info')->once()->with('Artisan command finished', Mockery::on(function ($context) {
+            return $context['durationMs'] === null;
+        }));
+
+        $listener = new LogArtisanCommand();
+        $listener->finished(new CommandFinished('migrate', $input, $output, 0));
+    }
+}


### PR DESCRIPTION
🤖 Resolves #17680 

## 👋 Introduction

Automatically logs the start and end of Artisan commands.

## 🕵️ Details

Logging command-specific details like row counts can't be done automatically.  However, I added an event for doing that manually at the end of a command.  To establish a pattern, I've added it to the external link checker.

## 🧪 Testing

1. Clear your laravel.log file.
2. Try running some Artisan commands, like `./artisan app:check-external-links`


## 📸 Screenshot

<img width="1510" height="423" alt="image" src="https://github.com/user-attachments/assets/8afb64b7-9dc6-487a-9bcf-1beb7ee2c7a5" />
