### PR TITLE
[Chore] Bump ES lib level in TS config

### DIFF
--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -5,6 +5,7 @@
     "module": "ESNext",
     "lib": [
       "ES2022",
+      "ES2023",
       "DOM",
       "DOM.Iterable"
     ],


### PR DESCRIPTION
🤖 Resolves #17977 

## 👋 Introduction

Updates our TS config to add the `ES2023` spec to our libs.

## 🕵️ Details

This is a highly supported version of the ES spec so should be safe and give us access to [more features](https://www.explainthis.io/en/swe/es2023).

## 🧪 Testing

1. Add a temporary call to a [new feature in es2023](https://www.explainthis.io/en/swe/es2023)
2. Build the app `pnpm dev:fresh`
3. Confirm it functions as expected
4. Run a typecheck `pnpm tsc --force`
5. Confirm no errors