### PR TITLE
[Fix] Keep auth events from being dropped on unload

### DIFF
--- a/apps/web/src/pages/Auth/SignInPage/SignInPage.tsx
+++ b/apps/web/src/pages/Auth/SignInPage/SignInPage.tsx
@@ -7,7 +7,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import ChevronDoubleRightIcon from "@heroicons/react/24/solid/ChevronDoubleRightIcon";
 import MapIcon from "@heroicons/react/24/outline/MapIcon";
 
-import { appInsights } from "@gc-digital-talent/app-insights";
+import { trackEvent } from "@gc-digital-talent/app-insights";
 import {
   Accordion,
   Container,
@@ -104,25 +104,11 @@ export const Component = () => {
   // the IdP. Shared by both the CanadaLogin and legacy GCKey layouts so the two
   // can't drift apart.
   const trackLoginInitiated = () => {
-    if (!appInsights) return;
-
-    const aiUserId = appInsights?.context?.user?.id || "unknown";
-
-    appInsights.trackEvent(
-      { name: "Auth Login Initiated" },
-      {
-        aiUserId,
-        pageUrl: window.location.href,
-        path: window.location.pathname,
-        timestamp: new Date().toISOString(),
-        userAgent: navigator.userAgent,
-        referrer: document.referrer || "none",
-        loginStatus: "initiated",
-      },
-    );
-    // The click triggers a full-page navigation off-site, so flush the buffer
-    // to avoid the event being dropped on unload.
-    void appInsights.flush();
+    trackEvent("Auth Login Initiated", {
+      path: window.location.pathname,
+      userAgent: navigator.userAgent,
+      loginStatus: "initiated",
+    });
   };
 
   const InstructionCards = () => {

--- a/packages/app-insights/src/index.tsx
+++ b/packages/app-insights/src/index.tsx
@@ -1,7 +1,12 @@
 import { AppInsightsContext, AppInsightsProvider } from "./components/Provider";
 import useAppInsightsContext from "./hooks/useAppInsightsContext";
 import useAppInsightsCustomEvent from "./hooks/useAppInsightsCustomEvent";
-import { reactPlugin, appInsights } from "./utils/reactPlugin";
+import {
+  reactPlugin,
+  appInsights,
+  appInsightsIsEnabled,
+} from "./utils/reactPlugin";
+import trackEvent from "./utils/trackEvent";
 
 export { AppInsightsContext, AppInsightsProvider };
 
@@ -10,4 +15,6 @@ export {
   useAppInsightsCustomEvent,
   reactPlugin,
   appInsights,
+  appInsightsIsEnabled,
+  trackEvent,
 };

--- a/packages/app-insights/src/utils/reactPlugin.ts
+++ b/packages/app-insights/src/utils/reactPlugin.ts
@@ -10,6 +10,12 @@ const aiConnectionString = getRuntimeVariable(
 const reactPlugin = new ReactPlugin();
 
 /**
+ * The SDK's `BreezeChannelIdentifier`.  It is exported at runtime but missing
+ * from the type declarations, so we can't import it.
+ */
+const SENDER_CHANNEL = "AppInsightsChannelPlugin";
+
+/**
  * Weird syntax here but it is required for pnpm
  *
  * REF: https://github.com/microsoft/TypeScript/issues/47663#issuecomment-1519138189
@@ -21,11 +27,28 @@ const appInsights = new AppInsights.ApplicationInsights({
     autoTrackPageVisitTime: true,
     disableFetchTracking: false,
     connectionString: aiConnectionString,
+    extensionConfig: {
+      [SENDER_CHANNEL]: {
+        // Keep every batch inside the 65000 byte limit of the only unload
+        // transport that survives navigation (`fetch` with `keepalive`).  The
+        // SDK default of 102400 is larger than that limit, so a full buffer can
+        // never be delivered on unload.  See #17454.
+        maxBatchSizeInBytes: 65000,
+        // If we overshoot anyway, split the oversized beacon into per-event
+        // beacons instead of falling back to a plain XHR that the navigation
+        // cancels.  Partial delivery beats losing the whole batch.
+        disableSendBeaconSplit: false,
+      },
+    },
   },
 });
 
-if (aiConnectionString) {
+// `appInsights` is constructed either way, so it is always truthy.  Only this
+// flag tells you whether it was actually loaded and can send anything.
+const appInsightsIsEnabled = !!aiConnectionString;
+
+if (appInsightsIsEnabled) {
   appInsights.loadAppInsights();
 }
 
-export { reactPlugin, appInsights };
+export { reactPlugin, appInsights, appInsightsIsEnabled };

--- a/packages/app-insights/src/utils/trackEvent.ts
+++ b/packages/app-insights/src/utils/trackEvent.ts
@@ -1,0 +1,29 @@
+import type { ICustomProperties } from "@microsoft/applicationinsights-web";
+
+import { appInsights, appInsightsIsEnabled } from "./reactPlugin";
+
+/**
+ * Track a custom event, adding the context properties our auth events share.
+ *
+ * Deliberately does not flush.  These events are followed by a full-page
+ * navigation off-site, but the SDK already flushes on `beforeunload` /
+ * `pagehide`.  Flushing by hand first drains the buffer into an extra send that
+ * can exceed the unload size limit and fall back to a plain XHR the navigation
+ * then cancels, losing the event entirely.  See #17454 and #17834.
+ */
+function trackEvent(name: string, properties?: ICustomProperties): void {
+  if (!appInsightsIsEnabled) return;
+
+  appInsights.trackEvent(
+    { name },
+    {
+      aiUserId: appInsights.context?.user?.id || "unknown",
+      pageUrl: window.location.href,
+      timestamp: new Date().toISOString(),
+      referrer: document.referrer || "none",
+      ...properties,
+    },
+  );
+}
+
+export default trackEvent;

--- a/packages/auth/src/utils/logout.ts
+++ b/packages/auth/src/utils/logout.ts
@@ -1,7 +1,7 @@
 import type { Locales } from "@gc-digital-talent/i18n";
 import { getRuntimeVariableNotNull } from "@gc-digital-talent/env";
 import { defaultLogger } from "@gc-digital-talent/logger";
-import { appInsights } from "@gc-digital-talent/app-insights";
+import { trackEvent } from "@gc-digital-talent/app-insights";
 
 export function getLogoutVars(locale: Locales) {
   const logoutUri = getRuntimeVariableNotNull("OAUTH_LOGOUT_URI");
@@ -79,21 +79,11 @@ function logoutAndRefreshPage({
   }
 
   // track the logout event in application insights
-  if (appInsights) {
-    const aiUserId = appInsights?.context?.user?.id || "unknown";
-    appInsights.trackEvent?.(
-      { name: "Auth Logout" },
-      {
-        aiUserId,
-        pageUrl: window.location.href,
-        timestamp: new Date().toISOString(),
-        referrer: document.referrer || "none",
-        source: "AuthenticationContainer",
-        authStatus: "logout",
-        logoutReason: logoutReason ?? "unknown",
-      },
-    );
-  }
+  trackEvent("Auth Logout", {
+    source: "AuthenticationContainer",
+    authStatus: "logout",
+    logoutReason: logoutReason ?? "unknown",
+  });
 
   // Post a logout message to the broadcast channel
   // so they know to logout as well

--- a/packages/auth/src/utils/setTokensFromLocation.ts
+++ b/packages/auth/src/utils/setTokensFromLocation.ts
@@ -1,5 +1,5 @@
 /* eslint-disable testing-library/no-debugging-utils */
-import { appInsights } from "@gc-digital-talent/app-insights";
+import { trackEvent } from "@gc-digital-talent/app-insights";
 import { getLogger } from "@gc-digital-talent/logger";
 
 import {
@@ -50,20 +50,9 @@ export function setTokensFromLocation(url: URL): boolean {
 
       // Log the successful login event
       logger.debug("Logging Auth login success event");
-      const referrer = document.referrer || "none";
-      if (appInsights) {
-        const aiUserId = appInsights?.context?.user?.id || "unknown";
-        appInsights.trackEvent?.(
-          { name: "Auth Login Success" },
-          {
-            aiUserId,
-            pageUrl: window.location.href,
-            timestamp: new Date().toISOString(),
-            referrer,
-            source: "AuthenticationContainer",
-          },
-        );
-      }
+      trackEvent("Auth Login Success", {
+        source: "AuthenticationContainer",
+      });
       // also clear the last logout reason
       localStorage.removeItem(LOGOUT_REASON_KEY);
     }


### PR DESCRIPTION
🤖 Resolves #17454

## 👋 Introduction

Auth events (`Auth Login Initiated`, `Auth Logout`) are tracked immediately before a full-page navigation off-site, and could be lost entirely. The premise in the issue — that we weren't flushing — turned out to be mostly wrong; the real cause is a size cliff in the SDK's sender. This caps the batch size so the SDK's own unload flush can actually deliver, then removes the manual flush that #17834 showed makes things worse.

## 🕵️ Details

Reading `@microsoft/applicationinsights-*@3.4.3`:

**The SDK already flushes on unload.** `AISku.js:405-460` registers `beforeunload` + `pagehide` + `visibilitychange` handlers that call `onunloadFlush(false)`, gated on `disableFlushOnBeforeUnload`/`disableFlushOnUnload`. Neither was set, so both default to `false` and the handlers *are* installed. Both auth navigations (the sign-in anchor click, and `window.location.href = …` in logout) fire `pagehide`, so both were already covered.

**But there's a 64KB cliff, and past it the SDK loses everything.** The unload flush hands the buffer to `_fetchKeepAliveSender`, which picks a transport by size (`Sender.js:1032-1050`):

| Payload | Transport | Survives navigation? |
|---|---|---|
| ≤ 65000 bytes | `fetch(…, {keepalive: true})` | ✅ |
| > 65000 bytes | `sendBeacon` → refused (quota is also ~64KB) → `_onBeaconRetry` → `disableSendBeaconSplit` defaults `true`, so **no split** → plain async XHR | ❌ everything lost |

Crossing it isn't exotic: `maxBatchSizeInBytes` defaults to **102400** (`Sender.js:37`), *larger than the 65000-byte limit of the only reliable unload transport*, so a full buffer could never be delivered on unload. With `enableAutoRouteTracking`, `autoTrackPageVisitTime` and `disableFetchTracking: false` all on, every GraphQL call adds a dependency event, so a fat buffer at logout time is ordinary.

**Why #17834 made it worse.** A manual `onunloadFlush()` doesn't avoid the cliff, it just runs the same gamble early — and if it loses, the buffer is already marked sent, so the SDK's own unload flush finds nothing left to save. That explains the total loss seen in review there.

### Commits

| | |
|---|---|
| `07efb6140d` | Cap the sender batch size below the unload limit, enable beacon splitting, export `appInsightsIsEnabled` |
| `d4a2666faf` | Add a shared `trackEvent` helper |
| `9febaa4fc8` | Remove the manual flush on sign-in |
| `b45c544e8c` | Route the three auth events through the helper |

### Notes for review

- **Config placement.** `disableSendBeaconSplit` is on `ISenderConfig`, not `IConfig`, so it doesn't typecheck at the config root (`TS2353`). Both settings are Sender settings, so they now live under the Breeze channel's `extensionConfig`. `BreezeChannelIdentifier` is exported at runtime but absent from the web package's type declarations, hence the commented local const for the identifier string. I verified the placement resolves by loading a real client and reading back `_senderConfig` — got `maxBatchSizeInBytes: 65000`, `disableSendBeaconSplit: false`, channel `AppInsightsChannelPlugin`.
- **Latent bug fixed along the way.** `appInsights` is constructed whether or not a connection string is present, so it is always truthy — the `if (appInsights)` / `if (!appInsights) return` guards at all three auth call sites never detected the unconfigured case (the normal state locally). Replaced with `appInsightsIsEnabled`.
- **Emitted telemetry is unchanged.** All three events keep identical property sets; the helper just centralises the four context properties (`aiUserId`, `pageUrl`, `timestamp`, `referrer`) they each rebuilt by hand.
- `logoutAndRefreshPage` stays synchronous, so `AuthenticationState.logout` and its callers are untouched.
- The sign-in anchor keeps its native click behaviour, so middle-click and ⌘-click still open a new tab.
- Cost of the batch-size cap: more frequent, smaller sends during normal browsing.
- Related: #17987 — `IAPLayout` constructs a second `ApplicationInsights` client on every render. Those extra clients each keep their own buffer competing for the same browser-wide unload budget, and none of this tuning reaches them.

## 🧪 Testing

> [!IMPORTANT]
> Steps 2-3 need a real connection string, and step 3 needs Azure. Automated checks (`pnpm lint` across all 21 packages, `tsc` for app-insights/auth/web, auth 35/35 and web 112/112 tests) pass.

1. **Unconfigured (the default local setup)** — `pnpm dev:fresh`, sign in and out. No console errors, and no ingestion requests attempted. This exercises the fixed `appInsightsIsEnabled` guard.
2. **With a real connection string** — `pnpm dev:fresh`, DevTools → Network, **"Preserve log" on** (the request fires as the page is leaving) and the type filter on **All**, URL filtered by `track`.
   - Click *Proceed to CanadaLogin* → a request carrying `Auth Login Initiated` as the page unloads.
   - Return from the IdP → `Auth Login Success` (ordinary XHR, no navigation involved).
   - Log out → `Auth Logout`.
   - The request should show as type **`fetch`**. If you see type **`ping`** (`sendBeacon`, which the XHR filter hides), the batch is still over 65000 bytes despite the cap — see below.
3. **Azure** — allow 2-5 min ingestion latency:
   ```kusto
   customEvents
   | where name in ("Auth Login Initiated", "Auth Login Success", "Auth Logout")
   | order by timestamp desc
   ```
   Compare counts against a pre-change baseline over the same period.

If events still go missing: first confirm the request leaves at all (an extension or Edge/Firefox tracking prevention will block the ingestion endpoint outright — test a clean profile). If the Network tab still shows `ping`, the next lever is trimming what's collected (`disableFetchTracking: true`, `autoTrackPageVisitTime: false`), which is deliberately out of scope here because it's the only option that costs telemetry we presumably want.

## 📸 Screenshot

N/A — no user-facing change.

## 🚚 Deployment

No deployment steps needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)