### PR TITLE
[Fix] Position duration in filter summary when empty

### DIFF
--- a/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
+++ b/apps/web/src/components/SearchRequestFilters/SearchRequestFilters.tsx
@@ -56,7 +56,8 @@ const ApplicantFilters = ({
   });
 
   const employmentDuration: string | undefined =
-    applicantFilter?.positionDuration
+    applicantFilter?.positionDuration &&
+    applicantFilter.positionDuration.length > 0
       ? intl.formatMessage(
           getEmploymentDuration(
             positionDurationToEmploymentDuration(


### PR DESCRIPTION
🤖 Resolves #17936 

## 👋 Introduction

Fixes an issue where we were showing "Indeterminate" in the filter summary even when no position was specified.

## 🕵️ Details

Oddly enough, even though the input demands only a single vlaue, position duration is an array. So, this simply adds an additional check to confirm the array is not empty.

## 🧪 Testing

1. Build `pnpm dev:fresh`
2. Navigate to `/search`
3. Submit the form withou selecting an employement duration
4. Confirm that the summary filters below the request form says "(none selected)" and not "Indeterminate"
5. Repeat steps 2-3 and for each employement duration option, confirming you see the appropriate sumary on the request form page

## 📸 Screenshot


<img width="1285" height="684" alt="image" src="https://github.com/user-attachments/assets/8272f0f9-0e24-48e6-b138-c16a194ab8b8" />
