### PR TITLE
[Refactor] Remove remaining full graphql object types

### DIFF
--- a/apps/web/src/components/Activity/Item.tsx
+++ b/apps/web/src/components/Activity/Item.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from "react";
 
-import type { Activity, FragmentType } from "@gc-digital-talent/graphql";
+import type { FragmentType } from "@gc-digital-talent/graphql";
 import { getFragment, graphql } from "@gc-digital-talent/graphql";
 
 import AssessmentStepActivityItem from "./Items/AssessmentStepActivityItem";
@@ -13,10 +13,7 @@ import type { CommonItemProps } from "./Items/BaseActivityItem";
 type SubComponentProps = Omit<PoolActivityItemProps, "query"> & CommonItemProps;
 type SubComponent = (props: SubComponentProps) => JSX.Element | null;
 
-const COMPONENT_MAP: Record<
-  NonNullable<Activity["subjectType"]>,
-  SubComponent
-> = {
+const COMPONENT_MAP: Record<string, SubComponent> = {
   "App\\Models\\AssessmentStep": AssessmentStepActivityItem,
   "App\\Models\\Pool": PoolActivityItem,
   "App\\Models\\PoolCandidate": PoolCandidateActivityItem,

--- a/apps/web/src/components/Activity/Items/AssessmentStepActivityItem.tsx
+++ b/apps/web/src/components/Activity/Items/AssessmentStepActivityItem.tsx
@@ -1,20 +1,20 @@
 import type { ReactNode } from "react";
 import { useIntl } from "react-intl";
 
-import type { ActivityProperties } from "@gc-digital-talent/graphql";
 import { getFragment } from "@gc-digital-talent/graphql";
 import type { Locales } from "@gc-digital-talent/i18n";
 import { getLocale } from "@gc-digital-talent/i18n";
 
 import type { CommonItemProps } from "./BaseActivityItem";
 import BaseItem, { BaseItem_Fragment } from "./BaseActivityItem";
+import type { ActivityItemProperties } from "./utils";
 import { getDeepAttribute, getEventInfo, parseAttributes } from "./utils";
 
 type AssessmentStepActivityItemProps = CommonItemProps;
 
 function getDescription(
   locale: Locales,
-  propsObj?: ActivityProperties | null,
+  propsObj?: ActivityItemProperties | null,
 ): ReactNode {
   let desc: ReactNode;
   if (propsObj) {

--- a/apps/web/src/components/Activity/Items/PoolCandidateActivityItem.tsx
+++ b/apps/web/src/components/Activity/Items/PoolCandidateActivityItem.tsx
@@ -3,7 +3,6 @@ import UserMinusIcon from "@heroicons/react/16/solid/UserMinusIcon";
 import UserPlusIcon from "@heroicons/react/16/solid/UserPlusIcon";
 import { useIntl, type IntlShape } from "react-intl";
 
-import type { ActivityProperties } from "@gc-digital-talent/graphql";
 import { ActivityEvent, getFragment } from "@gc-digital-talent/graphql";
 import {
   commonMessages,
@@ -18,11 +17,12 @@ import {
 
 import type { CommonItemProps } from "./BaseActivityItem";
 import BaseItem, { BaseItem_Fragment } from "./BaseActivityItem";
+import type { ActivityItemProperties } from "./utils";
 import { getEventInfo, parseAttributes } from "./utils";
 
 type PoolCandidateActivityItemProps = CommonItemProps;
 
-function getDescription(propsObj?: ActivityProperties | null): ReactNode {
+function getDescription(propsObj?: ActivityItemProperties | null): ReactNode {
   if (propsObj && "attributes" in propsObj) {
     const atts = parseAttributes(propsObj.attributes);
     if ("user_name" in atts && typeof atts.user_name === "string") {
@@ -36,7 +36,7 @@ function getDescription(propsObj?: ActivityProperties | null): ReactNode {
 function getDescriptionForSpecialApplicationCreated(
   intl: IntlShape,
   locale: Locales,
-  propsObj?: ActivityProperties | null,
+  propsObj?: ActivityItemProperties | null,
 ): string | null {
   if (propsObj && "attributes" in propsObj) {
     const atts = parseAttributes(propsObj.attributes);
@@ -98,7 +98,7 @@ function getDescriptionForSpecialApplicationCreated(
 function getDescriptionForSpecialApplicationSubmitted(
   intl: IntlShape,
   locale: Locales,
-  propsObj?: ActivityProperties | null,
+  propsObj?: ActivityItemProperties | null,
 ): string | null {
   if (propsObj && "attributes" in propsObj) {
     const atts = parseAttributes(propsObj.attributes);

--- a/apps/web/src/components/Activity/Items/PoolSkillActivityItem.tsx
+++ b/apps/web/src/components/Activity/Items/PoolSkillActivityItem.tsx
@@ -1,20 +1,20 @@
 import type { ReactNode } from "react";
 import { useIntl } from "react-intl";
 
-import type { ActivityProperties } from "@gc-digital-talent/graphql";
 import { getFragment } from "@gc-digital-talent/graphql";
 import type { Locales } from "@gc-digital-talent/i18n";
 import { getLocale } from "@gc-digital-talent/i18n";
 
 import type { CommonItemProps } from "./BaseActivityItem";
 import BaseItem, { BaseItem_Fragment } from "./BaseActivityItem";
+import type { ActivityItemProperties } from "./utils";
 import { getDeepAttribute, getEventInfo, parseAttributes } from "./utils";
 
 type PoolSkillActivityItemProps = CommonItemProps;
 
 function getDescription(
   locale: Locales,
-  propsObj?: ActivityProperties | null,
+  propsObj?: ActivityItemProperties | null,
 ): ReactNode {
   let desc: ReactNode;
   if (propsObj) {

--- a/apps/web/src/components/Activity/Items/utils.ts
+++ b/apps/web/src/components/Activity/Items/utils.ts
@@ -14,7 +14,6 @@ import { tv } from "tailwind-variants";
 import { isValid } from "date-fns/isValid";
 import { format } from "date-fns/format";
 
-import type { ActivityProperties } from "@gc-digital-talent/graphql";
 import { ActivityEvent } from "@gc-digital-talent/graphql";
 import type { IconType } from "@gc-digital-talent/ui";
 import { commonMessages } from "@gc-digital-talent/i18n";
@@ -44,6 +43,12 @@ export const icon = tv({
 });
 
 export type IconVariants = VariantProps<typeof icon>;
+
+export interface ActivityItemProperties {
+  __typename?: "ActivityProperties";
+  attributes?: unknown;
+  old?: unknown;
+}
 
 export interface ActivityEventInfo {
   message: MessageDescriptor;
@@ -227,7 +232,7 @@ const commonKeyMap = new Map<string, MessageDescriptor>([
 
 export function normalizePropKeys(
   intl: IntlShape,
-  propsObj?: ActivityProperties | null,
+  propsObj?: ActivityItemProperties | null,
   keyMap?: Map<string, MessageDescriptor>,
   logger?: Logger,
 ): string[] {

--- a/apps/web/src/components/ExperienceCard/AwardContent.tsx
+++ b/apps/web/src/components/ExperienceCard/AwardContent.tsx
@@ -13,7 +13,7 @@ import {
 import ContentSection from "./ContentSection";
 import type { ContentProps } from "./types";
 
-interface AwardContentExperience {
+export interface AwardContentExperience {
   __typename?: "AwardExperience";
   issuedBy?: string | null;
   awardedTo?: GenericLocalizedEnum<AwardedTo> | null;

--- a/apps/web/src/components/ExperienceCard/EducationContent.tsx
+++ b/apps/web/src/components/ExperienceCard/EducationContent.tsx
@@ -10,7 +10,7 @@ import { getExperienceFormLabels } from "~/utils/experienceUtils";
 import ContentSection from "./ContentSection";
 import type { ContentProps } from "./types";
 
-interface EducationContentExperience {
+export interface EducationContentExperience {
   __typename?: "EducationExperience";
   areaOfStudy?: string | null;
   thesisTitle?: string | null;

--- a/apps/web/src/components/ExperienceCard/SnapshotV1/AwardContentV1.tsx
+++ b/apps/web/src/components/ExperienceCard/SnapshotV1/AwardContentV1.tsx
@@ -1,17 +1,17 @@
 import { useIntl } from "react-intl";
 
 import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
-import type { AwardExperience } from "@gc-digital-talent/graphql";
 
 import { getExperienceFormLabels } from "~/utils/experienceUtils";
 
 import ContentSection from "../ContentSection";
 import type { ContentProps } from "../types";
+import type { AwardContentExperience } from "../AwardContent";
 
 const AwardContentV1 = ({
   experience: { awardedTo, issuedBy, awardedScope },
   headingLevel,
-}: ContentProps<Omit<AwardExperience, "user" | "relatedExperience">>) => {
+}: ContentProps<AwardContentExperience>) => {
   const intl = useIntl();
   const experienceFormLabels = getExperienceFormLabels(intl);
   const notAvailable = intl.formatMessage(commonMessages.notAvailable);

--- a/apps/web/src/components/ExperienceCard/SnapshotV1/EducationContentV1.tsx
+++ b/apps/web/src/components/ExperienceCard/SnapshotV1/EducationContentV1.tsx
@@ -1,17 +1,17 @@
 import { useIntl } from "react-intl";
 
 import { commonMessages, getLocalizedName } from "@gc-digital-talent/i18n";
-import type { EducationExperience } from "@gc-digital-talent/graphql";
 
 import { getExperienceFormLabels } from "~/utils/experienceUtils";
 
 import ContentSection from "../ContentSection";
 import type { ContentProps } from "../types";
+import type { EducationContentExperience } from "../EducationContent";
 
 const EducationContentV1 = ({
   experience: { areaOfStudy, status, thesisTitle },
   headingLevel,
-}: ContentProps<Omit<EducationExperience, "user">>) => {
+}: ContentProps<EducationContentExperience>) => {
   const intl = useIntl();
   const experienceFormLabels = getExperienceFormLabels(intl);
 

--- a/apps/web/src/components/ExperienceCard/SnapshotV1/PersonalContentV1.tsx
+++ b/apps/web/src/components/ExperienceCard/SnapshotV1/PersonalContentV1.tsx
@@ -1,14 +1,14 @@
 import { useIntl } from "react-intl";
 
 import { commonMessages } from "@gc-digital-talent/i18n";
-import type { PersonalExperience } from "@gc-digital-talent/graphql";
 
 import { getExperienceFormLabels } from "~/utils/experienceUtils";
 
 import ContentSection from "../ContentSection";
 import type { ContentProps } from "../types";
 
-interface PersonalExperienceV1 extends Omit<PersonalExperience, "user"> {
+interface PersonalExperienceV1 {
+  __typename?: "PersonalExperience";
   description?: string | null;
 }
 

--- a/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
+++ b/apps/web/src/components/NotificationDialog/NotificationDialog.tsx
@@ -8,7 +8,6 @@ import type { UseQueryExecute } from "urql";
 import { useQuery, useSubscription } from "urql";
 
 import { unpackMaybes, useIsSmallScreen } from "@gc-digital-talent/helpers";
-import type { UserNotification } from "@gc-digital-talent/graphql";
 import { graphql, NotificationType } from "@gc-digital-talent/graphql";
 import type { ButtonProps } from "@gc-digital-talent/ui";
 import {
@@ -166,6 +165,12 @@ const DialogPortalWithPresence = ({
   ) : null;
 };
 
+interface ReceivedNotification {
+  __typename?: "UserNotification";
+  id?: string | null;
+  type?: NotificationType | null;
+}
+
 const Notification_Subscription = graphql(/** GraphQL */ `
   subscription Notification {
     notificationReceived {
@@ -250,7 +255,7 @@ const NotificationDialog = ({
 
   useSubscription(
     { query: Notification_Subscription },
-    (prev, result): UserNotification[] => {
+    (prev, result): ReceivedNotification[] => {
       const notification = result.notificationReceived;
 
       if (!notification) return prev ?? [];


### PR DESCRIPTION
🤖 Resolves #17227 

## 👋 Introduction

Removes the reamining full graphql object types that were either overlooked or introduced inbetween PRs.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Login as `admin@test.com`
3. Start the queue and websocket server `make queue-work` and `make reverb-start`
4. Confirm the following works:
    - Viewing the process activity log
    - Viewing snapshot experiences of every type
    - Getting a file download ready toast